### PR TITLE
8258813: [TESTBUG] Fix incorrect Vector API test output message

### DIFF
--- a/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorTest.java
@@ -251,7 +251,7 @@ public class AbstractVectorTest {
         boolean apply(boolean a, boolean b);
     }
 
-    static void assertArraysEquals(boolean[] a, boolean[] b, boolean[] r, FBooleanBinOp f) {
+    static void assertArraysEquals(boolean[] r, boolean[] a, boolean[] b, FBooleanBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -57,36 +57,14 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -390,7 +368,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "byteProviderForIOOBE")
@@ -461,7 +439,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -472,7 +450,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteMaskProviderForIOOBE")
@@ -545,7 +523,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -569,7 +547,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -656,7 +634,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -671,7 +649,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -787,7 +765,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -868,7 +846,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -879,7 +857,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -956,7 +934,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -967,7 +945,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -68,7 +68,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a[i]);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte apply(byte[] a);
     }
 
-    static void assertReductionArraysEquals(byte[] a, byte[] b, byte c,
+    static void assertReductionArraysEquals(byte[] r, byte rc, byte[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(byte[] a, byte[] b, byte c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(byte[] r, byte rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Byte128VectorTests extends AbstractVectorTest {
         long apply(byte[] a);
     }
 
-    static void assertReductionLongArraysEquals(byte[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, byte[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Byte128VectorTests extends AbstractVectorTest {
         long apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(byte[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Byte128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(byte[] a, byte[] b, byte element, int index) {
+    static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[]a, byte[]r) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, int b);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FBinArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] r, byte[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(r, a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -802,7 +802,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, byte[] r, int offs) {
+    static void assertArraysEquals(byte[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -813,7 +813,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -824,7 +824,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1288,7 +1288,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Byte128VectorTests::ADD);
     }
     static byte add(byte a, byte b) {
         return (byte)(a + b);
@@ -1306,7 +1306,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::add);
+        assertArraysEquals(r, a, b, Byte128VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1326,7 +1326,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1344,7 +1344,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::add);
     }
     static byte SUB(byte a, byte b) {
         return (byte)(a - b);
@@ -1364,7 +1364,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Byte128VectorTests::SUB);
     }
     static byte sub(byte a, byte b) {
         return (byte)(a - b);
@@ -1382,7 +1382,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::sub);
+        assertArraysEquals(r, a, b, Byte128VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1402,7 +1402,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::SUB);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1420,7 +1420,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::sub);
     }
     static byte MUL(byte a, byte b) {
         return (byte)(a * b);
@@ -1440,7 +1440,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Byte128VectorTests::MUL);
     }
     static byte mul(byte a, byte b) {
         return (byte)(a * b);
@@ -1458,7 +1458,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::mul);
+        assertArraysEquals(r, a, b, Byte128VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1478,7 +1478,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::MUL);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1496,7 +1496,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::mul);
     }
 
 
@@ -1521,7 +1521,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Byte128VectorTests::DIV);
     }
     static byte div(byte a, byte b) {
         return (byte)(a / b);
@@ -1543,7 +1543,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::div);
+        assertArraysEquals(r, a, b, Byte128VectorTests::div);
     }
 
 
@@ -1567,7 +1567,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::DIV);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1589,7 +1589,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::div);
     }
 
     static byte FIRST_NONZERO(byte a, byte b) {
@@ -1610,7 +1610,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Byte128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1630,7 +1630,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::FIRST_NONZERO);
     }
 
     static byte AND(byte a, byte b) {
@@ -1651,7 +1651,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::AND);
+        assertArraysEquals(r, a, b, Byte128VectorTests::AND);
     }
     static byte and(byte a, byte b) {
         return (byte)(a & b);
@@ -1669,7 +1669,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::and);
+        assertArraysEquals(r, a, b, Byte128VectorTests::and);
     }
 
 
@@ -1691,7 +1691,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::AND);
     }
 
 
@@ -1713,7 +1713,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Byte128VectorTests::AND_NOT);
     }
 
 
@@ -1735,7 +1735,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::AND_NOT);
     }
 
 
@@ -1757,7 +1757,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::OR);
+        assertArraysEquals(r, a, b, Byte128VectorTests::OR);
     }
     static byte or(byte a, byte b) {
         return (byte)(a | b);
@@ -1775,7 +1775,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::or);
+        assertArraysEquals(r, a, b, Byte128VectorTests::or);
     }
 
 
@@ -1797,7 +1797,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::OR);
     }
 
 
@@ -1819,7 +1819,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::XOR);
+        assertArraysEquals(r, a, b, Byte128VectorTests::XOR);
     }
 
 
@@ -1841,7 +1841,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::XOR);
     }
 
 
@@ -1856,7 +1856,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1873,7 +1873,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1887,7 +1887,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1904,7 +1904,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1918,7 +1918,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1935,7 +1935,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::mul);
     }
 
 
@@ -1954,7 +1954,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::div);
     }
 
 
@@ -1975,7 +1975,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::div);
     }
 
 
@@ -1991,7 +1991,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::OR);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2005,7 +2005,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::or);
     }
 
 
@@ -2024,7 +2024,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::OR);
     }
 
 
@@ -2040,7 +2040,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::AND);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2054,7 +2054,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::and);
     }
 
 
@@ -2073,7 +2073,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte128VectorTests::AND);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Byte128VectorTests::OR);
     }
 
 
@@ -2108,7 +2108,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte128VectorTests::OR);
     }
 
 
@@ -2123,7 +2123,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Byte128VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -2140,7 +2140,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte128VectorTests::ADD);
     }
 
 
@@ -2163,7 +2163,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Byte128VectorTests::LSHL);
     }
 
 
@@ -2185,7 +2185,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::LSHL);
     }
 
 
@@ -2211,7 +2211,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Byte128VectorTests::ASHR);
     }
 
 
@@ -2233,7 +2233,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::ASHR);
     }
 
 
@@ -2259,7 +2259,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Byte128VectorTests::LSHR);
     }
 
 
@@ -2281,7 +2281,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::LSHR);
     }
 
 
@@ -2306,7 +2306,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Byte128VectorTests::LSHL_unary);
     }
 
 
@@ -2327,7 +2327,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte128VectorTests::LSHL_unary);
     }
 
 
@@ -2352,7 +2352,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte128VectorTests::LSHR_unary);
     }
 
 
@@ -2373,7 +2373,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte128VectorTests::LSHR_unary);
     }
 
 
@@ -2398,7 +2398,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte128VectorTests::ASHR_unary);
     }
 
 
@@ -2419,7 +2419,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte128VectorTests::ASHR_unary);
     }
 
 
@@ -2442,7 +2442,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Byte128VectorTests::MIN);
     }
     static byte min(byte a, byte b) {
         return (byte)(Math.min(a, b));
@@ -2460,7 +2460,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::min);
+        assertArraysEquals(r, a, b, Byte128VectorTests::min);
     }
     static byte MAX(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2480,7 +2480,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Byte128VectorTests::MAX);
     }
     static byte max(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2498,7 +2498,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::max);
+        assertArraysEquals(r, a, b, Byte128VectorTests::max);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2512,7 +2512,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::MIN);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2526,7 +2526,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::min);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2540,7 +2540,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::MAX);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2554,7 +2554,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Byte128VectorTests::max);
     }
 
     static byte ANDReduce(byte[] a, int idx) {
@@ -2597,7 +2597,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::ANDReduce, Byte128VectorTests::ANDReduceAll);
     }
 
@@ -2645,7 +2645,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::ANDReduceMasked, Byte128VectorTests::ANDReduceAllMasked);
     }
 
@@ -2690,7 +2690,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::ORReduce, Byte128VectorTests::ORReduceAll);
     }
 
@@ -2738,7 +2738,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::ORReduceMasked, Byte128VectorTests::ORReduceAllMasked);
     }
 
@@ -2783,7 +2783,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::XORReduce, Byte128VectorTests::XORReduceAll);
     }
 
@@ -2831,7 +2831,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::XORReduceMasked, Byte128VectorTests::XORReduceAllMasked);
     }
 
@@ -2873,7 +2873,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::ADDReduce, Byte128VectorTests::ADDReduceAll);
     }
     static byte ADDReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -2917,7 +2917,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::ADDReduceMasked, Byte128VectorTests::ADDReduceAllMasked);
     }
     static byte MULReduce(byte[] a, int idx) {
@@ -2958,7 +2958,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::MULReduce, Byte128VectorTests::MULReduceAll);
     }
     static byte MULReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3002,7 +3002,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::MULReduceMasked, Byte128VectorTests::MULReduceAllMasked);
     }
     static byte MINReduce(byte[] a, int idx) {
@@ -3043,7 +3043,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::MINReduce, Byte128VectorTests::MINReduceAll);
     }
     static byte MINReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3088,7 +3088,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::MINReduceMasked, Byte128VectorTests::MINReduceAllMasked);
     }
     static byte MAXReduce(byte[] a, int idx) {
@@ -3129,7 +3129,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte128VectorTests::MAXReduce, Byte128VectorTests::MAXReduceAll);
     }
     static byte MAXReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3174,7 +3174,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::MAXReduceMasked, Byte128VectorTests::MAXReduceAllMasked);
     }
 
@@ -3200,7 +3200,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte128VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte128VectorTests::anyTrue);
     }
 
 
@@ -3226,7 +3226,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte128VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte128VectorTests::allTrue);
     }
 
 
@@ -3242,7 +3242,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (byte)4, 0);
+        assertInsertArraysEquals(r, a, (byte)4, 0);
     }
     static boolean testIS_DEFAULT(byte a) {
         return bits(a)==0;
@@ -3791,7 +3791,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::blend);
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleProvider")
@@ -3808,7 +3808,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleMaskProvider")
@@ -3826,7 +3826,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "byteUnaryOpProvider")
     static void getByte128VectorTests(IntFunction<byte[]> fa) {
@@ -3981,7 +3981,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::get);
+        assertArraysEquals(r, a, Byte128VectorTests::get);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -3995,7 +3995,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4042,7 +4042,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Byte128VectorTests::sliceUnary);
     }
     static byte[] sliceBinary(byte[] a, byte[] b, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4071,7 +4071,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Byte128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Byte128VectorTests::sliceBinary);
     }
     static byte[] slice(byte[] a, byte[] b, int origin, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4104,7 +4104,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Byte128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Byte128VectorTests::slice);
     }
     static byte[] unsliceUnary(byte[] a, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4131,7 +4131,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Byte128VectorTests::unsliceUnary);
     }
     static byte[] unsliceBinary(byte[] a, byte[] b, int origin, int part, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4170,7 +4170,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Byte128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Byte128VectorTests::unsliceBinary);
     }
     static byte[] unslice(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4226,7 +4226,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Byte128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Byte128VectorTests::unslice);
     }
 
 
@@ -4275,7 +4275,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Byte128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Byte128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte128VectorTests(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4291,7 +4291,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Byte128VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Byte128VectorTests::bitwiseBlend);
     }
 
 
@@ -4314,7 +4314,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Byte128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Byte128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4332,7 +4332,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4347,7 +4347,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte128VectorTestsBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4361,7 +4361,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4376,7 +4376,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::bitwiseBlend);
     }
 
 
@@ -4396,7 +4396,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Byte128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Byte128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpMaskProvider")
@@ -4415,7 +4415,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Byte128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Byte128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4433,7 +4433,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte128VectorTestsDoubleBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4447,7 +4447,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte128VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte128VectorTests::bitwiseBlend);
     }
 
 
@@ -4466,7 +4466,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Byte128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Byte128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4490,7 +4490,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::NEG);
+        assertArraysEquals(r, a, Byte128VectorTests::NEG);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4505,7 +4505,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::neg);
+        assertArraysEquals(r, a, Byte128VectorTests::neg);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4523,7 +4523,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Byte128VectorTests::NEG);
     }
 
     static byte ABS(byte a) {
@@ -4546,7 +4546,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::ABS);
+        assertArraysEquals(r, a, Byte128VectorTests::ABS);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4561,7 +4561,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::abs);
+        assertArraysEquals(r, a, Byte128VectorTests::abs);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4579,7 +4579,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Byte128VectorTests::ABS);
     }
 
 
@@ -4605,7 +4605,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::NOT);
+        assertArraysEquals(r, a, Byte128VectorTests::NOT);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4620,7 +4620,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::not);
+        assertArraysEquals(r, a, Byte128VectorTests::not);
     }
 
 
@@ -4640,7 +4640,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte128VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Byte128VectorTests::NOT);
     }
 
 
@@ -4663,7 +4663,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte128VectorTests::ZOMO);
+        assertArraysEquals(r, a, Byte128VectorTests::ZOMO);
     }
 
 
@@ -4683,7 +4683,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte128VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Byte128VectorTests::ZOMO);
     }
 
 
@@ -4711,7 +4711,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::gather);
+        assertArraysEquals(r, a, b, Byte128VectorTests::gather);
     }
     static byte[] gatherMasked(byte a[], int ix, boolean[] mask, int[] b, int iy) {
         byte[] res = new byte[SPECIES.length()];
@@ -4739,7 +4739,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::gatherMasked);
     }
 
     static byte[] scatter(byte a[], int ix, int[] b, int iy) {
@@ -4764,7 +4764,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Byte128VectorTests::scatter);
     }
 
     static byte[] scatterMasked(byte r[], byte a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4802,7 +4802,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Byte128VectorTests::scatterMasked);
     }
 
 
@@ -4844,8 +4844,8 @@ public class Byte128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4855,8 +4855,8 @@ public class Byte128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4866,8 +4866,8 @@ public class Byte128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4907,7 +4907,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 
     static long ADDReduceLong(byte[] a, int idx) {
@@ -4944,7 +4944,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Byte128VectorTests::ADDReduceLong, Byte128VectorTests::ADDReduceAllLong);
     }
 
@@ -4985,7 +4985,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Byte128VectorTests::ADDReduceLongMasked, Byte128VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4997,7 +4997,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -5015,7 +5015,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte128VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte128VectorTests::blend);
     }
 
 
@@ -5032,7 +5032,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpSelectFromMaskProvider")
@@ -5051,7 +5051,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5128,7 +5128,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Byte128VectorTests::beq);
+        assertArraysEquals(r, a, b, Byte128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -57,36 +57,14 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -390,7 +368,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "byteProviderForIOOBE")
@@ -461,7 +439,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -472,7 +450,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteMaskProviderForIOOBE")
@@ -545,7 +523,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -569,7 +547,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -656,7 +634,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -671,7 +649,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -787,7 +765,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -868,7 +846,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -879,7 +857,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -956,7 +934,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -967,7 +945,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -68,7 +68,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a[i]);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte apply(byte[] a);
     }
 
-    static void assertReductionArraysEquals(byte[] a, byte[] b, byte c,
+    static void assertReductionArraysEquals(byte[] r, byte rc, byte[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(byte[] a, byte[] b, byte c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(byte[] r, byte rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Byte256VectorTests extends AbstractVectorTest {
         long apply(byte[] a);
     }
 
-    static void assertReductionLongArraysEquals(byte[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, byte[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Byte256VectorTests extends AbstractVectorTest {
         long apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(byte[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Byte256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(byte[] a, byte[] b, byte element, int index) {
+    static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[]a, byte[]r) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, int b);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FBinArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] r, byte[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(r, a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -802,7 +802,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, byte[] r, int offs) {
+    static void assertArraysEquals(byte[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -813,7 +813,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -824,7 +824,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1288,7 +1288,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Byte256VectorTests::ADD);
     }
     static byte add(byte a, byte b) {
         return (byte)(a + b);
@@ -1306,7 +1306,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::add);
+        assertArraysEquals(r, a, b, Byte256VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1326,7 +1326,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1344,7 +1344,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::add);
     }
     static byte SUB(byte a, byte b) {
         return (byte)(a - b);
@@ -1364,7 +1364,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Byte256VectorTests::SUB);
     }
     static byte sub(byte a, byte b) {
         return (byte)(a - b);
@@ -1382,7 +1382,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::sub);
+        assertArraysEquals(r, a, b, Byte256VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1402,7 +1402,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::SUB);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1420,7 +1420,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::sub);
     }
     static byte MUL(byte a, byte b) {
         return (byte)(a * b);
@@ -1440,7 +1440,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Byte256VectorTests::MUL);
     }
     static byte mul(byte a, byte b) {
         return (byte)(a * b);
@@ -1458,7 +1458,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::mul);
+        assertArraysEquals(r, a, b, Byte256VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1478,7 +1478,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::MUL);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1496,7 +1496,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::mul);
     }
 
 
@@ -1521,7 +1521,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Byte256VectorTests::DIV);
     }
     static byte div(byte a, byte b) {
         return (byte)(a / b);
@@ -1543,7 +1543,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::div);
+        assertArraysEquals(r, a, b, Byte256VectorTests::div);
     }
 
 
@@ -1567,7 +1567,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::DIV);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1589,7 +1589,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::div);
     }
 
     static byte FIRST_NONZERO(byte a, byte b) {
@@ -1610,7 +1610,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Byte256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1630,7 +1630,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::FIRST_NONZERO);
     }
 
     static byte AND(byte a, byte b) {
@@ -1651,7 +1651,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::AND);
+        assertArraysEquals(r, a, b, Byte256VectorTests::AND);
     }
     static byte and(byte a, byte b) {
         return (byte)(a & b);
@@ -1669,7 +1669,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::and);
+        assertArraysEquals(r, a, b, Byte256VectorTests::and);
     }
 
 
@@ -1691,7 +1691,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::AND);
     }
 
 
@@ -1713,7 +1713,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Byte256VectorTests::AND_NOT);
     }
 
 
@@ -1735,7 +1735,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::AND_NOT);
     }
 
 
@@ -1757,7 +1757,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::OR);
+        assertArraysEquals(r, a, b, Byte256VectorTests::OR);
     }
     static byte or(byte a, byte b) {
         return (byte)(a | b);
@@ -1775,7 +1775,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::or);
+        assertArraysEquals(r, a, b, Byte256VectorTests::or);
     }
 
 
@@ -1797,7 +1797,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::OR);
     }
 
 
@@ -1819,7 +1819,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::XOR);
+        assertArraysEquals(r, a, b, Byte256VectorTests::XOR);
     }
 
 
@@ -1841,7 +1841,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::XOR);
     }
 
 
@@ -1856,7 +1856,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1873,7 +1873,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1887,7 +1887,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1904,7 +1904,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1918,7 +1918,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1935,7 +1935,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::mul);
     }
 
 
@@ -1954,7 +1954,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::div);
     }
 
 
@@ -1975,7 +1975,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::div);
     }
 
 
@@ -1991,7 +1991,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::OR);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2005,7 +2005,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::or);
     }
 
 
@@ -2024,7 +2024,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::OR);
     }
 
 
@@ -2040,7 +2040,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::AND);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2054,7 +2054,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::and);
     }
 
 
@@ -2073,7 +2073,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte256VectorTests::AND);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Byte256VectorTests::OR);
     }
 
 
@@ -2108,7 +2108,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte256VectorTests::OR);
     }
 
 
@@ -2123,7 +2123,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Byte256VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -2140,7 +2140,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte256VectorTests::ADD);
     }
 
 
@@ -2163,7 +2163,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Byte256VectorTests::LSHL);
     }
 
 
@@ -2185,7 +2185,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::LSHL);
     }
 
 
@@ -2211,7 +2211,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Byte256VectorTests::ASHR);
     }
 
 
@@ -2233,7 +2233,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::ASHR);
     }
 
 
@@ -2259,7 +2259,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Byte256VectorTests::LSHR);
     }
 
 
@@ -2281,7 +2281,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::LSHR);
     }
 
 
@@ -2306,7 +2306,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Byte256VectorTests::LSHL_unary);
     }
 
 
@@ -2327,7 +2327,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte256VectorTests::LSHL_unary);
     }
 
 
@@ -2352,7 +2352,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte256VectorTests::LSHR_unary);
     }
 
 
@@ -2373,7 +2373,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte256VectorTests::LSHR_unary);
     }
 
 
@@ -2398,7 +2398,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte256VectorTests::ASHR_unary);
     }
 
 
@@ -2419,7 +2419,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte256VectorTests::ASHR_unary);
     }
 
 
@@ -2442,7 +2442,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Byte256VectorTests::MIN);
     }
     static byte min(byte a, byte b) {
         return (byte)(Math.min(a, b));
@@ -2460,7 +2460,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::min);
+        assertArraysEquals(r, a, b, Byte256VectorTests::min);
     }
     static byte MAX(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2480,7 +2480,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Byte256VectorTests::MAX);
     }
     static byte max(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2498,7 +2498,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::max);
+        assertArraysEquals(r, a, b, Byte256VectorTests::max);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2512,7 +2512,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::MIN);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2526,7 +2526,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::min);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2540,7 +2540,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::MAX);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2554,7 +2554,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Byte256VectorTests::max);
     }
 
     static byte ANDReduce(byte[] a, int idx) {
@@ -2597,7 +2597,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::ANDReduce, Byte256VectorTests::ANDReduceAll);
     }
 
@@ -2645,7 +2645,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::ANDReduceMasked, Byte256VectorTests::ANDReduceAllMasked);
     }
 
@@ -2690,7 +2690,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::ORReduce, Byte256VectorTests::ORReduceAll);
     }
 
@@ -2738,7 +2738,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::ORReduceMasked, Byte256VectorTests::ORReduceAllMasked);
     }
 
@@ -2783,7 +2783,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::XORReduce, Byte256VectorTests::XORReduceAll);
     }
 
@@ -2831,7 +2831,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::XORReduceMasked, Byte256VectorTests::XORReduceAllMasked);
     }
 
@@ -2873,7 +2873,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::ADDReduce, Byte256VectorTests::ADDReduceAll);
     }
     static byte ADDReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -2917,7 +2917,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::ADDReduceMasked, Byte256VectorTests::ADDReduceAllMasked);
     }
     static byte MULReduce(byte[] a, int idx) {
@@ -2958,7 +2958,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::MULReduce, Byte256VectorTests::MULReduceAll);
     }
     static byte MULReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3002,7 +3002,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::MULReduceMasked, Byte256VectorTests::MULReduceAllMasked);
     }
     static byte MINReduce(byte[] a, int idx) {
@@ -3043,7 +3043,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::MINReduce, Byte256VectorTests::MINReduceAll);
     }
     static byte MINReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3088,7 +3088,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::MINReduceMasked, Byte256VectorTests::MINReduceAllMasked);
     }
     static byte MAXReduce(byte[] a, int idx) {
@@ -3129,7 +3129,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte256VectorTests::MAXReduce, Byte256VectorTests::MAXReduceAll);
     }
     static byte MAXReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3174,7 +3174,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::MAXReduceMasked, Byte256VectorTests::MAXReduceAllMasked);
     }
 
@@ -3200,7 +3200,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte256VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte256VectorTests::anyTrue);
     }
 
 
@@ -3226,7 +3226,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte256VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte256VectorTests::allTrue);
     }
 
 
@@ -3242,7 +3242,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (byte)4, 0);
+        assertInsertArraysEquals(r, a, (byte)4, 0);
     }
     static boolean testIS_DEFAULT(byte a) {
         return bits(a)==0;
@@ -3791,7 +3791,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::blend);
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleProvider")
@@ -3808,7 +3808,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleMaskProvider")
@@ -3826,7 +3826,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "byteUnaryOpProvider")
     static void getByte256VectorTests(IntFunction<byte[]> fa) {
@@ -3981,7 +3981,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::get);
+        assertArraysEquals(r, a, Byte256VectorTests::get);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -3995,7 +3995,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4042,7 +4042,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Byte256VectorTests::sliceUnary);
     }
     static byte[] sliceBinary(byte[] a, byte[] b, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4071,7 +4071,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Byte256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Byte256VectorTests::sliceBinary);
     }
     static byte[] slice(byte[] a, byte[] b, int origin, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4104,7 +4104,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Byte256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Byte256VectorTests::slice);
     }
     static byte[] unsliceUnary(byte[] a, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4131,7 +4131,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Byte256VectorTests::unsliceUnary);
     }
     static byte[] unsliceBinary(byte[] a, byte[] b, int origin, int part, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4170,7 +4170,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Byte256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Byte256VectorTests::unsliceBinary);
     }
     static byte[] unslice(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4226,7 +4226,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Byte256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Byte256VectorTests::unslice);
     }
 
 
@@ -4275,7 +4275,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Byte256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Byte256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte256VectorTests(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4291,7 +4291,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Byte256VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Byte256VectorTests::bitwiseBlend);
     }
 
 
@@ -4314,7 +4314,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Byte256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Byte256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4332,7 +4332,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4347,7 +4347,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte256VectorTestsBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4361,7 +4361,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4376,7 +4376,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::bitwiseBlend);
     }
 
 
@@ -4396,7 +4396,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Byte256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Byte256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpMaskProvider")
@@ -4415,7 +4415,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Byte256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Byte256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4433,7 +4433,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte256VectorTestsDoubleBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4447,7 +4447,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte256VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte256VectorTests::bitwiseBlend);
     }
 
 
@@ -4466,7 +4466,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Byte256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Byte256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4490,7 +4490,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::NEG);
+        assertArraysEquals(r, a, Byte256VectorTests::NEG);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4505,7 +4505,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::neg);
+        assertArraysEquals(r, a, Byte256VectorTests::neg);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4523,7 +4523,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Byte256VectorTests::NEG);
     }
 
     static byte ABS(byte a) {
@@ -4546,7 +4546,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::ABS);
+        assertArraysEquals(r, a, Byte256VectorTests::ABS);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4561,7 +4561,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::abs);
+        assertArraysEquals(r, a, Byte256VectorTests::abs);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4579,7 +4579,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Byte256VectorTests::ABS);
     }
 
 
@@ -4605,7 +4605,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::NOT);
+        assertArraysEquals(r, a, Byte256VectorTests::NOT);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4620,7 +4620,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::not);
+        assertArraysEquals(r, a, Byte256VectorTests::not);
     }
 
 
@@ -4640,7 +4640,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte256VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Byte256VectorTests::NOT);
     }
 
 
@@ -4663,7 +4663,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte256VectorTests::ZOMO);
+        assertArraysEquals(r, a, Byte256VectorTests::ZOMO);
     }
 
 
@@ -4683,7 +4683,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte256VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Byte256VectorTests::ZOMO);
     }
 
 
@@ -4711,7 +4711,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::gather);
+        assertArraysEquals(r, a, b, Byte256VectorTests::gather);
     }
     static byte[] gatherMasked(byte a[], int ix, boolean[] mask, int[] b, int iy) {
         byte[] res = new byte[SPECIES.length()];
@@ -4739,7 +4739,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::gatherMasked);
     }
 
     static byte[] scatter(byte a[], int ix, int[] b, int iy) {
@@ -4764,7 +4764,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Byte256VectorTests::scatter);
     }
 
     static byte[] scatterMasked(byte r[], byte a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4802,7 +4802,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Byte256VectorTests::scatterMasked);
     }
 
 
@@ -4844,8 +4844,8 @@ public class Byte256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4855,8 +4855,8 @@ public class Byte256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4866,8 +4866,8 @@ public class Byte256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4907,7 +4907,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 
     static long ADDReduceLong(byte[] a, int idx) {
@@ -4944,7 +4944,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Byte256VectorTests::ADDReduceLong, Byte256VectorTests::ADDReduceAllLong);
     }
 
@@ -4985,7 +4985,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Byte256VectorTests::ADDReduceLongMasked, Byte256VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4997,7 +4997,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -5015,7 +5015,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte256VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte256VectorTests::blend);
     }
 
 
@@ -5032,7 +5032,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpSelectFromMaskProvider")
@@ -5051,7 +5051,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5128,7 +5128,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Byte256VectorTests::beq);
+        assertArraysEquals(r, a, b, Byte256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -57,36 +57,14 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -390,7 +368,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "byteProviderForIOOBE")
@@ -461,7 +439,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -472,7 +450,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteMaskProviderForIOOBE")
@@ -545,7 +523,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -569,7 +547,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -656,7 +634,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -671,7 +649,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -787,7 +765,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -868,7 +846,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -879,7 +857,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -956,7 +934,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -967,7 +945,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -68,7 +68,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a[i]);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte apply(byte[] a);
     }
 
-    static void assertReductionArraysEquals(byte[] a, byte[] b, byte c,
+    static void assertReductionArraysEquals(byte[] r, byte rc, byte[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(byte[] a, byte[] b, byte c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(byte[] r, byte rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Byte512VectorTests extends AbstractVectorTest {
         long apply(byte[] a);
     }
 
-    static void assertReductionLongArraysEquals(byte[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, byte[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Byte512VectorTests extends AbstractVectorTest {
         long apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(byte[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Byte512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(byte[] a, byte[] b, byte element, int index) {
+    static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[]a, byte[]r) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, int b);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FBinArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] r, byte[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(r, a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -802,7 +802,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, byte[] r, int offs) {
+    static void assertArraysEquals(byte[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -813,7 +813,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -824,7 +824,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1288,7 +1288,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Byte512VectorTests::ADD);
     }
     static byte add(byte a, byte b) {
         return (byte)(a + b);
@@ -1306,7 +1306,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::add);
+        assertArraysEquals(r, a, b, Byte512VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1326,7 +1326,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1344,7 +1344,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::add);
     }
     static byte SUB(byte a, byte b) {
         return (byte)(a - b);
@@ -1364,7 +1364,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Byte512VectorTests::SUB);
     }
     static byte sub(byte a, byte b) {
         return (byte)(a - b);
@@ -1382,7 +1382,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::sub);
+        assertArraysEquals(r, a, b, Byte512VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1402,7 +1402,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::SUB);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1420,7 +1420,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::sub);
     }
     static byte MUL(byte a, byte b) {
         return (byte)(a * b);
@@ -1440,7 +1440,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Byte512VectorTests::MUL);
     }
     static byte mul(byte a, byte b) {
         return (byte)(a * b);
@@ -1458,7 +1458,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::mul);
+        assertArraysEquals(r, a, b, Byte512VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1478,7 +1478,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::MUL);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1496,7 +1496,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::mul);
     }
 
 
@@ -1521,7 +1521,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Byte512VectorTests::DIV);
     }
     static byte div(byte a, byte b) {
         return (byte)(a / b);
@@ -1543,7 +1543,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::div);
+        assertArraysEquals(r, a, b, Byte512VectorTests::div);
     }
 
 
@@ -1567,7 +1567,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::DIV);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1589,7 +1589,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::div);
     }
 
     static byte FIRST_NONZERO(byte a, byte b) {
@@ -1610,7 +1610,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Byte512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1630,7 +1630,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::FIRST_NONZERO);
     }
 
     static byte AND(byte a, byte b) {
@@ -1651,7 +1651,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::AND);
+        assertArraysEquals(r, a, b, Byte512VectorTests::AND);
     }
     static byte and(byte a, byte b) {
         return (byte)(a & b);
@@ -1669,7 +1669,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::and);
+        assertArraysEquals(r, a, b, Byte512VectorTests::and);
     }
 
 
@@ -1691,7 +1691,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::AND);
     }
 
 
@@ -1713,7 +1713,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Byte512VectorTests::AND_NOT);
     }
 
 
@@ -1735,7 +1735,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::AND_NOT);
     }
 
 
@@ -1757,7 +1757,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::OR);
+        assertArraysEquals(r, a, b, Byte512VectorTests::OR);
     }
     static byte or(byte a, byte b) {
         return (byte)(a | b);
@@ -1775,7 +1775,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::or);
+        assertArraysEquals(r, a, b, Byte512VectorTests::or);
     }
 
 
@@ -1797,7 +1797,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::OR);
     }
 
 
@@ -1819,7 +1819,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::XOR);
+        assertArraysEquals(r, a, b, Byte512VectorTests::XOR);
     }
 
 
@@ -1841,7 +1841,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::XOR);
     }
 
 
@@ -1856,7 +1856,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1873,7 +1873,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1887,7 +1887,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1904,7 +1904,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1918,7 +1918,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1935,7 +1935,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::mul);
     }
 
 
@@ -1954,7 +1954,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::div);
     }
 
 
@@ -1975,7 +1975,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::div);
     }
 
 
@@ -1991,7 +1991,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::OR);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2005,7 +2005,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::or);
     }
 
 
@@ -2024,7 +2024,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::OR);
     }
 
 
@@ -2040,7 +2040,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::AND);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2054,7 +2054,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::and);
     }
 
 
@@ -2073,7 +2073,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte512VectorTests::AND);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Byte512VectorTests::OR);
     }
 
 
@@ -2108,7 +2108,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte512VectorTests::OR);
     }
 
 
@@ -2123,7 +2123,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Byte512VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -2140,7 +2140,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte512VectorTests::ADD);
     }
 
 
@@ -2163,7 +2163,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Byte512VectorTests::LSHL);
     }
 
 
@@ -2185,7 +2185,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::LSHL);
     }
 
 
@@ -2211,7 +2211,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Byte512VectorTests::ASHR);
     }
 
 
@@ -2233,7 +2233,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::ASHR);
     }
 
 
@@ -2259,7 +2259,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Byte512VectorTests::LSHR);
     }
 
 
@@ -2281,7 +2281,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::LSHR);
     }
 
 
@@ -2306,7 +2306,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Byte512VectorTests::LSHL_unary);
     }
 
 
@@ -2327,7 +2327,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte512VectorTests::LSHL_unary);
     }
 
 
@@ -2352,7 +2352,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte512VectorTests::LSHR_unary);
     }
 
 
@@ -2373,7 +2373,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte512VectorTests::LSHR_unary);
     }
 
 
@@ -2398,7 +2398,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte512VectorTests::ASHR_unary);
     }
 
 
@@ -2419,7 +2419,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte512VectorTests::ASHR_unary);
     }
 
 
@@ -2442,7 +2442,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Byte512VectorTests::MIN);
     }
     static byte min(byte a, byte b) {
         return (byte)(Math.min(a, b));
@@ -2460,7 +2460,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::min);
+        assertArraysEquals(r, a, b, Byte512VectorTests::min);
     }
     static byte MAX(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2480,7 +2480,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Byte512VectorTests::MAX);
     }
     static byte max(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2498,7 +2498,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::max);
+        assertArraysEquals(r, a, b, Byte512VectorTests::max);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2512,7 +2512,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::MIN);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2526,7 +2526,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::min);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2540,7 +2540,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::MAX);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2554,7 +2554,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Byte512VectorTests::max);
     }
 
     static byte ANDReduce(byte[] a, int idx) {
@@ -2597,7 +2597,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::ANDReduce, Byte512VectorTests::ANDReduceAll);
     }
 
@@ -2645,7 +2645,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::ANDReduceMasked, Byte512VectorTests::ANDReduceAllMasked);
     }
 
@@ -2690,7 +2690,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::ORReduce, Byte512VectorTests::ORReduceAll);
     }
 
@@ -2738,7 +2738,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::ORReduceMasked, Byte512VectorTests::ORReduceAllMasked);
     }
 
@@ -2783,7 +2783,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::XORReduce, Byte512VectorTests::XORReduceAll);
     }
 
@@ -2831,7 +2831,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::XORReduceMasked, Byte512VectorTests::XORReduceAllMasked);
     }
 
@@ -2873,7 +2873,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::ADDReduce, Byte512VectorTests::ADDReduceAll);
     }
     static byte ADDReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -2917,7 +2917,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::ADDReduceMasked, Byte512VectorTests::ADDReduceAllMasked);
     }
     static byte MULReduce(byte[] a, int idx) {
@@ -2958,7 +2958,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::MULReduce, Byte512VectorTests::MULReduceAll);
     }
     static byte MULReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3002,7 +3002,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::MULReduceMasked, Byte512VectorTests::MULReduceAllMasked);
     }
     static byte MINReduce(byte[] a, int idx) {
@@ -3043,7 +3043,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::MINReduce, Byte512VectorTests::MINReduceAll);
     }
     static byte MINReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3088,7 +3088,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::MINReduceMasked, Byte512VectorTests::MINReduceAllMasked);
     }
     static byte MAXReduce(byte[] a, int idx) {
@@ -3129,7 +3129,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte512VectorTests::MAXReduce, Byte512VectorTests::MAXReduceAll);
     }
     static byte MAXReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3174,7 +3174,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::MAXReduceMasked, Byte512VectorTests::MAXReduceAllMasked);
     }
 
@@ -3200,7 +3200,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte512VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte512VectorTests::anyTrue);
     }
 
 
@@ -3226,7 +3226,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte512VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte512VectorTests::allTrue);
     }
 
 
@@ -3242,7 +3242,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (byte)4, 0);
+        assertInsertArraysEquals(r, a, (byte)4, 0);
     }
     static boolean testIS_DEFAULT(byte a) {
         return bits(a)==0;
@@ -3791,7 +3791,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::blend);
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleProvider")
@@ -3808,7 +3808,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleMaskProvider")
@@ -3826,7 +3826,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "byteUnaryOpProvider")
     static void getByte512VectorTests(IntFunction<byte[]> fa) {
@@ -3981,7 +3981,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::get);
+        assertArraysEquals(r, a, Byte512VectorTests::get);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -3995,7 +3995,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4042,7 +4042,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Byte512VectorTests::sliceUnary);
     }
     static byte[] sliceBinary(byte[] a, byte[] b, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4071,7 +4071,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Byte512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Byte512VectorTests::sliceBinary);
     }
     static byte[] slice(byte[] a, byte[] b, int origin, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4104,7 +4104,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Byte512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Byte512VectorTests::slice);
     }
     static byte[] unsliceUnary(byte[] a, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4131,7 +4131,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Byte512VectorTests::unsliceUnary);
     }
     static byte[] unsliceBinary(byte[] a, byte[] b, int origin, int part, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4170,7 +4170,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Byte512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Byte512VectorTests::unsliceBinary);
     }
     static byte[] unslice(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4226,7 +4226,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Byte512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Byte512VectorTests::unslice);
     }
 
 
@@ -4275,7 +4275,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Byte512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Byte512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte512VectorTests(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4291,7 +4291,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Byte512VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Byte512VectorTests::bitwiseBlend);
     }
 
 
@@ -4314,7 +4314,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Byte512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Byte512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4332,7 +4332,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4347,7 +4347,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte512VectorTestsBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4361,7 +4361,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4376,7 +4376,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::bitwiseBlend);
     }
 
 
@@ -4396,7 +4396,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Byte512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Byte512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpMaskProvider")
@@ -4415,7 +4415,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Byte512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Byte512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4433,7 +4433,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte512VectorTestsDoubleBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4447,7 +4447,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte512VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte512VectorTests::bitwiseBlend);
     }
 
 
@@ -4466,7 +4466,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Byte512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Byte512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4490,7 +4490,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::NEG);
+        assertArraysEquals(r, a, Byte512VectorTests::NEG);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4505,7 +4505,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::neg);
+        assertArraysEquals(r, a, Byte512VectorTests::neg);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4523,7 +4523,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Byte512VectorTests::NEG);
     }
 
     static byte ABS(byte a) {
@@ -4546,7 +4546,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::ABS);
+        assertArraysEquals(r, a, Byte512VectorTests::ABS);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4561,7 +4561,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::abs);
+        assertArraysEquals(r, a, Byte512VectorTests::abs);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4579,7 +4579,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Byte512VectorTests::ABS);
     }
 
 
@@ -4605,7 +4605,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::NOT);
+        assertArraysEquals(r, a, Byte512VectorTests::NOT);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4620,7 +4620,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::not);
+        assertArraysEquals(r, a, Byte512VectorTests::not);
     }
 
 
@@ -4640,7 +4640,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte512VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Byte512VectorTests::NOT);
     }
 
 
@@ -4663,7 +4663,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte512VectorTests::ZOMO);
+        assertArraysEquals(r, a, Byte512VectorTests::ZOMO);
     }
 
 
@@ -4683,7 +4683,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte512VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Byte512VectorTests::ZOMO);
     }
 
 
@@ -4711,7 +4711,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::gather);
+        assertArraysEquals(r, a, b, Byte512VectorTests::gather);
     }
     static byte[] gatherMasked(byte a[], int ix, boolean[] mask, int[] b, int iy) {
         byte[] res = new byte[SPECIES.length()];
@@ -4739,7 +4739,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::gatherMasked);
     }
 
     static byte[] scatter(byte a[], int ix, int[] b, int iy) {
@@ -4764,7 +4764,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Byte512VectorTests::scatter);
     }
 
     static byte[] scatterMasked(byte r[], byte a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4802,7 +4802,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Byte512VectorTests::scatterMasked);
     }
 
 
@@ -4844,8 +4844,8 @@ public class Byte512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4855,8 +4855,8 @@ public class Byte512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4866,8 +4866,8 @@ public class Byte512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4907,7 +4907,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 
     static long ADDReduceLong(byte[] a, int idx) {
@@ -4944,7 +4944,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Byte512VectorTests::ADDReduceLong, Byte512VectorTests::ADDReduceAllLong);
     }
 
@@ -4985,7 +4985,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Byte512VectorTests::ADDReduceLongMasked, Byte512VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4997,7 +4997,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -5015,7 +5015,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte512VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte512VectorTests::blend);
     }
 
 
@@ -5032,7 +5032,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpSelectFromMaskProvider")
@@ -5051,7 +5051,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5128,7 +5128,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Byte512VectorTests::beq);
+        assertArraysEquals(r, a, b, Byte512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -57,36 +57,14 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -390,7 +368,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "byteProviderForIOOBE")
@@ -461,7 +439,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -472,7 +450,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteMaskProviderForIOOBE")
@@ -545,7 +523,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -569,7 +547,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -656,7 +634,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -671,7 +649,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -787,7 +765,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -868,7 +846,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -879,7 +857,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -956,7 +934,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -967,7 +945,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -68,7 +68,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a[i]);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte apply(byte[] a);
     }
 
-    static void assertReductionArraysEquals(byte[] a, byte[] b, byte c,
+    static void assertReductionArraysEquals(byte[] r, byte rc, byte[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(byte[] a, byte[] b, byte c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(byte[] r, byte rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Byte64VectorTests extends AbstractVectorTest {
         long apply(byte[] a);
     }
 
-    static void assertReductionLongArraysEquals(byte[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, byte[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Byte64VectorTests extends AbstractVectorTest {
         long apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(byte[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Byte64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(byte[] a, byte[] b, byte element, int index) {
+    static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[]a, byte[]r) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte apply(byte[] a, int b);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FBinArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] r, byte[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(r, a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -802,7 +802,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, byte[] r, int offs) {
+    static void assertArraysEquals(byte[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -813,7 +813,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -824,7 +824,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1288,7 +1288,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Byte64VectorTests::ADD);
     }
     static byte add(byte a, byte b) {
         return (byte)(a + b);
@@ -1306,7 +1306,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::add);
+        assertArraysEquals(r, a, b, Byte64VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1326,7 +1326,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1344,7 +1344,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::add);
     }
     static byte SUB(byte a, byte b) {
         return (byte)(a - b);
@@ -1364,7 +1364,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Byte64VectorTests::SUB);
     }
     static byte sub(byte a, byte b) {
         return (byte)(a - b);
@@ -1382,7 +1382,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::sub);
+        assertArraysEquals(r, a, b, Byte64VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1402,7 +1402,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::SUB);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1420,7 +1420,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::sub);
     }
     static byte MUL(byte a, byte b) {
         return (byte)(a * b);
@@ -1440,7 +1440,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Byte64VectorTests::MUL);
     }
     static byte mul(byte a, byte b) {
         return (byte)(a * b);
@@ -1458,7 +1458,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::mul);
+        assertArraysEquals(r, a, b, Byte64VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1478,7 +1478,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::MUL);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1496,7 +1496,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::mul);
     }
 
 
@@ -1521,7 +1521,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Byte64VectorTests::DIV);
     }
     static byte div(byte a, byte b) {
         return (byte)(a / b);
@@ -1543,7 +1543,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::div);
+        assertArraysEquals(r, a, b, Byte64VectorTests::div);
     }
 
 
@@ -1567,7 +1567,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::DIV);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1589,7 +1589,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::div);
     }
 
     static byte FIRST_NONZERO(byte a, byte b) {
@@ -1610,7 +1610,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Byte64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1630,7 +1630,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::FIRST_NONZERO);
     }
 
     static byte AND(byte a, byte b) {
@@ -1651,7 +1651,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::AND);
+        assertArraysEquals(r, a, b, Byte64VectorTests::AND);
     }
     static byte and(byte a, byte b) {
         return (byte)(a & b);
@@ -1669,7 +1669,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::and);
+        assertArraysEquals(r, a, b, Byte64VectorTests::and);
     }
 
 
@@ -1691,7 +1691,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::AND);
     }
 
 
@@ -1713,7 +1713,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Byte64VectorTests::AND_NOT);
     }
 
 
@@ -1735,7 +1735,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::AND_NOT);
     }
 
 
@@ -1757,7 +1757,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::OR);
+        assertArraysEquals(r, a, b, Byte64VectorTests::OR);
     }
     static byte or(byte a, byte b) {
         return (byte)(a | b);
@@ -1775,7 +1775,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::or);
+        assertArraysEquals(r, a, b, Byte64VectorTests::or);
     }
 
 
@@ -1797,7 +1797,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::OR);
     }
 
 
@@ -1819,7 +1819,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::XOR);
+        assertArraysEquals(r, a, b, Byte64VectorTests::XOR);
     }
 
 
@@ -1841,7 +1841,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::XOR);
     }
 
 
@@ -1856,7 +1856,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1873,7 +1873,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1887,7 +1887,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1904,7 +1904,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1918,7 +1918,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1935,7 +1935,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::mul);
     }
 
 
@@ -1954,7 +1954,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::div);
     }
 
 
@@ -1975,7 +1975,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::div);
     }
 
 
@@ -1991,7 +1991,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::OR);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2005,7 +2005,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::or);
     }
 
 
@@ -2024,7 +2024,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::OR);
     }
 
 
@@ -2040,7 +2040,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::AND);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2054,7 +2054,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::and);
     }
 
 
@@ -2073,7 +2073,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Byte64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Byte64VectorTests::AND);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Byte64VectorTests::OR);
     }
 
 
@@ -2108,7 +2108,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte64VectorTests::OR);
     }
 
 
@@ -2123,7 +2123,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Byte64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Byte64VectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -2140,7 +2140,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte64VectorTests::ADD);
     }
 
 
@@ -2163,7 +2163,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Byte64VectorTests::LSHL);
     }
 
 
@@ -2185,7 +2185,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::LSHL);
     }
 
 
@@ -2211,7 +2211,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Byte64VectorTests::ASHR);
     }
 
 
@@ -2233,7 +2233,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::ASHR);
     }
 
 
@@ -2259,7 +2259,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Byte64VectorTests::LSHR);
     }
 
 
@@ -2281,7 +2281,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::LSHR);
     }
 
 
@@ -2306,7 +2306,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Byte64VectorTests::LSHL_unary);
     }
 
 
@@ -2327,7 +2327,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte64VectorTests::LSHL_unary);
     }
 
 
@@ -2352,7 +2352,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte64VectorTests::LSHR_unary);
     }
 
 
@@ -2373,7 +2373,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte64VectorTests::LSHR_unary);
     }
 
 
@@ -2398,7 +2398,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Byte64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Byte64VectorTests::ASHR_unary);
     }
 
 
@@ -2419,7 +2419,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Byte64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Byte64VectorTests::ASHR_unary);
     }
 
 
@@ -2442,7 +2442,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Byte64VectorTests::MIN);
     }
     static byte min(byte a, byte b) {
         return (byte)(Math.min(a, b));
@@ -2460,7 +2460,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::min);
+        assertArraysEquals(r, a, b, Byte64VectorTests::min);
     }
     static byte MAX(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2480,7 +2480,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Byte64VectorTests::MAX);
     }
     static byte max(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2498,7 +2498,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::max);
+        assertArraysEquals(r, a, b, Byte64VectorTests::max);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2512,7 +2512,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::MIN);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2526,7 +2526,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::min);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2540,7 +2540,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::MAX);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2554,7 +2554,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Byte64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Byte64VectorTests::max);
     }
 
     static byte ANDReduce(byte[] a, int idx) {
@@ -2597,7 +2597,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::ANDReduce, Byte64VectorTests::ANDReduceAll);
     }
 
@@ -2645,7 +2645,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::ANDReduceMasked, Byte64VectorTests::ANDReduceAllMasked);
     }
 
@@ -2690,7 +2690,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::ORReduce, Byte64VectorTests::ORReduceAll);
     }
 
@@ -2738,7 +2738,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::ORReduceMasked, Byte64VectorTests::ORReduceAllMasked);
     }
 
@@ -2783,7 +2783,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::XORReduce, Byte64VectorTests::XORReduceAll);
     }
 
@@ -2831,7 +2831,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::XORReduceMasked, Byte64VectorTests::XORReduceAllMasked);
     }
 
@@ -2873,7 +2873,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::ADDReduce, Byte64VectorTests::ADDReduceAll);
     }
     static byte ADDReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -2917,7 +2917,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::ADDReduceMasked, Byte64VectorTests::ADDReduceAllMasked);
     }
     static byte MULReduce(byte[] a, int idx) {
@@ -2958,7 +2958,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::MULReduce, Byte64VectorTests::MULReduceAll);
     }
     static byte MULReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3002,7 +3002,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::MULReduceMasked, Byte64VectorTests::MULReduceAllMasked);
     }
     static byte MINReduce(byte[] a, int idx) {
@@ -3043,7 +3043,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::MINReduce, Byte64VectorTests::MINReduceAll);
     }
     static byte MINReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3088,7 +3088,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::MINReduceMasked, Byte64VectorTests::MINReduceAllMasked);
     }
     static byte MAXReduce(byte[] a, int idx) {
@@ -3129,7 +3129,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Byte64VectorTests::MAXReduce, Byte64VectorTests::MAXReduceAll);
     }
     static byte MAXReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3174,7 +3174,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::MAXReduceMasked, Byte64VectorTests::MAXReduceAllMasked);
     }
 
@@ -3200,7 +3200,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte64VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte64VectorTests::anyTrue);
     }
 
 
@@ -3226,7 +3226,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Byte64VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Byte64VectorTests::allTrue);
     }
 
 
@@ -3242,7 +3242,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (byte)4, 0);
+        assertInsertArraysEquals(r, a, (byte)4, 0);
     }
     static boolean testIS_DEFAULT(byte a) {
         return bits(a)==0;
@@ -3791,7 +3791,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::blend);
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleProvider")
@@ -3808,7 +3808,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleMaskProvider")
@@ -3826,7 +3826,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "byteUnaryOpProvider")
     static void getByte64VectorTests(IntFunction<byte[]> fa) {
@@ -3981,7 +3981,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::get);
+        assertArraysEquals(r, a, Byte64VectorTests::get);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -3995,7 +3995,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4042,7 +4042,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Byte64VectorTests::sliceUnary);
     }
     static byte[] sliceBinary(byte[] a, byte[] b, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4071,7 +4071,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Byte64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Byte64VectorTests::sliceBinary);
     }
     static byte[] slice(byte[] a, byte[] b, int origin, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4104,7 +4104,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Byte64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Byte64VectorTests::slice);
     }
     static byte[] unsliceUnary(byte[] a, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4131,7 +4131,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Byte64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Byte64VectorTests::unsliceUnary);
     }
     static byte[] unsliceBinary(byte[] a, byte[] b, int origin, int part, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4170,7 +4170,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Byte64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Byte64VectorTests::unsliceBinary);
     }
     static byte[] unslice(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4226,7 +4226,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Byte64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Byte64VectorTests::unslice);
     }
 
 
@@ -4275,7 +4275,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Byte64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Byte64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte64VectorTests(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4291,7 +4291,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Byte64VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Byte64VectorTests::bitwiseBlend);
     }
 
 
@@ -4314,7 +4314,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Byte64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Byte64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4332,7 +4332,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4347,7 +4347,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte64VectorTestsBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4361,7 +4361,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4376,7 +4376,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::bitwiseBlend);
     }
 
 
@@ -4396,7 +4396,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Byte64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Byte64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpMaskProvider")
@@ -4415,7 +4415,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Byte64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Byte64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4433,7 +4433,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByte64VectorTestsDoubleBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4447,7 +4447,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Byte64VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Byte64VectorTests::bitwiseBlend);
     }
 
 
@@ -4466,7 +4466,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Byte64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Byte64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4490,7 +4490,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::NEG);
+        assertArraysEquals(r, a, Byte64VectorTests::NEG);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4505,7 +4505,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::neg);
+        assertArraysEquals(r, a, Byte64VectorTests::neg);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4523,7 +4523,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Byte64VectorTests::NEG);
     }
 
     static byte ABS(byte a) {
@@ -4546,7 +4546,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::ABS);
+        assertArraysEquals(r, a, Byte64VectorTests::ABS);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4561,7 +4561,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::abs);
+        assertArraysEquals(r, a, Byte64VectorTests::abs);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4579,7 +4579,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Byte64VectorTests::ABS);
     }
 
 
@@ -4605,7 +4605,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::NOT);
+        assertArraysEquals(r, a, Byte64VectorTests::NOT);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4620,7 +4620,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::not);
+        assertArraysEquals(r, a, Byte64VectorTests::not);
     }
 
 
@@ -4640,7 +4640,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte64VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Byte64VectorTests::NOT);
     }
 
 
@@ -4663,7 +4663,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Byte64VectorTests::ZOMO);
+        assertArraysEquals(r, a, Byte64VectorTests::ZOMO);
     }
 
 
@@ -4683,7 +4683,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Byte64VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Byte64VectorTests::ZOMO);
     }
 
 
@@ -4711,7 +4711,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::gather);
+        assertArraysEquals(r, a, b, Byte64VectorTests::gather);
     }
     static byte[] gatherMasked(byte a[], int ix, boolean[] mask, int[] b, int iy) {
         byte[] res = new byte[SPECIES.length()];
@@ -4739,7 +4739,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::gatherMasked);
     }
 
     static byte[] scatter(byte a[], int ix, int[] b, int iy) {
@@ -4764,7 +4764,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Byte64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Byte64VectorTests::scatter);
     }
 
     static byte[] scatterMasked(byte r[], byte a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4802,7 +4802,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Byte64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Byte64VectorTests::scatterMasked);
     }
 
 
@@ -4844,8 +4844,8 @@ public class Byte64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4855,8 +4855,8 @@ public class Byte64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4866,8 +4866,8 @@ public class Byte64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4907,7 +4907,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 
     static long ADDReduceLong(byte[] a, int idx) {
@@ -4944,7 +4944,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Byte64VectorTests::ADDReduceLong, Byte64VectorTests::ADDReduceAllLong);
     }
 
@@ -4985,7 +4985,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Byte64VectorTests::ADDReduceLongMasked, Byte64VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4997,7 +4997,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -5015,7 +5015,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Byte64VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Byte64VectorTests::blend);
     }
 
 
@@ -5032,7 +5032,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpSelectFromMaskProvider")
@@ -5051,7 +5051,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5128,7 +5128,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Byte64VectorTests::beq);
+        assertArraysEquals(r, a, b, Byte64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -66,36 +66,14 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -399,7 +377,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "byteProviderForIOOBE")
@@ -470,7 +448,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -481,7 +459,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteMaskProviderForIOOBE")
@@ -554,7 +532,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -578,7 +556,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -665,7 +643,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -680,7 +658,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -796,7 +774,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
@@ -877,7 +855,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -888,7 +866,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
@@ -965,7 +943,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -976,7 +954,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -73,7 +73,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte a);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FUnArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a[i]);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte apply(byte[] a);
     }
 
-    static void assertReductionArraysEquals(byte[] a, byte[] b, byte c,
+    static void assertReductionArraysEquals(byte[] r, byte rc, byte[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(byte[] a, byte[] b, byte c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(byte[] r, byte rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -167,17 +167,17 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         long apply(byte[] a);
     }
 
-    static void assertReductionLongArraysEquals(byte[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, byte[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -189,17 +189,17 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         long apply(byte[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(byte[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, byte[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -207,37 +207,37 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(byte[] a, byte[] b, byte element, int index) {
+    static void assertInsertArraysEquals(byte[] r, byte[] a, byte element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -251,7 +251,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -265,7 +265,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(byte[] a, byte[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(byte[] r, byte[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -285,7 +285,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(byte[] a, byte[] r, byte[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(byte[] r, byte[] a, byte[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -305,7 +305,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[]a, byte[]r) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -334,7 +334,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -345,7 +345,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -357,7 +357,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -369,11 +369,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -384,11 +384,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -402,11 +402,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -420,7 +420,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, FBinOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -434,11 +434,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(byte[] a, byte[] b, byte[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(byte[] r, byte[] a, byte[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -464,7 +464,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -475,11 +475,11 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -491,7 +491,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -504,7 +504,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,12 +517,12 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -538,12 +538,12 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,12 +574,12 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(byte[] a, byte[] b, byte[] c, byte[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(byte[] r, byte[] a, byte[] b, byte[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -602,7 +602,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte apply(byte[] a, int b);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, FBinArrayOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -617,7 +617,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -644,7 +644,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] r, byte[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -665,7 +665,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, int[] b, byte[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -675,7 +675,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(r, a, i, mask, b, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -692,7 +692,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(byte[] r, byte[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -702,7 +702,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -712,7 +712,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -722,7 +722,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -733,7 +733,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -743,7 +743,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -754,7 +754,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -764,7 +764,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -776,7 +776,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         byte[] apply(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(byte[] a, byte[] b, byte[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(byte[] r, byte[] a, byte[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -786,7 +786,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             byte[] ref = f.apply(a, b, origin, part, mask, i);
             byte[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -795,7 +795,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -807,7 +807,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(byte[] a, byte[] r, int offs) {
+    static void assertArraysEquals(byte[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -818,7 +818,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -829,7 +829,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(byte[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, byte[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1293,7 +1293,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::ADD);
     }
     static byte add(byte a, byte b) {
         return (byte)(a + b);
@@ -1311,7 +1311,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::add);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1331,7 +1331,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1349,7 +1349,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::add);
     }
     static byte SUB(byte a, byte b) {
         return (byte)(a - b);
@@ -1369,7 +1369,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::SUB);
     }
     static byte sub(byte a, byte b) {
         return (byte)(a - b);
@@ -1387,7 +1387,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1407,7 +1407,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1425,7 +1425,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::sub);
     }
     static byte MUL(byte a, byte b) {
         return (byte)(a * b);
@@ -1445,7 +1445,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::MUL);
     }
     static byte mul(byte a, byte b) {
         return (byte)(a * b);
@@ -1463,7 +1463,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1483,7 +1483,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1501,7 +1501,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::mul);
     }
 
 
@@ -1526,7 +1526,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::DIV);
     }
     static byte div(byte a, byte b) {
         return (byte)(a / b);
@@ -1548,7 +1548,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::div);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::div);
     }
 
 
@@ -1572,7 +1572,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1594,7 +1594,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::div);
     }
 
     static byte FIRST_NONZERO(byte a, byte b) {
@@ -1615,7 +1615,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1635,7 +1635,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::FIRST_NONZERO);
     }
 
     static byte AND(byte a, byte b) {
@@ -1656,7 +1656,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::AND);
     }
     static byte and(byte a, byte b) {
         return (byte)(a & b);
@@ -1674,7 +1674,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::and);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::and);
     }
 
 
@@ -1696,7 +1696,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::AND);
     }
 
 
@@ -1718,7 +1718,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::AND_NOT);
     }
 
 
@@ -1740,7 +1740,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::AND_NOT);
     }
 
 
@@ -1762,7 +1762,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::OR);
     }
     static byte or(byte a, byte b) {
         return (byte)(a | b);
@@ -1780,7 +1780,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::or);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::or);
     }
 
 
@@ -1802,7 +1802,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::OR);
     }
 
 
@@ -1824,7 +1824,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::XOR);
     }
 
 
@@ -1846,7 +1846,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::XOR);
     }
 
 
@@ -1861,7 +1861,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1878,7 +1878,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::add);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1892,7 +1892,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1909,7 +1909,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -1923,7 +1923,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -1940,7 +1940,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::mul);
     }
 
 
@@ -1959,7 +1959,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::div);
     }
 
 
@@ -1980,7 +1980,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::div);
     }
 
 
@@ -1996,7 +1996,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::OR);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2010,7 +2010,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::or);
     }
 
 
@@ -2029,7 +2029,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::OR);
     }
 
 
@@ -2045,7 +2045,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::AND);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2059,7 +2059,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::and);
     }
 
 
@@ -2078,7 +2078,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ByteMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, ByteMaxVectorTests::AND);
     }
 
 
@@ -2094,7 +2094,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, ByteMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, ByteMaxVectorTests::OR);
     }
 
 
@@ -2113,7 +2113,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, ByteMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ByteMaxVectorTests::OR);
     }
 
 
@@ -2128,7 +2128,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, ByteMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, ByteMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -2145,7 +2145,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, ByteMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ByteMaxVectorTests::ADD);
     }
 
 
@@ -2168,7 +2168,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::LSHL);
     }
 
 
@@ -2190,7 +2190,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::LSHL);
     }
 
 
@@ -2216,7 +2216,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::ASHR);
     }
 
 
@@ -2238,7 +2238,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::ASHR);
     }
 
 
@@ -2264,7 +2264,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::LSHR);
     }
 
 
@@ -2286,7 +2286,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::LSHR);
     }
 
 
@@ -2311,7 +2311,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ByteMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, ByteMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2332,7 +2332,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ByteMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, ByteMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2357,7 +2357,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ByteMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, ByteMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2378,7 +2378,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ByteMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, ByteMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2403,7 +2403,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ByteMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, ByteMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2424,7 +2424,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ByteMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, ByteMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2447,7 +2447,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::MIN);
     }
     static byte min(byte a, byte b) {
         return (byte)(Math.min(a, b));
@@ -2465,7 +2465,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::min);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::min);
     }
     static byte MAX(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2485,7 +2485,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::MAX);
     }
     static byte max(byte a, byte b) {
         return (byte)(Math.max(a, b));
@@ -2503,7 +2503,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::max);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::max);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2517,7 +2517,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2531,7 +2531,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::min);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2545,7 +2545,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "byteBinaryOpProvider")
@@ -2559,7 +2559,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ByteMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, ByteMaxVectorTests::max);
     }
 
     static byte ANDReduce(byte[] a, int idx) {
@@ -2602,7 +2602,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::ANDReduce, ByteMaxVectorTests::ANDReduceAll);
     }
 
@@ -2650,7 +2650,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::ANDReduceMasked, ByteMaxVectorTests::ANDReduceAllMasked);
     }
 
@@ -2695,7 +2695,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::ORReduce, ByteMaxVectorTests::ORReduceAll);
     }
 
@@ -2743,7 +2743,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::ORReduceMasked, ByteMaxVectorTests::ORReduceAllMasked);
     }
 
@@ -2788,7 +2788,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::XORReduce, ByteMaxVectorTests::XORReduceAll);
     }
 
@@ -2836,7 +2836,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::XORReduceMasked, ByteMaxVectorTests::XORReduceAllMasked);
     }
 
@@ -2878,7 +2878,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::ADDReduce, ByteMaxVectorTests::ADDReduceAll);
     }
     static byte ADDReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -2922,7 +2922,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::ADDReduceMasked, ByteMaxVectorTests::ADDReduceAllMasked);
     }
     static byte MULReduce(byte[] a, int idx) {
@@ -2963,7 +2963,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::MULReduce, ByteMaxVectorTests::MULReduceAll);
     }
     static byte MULReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3007,7 +3007,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::MULReduceMasked, ByteMaxVectorTests::MULReduceAllMasked);
     }
     static byte MINReduce(byte[] a, int idx) {
@@ -3048,7 +3048,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::MINReduce, ByteMaxVectorTests::MINReduceAll);
     }
     static byte MINReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3093,7 +3093,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::MINReduceMasked, ByteMaxVectorTests::MINReduceAllMasked);
     }
     static byte MAXReduce(byte[] a, int idx) {
@@ -3134,7 +3134,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ByteMaxVectorTests::MAXReduce, ByteMaxVectorTests::MAXReduceAll);
     }
     static byte MAXReduceMasked(byte[] a, int idx, boolean[] mask) {
@@ -3179,7 +3179,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::MAXReduceMasked, ByteMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -3205,7 +3205,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, ByteMaxVectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, ByteMaxVectorTests::anyTrue);
     }
 
 
@@ -3231,7 +3231,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, ByteMaxVectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, ByteMaxVectorTests::allTrue);
     }
 
 
@@ -3247,7 +3247,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (byte)4, 0);
+        assertInsertArraysEquals(r, a, (byte)4, 0);
     }
     static boolean testIS_DEFAULT(byte a) {
         return bits(a)==0;
@@ -3796,7 +3796,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleProvider")
@@ -3813,7 +3813,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpShuffleMaskProvider")
@@ -3831,7 +3831,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "byteUnaryOpProvider")
     static void getByteMaxVectorTests(IntFunction<byte[]> fa) {
@@ -3986,7 +3986,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::get);
+        assertArraysEquals(r, a, ByteMaxVectorTests::get);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4000,7 +4000,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4047,7 +4047,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, ByteMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, ByteMaxVectorTests::sliceUnary);
     }
     static byte[] sliceBinary(byte[] a, byte[] b, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4076,7 +4076,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, ByteMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, ByteMaxVectorTests::sliceBinary);
     }
     static byte[] slice(byte[] a, byte[] b, int origin, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4109,7 +4109,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, ByteMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, ByteMaxVectorTests::slice);
     }
     static byte[] unsliceUnary(byte[] a, int origin, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4136,7 +4136,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, ByteMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, ByteMaxVectorTests::unsliceUnary);
     }
     static byte[] unsliceBinary(byte[] a, byte[] b, int origin, int part, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4175,7 +4175,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, ByteMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, ByteMaxVectorTests::unsliceBinary);
     }
     static byte[] unslice(byte[] a, byte[] b, int origin, int part, boolean[] mask, int idx) {
         byte[] res = new byte[SPECIES.length()];
@@ -4231,7 +4231,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, ByteMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, ByteMaxVectorTests::unslice);
     }
 
 
@@ -4280,7 +4280,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, ByteMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, ByteMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByteMaxVectorTests(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4296,7 +4296,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, ByteMaxVectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, ByteMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4319,7 +4319,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, ByteMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, ByteMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4337,7 +4337,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4352,7 +4352,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByteMaxVectorTestsBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4366,7 +4366,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "byteTernaryOpProvider")
@@ -4381,7 +4381,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ByteVector cv = ByteVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4401,7 +4401,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, ByteMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, ByteMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "byteTernaryOpMaskProvider")
@@ -4420,7 +4420,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, ByteMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, ByteMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4438,7 +4438,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "byteTernaryOpProvider")
     static void bitwiseBlendByteMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<byte[]> fa, IntFunction<byte[]> fb, IntFunction<byte[]> fc) {
@@ -4452,7 +4452,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, ByteMaxVectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, ByteMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4471,7 +4471,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, ByteMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, ByteMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4495,7 +4495,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::NEG);
+        assertArraysEquals(r, a, ByteMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4510,7 +4510,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::neg);
+        assertArraysEquals(r, a, ByteMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4528,7 +4528,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ByteMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, ByteMaxVectorTests::NEG);
     }
 
     static byte ABS(byte a) {
@@ -4551,7 +4551,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::ABS);
+        assertArraysEquals(r, a, ByteMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4566,7 +4566,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::abs);
+        assertArraysEquals(r, a, ByteMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "byteUnaryOpMaskProvider")
@@ -4584,7 +4584,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ByteMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, ByteMaxVectorTests::ABS);
     }
 
 
@@ -4610,7 +4610,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::NOT);
+        assertArraysEquals(r, a, ByteMaxVectorTests::NOT);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")
@@ -4625,7 +4625,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::not);
+        assertArraysEquals(r, a, ByteMaxVectorTests::not);
     }
 
 
@@ -4645,7 +4645,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ByteMaxVectorTests::NOT);
+        assertArraysEquals(r, a, mask, ByteMaxVectorTests::NOT);
     }
 
 
@@ -4668,7 +4668,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ByteMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, ByteMaxVectorTests::ZOMO);
     }
 
 
@@ -4688,7 +4688,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ByteMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, ByteMaxVectorTests::ZOMO);
     }
 
 
@@ -4716,7 +4716,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::gather);
     }
     static byte[] gatherMasked(byte a[], int ix, boolean[] mask, int[] b, int iy) {
         byte[] res = new byte[SPECIES.length()];
@@ -4744,7 +4744,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::gatherMasked);
     }
 
     static byte[] scatter(byte a[], int ix, int[] b, int iy) {
@@ -4769,7 +4769,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::scatter);
     }
 
     static byte[] scatterMasked(byte r[], byte a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4807,7 +4807,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ByteMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, ByteMaxVectorTests::scatterMasked);
     }
 
 
@@ -4849,8 +4849,8 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4860,8 +4860,8 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4871,8 +4871,8 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4912,7 +4912,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ByteVector av = ByteVector.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 
     static long ADDReduceLong(byte[] a, int idx) {
@@ -4949,7 +4949,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 ByteMaxVectorTests::ADDReduceLong, ByteMaxVectorTests::ADDReduceAllLong);
     }
 
@@ -4990,7 +4990,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 ByteMaxVectorTests::ADDReduceLongMasked, ByteMaxVectorTests::ADDReduceAllLongMasked);
     }
 
@@ -5002,7 +5002,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ByteVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "byteBinaryOpMaskProvider")
@@ -5020,7 +5020,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, ByteMaxVectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ByteMaxVectorTests::blend);
     }
 
 
@@ -5037,7 +5037,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "byteUnaryOpSelectFromMaskProvider")
@@ -5056,7 +5056,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5133,7 +5133,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, ByteMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, ByteMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(double[] a, double[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "doubleProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new double[a.length];
@@ -483,7 +461,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -68,7 +68,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a[i]);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Double128VectorTests extends AbstractVectorTest {
         double apply(double[] a);
     }
 
-    static void assertReductionArraysEquals(double[] a, double[] b, double c,
+    static void assertReductionArraysEquals(double[] r, double rc, double[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Double128VectorTests extends AbstractVectorTest {
         double apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(double[] a, double[] b, double c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(double[] r, double rc, double[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Double128VectorTests extends AbstractVectorTest {
         long apply(double[] a);
     }
 
-    static void assertReductionLongArraysEquals(double[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, double[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Double128VectorTests extends AbstractVectorTest {
         long apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(double[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, double[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Double128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(double[] a, double[] b, double element, int index) {
+    static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[]a, double[]r) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double apply(double[] a, int b);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FBinArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] r, double[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(r, a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(double[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(double[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1396,7 +1396,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Double128VectorTests::ADD);
     }
     static double add(double a, double b) {
         return (double)(a + b);
@@ -1414,7 +1414,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::add);
+        assertArraysEquals(r, a, b, Double128VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1434,7 +1434,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1452,7 +1452,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::add);
     }
     static double SUB(double a, double b) {
         return (double)(a - b);
@@ -1472,7 +1472,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Double128VectorTests::SUB);
     }
     static double sub(double a, double b) {
         return (double)(a - b);
@@ -1490,7 +1490,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::sub);
+        assertArraysEquals(r, a, b, Double128VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1510,7 +1510,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::SUB);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1528,7 +1528,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::sub);
     }
     static double MUL(double a, double b) {
         return (double)(a * b);
@@ -1548,7 +1548,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Double128VectorTests::MUL);
     }
     static double mul(double a, double b) {
         return (double)(a * b);
@@ -1566,7 +1566,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::mul);
+        assertArraysEquals(r, a, b, Double128VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1586,7 +1586,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::MUL);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1604,7 +1604,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::mul);
     }
 
     static double DIV(double a, double b) {
@@ -1625,7 +1625,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Double128VectorTests::DIV);
     }
     static double div(double a, double b) {
         return (double)(a / b);
@@ -1643,7 +1643,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::div);
+        assertArraysEquals(r, a, b, Double128VectorTests::div);
     }
 
 
@@ -1665,7 +1665,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::DIV);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1683,7 +1683,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::div);
     }
 
 
@@ -1706,7 +1706,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Double128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1726,7 +1726,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1748,7 +1748,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1765,7 +1765,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Double128VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1779,7 +1779,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1796,7 +1796,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Double128VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1810,7 +1810,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1827,7 +1827,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Double128VectorTests::mul);
     }
 
 
@@ -1842,7 +1842,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::div);
     }
 
 
@@ -1861,7 +1861,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Double128VectorTests::div);
     }
 
 
@@ -1884,7 +1884,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Double128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Double128VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double128VectorTests::ADD);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Double128VectorTests::MIN);
     }
     static double min(double a, double b) {
         return (double)(Math.min(a, b));
@@ -1975,7 +1975,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::min);
+        assertArraysEquals(r, a, b, Double128VectorTests::min);
     }
     static double MAX(double a, double b) {
         return (double)(Math.max(a, b));
@@ -1995,7 +1995,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Double128VectorTests::MAX);
     }
     static double max(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2013,7 +2013,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::max);
+        assertArraysEquals(r, a, b, Double128VectorTests::max);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2027,7 +2027,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::MIN);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::min);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2055,7 +2055,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::MAX);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2069,7 +2069,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Double128VectorTests::max);
     }
 
 
@@ -2121,7 +2121,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double128VectorTests::ADDReduce, Double128VectorTests::ADDReduceAll);
     }
     static double ADDReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2165,7 +2165,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double128VectorTests::ADDReduceMasked, Double128VectorTests::ADDReduceAllMasked);
     }
     static double MULReduce(double[] a, int idx) {
@@ -2206,7 +2206,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double128VectorTests::MULReduce, Double128VectorTests::MULReduceAll);
     }
     static double MULReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2250,7 +2250,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double128VectorTests::MULReduceMasked, Double128VectorTests::MULReduceAllMasked);
     }
     static double MINReduce(double[] a, int idx) {
@@ -2291,7 +2291,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double128VectorTests::MINReduce, Double128VectorTests::MINReduceAll);
     }
     static double MINReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2336,7 +2336,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double128VectorTests::MINReduceMasked, Double128VectorTests::MINReduceAllMasked);
     }
     static double MAXReduce(double[] a, int idx) {
@@ -2377,7 +2377,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double128VectorTests::MAXReduce, Double128VectorTests::MAXReduceAll);
     }
     static double MAXReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2422,7 +2422,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double128VectorTests::MAXReduceMasked, Double128VectorTests::MAXReduceAllMasked);
     }
 
@@ -2442,7 +2442,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (double)4, 0);
+        assertInsertArraysEquals(r, a, (double)4, 0);
     }
     static boolean testIS_DEFAULT(double a) {
         return bits(a)==0;
@@ -3108,7 +3108,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::blend);
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleProvider")
@@ -3125,7 +3125,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleMaskProvider")
@@ -3143,7 +3143,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "doubleUnaryOpProvider")
     static void getDouble128VectorTests(IntFunction<double[]> fa) {
@@ -3298,7 +3298,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::get);
+        assertArraysEquals(r, a, Double128VectorTests::get);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -3312,7 +3312,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3359,7 +3359,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Double128VectorTests::sliceUnary);
     }
     static double[] sliceBinary(double[] a, double[] b, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3388,7 +3388,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Double128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Double128VectorTests::sliceBinary);
     }
     static double[] slice(double[] a, double[] b, int origin, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3421,7 +3421,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Double128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Double128VectorTests::slice);
     }
     static double[] unsliceUnary(double[] a, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3448,7 +3448,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Double128VectorTests::unsliceUnary);
     }
     static double[] unsliceBinary(double[] a, double[] b, int origin, int part, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3487,7 +3487,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Double128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Double128VectorTests::unsliceBinary);
     }
     static double[] unslice(double[] a, double[] b, int origin, int part, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3543,7 +3543,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Double128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Double128VectorTests::unslice);
     }
 
     static double SIN(double a) {
@@ -3566,7 +3566,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::SIN, Double128VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::SIN, Double128VectorTests::strictSIN);
     }
 
 
@@ -3590,7 +3590,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::EXP, Double128VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::EXP, Double128VectorTests::strictEXP);
     }
 
 
@@ -3614,7 +3614,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::LOG1P, Double128VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::LOG1P, Double128VectorTests::strictLOG1P);
     }
 
 
@@ -3638,7 +3638,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::LOG, Double128VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::LOG, Double128VectorTests::strictLOG);
     }
 
 
@@ -3662,7 +3662,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::LOG10, Double128VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::LOG10, Double128VectorTests::strictLOG10);
     }
 
 
@@ -3686,7 +3686,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::EXPM1, Double128VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::EXPM1, Double128VectorTests::strictEXPM1);
     }
 
 
@@ -3710,7 +3710,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::COS, Double128VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::COS, Double128VectorTests::strictCOS);
     }
 
 
@@ -3734,7 +3734,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::TAN, Double128VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::TAN, Double128VectorTests::strictTAN);
     }
 
 
@@ -3758,7 +3758,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::SINH, Double128VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::SINH, Double128VectorTests::strictSINH);
     }
 
 
@@ -3782,7 +3782,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::COSH, Double128VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::COSH, Double128VectorTests::strictCOSH);
     }
 
 
@@ -3806,7 +3806,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::TANH, Double128VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::TANH, Double128VectorTests::strictTANH);
     }
 
 
@@ -3830,7 +3830,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::ASIN, Double128VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::ASIN, Double128VectorTests::strictASIN);
     }
 
 
@@ -3854,7 +3854,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::ACOS, Double128VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::ACOS, Double128VectorTests::strictACOS);
     }
 
 
@@ -3878,7 +3878,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::ATAN, Double128VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::ATAN, Double128VectorTests::strictATAN);
     }
 
 
@@ -3902,7 +3902,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double128VectorTests::CBRT, Double128VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Double128VectorTests::CBRT, Double128VectorTests::strictCBRT);
     }
 
 
@@ -3928,7 +3928,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::HYPOT, Double128VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::HYPOT, Double128VectorTests::strictHYPOT);
     }
 
 
@@ -3955,7 +3955,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::POW, Double128VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::POW, Double128VectorTests::strictPOW);
     }
 
     static double pow(double a, double b) {
@@ -3980,7 +3980,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::pow, Double128VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::pow, Double128VectorTests::strictpow);
     }
 
 
@@ -4007,7 +4007,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::ATAN2, Double128VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::ATAN2, Double128VectorTests::strictATAN2);
     }
 
 
@@ -4023,7 +4023,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::POW, Double128VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::POW, Double128VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -4037,7 +4037,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double128VectorTests::pow, Double128VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double128VectorTests::pow, Double128VectorTests::strictpow);
     }
 
 
@@ -4073,7 +4073,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Double128VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Double128VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble128VectorTests(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4096,7 +4096,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Double128VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Double128VectorTests::fma);
     }
 
 
@@ -4126,7 +4126,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Double128VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Double128VectorTests::FMA);
     }
 
 
@@ -4145,7 +4145,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             DoubleVector bv = DoubleVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Double128VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Double128VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpProvider")
@@ -4160,7 +4160,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             DoubleVector cv = DoubleVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Double128VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Double128VectorTests::FMA);
     }
 
 
@@ -4180,7 +4180,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Double128VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Double128VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpMaskProvider")
@@ -4199,7 +4199,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Double128VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Double128VectorTests::FMA);
     }
 
 
@@ -4224,7 +4224,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double128VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double128VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble128VectorTestsDoubleBroadcastSmokeTest(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4245,7 +4245,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double128VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double128VectorTests::fma);
     }
 
 
@@ -4271,7 +4271,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Double128VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Double128VectorTests::FMA);
     }
 
 
@@ -4297,7 +4297,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::NEG);
+        assertArraysEquals(r, a, Double128VectorTests::NEG);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4312,7 +4312,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::neg);
+        assertArraysEquals(r, a, Double128VectorTests::neg);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Double128VectorTests::NEG);
     }
 
     static double ABS(double a) {
@@ -4353,7 +4353,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::ABS);
+        assertArraysEquals(r, a, Double128VectorTests::ABS);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4368,7 +4368,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::abs);
+        assertArraysEquals(r, a, Double128VectorTests::abs);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4386,7 +4386,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Double128VectorTests::ABS);
     }
 
 
@@ -4418,7 +4418,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::SQRT);
+        assertArraysEquals(r, a, Double128VectorTests::SQRT);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4433,7 +4433,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double128VectorTests::sqrt);
+        assertArraysEquals(r, a, Double128VectorTests::sqrt);
     }
 
 
@@ -4453,7 +4453,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double128VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Double128VectorTests::SQRT);
     }
 
     static double[] gather(double a[], int ix, int[] b, int iy) {
@@ -4478,7 +4478,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::gather);
+        assertArraysEquals(r, a, b, Double128VectorTests::gather);
     }
     static double[] gatherMasked(double a[], int ix, boolean[] mask, int[] b, int iy) {
         double[] res = new double[SPECIES.length()];
@@ -4506,7 +4506,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::gatherMasked);
     }
 
     static double[] scatter(double a[], int ix, int[] b, int iy) {
@@ -4531,7 +4531,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Double128VectorTests::scatter);
     }
 
     static double[] scatterMasked(double r[], double a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4569,7 +4569,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Double128VectorTests::scatterMasked);
     }
 
 
@@ -4611,8 +4611,8 @@ public class Double128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4622,8 +4622,8 @@ public class Double128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4690,7 +4690,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Double128VectorTests::ADDReduceLong, Double128VectorTests::ADDReduceAllLong);
     }
 
@@ -4731,7 +4731,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Double128VectorTests::ADDReduceLongMasked, Double128VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4743,7 +4743,7 @@ public class Double128VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -4761,7 +4761,7 @@ public class Double128VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double128VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double128VectorTests::blend);
     }
 
 
@@ -4778,7 +4778,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpSelectFromMaskProvider")
@@ -4797,7 +4797,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4874,7 +4874,7 @@ public class Double128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Double128VectorTests::beq);
+        assertArraysEquals(r, a, b, Double128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(double[] a, double[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "doubleProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new double[a.length];
@@ -483,7 +461,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -68,7 +68,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a[i]);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Double256VectorTests extends AbstractVectorTest {
         double apply(double[] a);
     }
 
-    static void assertReductionArraysEquals(double[] a, double[] b, double c,
+    static void assertReductionArraysEquals(double[] r, double rc, double[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Double256VectorTests extends AbstractVectorTest {
         double apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(double[] a, double[] b, double c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(double[] r, double rc, double[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Double256VectorTests extends AbstractVectorTest {
         long apply(double[] a);
     }
 
-    static void assertReductionLongArraysEquals(double[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, double[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Double256VectorTests extends AbstractVectorTest {
         long apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(double[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, double[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Double256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(double[] a, double[] b, double element, int index) {
+    static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[]a, double[]r) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double apply(double[] a, int b);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FBinArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] r, double[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(r, a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(double[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(double[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1396,7 +1396,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Double256VectorTests::ADD);
     }
     static double add(double a, double b) {
         return (double)(a + b);
@@ -1414,7 +1414,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::add);
+        assertArraysEquals(r, a, b, Double256VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1434,7 +1434,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1452,7 +1452,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::add);
     }
     static double SUB(double a, double b) {
         return (double)(a - b);
@@ -1472,7 +1472,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Double256VectorTests::SUB);
     }
     static double sub(double a, double b) {
         return (double)(a - b);
@@ -1490,7 +1490,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::sub);
+        assertArraysEquals(r, a, b, Double256VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1510,7 +1510,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::SUB);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1528,7 +1528,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::sub);
     }
     static double MUL(double a, double b) {
         return (double)(a * b);
@@ -1548,7 +1548,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Double256VectorTests::MUL);
     }
     static double mul(double a, double b) {
         return (double)(a * b);
@@ -1566,7 +1566,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::mul);
+        assertArraysEquals(r, a, b, Double256VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1586,7 +1586,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::MUL);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1604,7 +1604,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::mul);
     }
 
     static double DIV(double a, double b) {
@@ -1625,7 +1625,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Double256VectorTests::DIV);
     }
     static double div(double a, double b) {
         return (double)(a / b);
@@ -1643,7 +1643,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::div);
+        assertArraysEquals(r, a, b, Double256VectorTests::div);
     }
 
 
@@ -1665,7 +1665,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::DIV);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1683,7 +1683,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::div);
     }
 
 
@@ -1706,7 +1706,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Double256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1726,7 +1726,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1748,7 +1748,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1765,7 +1765,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Double256VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1779,7 +1779,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1796,7 +1796,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Double256VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1810,7 +1810,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1827,7 +1827,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Double256VectorTests::mul);
     }
 
 
@@ -1842,7 +1842,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::div);
     }
 
 
@@ -1861,7 +1861,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Double256VectorTests::div);
     }
 
 
@@ -1884,7 +1884,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Double256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Double256VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double256VectorTests::ADD);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Double256VectorTests::MIN);
     }
     static double min(double a, double b) {
         return (double)(Math.min(a, b));
@@ -1975,7 +1975,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::min);
+        assertArraysEquals(r, a, b, Double256VectorTests::min);
     }
     static double MAX(double a, double b) {
         return (double)(Math.max(a, b));
@@ -1995,7 +1995,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Double256VectorTests::MAX);
     }
     static double max(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2013,7 +2013,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::max);
+        assertArraysEquals(r, a, b, Double256VectorTests::max);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2027,7 +2027,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::MIN);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::min);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2055,7 +2055,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::MAX);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2069,7 +2069,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Double256VectorTests::max);
     }
 
 
@@ -2121,7 +2121,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double256VectorTests::ADDReduce, Double256VectorTests::ADDReduceAll);
     }
     static double ADDReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2165,7 +2165,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double256VectorTests::ADDReduceMasked, Double256VectorTests::ADDReduceAllMasked);
     }
     static double MULReduce(double[] a, int idx) {
@@ -2206,7 +2206,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double256VectorTests::MULReduce, Double256VectorTests::MULReduceAll);
     }
     static double MULReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2250,7 +2250,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double256VectorTests::MULReduceMasked, Double256VectorTests::MULReduceAllMasked);
     }
     static double MINReduce(double[] a, int idx) {
@@ -2291,7 +2291,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double256VectorTests::MINReduce, Double256VectorTests::MINReduceAll);
     }
     static double MINReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2336,7 +2336,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double256VectorTests::MINReduceMasked, Double256VectorTests::MINReduceAllMasked);
     }
     static double MAXReduce(double[] a, int idx) {
@@ -2377,7 +2377,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double256VectorTests::MAXReduce, Double256VectorTests::MAXReduceAll);
     }
     static double MAXReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2422,7 +2422,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double256VectorTests::MAXReduceMasked, Double256VectorTests::MAXReduceAllMasked);
     }
 
@@ -2442,7 +2442,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (double)4, 0);
+        assertInsertArraysEquals(r, a, (double)4, 0);
     }
     static boolean testIS_DEFAULT(double a) {
         return bits(a)==0;
@@ -3108,7 +3108,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::blend);
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleProvider")
@@ -3125,7 +3125,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleMaskProvider")
@@ -3143,7 +3143,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "doubleUnaryOpProvider")
     static void getDouble256VectorTests(IntFunction<double[]> fa) {
@@ -3298,7 +3298,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::get);
+        assertArraysEquals(r, a, Double256VectorTests::get);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -3312,7 +3312,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3359,7 +3359,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Double256VectorTests::sliceUnary);
     }
     static double[] sliceBinary(double[] a, double[] b, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3388,7 +3388,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Double256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Double256VectorTests::sliceBinary);
     }
     static double[] slice(double[] a, double[] b, int origin, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3421,7 +3421,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Double256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Double256VectorTests::slice);
     }
     static double[] unsliceUnary(double[] a, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3448,7 +3448,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Double256VectorTests::unsliceUnary);
     }
     static double[] unsliceBinary(double[] a, double[] b, int origin, int part, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3487,7 +3487,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Double256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Double256VectorTests::unsliceBinary);
     }
     static double[] unslice(double[] a, double[] b, int origin, int part, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3543,7 +3543,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Double256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Double256VectorTests::unslice);
     }
 
     static double SIN(double a) {
@@ -3566,7 +3566,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::SIN, Double256VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::SIN, Double256VectorTests::strictSIN);
     }
 
 
@@ -3590,7 +3590,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::EXP, Double256VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::EXP, Double256VectorTests::strictEXP);
     }
 
 
@@ -3614,7 +3614,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::LOG1P, Double256VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::LOG1P, Double256VectorTests::strictLOG1P);
     }
 
 
@@ -3638,7 +3638,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::LOG, Double256VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::LOG, Double256VectorTests::strictLOG);
     }
 
 
@@ -3662,7 +3662,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::LOG10, Double256VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::LOG10, Double256VectorTests::strictLOG10);
     }
 
 
@@ -3686,7 +3686,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::EXPM1, Double256VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::EXPM1, Double256VectorTests::strictEXPM1);
     }
 
 
@@ -3710,7 +3710,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::COS, Double256VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::COS, Double256VectorTests::strictCOS);
     }
 
 
@@ -3734,7 +3734,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::TAN, Double256VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::TAN, Double256VectorTests::strictTAN);
     }
 
 
@@ -3758,7 +3758,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::SINH, Double256VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::SINH, Double256VectorTests::strictSINH);
     }
 
 
@@ -3782,7 +3782,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::COSH, Double256VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::COSH, Double256VectorTests::strictCOSH);
     }
 
 
@@ -3806,7 +3806,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::TANH, Double256VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::TANH, Double256VectorTests::strictTANH);
     }
 
 
@@ -3830,7 +3830,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::ASIN, Double256VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::ASIN, Double256VectorTests::strictASIN);
     }
 
 
@@ -3854,7 +3854,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::ACOS, Double256VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::ACOS, Double256VectorTests::strictACOS);
     }
 
 
@@ -3878,7 +3878,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::ATAN, Double256VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::ATAN, Double256VectorTests::strictATAN);
     }
 
 
@@ -3902,7 +3902,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double256VectorTests::CBRT, Double256VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Double256VectorTests::CBRT, Double256VectorTests::strictCBRT);
     }
 
 
@@ -3928,7 +3928,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::HYPOT, Double256VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::HYPOT, Double256VectorTests::strictHYPOT);
     }
 
 
@@ -3955,7 +3955,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::POW, Double256VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::POW, Double256VectorTests::strictPOW);
     }
 
     static double pow(double a, double b) {
@@ -3980,7 +3980,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::pow, Double256VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::pow, Double256VectorTests::strictpow);
     }
 
 
@@ -4007,7 +4007,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::ATAN2, Double256VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::ATAN2, Double256VectorTests::strictATAN2);
     }
 
 
@@ -4023,7 +4023,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::POW, Double256VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::POW, Double256VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -4037,7 +4037,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double256VectorTests::pow, Double256VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double256VectorTests::pow, Double256VectorTests::strictpow);
     }
 
 
@@ -4073,7 +4073,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Double256VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Double256VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble256VectorTests(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4096,7 +4096,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Double256VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Double256VectorTests::fma);
     }
 
 
@@ -4126,7 +4126,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Double256VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Double256VectorTests::FMA);
     }
 
 
@@ -4145,7 +4145,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             DoubleVector bv = DoubleVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Double256VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Double256VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpProvider")
@@ -4160,7 +4160,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             DoubleVector cv = DoubleVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Double256VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Double256VectorTests::FMA);
     }
 
 
@@ -4180,7 +4180,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Double256VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Double256VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpMaskProvider")
@@ -4199,7 +4199,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Double256VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Double256VectorTests::FMA);
     }
 
 
@@ -4224,7 +4224,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double256VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double256VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble256VectorTestsDoubleBroadcastSmokeTest(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4245,7 +4245,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double256VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double256VectorTests::fma);
     }
 
 
@@ -4271,7 +4271,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Double256VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Double256VectorTests::FMA);
     }
 
 
@@ -4297,7 +4297,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::NEG);
+        assertArraysEquals(r, a, Double256VectorTests::NEG);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4312,7 +4312,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::neg);
+        assertArraysEquals(r, a, Double256VectorTests::neg);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Double256VectorTests::NEG);
     }
 
     static double ABS(double a) {
@@ -4353,7 +4353,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::ABS);
+        assertArraysEquals(r, a, Double256VectorTests::ABS);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4368,7 +4368,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::abs);
+        assertArraysEquals(r, a, Double256VectorTests::abs);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4386,7 +4386,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Double256VectorTests::ABS);
     }
 
 
@@ -4418,7 +4418,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::SQRT);
+        assertArraysEquals(r, a, Double256VectorTests::SQRT);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4433,7 +4433,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double256VectorTests::sqrt);
+        assertArraysEquals(r, a, Double256VectorTests::sqrt);
     }
 
 
@@ -4453,7 +4453,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double256VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Double256VectorTests::SQRT);
     }
 
     static double[] gather(double a[], int ix, int[] b, int iy) {
@@ -4478,7 +4478,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::gather);
+        assertArraysEquals(r, a, b, Double256VectorTests::gather);
     }
     static double[] gatherMasked(double a[], int ix, boolean[] mask, int[] b, int iy) {
         double[] res = new double[SPECIES.length()];
@@ -4506,7 +4506,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::gatherMasked);
     }
 
     static double[] scatter(double a[], int ix, int[] b, int iy) {
@@ -4531,7 +4531,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Double256VectorTests::scatter);
     }
 
     static double[] scatterMasked(double r[], double a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4569,7 +4569,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Double256VectorTests::scatterMasked);
     }
 
 
@@ -4611,8 +4611,8 @@ public class Double256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4622,8 +4622,8 @@ public class Double256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4690,7 +4690,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Double256VectorTests::ADDReduceLong, Double256VectorTests::ADDReduceAllLong);
     }
 
@@ -4731,7 +4731,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Double256VectorTests::ADDReduceLongMasked, Double256VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4743,7 +4743,7 @@ public class Double256VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -4761,7 +4761,7 @@ public class Double256VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double256VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double256VectorTests::blend);
     }
 
 
@@ -4778,7 +4778,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpSelectFromMaskProvider")
@@ -4797,7 +4797,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4874,7 +4874,7 @@ public class Double256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Double256VectorTests::beq);
+        assertArraysEquals(r, a, b, Double256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(double[] a, double[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "doubleProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new double[a.length];
@@ -483,7 +461,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -68,7 +68,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a[i]);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Double512VectorTests extends AbstractVectorTest {
         double apply(double[] a);
     }
 
-    static void assertReductionArraysEquals(double[] a, double[] b, double c,
+    static void assertReductionArraysEquals(double[] r, double rc, double[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Double512VectorTests extends AbstractVectorTest {
         double apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(double[] a, double[] b, double c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(double[] r, double rc, double[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Double512VectorTests extends AbstractVectorTest {
         long apply(double[] a);
     }
 
-    static void assertReductionLongArraysEquals(double[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, double[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Double512VectorTests extends AbstractVectorTest {
         long apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(double[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, double[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Double512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(double[] a, double[] b, double element, int index) {
+    static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[]a, double[]r) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double apply(double[] a, int b);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FBinArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] r, double[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(r, a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(double[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(double[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1396,7 +1396,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Double512VectorTests::ADD);
     }
     static double add(double a, double b) {
         return (double)(a + b);
@@ -1414,7 +1414,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::add);
+        assertArraysEquals(r, a, b, Double512VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1434,7 +1434,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1452,7 +1452,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::add);
     }
     static double SUB(double a, double b) {
         return (double)(a - b);
@@ -1472,7 +1472,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Double512VectorTests::SUB);
     }
     static double sub(double a, double b) {
         return (double)(a - b);
@@ -1490,7 +1490,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::sub);
+        assertArraysEquals(r, a, b, Double512VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1510,7 +1510,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::SUB);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1528,7 +1528,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::sub);
     }
     static double MUL(double a, double b) {
         return (double)(a * b);
@@ -1548,7 +1548,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Double512VectorTests::MUL);
     }
     static double mul(double a, double b) {
         return (double)(a * b);
@@ -1566,7 +1566,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::mul);
+        assertArraysEquals(r, a, b, Double512VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1586,7 +1586,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::MUL);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1604,7 +1604,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::mul);
     }
 
     static double DIV(double a, double b) {
@@ -1625,7 +1625,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Double512VectorTests::DIV);
     }
     static double div(double a, double b) {
         return (double)(a / b);
@@ -1643,7 +1643,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::div);
+        assertArraysEquals(r, a, b, Double512VectorTests::div);
     }
 
 
@@ -1665,7 +1665,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::DIV);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1683,7 +1683,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::div);
     }
 
 
@@ -1706,7 +1706,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Double512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1726,7 +1726,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1748,7 +1748,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1765,7 +1765,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Double512VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1779,7 +1779,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1796,7 +1796,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Double512VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1810,7 +1810,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1827,7 +1827,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Double512VectorTests::mul);
     }
 
 
@@ -1842,7 +1842,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::div);
     }
 
 
@@ -1861,7 +1861,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Double512VectorTests::div);
     }
 
 
@@ -1884,7 +1884,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Double512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Double512VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double512VectorTests::ADD);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Double512VectorTests::MIN);
     }
     static double min(double a, double b) {
         return (double)(Math.min(a, b));
@@ -1975,7 +1975,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::min);
+        assertArraysEquals(r, a, b, Double512VectorTests::min);
     }
     static double MAX(double a, double b) {
         return (double)(Math.max(a, b));
@@ -1995,7 +1995,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Double512VectorTests::MAX);
     }
     static double max(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2013,7 +2013,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::max);
+        assertArraysEquals(r, a, b, Double512VectorTests::max);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2027,7 +2027,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::MIN);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::min);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2055,7 +2055,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::MAX);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2069,7 +2069,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Double512VectorTests::max);
     }
 
 
@@ -2121,7 +2121,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double512VectorTests::ADDReduce, Double512VectorTests::ADDReduceAll);
     }
     static double ADDReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2165,7 +2165,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double512VectorTests::ADDReduceMasked, Double512VectorTests::ADDReduceAllMasked);
     }
     static double MULReduce(double[] a, int idx) {
@@ -2206,7 +2206,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double512VectorTests::MULReduce, Double512VectorTests::MULReduceAll);
     }
     static double MULReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2250,7 +2250,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double512VectorTests::MULReduceMasked, Double512VectorTests::MULReduceAllMasked);
     }
     static double MINReduce(double[] a, int idx) {
@@ -2291,7 +2291,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double512VectorTests::MINReduce, Double512VectorTests::MINReduceAll);
     }
     static double MINReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2336,7 +2336,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double512VectorTests::MINReduceMasked, Double512VectorTests::MINReduceAllMasked);
     }
     static double MAXReduce(double[] a, int idx) {
@@ -2377,7 +2377,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double512VectorTests::MAXReduce, Double512VectorTests::MAXReduceAll);
     }
     static double MAXReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2422,7 +2422,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double512VectorTests::MAXReduceMasked, Double512VectorTests::MAXReduceAllMasked);
     }
 
@@ -2442,7 +2442,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (double)4, 0);
+        assertInsertArraysEquals(r, a, (double)4, 0);
     }
     static boolean testIS_DEFAULT(double a) {
         return bits(a)==0;
@@ -3108,7 +3108,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::blend);
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleProvider")
@@ -3125,7 +3125,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleMaskProvider")
@@ -3143,7 +3143,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "doubleUnaryOpProvider")
     static void getDouble512VectorTests(IntFunction<double[]> fa) {
@@ -3298,7 +3298,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::get);
+        assertArraysEquals(r, a, Double512VectorTests::get);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -3312,7 +3312,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3359,7 +3359,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Double512VectorTests::sliceUnary);
     }
     static double[] sliceBinary(double[] a, double[] b, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3388,7 +3388,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Double512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Double512VectorTests::sliceBinary);
     }
     static double[] slice(double[] a, double[] b, int origin, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3421,7 +3421,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Double512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Double512VectorTests::slice);
     }
     static double[] unsliceUnary(double[] a, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3448,7 +3448,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Double512VectorTests::unsliceUnary);
     }
     static double[] unsliceBinary(double[] a, double[] b, int origin, int part, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3487,7 +3487,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Double512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Double512VectorTests::unsliceBinary);
     }
     static double[] unslice(double[] a, double[] b, int origin, int part, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3543,7 +3543,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Double512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Double512VectorTests::unslice);
     }
 
     static double SIN(double a) {
@@ -3566,7 +3566,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::SIN, Double512VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::SIN, Double512VectorTests::strictSIN);
     }
 
 
@@ -3590,7 +3590,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::EXP, Double512VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::EXP, Double512VectorTests::strictEXP);
     }
 
 
@@ -3614,7 +3614,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::LOG1P, Double512VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::LOG1P, Double512VectorTests::strictLOG1P);
     }
 
 
@@ -3638,7 +3638,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::LOG, Double512VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::LOG, Double512VectorTests::strictLOG);
     }
 
 
@@ -3662,7 +3662,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::LOG10, Double512VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::LOG10, Double512VectorTests::strictLOG10);
     }
 
 
@@ -3686,7 +3686,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::EXPM1, Double512VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::EXPM1, Double512VectorTests::strictEXPM1);
     }
 
 
@@ -3710,7 +3710,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::COS, Double512VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::COS, Double512VectorTests::strictCOS);
     }
 
 
@@ -3734,7 +3734,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::TAN, Double512VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::TAN, Double512VectorTests::strictTAN);
     }
 
 
@@ -3758,7 +3758,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::SINH, Double512VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::SINH, Double512VectorTests::strictSINH);
     }
 
 
@@ -3782,7 +3782,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::COSH, Double512VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::COSH, Double512VectorTests::strictCOSH);
     }
 
 
@@ -3806,7 +3806,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::TANH, Double512VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::TANH, Double512VectorTests::strictTANH);
     }
 
 
@@ -3830,7 +3830,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::ASIN, Double512VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::ASIN, Double512VectorTests::strictASIN);
     }
 
 
@@ -3854,7 +3854,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::ACOS, Double512VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::ACOS, Double512VectorTests::strictACOS);
     }
 
 
@@ -3878,7 +3878,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::ATAN, Double512VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::ATAN, Double512VectorTests::strictATAN);
     }
 
 
@@ -3902,7 +3902,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double512VectorTests::CBRT, Double512VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Double512VectorTests::CBRT, Double512VectorTests::strictCBRT);
     }
 
 
@@ -3928,7 +3928,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::HYPOT, Double512VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::HYPOT, Double512VectorTests::strictHYPOT);
     }
 
 
@@ -3955,7 +3955,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::POW, Double512VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::POW, Double512VectorTests::strictPOW);
     }
 
     static double pow(double a, double b) {
@@ -3980,7 +3980,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::pow, Double512VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::pow, Double512VectorTests::strictpow);
     }
 
 
@@ -4007,7 +4007,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::ATAN2, Double512VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::ATAN2, Double512VectorTests::strictATAN2);
     }
 
 
@@ -4023,7 +4023,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::POW, Double512VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::POW, Double512VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -4037,7 +4037,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double512VectorTests::pow, Double512VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double512VectorTests::pow, Double512VectorTests::strictpow);
     }
 
 
@@ -4073,7 +4073,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Double512VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Double512VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble512VectorTests(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4096,7 +4096,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Double512VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Double512VectorTests::fma);
     }
 
 
@@ -4126,7 +4126,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Double512VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Double512VectorTests::FMA);
     }
 
 
@@ -4145,7 +4145,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             DoubleVector bv = DoubleVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Double512VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Double512VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpProvider")
@@ -4160,7 +4160,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             DoubleVector cv = DoubleVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Double512VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Double512VectorTests::FMA);
     }
 
 
@@ -4180,7 +4180,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Double512VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Double512VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpMaskProvider")
@@ -4199,7 +4199,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Double512VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Double512VectorTests::FMA);
     }
 
 
@@ -4224,7 +4224,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double512VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double512VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble512VectorTestsDoubleBroadcastSmokeTest(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4245,7 +4245,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double512VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double512VectorTests::fma);
     }
 
 
@@ -4271,7 +4271,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Double512VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Double512VectorTests::FMA);
     }
 
 
@@ -4297,7 +4297,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::NEG);
+        assertArraysEquals(r, a, Double512VectorTests::NEG);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4312,7 +4312,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::neg);
+        assertArraysEquals(r, a, Double512VectorTests::neg);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Double512VectorTests::NEG);
     }
 
     static double ABS(double a) {
@@ -4353,7 +4353,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::ABS);
+        assertArraysEquals(r, a, Double512VectorTests::ABS);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4368,7 +4368,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::abs);
+        assertArraysEquals(r, a, Double512VectorTests::abs);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4386,7 +4386,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Double512VectorTests::ABS);
     }
 
 
@@ -4418,7 +4418,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::SQRT);
+        assertArraysEquals(r, a, Double512VectorTests::SQRT);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4433,7 +4433,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double512VectorTests::sqrt);
+        assertArraysEquals(r, a, Double512VectorTests::sqrt);
     }
 
 
@@ -4453,7 +4453,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double512VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Double512VectorTests::SQRT);
     }
 
     static double[] gather(double a[], int ix, int[] b, int iy) {
@@ -4478,7 +4478,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::gather);
+        assertArraysEquals(r, a, b, Double512VectorTests::gather);
     }
     static double[] gatherMasked(double a[], int ix, boolean[] mask, int[] b, int iy) {
         double[] res = new double[SPECIES.length()];
@@ -4506,7 +4506,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::gatherMasked);
     }
 
     static double[] scatter(double a[], int ix, int[] b, int iy) {
@@ -4531,7 +4531,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Double512VectorTests::scatter);
     }
 
     static double[] scatterMasked(double r[], double a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4569,7 +4569,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Double512VectorTests::scatterMasked);
     }
 
 
@@ -4611,8 +4611,8 @@ public class Double512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4622,8 +4622,8 @@ public class Double512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4690,7 +4690,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Double512VectorTests::ADDReduceLong, Double512VectorTests::ADDReduceAllLong);
     }
 
@@ -4731,7 +4731,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Double512VectorTests::ADDReduceLongMasked, Double512VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4743,7 +4743,7 @@ public class Double512VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -4761,7 +4761,7 @@ public class Double512VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double512VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double512VectorTests::blend);
     }
 
 
@@ -4778,7 +4778,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpSelectFromMaskProvider")
@@ -4797,7 +4797,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4874,7 +4874,7 @@ public class Double512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Double512VectorTests::beq);
+        assertArraysEquals(r, a, b, Double512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(double[] a, double[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "doubleProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new double[a.length];
@@ -483,7 +461,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -68,7 +68,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a[i]);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Double64VectorTests extends AbstractVectorTest {
         double apply(double[] a);
     }
 
-    static void assertReductionArraysEquals(double[] a, double[] b, double c,
+    static void assertReductionArraysEquals(double[] r, double rc, double[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Double64VectorTests extends AbstractVectorTest {
         double apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(double[] a, double[] b, double c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(double[] r, double rc, double[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Double64VectorTests extends AbstractVectorTest {
         long apply(double[] a);
     }
 
-    static void assertReductionLongArraysEquals(double[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, double[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Double64VectorTests extends AbstractVectorTest {
         long apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(double[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, double[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Double64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(double[] a, double[] b, double element, int index) {
+    static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[]a, double[]r) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double apply(double[] a, int b);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FBinArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] r, double[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(r, a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(double[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(double[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1396,7 +1396,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Double64VectorTests::ADD);
     }
     static double add(double a, double b) {
         return (double)(a + b);
@@ -1414,7 +1414,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::add);
+        assertArraysEquals(r, a, b, Double64VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1434,7 +1434,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1452,7 +1452,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::add);
     }
     static double SUB(double a, double b) {
         return (double)(a - b);
@@ -1472,7 +1472,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Double64VectorTests::SUB);
     }
     static double sub(double a, double b) {
         return (double)(a - b);
@@ -1490,7 +1490,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::sub);
+        assertArraysEquals(r, a, b, Double64VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1510,7 +1510,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::SUB);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1528,7 +1528,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::sub);
     }
     static double MUL(double a, double b) {
         return (double)(a * b);
@@ -1548,7 +1548,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Double64VectorTests::MUL);
     }
     static double mul(double a, double b) {
         return (double)(a * b);
@@ -1566,7 +1566,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::mul);
+        assertArraysEquals(r, a, b, Double64VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1586,7 +1586,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::MUL);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1604,7 +1604,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::mul);
     }
 
     static double DIV(double a, double b) {
@@ -1625,7 +1625,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Double64VectorTests::DIV);
     }
     static double div(double a, double b) {
         return (double)(a / b);
@@ -1643,7 +1643,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::div);
+        assertArraysEquals(r, a, b, Double64VectorTests::div);
     }
 
 
@@ -1665,7 +1665,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::DIV);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1683,7 +1683,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::div);
     }
 
 
@@ -1706,7 +1706,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Double64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1726,7 +1726,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1748,7 +1748,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1765,7 +1765,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Double64VectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1779,7 +1779,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1796,7 +1796,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Double64VectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1810,7 +1810,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1827,7 +1827,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Double64VectorTests::mul);
     }
 
 
@@ -1842,7 +1842,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::div);
     }
 
 
@@ -1861,7 +1861,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Double64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Double64VectorTests::div);
     }
 
 
@@ -1884,7 +1884,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Double64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Double64VectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double64VectorTests::ADD);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Double64VectorTests::MIN);
     }
     static double min(double a, double b) {
         return (double)(Math.min(a, b));
@@ -1975,7 +1975,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::min);
+        assertArraysEquals(r, a, b, Double64VectorTests::min);
     }
     static double MAX(double a, double b) {
         return (double)(Math.max(a, b));
@@ -1995,7 +1995,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Double64VectorTests::MAX);
     }
     static double max(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2013,7 +2013,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::max);
+        assertArraysEquals(r, a, b, Double64VectorTests::max);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2027,7 +2027,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::MIN);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::min);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2055,7 +2055,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::MAX);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2069,7 +2069,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Double64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Double64VectorTests::max);
     }
 
 
@@ -2121,7 +2121,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double64VectorTests::ADDReduce, Double64VectorTests::ADDReduceAll);
     }
     static double ADDReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2165,7 +2165,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double64VectorTests::ADDReduceMasked, Double64VectorTests::ADDReduceAllMasked);
     }
     static double MULReduce(double[] a, int idx) {
@@ -2206,7 +2206,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double64VectorTests::MULReduce, Double64VectorTests::MULReduceAll);
     }
     static double MULReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2250,7 +2250,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double64VectorTests::MULReduceMasked, Double64VectorTests::MULReduceAllMasked);
     }
     static double MINReduce(double[] a, int idx) {
@@ -2291,7 +2291,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double64VectorTests::MINReduce, Double64VectorTests::MINReduceAll);
     }
     static double MINReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2336,7 +2336,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double64VectorTests::MINReduceMasked, Double64VectorTests::MINReduceAllMasked);
     }
     static double MAXReduce(double[] a, int idx) {
@@ -2377,7 +2377,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Double64VectorTests::MAXReduce, Double64VectorTests::MAXReduceAll);
     }
     static double MAXReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2422,7 +2422,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Double64VectorTests::MAXReduceMasked, Double64VectorTests::MAXReduceAllMasked);
     }
 
@@ -2442,7 +2442,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (double)4, 0);
+        assertInsertArraysEquals(r, a, (double)4, 0);
     }
     static boolean testIS_DEFAULT(double a) {
         return bits(a)==0;
@@ -3108,7 +3108,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::blend);
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleProvider")
@@ -3125,7 +3125,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleMaskProvider")
@@ -3143,7 +3143,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "doubleUnaryOpProvider")
     static void getDouble64VectorTests(IntFunction<double[]> fa) {
@@ -3298,7 +3298,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::get);
+        assertArraysEquals(r, a, Double64VectorTests::get);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -3312,7 +3312,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3359,7 +3359,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Double64VectorTests::sliceUnary);
     }
     static double[] sliceBinary(double[] a, double[] b, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3388,7 +3388,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Double64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Double64VectorTests::sliceBinary);
     }
     static double[] slice(double[] a, double[] b, int origin, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3421,7 +3421,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Double64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Double64VectorTests::slice);
     }
     static double[] unsliceUnary(double[] a, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3448,7 +3448,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Double64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Double64VectorTests::unsliceUnary);
     }
     static double[] unsliceBinary(double[] a, double[] b, int origin, int part, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3487,7 +3487,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Double64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Double64VectorTests::unsliceBinary);
     }
     static double[] unslice(double[] a, double[] b, int origin, int part, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3543,7 +3543,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Double64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Double64VectorTests::unslice);
     }
 
     static double SIN(double a) {
@@ -3566,7 +3566,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::SIN, Double64VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::SIN, Double64VectorTests::strictSIN);
     }
 
 
@@ -3590,7 +3590,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::EXP, Double64VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::EXP, Double64VectorTests::strictEXP);
     }
 
 
@@ -3614,7 +3614,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::LOG1P, Double64VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::LOG1P, Double64VectorTests::strictLOG1P);
     }
 
 
@@ -3638,7 +3638,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::LOG, Double64VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::LOG, Double64VectorTests::strictLOG);
     }
 
 
@@ -3662,7 +3662,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::LOG10, Double64VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::LOG10, Double64VectorTests::strictLOG10);
     }
 
 
@@ -3686,7 +3686,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::EXPM1, Double64VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::EXPM1, Double64VectorTests::strictEXPM1);
     }
 
 
@@ -3710,7 +3710,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::COS, Double64VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::COS, Double64VectorTests::strictCOS);
     }
 
 
@@ -3734,7 +3734,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::TAN, Double64VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::TAN, Double64VectorTests::strictTAN);
     }
 
 
@@ -3758,7 +3758,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::SINH, Double64VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::SINH, Double64VectorTests::strictSINH);
     }
 
 
@@ -3782,7 +3782,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::COSH, Double64VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::COSH, Double64VectorTests::strictCOSH);
     }
 
 
@@ -3806,7 +3806,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::TANH, Double64VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::TANH, Double64VectorTests::strictTANH);
     }
 
 
@@ -3830,7 +3830,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::ASIN, Double64VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::ASIN, Double64VectorTests::strictASIN);
     }
 
 
@@ -3854,7 +3854,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::ACOS, Double64VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::ACOS, Double64VectorTests::strictACOS);
     }
 
 
@@ -3878,7 +3878,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::ATAN, Double64VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::ATAN, Double64VectorTests::strictATAN);
     }
 
 
@@ -3902,7 +3902,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Double64VectorTests::CBRT, Double64VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Double64VectorTests::CBRT, Double64VectorTests::strictCBRT);
     }
 
 
@@ -3928,7 +3928,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::HYPOT, Double64VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::HYPOT, Double64VectorTests::strictHYPOT);
     }
 
 
@@ -3955,7 +3955,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::POW, Double64VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::POW, Double64VectorTests::strictPOW);
     }
 
     static double pow(double a, double b) {
@@ -3980,7 +3980,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::pow, Double64VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::pow, Double64VectorTests::strictpow);
     }
 
 
@@ -4007,7 +4007,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::ATAN2, Double64VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::ATAN2, Double64VectorTests::strictATAN2);
     }
 
 
@@ -4023,7 +4023,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::POW, Double64VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::POW, Double64VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -4037,7 +4037,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Double64VectorTests::pow, Double64VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Double64VectorTests::pow, Double64VectorTests::strictpow);
     }
 
 
@@ -4073,7 +4073,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Double64VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Double64VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble64VectorTests(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4096,7 +4096,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Double64VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Double64VectorTests::fma);
     }
 
 
@@ -4126,7 +4126,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Double64VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Double64VectorTests::FMA);
     }
 
 
@@ -4145,7 +4145,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             DoubleVector bv = DoubleVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Double64VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Double64VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpProvider")
@@ -4160,7 +4160,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             DoubleVector cv = DoubleVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Double64VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Double64VectorTests::FMA);
     }
 
 
@@ -4180,7 +4180,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Double64VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Double64VectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpMaskProvider")
@@ -4199,7 +4199,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Double64VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Double64VectorTests::FMA);
     }
 
 
@@ -4224,7 +4224,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double64VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double64VectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDouble64VectorTestsDoubleBroadcastSmokeTest(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4245,7 +4245,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Double64VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Double64VectorTests::fma);
     }
 
 
@@ -4271,7 +4271,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Double64VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Double64VectorTests::FMA);
     }
 
 
@@ -4297,7 +4297,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::NEG);
+        assertArraysEquals(r, a, Double64VectorTests::NEG);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4312,7 +4312,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::neg);
+        assertArraysEquals(r, a, Double64VectorTests::neg);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Double64VectorTests::NEG);
     }
 
     static double ABS(double a) {
@@ -4353,7 +4353,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::ABS);
+        assertArraysEquals(r, a, Double64VectorTests::ABS);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4368,7 +4368,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::abs);
+        assertArraysEquals(r, a, Double64VectorTests::abs);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4386,7 +4386,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Double64VectorTests::ABS);
     }
 
 
@@ -4418,7 +4418,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::SQRT);
+        assertArraysEquals(r, a, Double64VectorTests::SQRT);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4433,7 +4433,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Double64VectorTests::sqrt);
+        assertArraysEquals(r, a, Double64VectorTests::sqrt);
     }
 
 
@@ -4453,7 +4453,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Double64VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Double64VectorTests::SQRT);
     }
 
     static double[] gather(double a[], int ix, int[] b, int iy) {
@@ -4478,7 +4478,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::gather);
+        assertArraysEquals(r, a, b, Double64VectorTests::gather);
     }
     static double[] gatherMasked(double a[], int ix, boolean[] mask, int[] b, int iy) {
         double[] res = new double[SPECIES.length()];
@@ -4506,7 +4506,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::gatherMasked);
     }
 
     static double[] scatter(double a[], int ix, int[] b, int iy) {
@@ -4531,7 +4531,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Double64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Double64VectorTests::scatter);
     }
 
     static double[] scatterMasked(double r[], double a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4569,7 +4569,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Double64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Double64VectorTests::scatterMasked);
     }
 
 
@@ -4611,8 +4611,8 @@ public class Double64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4622,8 +4622,8 @@ public class Double64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4690,7 +4690,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Double64VectorTests::ADDReduceLong, Double64VectorTests::ADDReduceAllLong);
     }
 
@@ -4731,7 +4731,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Double64VectorTests::ADDReduceLongMasked, Double64VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4743,7 +4743,7 @@ public class Double64VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -4761,7 +4761,7 @@ public class Double64VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Double64VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Double64VectorTests::blend);
     }
 
 
@@ -4778,7 +4778,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpSelectFromMaskProvider")
@@ -4797,7 +4797,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4874,7 +4874,7 @@ public class Double64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Double64VectorTests::beq);
+        assertArraysEquals(r, a, b, Double64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -67,47 +67,25 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (double) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (double) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(double[] a, double[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (double) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -410,7 +388,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "doubleProviderForIOOBE")
@@ -481,7 +459,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new double[a.length];
@@ -492,7 +470,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleMaskProviderForIOOBE")
@@ -565,7 +543,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -589,7 +567,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -676,7 +654,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -691,7 +669,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -807,7 +785,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
@@ -888,7 +866,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -899,7 +877,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
@@ -976,7 +954,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -987,7 +965,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -73,7 +73,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double a);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FUnArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a[i]);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(double[] r, double[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double apply(double[] a);
     }
 
-    static void assertReductionArraysEquals(double[] a, double[] b, double c,
+    static void assertReductionArraysEquals(double[] r, double rc, double[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(double[] a, double[] b, double c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(double[] r, double rc, double[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -167,17 +167,17 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         long apply(double[] a);
     }
 
-    static void assertReductionLongArraysEquals(double[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, double[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -189,17 +189,17 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         long apply(double[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(double[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, double[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -207,37 +207,37 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(double[] a, double[] b, double element, int index) {
+    static void assertInsertArraysEquals(double[] r, double[] a, double element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -251,7 +251,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -265,7 +265,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(double[] a, double[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(double[] r, double[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -285,7 +285,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(double[] a, double[] r, double[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(double[] r, double[] a, double[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -305,7 +305,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[]a, double[]r) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -334,7 +334,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -345,7 +345,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -357,7 +357,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -369,11 +369,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -384,11 +384,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -402,11 +402,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -420,7 +420,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, FBinOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -434,11 +434,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(double[] a, double[] b, double[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(double[] r, double[] a, double[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -464,7 +464,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -475,11 +475,11 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -491,7 +491,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -504,7 +504,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,12 +517,12 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -538,12 +538,12 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,12 +574,12 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(double[] a, double[] b, double[] c, double[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(double[] r, double[] a, double[] b, double[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -618,7 +618,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -632,7 +632,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -646,7 +646,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(double[] a, double[] b, double[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(double[] r, double[] a, double[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -676,7 +676,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double apply(double[] a, int b);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, FBinArrayOp f) {
+    static void assertArraysEquals(double[] r, double[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -691,7 +691,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -718,7 +718,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] r, double[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -728,7 +728,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -739,7 +739,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(double[] a, int[] b, double[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -749,7 +749,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(r, a, i, mask, b, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -766,7 +766,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(double[] r, double[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -776,7 +776,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -786,7 +786,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -796,7 +796,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -807,7 +807,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -817,7 +817,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -828,7 +828,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -838,7 +838,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -850,7 +850,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         double[] apply(double[] a, double[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(double[] a, double[] b, double[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(double[] r, double[] a, double[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -860,7 +860,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             double[] ref = f.apply(a, b, origin, part, mask, i);
             double[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -902,7 +902,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(double[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -948,7 +948,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(double[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, double[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1401,7 +1401,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::ADD);
     }
     static double add(double a, double b) {
         return (double)(a + b);
@@ -1419,7 +1419,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::add);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1439,7 +1439,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1457,7 +1457,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::add);
     }
     static double SUB(double a, double b) {
         return (double)(a - b);
@@ -1477,7 +1477,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::SUB);
     }
     static double sub(double a, double b) {
         return (double)(a - b);
@@ -1495,7 +1495,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1515,7 +1515,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1533,7 +1533,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::sub);
     }
     static double MUL(double a, double b) {
         return (double)(a * b);
@@ -1553,7 +1553,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::MUL);
     }
     static double mul(double a, double b) {
         return (double)(a * b);
@@ -1571,7 +1571,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1591,7 +1591,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1609,7 +1609,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::mul);
     }
 
     static double DIV(double a, double b) {
@@ -1630,7 +1630,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::DIV);
     }
     static double div(double a, double b) {
         return (double)(a / b);
@@ -1648,7 +1648,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::div);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::div);
     }
 
 
@@ -1670,7 +1670,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1688,7 +1688,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::div);
     }
 
 
@@ -1711,7 +1711,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1731,7 +1731,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::FIRST_NONZERO);
     }
 
 
@@ -1753,7 +1753,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1770,7 +1770,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, DoubleMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, DoubleMaxVectorTests::add);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1784,7 +1784,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1801,7 +1801,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, DoubleMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, DoubleMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -1815,7 +1815,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1832,7 +1832,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, DoubleMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, DoubleMaxVectorTests::mul);
     }
 
 
@@ -1847,7 +1847,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::div);
     }
 
 
@@ -1866,7 +1866,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, DoubleMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, DoubleMaxVectorTests::div);
     }
 
 
@@ -1889,7 +1889,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, DoubleMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, DoubleMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -1906,7 +1906,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, DoubleMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, DoubleMaxVectorTests::ADD);
     }
 
 
@@ -1962,7 +1962,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::MIN);
     }
     static double min(double a, double b) {
         return (double)(Math.min(a, b));
@@ -1980,7 +1980,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::min);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::min);
     }
     static double MAX(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2000,7 +2000,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::MAX);
     }
     static double max(double a, double b) {
         return (double)(Math.max(a, b));
@@ -2018,7 +2018,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::max);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::max);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2032,7 +2032,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2046,7 +2046,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::min);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2060,7 +2060,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -2074,7 +2074,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, DoubleMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, DoubleMaxVectorTests::max);
     }
 
 
@@ -2126,7 +2126,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 DoubleMaxVectorTests::ADDReduce, DoubleMaxVectorTests::ADDReduceAll);
     }
     static double ADDReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2170,7 +2170,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 DoubleMaxVectorTests::ADDReduceMasked, DoubleMaxVectorTests::ADDReduceAllMasked);
     }
     static double MULReduce(double[] a, int idx) {
@@ -2211,7 +2211,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 DoubleMaxVectorTests::MULReduce, DoubleMaxVectorTests::MULReduceAll);
     }
     static double MULReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2255,7 +2255,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 DoubleMaxVectorTests::MULReduceMasked, DoubleMaxVectorTests::MULReduceAllMasked);
     }
     static double MINReduce(double[] a, int idx) {
@@ -2296,7 +2296,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 DoubleMaxVectorTests::MINReduce, DoubleMaxVectorTests::MINReduceAll);
     }
     static double MINReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2341,7 +2341,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 DoubleMaxVectorTests::MINReduceMasked, DoubleMaxVectorTests::MINReduceAllMasked);
     }
     static double MAXReduce(double[] a, int idx) {
@@ -2382,7 +2382,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 DoubleMaxVectorTests::MAXReduce, DoubleMaxVectorTests::MAXReduceAll);
     }
     static double MAXReduceMasked(double[] a, int idx, boolean[] mask) {
@@ -2427,7 +2427,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 DoubleMaxVectorTests::MAXReduceMasked, DoubleMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -2447,7 +2447,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (double)4, 0);
+        assertInsertArraysEquals(r, a, (double)4, 0);
     }
     static boolean testIS_DEFAULT(double a) {
         return bits(a)==0;
@@ -3113,7 +3113,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleProvider")
@@ -3130,7 +3130,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpShuffleMaskProvider")
@@ -3148,7 +3148,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "doubleUnaryOpProvider")
     static void getDoubleMaxVectorTests(IntFunction<double[]> fa) {
@@ -3303,7 +3303,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::get);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::get);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -3317,7 +3317,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3364,7 +3364,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, DoubleMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, DoubleMaxVectorTests::sliceUnary);
     }
     static double[] sliceBinary(double[] a, double[] b, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3393,7 +3393,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, DoubleMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, DoubleMaxVectorTests::sliceBinary);
     }
     static double[] slice(double[] a, double[] b, int origin, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3426,7 +3426,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, DoubleMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, DoubleMaxVectorTests::slice);
     }
     static double[] unsliceUnary(double[] a, int origin, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3453,7 +3453,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, DoubleMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, DoubleMaxVectorTests::unsliceUnary);
     }
     static double[] unsliceBinary(double[] a, double[] b, int origin, int part, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3492,7 +3492,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, DoubleMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, DoubleMaxVectorTests::unsliceBinary);
     }
     static double[] unslice(double[] a, double[] b, int origin, int part, boolean[] mask, int idx) {
         double[] res = new double[SPECIES.length()];
@@ -3548,7 +3548,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, DoubleMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, DoubleMaxVectorTests::unslice);
     }
 
     static double SIN(double a) {
@@ -3571,7 +3571,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::SIN, DoubleMaxVectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::SIN, DoubleMaxVectorTests::strictSIN);
     }
 
 
@@ -3595,7 +3595,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::EXP, DoubleMaxVectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::EXP, DoubleMaxVectorTests::strictEXP);
     }
 
 
@@ -3619,7 +3619,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::LOG1P, DoubleMaxVectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::LOG1P, DoubleMaxVectorTests::strictLOG1P);
     }
 
 
@@ -3643,7 +3643,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::LOG, DoubleMaxVectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::LOG, DoubleMaxVectorTests::strictLOG);
     }
 
 
@@ -3667,7 +3667,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::LOG10, DoubleMaxVectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::LOG10, DoubleMaxVectorTests::strictLOG10);
     }
 
 
@@ -3691,7 +3691,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::EXPM1, DoubleMaxVectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::EXPM1, DoubleMaxVectorTests::strictEXPM1);
     }
 
 
@@ -3715,7 +3715,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::COS, DoubleMaxVectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::COS, DoubleMaxVectorTests::strictCOS);
     }
 
 
@@ -3739,7 +3739,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::TAN, DoubleMaxVectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::TAN, DoubleMaxVectorTests::strictTAN);
     }
 
 
@@ -3763,7 +3763,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::SINH, DoubleMaxVectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::SINH, DoubleMaxVectorTests::strictSINH);
     }
 
 
@@ -3787,7 +3787,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::COSH, DoubleMaxVectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::COSH, DoubleMaxVectorTests::strictCOSH);
     }
 
 
@@ -3811,7 +3811,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::TANH, DoubleMaxVectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::TANH, DoubleMaxVectorTests::strictTANH);
     }
 
 
@@ -3835,7 +3835,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::ASIN, DoubleMaxVectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::ASIN, DoubleMaxVectorTests::strictASIN);
     }
 
 
@@ -3859,7 +3859,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::ACOS, DoubleMaxVectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::ACOS, DoubleMaxVectorTests::strictACOS);
     }
 
 
@@ -3883,7 +3883,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::ATAN, DoubleMaxVectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::ATAN, DoubleMaxVectorTests::strictATAN);
     }
 
 
@@ -3907,7 +3907,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, DoubleMaxVectorTests::CBRT, DoubleMaxVectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, DoubleMaxVectorTests::CBRT, DoubleMaxVectorTests::strictCBRT);
     }
 
 
@@ -3933,7 +3933,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::HYPOT, DoubleMaxVectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::HYPOT, DoubleMaxVectorTests::strictHYPOT);
     }
 
 
@@ -3960,7 +3960,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::POW, DoubleMaxVectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::POW, DoubleMaxVectorTests::strictPOW);
     }
 
     static double pow(double a, double b) {
@@ -3985,7 +3985,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::pow, DoubleMaxVectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::pow, DoubleMaxVectorTests::strictpow);
     }
 
 
@@ -4012,7 +4012,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::ATAN2, DoubleMaxVectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::ATAN2, DoubleMaxVectorTests::strictATAN2);
     }
 
 
@@ -4028,7 +4028,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::POW, DoubleMaxVectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::POW, DoubleMaxVectorTests::strictPOW);
     }
 
     @Test(dataProvider = "doubleBinaryOpProvider")
@@ -4042,7 +4042,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, DoubleMaxVectorTests::pow, DoubleMaxVectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, DoubleMaxVectorTests::pow, DoubleMaxVectorTests::strictpow);
     }
 
 
@@ -4078,7 +4078,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, DoubleMaxVectorTests::FMA);
+        assertArraysEquals(r, a, b, c, DoubleMaxVectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDoubleMaxVectorTests(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4101,7 +4101,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, DoubleMaxVectorTests::fma);
+        assertArraysEquals(r, a, b, c, DoubleMaxVectorTests::fma);
     }
 
 
@@ -4131,7 +4131,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, DoubleMaxVectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, DoubleMaxVectorTests::FMA);
     }
 
 
@@ -4150,7 +4150,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             DoubleVector bv = DoubleVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, DoubleMaxVectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, DoubleMaxVectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpProvider")
@@ -4165,7 +4165,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             DoubleVector cv = DoubleVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, DoubleMaxVectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, DoubleMaxVectorTests::FMA);
     }
 
 
@@ -4185,7 +4185,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, DoubleMaxVectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, DoubleMaxVectorTests::FMA);
     }
 
     @Test(dataProvider = "doubleTernaryOpMaskProvider")
@@ -4204,7 +4204,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, DoubleMaxVectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, DoubleMaxVectorTests::FMA);
     }
 
 
@@ -4229,7 +4229,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, DoubleMaxVectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, DoubleMaxVectorTests::FMA);
     }
     @Test(dataProvider = "doubleTernaryOpProvider")
     static void fmaDoubleMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<double[]> fa, IntFunction<double[]> fb, IntFunction<double[]> fc) {
@@ -4250,7 +4250,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, DoubleMaxVectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, DoubleMaxVectorTests::fma);
     }
 
 
@@ -4276,7 +4276,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, DoubleMaxVectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, DoubleMaxVectorTests::FMA);
     }
 
 
@@ -4302,7 +4302,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::NEG);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4317,7 +4317,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::neg);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4335,7 +4335,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, DoubleMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, DoubleMaxVectorTests::NEG);
     }
 
     static double ABS(double a) {
@@ -4358,7 +4358,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::ABS);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4373,7 +4373,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::abs);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "doubleUnaryOpMaskProvider")
@@ -4391,7 +4391,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, DoubleMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, DoubleMaxVectorTests::ABS);
     }
 
 
@@ -4423,7 +4423,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::SQRT);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::SQRT);
     }
 
     @Test(dataProvider = "doubleUnaryOpProvider")
@@ -4438,7 +4438,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, DoubleMaxVectorTests::sqrt);
+        assertArraysEquals(r, a, DoubleMaxVectorTests::sqrt);
     }
 
 
@@ -4458,7 +4458,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, DoubleMaxVectorTests::SQRT);
+        assertArraysEquals(r, a, mask, DoubleMaxVectorTests::SQRT);
     }
 
     static double[] gather(double a[], int ix, int[] b, int iy) {
@@ -4483,7 +4483,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::gather);
     }
     static double[] gatherMasked(double a[], int ix, boolean[] mask, int[] b, int iy) {
         double[] res = new double[SPECIES.length()];
@@ -4511,7 +4511,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::gatherMasked);
     }
 
     static double[] scatter(double a[], int ix, int[] b, int iy) {
@@ -4536,7 +4536,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::scatter);
     }
 
     static double[] scatterMasked(double r[], double a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4574,7 +4574,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, DoubleMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, DoubleMaxVectorTests::scatterMasked);
     }
 
 
@@ -4616,8 +4616,8 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4627,8 +4627,8 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector av = DoubleVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4695,7 +4695,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 DoubleMaxVectorTests::ADDReduceLong, DoubleMaxVectorTests::ADDReduceAllLong);
     }
 
@@ -4736,7 +4736,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 DoubleMaxVectorTests::ADDReduceLongMasked, DoubleMaxVectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4748,7 +4748,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             DoubleVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "doubleBinaryOpMaskProvider")
@@ -4766,7 +4766,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, DoubleMaxVectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, DoubleMaxVectorTests::blend);
     }
 
 
@@ -4783,7 +4783,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "doubleUnaryOpSelectFromMaskProvider")
@@ -4802,7 +4802,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4879,7 +4879,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, DoubleMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, DoubleMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(float[] a, float[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "floatProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new float[a.length];
@@ -483,7 +461,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -68,7 +68,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a[i]);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Float128VectorTests extends AbstractVectorTest {
         float apply(float[] a);
     }
 
-    static void assertReductionArraysEquals(float[] a, float[] b, float c,
+    static void assertReductionArraysEquals(float[] r, float rc, float[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Float128VectorTests extends AbstractVectorTest {
         float apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(float[] a, float[] b, float c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(float[] r, float rc, float[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Float128VectorTests extends AbstractVectorTest {
         long apply(float[] a);
     }
 
-    static void assertReductionLongArraysEquals(float[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, float[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Float128VectorTests extends AbstractVectorTest {
         long apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(float[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, float[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Float128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(float[] a, float[] b, float element, int index) {
+    static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[]a, float[]r) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float apply(float[] a, int b);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FBinArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] r, float[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(r, a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(float[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(float[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -954,7 +954,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1406,7 +1406,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Float128VectorTests::ADD);
     }
     static float add(float a, float b) {
         return (float)(a + b);
@@ -1424,7 +1424,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::add);
+        assertArraysEquals(r, a, b, Float128VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::add);
     }
     static float SUB(float a, float b) {
         return (float)(a - b);
@@ -1482,7 +1482,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Float128VectorTests::SUB);
     }
     static float sub(float a, float b) {
         return (float)(a - b);
@@ -1500,7 +1500,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::sub);
+        assertArraysEquals(r, a, b, Float128VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1520,7 +1520,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::SUB);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1538,7 +1538,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::sub);
     }
     static float MUL(float a, float b) {
         return (float)(a * b);
@@ -1558,7 +1558,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Float128VectorTests::MUL);
     }
     static float mul(float a, float b) {
         return (float)(a * b);
@@ -1576,7 +1576,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::mul);
+        assertArraysEquals(r, a, b, Float128VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::MUL);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1614,7 +1614,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::mul);
     }
 
     static float DIV(float a, float b) {
@@ -1635,7 +1635,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Float128VectorTests::DIV);
     }
     static float div(float a, float b) {
         return (float)(a / b);
@@ -1653,7 +1653,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::div);
+        assertArraysEquals(r, a, b, Float128VectorTests::div);
     }
 
 
@@ -1675,7 +1675,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::DIV);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1693,7 +1693,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::div);
     }
 
 
@@ -1716,7 +1716,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Float128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1736,7 +1736,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1758,7 +1758,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1775,7 +1775,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Float128VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1789,7 +1789,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1806,7 +1806,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Float128VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1820,7 +1820,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1837,7 +1837,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Float128VectorTests::mul);
     }
 
 
@@ -1852,7 +1852,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::div);
     }
 
 
@@ -1871,7 +1871,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Float128VectorTests::div);
     }
 
 
@@ -1894,7 +1894,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Float128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Float128VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1911,7 +1911,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float128VectorTests::ADD);
     }
 
 
@@ -1967,7 +1967,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Float128VectorTests::MIN);
     }
     static float min(float a, float b) {
         return (float)(Math.min(a, b));
@@ -1985,7 +1985,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::min);
+        assertArraysEquals(r, a, b, Float128VectorTests::min);
     }
     static float MAX(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2005,7 +2005,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Float128VectorTests::MAX);
     }
     static float max(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2023,7 +2023,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::max);
+        assertArraysEquals(r, a, b, Float128VectorTests::max);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2037,7 +2037,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::MIN);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2051,7 +2051,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::min);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2065,7 +2065,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::MAX);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2079,7 +2079,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Float128VectorTests::max);
     }
 
 
@@ -2131,7 +2131,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float128VectorTests::ADDReduce, Float128VectorTests::ADDReduceAll);
     }
     static float ADDReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2175,7 +2175,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float128VectorTests::ADDReduceMasked, Float128VectorTests::ADDReduceAllMasked);
     }
     static float MULReduce(float[] a, int idx) {
@@ -2216,7 +2216,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float128VectorTests::MULReduce, Float128VectorTests::MULReduceAll);
     }
     static float MULReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2260,7 +2260,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float128VectorTests::MULReduceMasked, Float128VectorTests::MULReduceAllMasked);
     }
     static float MINReduce(float[] a, int idx) {
@@ -2301,7 +2301,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float128VectorTests::MINReduce, Float128VectorTests::MINReduceAll);
     }
     static float MINReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2346,7 +2346,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float128VectorTests::MINReduceMasked, Float128VectorTests::MINReduceAllMasked);
     }
     static float MAXReduce(float[] a, int idx) {
@@ -2387,7 +2387,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float128VectorTests::MAXReduce, Float128VectorTests::MAXReduceAll);
     }
     static float MAXReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2432,7 +2432,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float128VectorTests::MAXReduceMasked, Float128VectorTests::MAXReduceAllMasked);
     }
 
@@ -2452,7 +2452,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (float)4, 0);
+        assertInsertArraysEquals(r, a, (float)4, 0);
     }
     static boolean testIS_DEFAULT(float a) {
         return bits(a)==0;
@@ -3118,7 +3118,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::blend);
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleProvider")
@@ -3135,7 +3135,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleMaskProvider")
@@ -3153,7 +3153,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "floatUnaryOpProvider")
     static void getFloat128VectorTests(IntFunction<float[]> fa) {
@@ -3308,7 +3308,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::get);
+        assertArraysEquals(r, a, Float128VectorTests::get);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -3322,7 +3322,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3369,7 +3369,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Float128VectorTests::sliceUnary);
     }
     static float[] sliceBinary(float[] a, float[] b, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3398,7 +3398,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Float128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Float128VectorTests::sliceBinary);
     }
     static float[] slice(float[] a, float[] b, int origin, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3431,7 +3431,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Float128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Float128VectorTests::slice);
     }
     static float[] unsliceUnary(float[] a, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3458,7 +3458,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Float128VectorTests::unsliceUnary);
     }
     static float[] unsliceBinary(float[] a, float[] b, int origin, int part, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3497,7 +3497,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Float128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Float128VectorTests::unsliceBinary);
     }
     static float[] unslice(float[] a, float[] b, int origin, int part, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3553,7 +3553,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Float128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Float128VectorTests::unslice);
     }
 
     static float SIN(float a) {
@@ -3576,7 +3576,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::SIN, Float128VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::SIN, Float128VectorTests::strictSIN);
     }
 
 
@@ -3600,7 +3600,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::EXP, Float128VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::EXP, Float128VectorTests::strictEXP);
     }
 
 
@@ -3624,7 +3624,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::LOG1P, Float128VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::LOG1P, Float128VectorTests::strictLOG1P);
     }
 
 
@@ -3648,7 +3648,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::LOG, Float128VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::LOG, Float128VectorTests::strictLOG);
     }
 
 
@@ -3672,7 +3672,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::LOG10, Float128VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::LOG10, Float128VectorTests::strictLOG10);
     }
 
 
@@ -3696,7 +3696,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::EXPM1, Float128VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::EXPM1, Float128VectorTests::strictEXPM1);
     }
 
 
@@ -3720,7 +3720,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::COS, Float128VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::COS, Float128VectorTests::strictCOS);
     }
 
 
@@ -3744,7 +3744,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::TAN, Float128VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::TAN, Float128VectorTests::strictTAN);
     }
 
 
@@ -3768,7 +3768,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::SINH, Float128VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::SINH, Float128VectorTests::strictSINH);
     }
 
 
@@ -3792,7 +3792,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::COSH, Float128VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::COSH, Float128VectorTests::strictCOSH);
     }
 
 
@@ -3816,7 +3816,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::TANH, Float128VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::TANH, Float128VectorTests::strictTANH);
     }
 
 
@@ -3840,7 +3840,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::ASIN, Float128VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::ASIN, Float128VectorTests::strictASIN);
     }
 
 
@@ -3864,7 +3864,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::ACOS, Float128VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::ACOS, Float128VectorTests::strictACOS);
     }
 
 
@@ -3888,7 +3888,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::ATAN, Float128VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::ATAN, Float128VectorTests::strictATAN);
     }
 
 
@@ -3912,7 +3912,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float128VectorTests::CBRT, Float128VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Float128VectorTests::CBRT, Float128VectorTests::strictCBRT);
     }
 
 
@@ -3938,7 +3938,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::HYPOT, Float128VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::HYPOT, Float128VectorTests::strictHYPOT);
     }
 
 
@@ -3965,7 +3965,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::POW, Float128VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::POW, Float128VectorTests::strictPOW);
     }
 
     static float pow(float a, float b) {
@@ -3990,7 +3990,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::pow, Float128VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::pow, Float128VectorTests::strictpow);
     }
 
 
@@ -4017,7 +4017,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::ATAN2, Float128VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::ATAN2, Float128VectorTests::strictATAN2);
     }
 
 
@@ -4033,7 +4033,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::POW, Float128VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::POW, Float128VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -4047,7 +4047,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float128VectorTests::pow, Float128VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float128VectorTests::pow, Float128VectorTests::strictpow);
     }
 
 
@@ -4076,7 +4076,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Float128VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Float128VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat128VectorTests(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4092,7 +4092,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Float128VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Float128VectorTests::fma);
     }
 
 
@@ -4115,7 +4115,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Float128VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Float128VectorTests::FMA);
     }
 
 
@@ -4134,7 +4134,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             FloatVector bv = FloatVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Float128VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Float128VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpProvider")
@@ -4149,7 +4149,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             FloatVector cv = FloatVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Float128VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Float128VectorTests::FMA);
     }
 
 
@@ -4169,7 +4169,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Float128VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Float128VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpMaskProvider")
@@ -4188,7 +4188,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Float128VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Float128VectorTests::FMA);
     }
 
 
@@ -4206,7 +4206,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float128VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float128VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat128VectorTestsDoubleBroadcastSmokeTest(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4220,7 +4220,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float128VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float128VectorTests::fma);
     }
 
 
@@ -4239,7 +4239,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Float128VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Float128VectorTests::FMA);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::NEG);
+        assertArraysEquals(r, a, Float128VectorTests::NEG);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4280,7 +4280,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::neg);
+        assertArraysEquals(r, a, Float128VectorTests::neg);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4298,7 +4298,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Float128VectorTests::NEG);
     }
 
     static float ABS(float a) {
@@ -4321,7 +4321,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::ABS);
+        assertArraysEquals(r, a, Float128VectorTests::ABS);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4336,7 +4336,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::abs);
+        assertArraysEquals(r, a, Float128VectorTests::abs);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4354,7 +4354,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Float128VectorTests::ABS);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::SQRT);
+        assertArraysEquals(r, a, Float128VectorTests::SQRT);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4401,7 +4401,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float128VectorTests::sqrt);
+        assertArraysEquals(r, a, Float128VectorTests::sqrt);
     }
 
 
@@ -4421,7 +4421,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float128VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Float128VectorTests::SQRT);
     }
 
     static float[] gather(float a[], int ix, int[] b, int iy) {
@@ -4446,7 +4446,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::gather);
+        assertArraysEquals(r, a, b, Float128VectorTests::gather);
     }
     static float[] gatherMasked(float a[], int ix, boolean[] mask, int[] b, int iy) {
         float[] res = new float[SPECIES.length()];
@@ -4474,7 +4474,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::gatherMasked);
     }
 
     static float[] scatter(float a[], int ix, int[] b, int iy) {
@@ -4499,7 +4499,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Float128VectorTests::scatter);
     }
 
     static float[] scatterMasked(float r[], float a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4537,7 +4537,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Float128VectorTests::scatterMasked);
     }
 
 
@@ -4579,8 +4579,8 @@ public class Float128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4590,8 +4590,8 @@ public class Float128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4601,8 +4601,8 @@ public class Float128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4668,7 +4668,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Float128VectorTests::ADDReduceLong, Float128VectorTests::ADDReduceAllLong);
     }
 
@@ -4709,7 +4709,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Float128VectorTests::ADDReduceLongMasked, Float128VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4721,7 +4721,7 @@ public class Float128VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -4739,7 +4739,7 @@ public class Float128VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float128VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float128VectorTests::blend);
     }
 
 
@@ -4756,7 +4756,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpSelectFromMaskProvider")
@@ -4775,7 +4775,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4852,7 +4852,7 @@ public class Float128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Float128VectorTests::beq);
+        assertArraysEquals(r, a, b, Float128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(float[] a, float[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "floatProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new float[a.length];
@@ -483,7 +461,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -68,7 +68,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a[i]);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Float256VectorTests extends AbstractVectorTest {
         float apply(float[] a);
     }
 
-    static void assertReductionArraysEquals(float[] a, float[] b, float c,
+    static void assertReductionArraysEquals(float[] r, float rc, float[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Float256VectorTests extends AbstractVectorTest {
         float apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(float[] a, float[] b, float c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(float[] r, float rc, float[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Float256VectorTests extends AbstractVectorTest {
         long apply(float[] a);
     }
 
-    static void assertReductionLongArraysEquals(float[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, float[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Float256VectorTests extends AbstractVectorTest {
         long apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(float[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, float[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Float256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(float[] a, float[] b, float element, int index) {
+    static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[]a, float[]r) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float apply(float[] a, int b);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FBinArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] r, float[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(r, a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(float[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(float[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -954,7 +954,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1406,7 +1406,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Float256VectorTests::ADD);
     }
     static float add(float a, float b) {
         return (float)(a + b);
@@ -1424,7 +1424,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::add);
+        assertArraysEquals(r, a, b, Float256VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::add);
     }
     static float SUB(float a, float b) {
         return (float)(a - b);
@@ -1482,7 +1482,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Float256VectorTests::SUB);
     }
     static float sub(float a, float b) {
         return (float)(a - b);
@@ -1500,7 +1500,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::sub);
+        assertArraysEquals(r, a, b, Float256VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1520,7 +1520,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::SUB);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1538,7 +1538,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::sub);
     }
     static float MUL(float a, float b) {
         return (float)(a * b);
@@ -1558,7 +1558,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Float256VectorTests::MUL);
     }
     static float mul(float a, float b) {
         return (float)(a * b);
@@ -1576,7 +1576,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::mul);
+        assertArraysEquals(r, a, b, Float256VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::MUL);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1614,7 +1614,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::mul);
     }
 
     static float DIV(float a, float b) {
@@ -1635,7 +1635,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Float256VectorTests::DIV);
     }
     static float div(float a, float b) {
         return (float)(a / b);
@@ -1653,7 +1653,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::div);
+        assertArraysEquals(r, a, b, Float256VectorTests::div);
     }
 
 
@@ -1675,7 +1675,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::DIV);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1693,7 +1693,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::div);
     }
 
 
@@ -1716,7 +1716,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Float256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1736,7 +1736,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1758,7 +1758,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1775,7 +1775,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Float256VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1789,7 +1789,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1806,7 +1806,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Float256VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1820,7 +1820,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1837,7 +1837,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Float256VectorTests::mul);
     }
 
 
@@ -1852,7 +1852,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::div);
     }
 
 
@@ -1871,7 +1871,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Float256VectorTests::div);
     }
 
 
@@ -1894,7 +1894,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Float256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Float256VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1911,7 +1911,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float256VectorTests::ADD);
     }
 
 
@@ -1967,7 +1967,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Float256VectorTests::MIN);
     }
     static float min(float a, float b) {
         return (float)(Math.min(a, b));
@@ -1985,7 +1985,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::min);
+        assertArraysEquals(r, a, b, Float256VectorTests::min);
     }
     static float MAX(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2005,7 +2005,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Float256VectorTests::MAX);
     }
     static float max(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2023,7 +2023,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::max);
+        assertArraysEquals(r, a, b, Float256VectorTests::max);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2037,7 +2037,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::MIN);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2051,7 +2051,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::min);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2065,7 +2065,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::MAX);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2079,7 +2079,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Float256VectorTests::max);
     }
 
 
@@ -2131,7 +2131,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float256VectorTests::ADDReduce, Float256VectorTests::ADDReduceAll);
     }
     static float ADDReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2175,7 +2175,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float256VectorTests::ADDReduceMasked, Float256VectorTests::ADDReduceAllMasked);
     }
     static float MULReduce(float[] a, int idx) {
@@ -2216,7 +2216,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float256VectorTests::MULReduce, Float256VectorTests::MULReduceAll);
     }
     static float MULReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2260,7 +2260,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float256VectorTests::MULReduceMasked, Float256VectorTests::MULReduceAllMasked);
     }
     static float MINReduce(float[] a, int idx) {
@@ -2301,7 +2301,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float256VectorTests::MINReduce, Float256VectorTests::MINReduceAll);
     }
     static float MINReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2346,7 +2346,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float256VectorTests::MINReduceMasked, Float256VectorTests::MINReduceAllMasked);
     }
     static float MAXReduce(float[] a, int idx) {
@@ -2387,7 +2387,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float256VectorTests::MAXReduce, Float256VectorTests::MAXReduceAll);
     }
     static float MAXReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2432,7 +2432,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float256VectorTests::MAXReduceMasked, Float256VectorTests::MAXReduceAllMasked);
     }
 
@@ -2452,7 +2452,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (float)4, 0);
+        assertInsertArraysEquals(r, a, (float)4, 0);
     }
     static boolean testIS_DEFAULT(float a) {
         return bits(a)==0;
@@ -3118,7 +3118,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::blend);
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleProvider")
@@ -3135,7 +3135,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleMaskProvider")
@@ -3153,7 +3153,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "floatUnaryOpProvider")
     static void getFloat256VectorTests(IntFunction<float[]> fa) {
@@ -3308,7 +3308,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::get);
+        assertArraysEquals(r, a, Float256VectorTests::get);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -3322,7 +3322,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3369,7 +3369,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Float256VectorTests::sliceUnary);
     }
     static float[] sliceBinary(float[] a, float[] b, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3398,7 +3398,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Float256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Float256VectorTests::sliceBinary);
     }
     static float[] slice(float[] a, float[] b, int origin, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3431,7 +3431,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Float256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Float256VectorTests::slice);
     }
     static float[] unsliceUnary(float[] a, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3458,7 +3458,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Float256VectorTests::unsliceUnary);
     }
     static float[] unsliceBinary(float[] a, float[] b, int origin, int part, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3497,7 +3497,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Float256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Float256VectorTests::unsliceBinary);
     }
     static float[] unslice(float[] a, float[] b, int origin, int part, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3553,7 +3553,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Float256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Float256VectorTests::unslice);
     }
 
     static float SIN(float a) {
@@ -3576,7 +3576,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::SIN, Float256VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::SIN, Float256VectorTests::strictSIN);
     }
 
 
@@ -3600,7 +3600,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::EXP, Float256VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::EXP, Float256VectorTests::strictEXP);
     }
 
 
@@ -3624,7 +3624,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::LOG1P, Float256VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::LOG1P, Float256VectorTests::strictLOG1P);
     }
 
 
@@ -3648,7 +3648,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::LOG, Float256VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::LOG, Float256VectorTests::strictLOG);
     }
 
 
@@ -3672,7 +3672,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::LOG10, Float256VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::LOG10, Float256VectorTests::strictLOG10);
     }
 
 
@@ -3696,7 +3696,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::EXPM1, Float256VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::EXPM1, Float256VectorTests::strictEXPM1);
     }
 
 
@@ -3720,7 +3720,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::COS, Float256VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::COS, Float256VectorTests::strictCOS);
     }
 
 
@@ -3744,7 +3744,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::TAN, Float256VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::TAN, Float256VectorTests::strictTAN);
     }
 
 
@@ -3768,7 +3768,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::SINH, Float256VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::SINH, Float256VectorTests::strictSINH);
     }
 
 
@@ -3792,7 +3792,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::COSH, Float256VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::COSH, Float256VectorTests::strictCOSH);
     }
 
 
@@ -3816,7 +3816,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::TANH, Float256VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::TANH, Float256VectorTests::strictTANH);
     }
 
 
@@ -3840,7 +3840,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::ASIN, Float256VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::ASIN, Float256VectorTests::strictASIN);
     }
 
 
@@ -3864,7 +3864,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::ACOS, Float256VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::ACOS, Float256VectorTests::strictACOS);
     }
 
 
@@ -3888,7 +3888,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::ATAN, Float256VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::ATAN, Float256VectorTests::strictATAN);
     }
 
 
@@ -3912,7 +3912,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float256VectorTests::CBRT, Float256VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Float256VectorTests::CBRT, Float256VectorTests::strictCBRT);
     }
 
 
@@ -3938,7 +3938,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::HYPOT, Float256VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::HYPOT, Float256VectorTests::strictHYPOT);
     }
 
 
@@ -3965,7 +3965,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::POW, Float256VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::POW, Float256VectorTests::strictPOW);
     }
 
     static float pow(float a, float b) {
@@ -3990,7 +3990,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::pow, Float256VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::pow, Float256VectorTests::strictpow);
     }
 
 
@@ -4017,7 +4017,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::ATAN2, Float256VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::ATAN2, Float256VectorTests::strictATAN2);
     }
 
 
@@ -4033,7 +4033,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::POW, Float256VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::POW, Float256VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -4047,7 +4047,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float256VectorTests::pow, Float256VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float256VectorTests::pow, Float256VectorTests::strictpow);
     }
 
 
@@ -4076,7 +4076,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Float256VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Float256VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat256VectorTests(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4092,7 +4092,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Float256VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Float256VectorTests::fma);
     }
 
 
@@ -4115,7 +4115,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Float256VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Float256VectorTests::FMA);
     }
 
 
@@ -4134,7 +4134,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             FloatVector bv = FloatVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Float256VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Float256VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpProvider")
@@ -4149,7 +4149,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             FloatVector cv = FloatVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Float256VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Float256VectorTests::FMA);
     }
 
 
@@ -4169,7 +4169,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Float256VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Float256VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpMaskProvider")
@@ -4188,7 +4188,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Float256VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Float256VectorTests::FMA);
     }
 
 
@@ -4206,7 +4206,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float256VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float256VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat256VectorTestsDoubleBroadcastSmokeTest(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4220,7 +4220,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float256VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float256VectorTests::fma);
     }
 
 
@@ -4239,7 +4239,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Float256VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Float256VectorTests::FMA);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::NEG);
+        assertArraysEquals(r, a, Float256VectorTests::NEG);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4280,7 +4280,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::neg);
+        assertArraysEquals(r, a, Float256VectorTests::neg);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4298,7 +4298,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Float256VectorTests::NEG);
     }
 
     static float ABS(float a) {
@@ -4321,7 +4321,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::ABS);
+        assertArraysEquals(r, a, Float256VectorTests::ABS);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4336,7 +4336,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::abs);
+        assertArraysEquals(r, a, Float256VectorTests::abs);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4354,7 +4354,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Float256VectorTests::ABS);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::SQRT);
+        assertArraysEquals(r, a, Float256VectorTests::SQRT);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4401,7 +4401,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float256VectorTests::sqrt);
+        assertArraysEquals(r, a, Float256VectorTests::sqrt);
     }
 
 
@@ -4421,7 +4421,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float256VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Float256VectorTests::SQRT);
     }
 
     static float[] gather(float a[], int ix, int[] b, int iy) {
@@ -4446,7 +4446,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::gather);
+        assertArraysEquals(r, a, b, Float256VectorTests::gather);
     }
     static float[] gatherMasked(float a[], int ix, boolean[] mask, int[] b, int iy) {
         float[] res = new float[SPECIES.length()];
@@ -4474,7 +4474,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::gatherMasked);
     }
 
     static float[] scatter(float a[], int ix, int[] b, int iy) {
@@ -4499,7 +4499,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Float256VectorTests::scatter);
     }
 
     static float[] scatterMasked(float r[], float a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4537,7 +4537,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Float256VectorTests::scatterMasked);
     }
 
 
@@ -4579,8 +4579,8 @@ public class Float256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4590,8 +4590,8 @@ public class Float256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4601,8 +4601,8 @@ public class Float256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4668,7 +4668,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Float256VectorTests::ADDReduceLong, Float256VectorTests::ADDReduceAllLong);
     }
 
@@ -4709,7 +4709,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Float256VectorTests::ADDReduceLongMasked, Float256VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4721,7 +4721,7 @@ public class Float256VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -4739,7 +4739,7 @@ public class Float256VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float256VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float256VectorTests::blend);
     }
 
 
@@ -4756,7 +4756,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpSelectFromMaskProvider")
@@ -4775,7 +4775,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4852,7 +4852,7 @@ public class Float256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Float256VectorTests::beq);
+        assertArraysEquals(r, a, b, Float256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(float[] a, float[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "floatProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new float[a.length];
@@ -483,7 +461,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -68,7 +68,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a[i]);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Float512VectorTests extends AbstractVectorTest {
         float apply(float[] a);
     }
 
-    static void assertReductionArraysEquals(float[] a, float[] b, float c,
+    static void assertReductionArraysEquals(float[] r, float rc, float[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Float512VectorTests extends AbstractVectorTest {
         float apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(float[] a, float[] b, float c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(float[] r, float rc, float[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Float512VectorTests extends AbstractVectorTest {
         long apply(float[] a);
     }
 
-    static void assertReductionLongArraysEquals(float[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, float[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Float512VectorTests extends AbstractVectorTest {
         long apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(float[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, float[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Float512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(float[] a, float[] b, float element, int index) {
+    static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[]a, float[]r) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float apply(float[] a, int b);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FBinArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] r, float[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(r, a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(float[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(float[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -954,7 +954,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1406,7 +1406,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Float512VectorTests::ADD);
     }
     static float add(float a, float b) {
         return (float)(a + b);
@@ -1424,7 +1424,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::add);
+        assertArraysEquals(r, a, b, Float512VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::add);
     }
     static float SUB(float a, float b) {
         return (float)(a - b);
@@ -1482,7 +1482,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Float512VectorTests::SUB);
     }
     static float sub(float a, float b) {
         return (float)(a - b);
@@ -1500,7 +1500,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::sub);
+        assertArraysEquals(r, a, b, Float512VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1520,7 +1520,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::SUB);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1538,7 +1538,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::sub);
     }
     static float MUL(float a, float b) {
         return (float)(a * b);
@@ -1558,7 +1558,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Float512VectorTests::MUL);
     }
     static float mul(float a, float b) {
         return (float)(a * b);
@@ -1576,7 +1576,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::mul);
+        assertArraysEquals(r, a, b, Float512VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::MUL);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1614,7 +1614,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::mul);
     }
 
     static float DIV(float a, float b) {
@@ -1635,7 +1635,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Float512VectorTests::DIV);
     }
     static float div(float a, float b) {
         return (float)(a / b);
@@ -1653,7 +1653,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::div);
+        assertArraysEquals(r, a, b, Float512VectorTests::div);
     }
 
 
@@ -1675,7 +1675,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::DIV);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1693,7 +1693,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::div);
     }
 
 
@@ -1716,7 +1716,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Float512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1736,7 +1736,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1758,7 +1758,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1775,7 +1775,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Float512VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1789,7 +1789,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1806,7 +1806,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Float512VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1820,7 +1820,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1837,7 +1837,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Float512VectorTests::mul);
     }
 
 
@@ -1852,7 +1852,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::div);
     }
 
 
@@ -1871,7 +1871,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Float512VectorTests::div);
     }
 
 
@@ -1894,7 +1894,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Float512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Float512VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1911,7 +1911,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float512VectorTests::ADD);
     }
 
 
@@ -1967,7 +1967,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Float512VectorTests::MIN);
     }
     static float min(float a, float b) {
         return (float)(Math.min(a, b));
@@ -1985,7 +1985,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::min);
+        assertArraysEquals(r, a, b, Float512VectorTests::min);
     }
     static float MAX(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2005,7 +2005,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Float512VectorTests::MAX);
     }
     static float max(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2023,7 +2023,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::max);
+        assertArraysEquals(r, a, b, Float512VectorTests::max);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2037,7 +2037,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::MIN);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2051,7 +2051,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::min);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2065,7 +2065,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::MAX);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2079,7 +2079,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Float512VectorTests::max);
     }
 
 
@@ -2131,7 +2131,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float512VectorTests::ADDReduce, Float512VectorTests::ADDReduceAll);
     }
     static float ADDReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2175,7 +2175,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float512VectorTests::ADDReduceMasked, Float512VectorTests::ADDReduceAllMasked);
     }
     static float MULReduce(float[] a, int idx) {
@@ -2216,7 +2216,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float512VectorTests::MULReduce, Float512VectorTests::MULReduceAll);
     }
     static float MULReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2260,7 +2260,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float512VectorTests::MULReduceMasked, Float512VectorTests::MULReduceAllMasked);
     }
     static float MINReduce(float[] a, int idx) {
@@ -2301,7 +2301,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float512VectorTests::MINReduce, Float512VectorTests::MINReduceAll);
     }
     static float MINReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2346,7 +2346,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float512VectorTests::MINReduceMasked, Float512VectorTests::MINReduceAllMasked);
     }
     static float MAXReduce(float[] a, int idx) {
@@ -2387,7 +2387,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float512VectorTests::MAXReduce, Float512VectorTests::MAXReduceAll);
     }
     static float MAXReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2432,7 +2432,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float512VectorTests::MAXReduceMasked, Float512VectorTests::MAXReduceAllMasked);
     }
 
@@ -2452,7 +2452,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (float)4, 0);
+        assertInsertArraysEquals(r, a, (float)4, 0);
     }
     static boolean testIS_DEFAULT(float a) {
         return bits(a)==0;
@@ -3118,7 +3118,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::blend);
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleProvider")
@@ -3135,7 +3135,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleMaskProvider")
@@ -3153,7 +3153,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "floatUnaryOpProvider")
     static void getFloat512VectorTests(IntFunction<float[]> fa) {
@@ -3308,7 +3308,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::get);
+        assertArraysEquals(r, a, Float512VectorTests::get);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -3322,7 +3322,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3369,7 +3369,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Float512VectorTests::sliceUnary);
     }
     static float[] sliceBinary(float[] a, float[] b, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3398,7 +3398,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Float512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Float512VectorTests::sliceBinary);
     }
     static float[] slice(float[] a, float[] b, int origin, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3431,7 +3431,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Float512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Float512VectorTests::slice);
     }
     static float[] unsliceUnary(float[] a, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3458,7 +3458,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Float512VectorTests::unsliceUnary);
     }
     static float[] unsliceBinary(float[] a, float[] b, int origin, int part, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3497,7 +3497,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Float512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Float512VectorTests::unsliceBinary);
     }
     static float[] unslice(float[] a, float[] b, int origin, int part, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3553,7 +3553,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Float512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Float512VectorTests::unslice);
     }
 
     static float SIN(float a) {
@@ -3576,7 +3576,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::SIN, Float512VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::SIN, Float512VectorTests::strictSIN);
     }
 
 
@@ -3600,7 +3600,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::EXP, Float512VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::EXP, Float512VectorTests::strictEXP);
     }
 
 
@@ -3624,7 +3624,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::LOG1P, Float512VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::LOG1P, Float512VectorTests::strictLOG1P);
     }
 
 
@@ -3648,7 +3648,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::LOG, Float512VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::LOG, Float512VectorTests::strictLOG);
     }
 
 
@@ -3672,7 +3672,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::LOG10, Float512VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::LOG10, Float512VectorTests::strictLOG10);
     }
 
 
@@ -3696,7 +3696,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::EXPM1, Float512VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::EXPM1, Float512VectorTests::strictEXPM1);
     }
 
 
@@ -3720,7 +3720,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::COS, Float512VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::COS, Float512VectorTests::strictCOS);
     }
 
 
@@ -3744,7 +3744,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::TAN, Float512VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::TAN, Float512VectorTests::strictTAN);
     }
 
 
@@ -3768,7 +3768,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::SINH, Float512VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::SINH, Float512VectorTests::strictSINH);
     }
 
 
@@ -3792,7 +3792,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::COSH, Float512VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::COSH, Float512VectorTests::strictCOSH);
     }
 
 
@@ -3816,7 +3816,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::TANH, Float512VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::TANH, Float512VectorTests::strictTANH);
     }
 
 
@@ -3840,7 +3840,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::ASIN, Float512VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::ASIN, Float512VectorTests::strictASIN);
     }
 
 
@@ -3864,7 +3864,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::ACOS, Float512VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::ACOS, Float512VectorTests::strictACOS);
     }
 
 
@@ -3888,7 +3888,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::ATAN, Float512VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::ATAN, Float512VectorTests::strictATAN);
     }
 
 
@@ -3912,7 +3912,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float512VectorTests::CBRT, Float512VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Float512VectorTests::CBRT, Float512VectorTests::strictCBRT);
     }
 
 
@@ -3938,7 +3938,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::HYPOT, Float512VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::HYPOT, Float512VectorTests::strictHYPOT);
     }
 
 
@@ -3965,7 +3965,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::POW, Float512VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::POW, Float512VectorTests::strictPOW);
     }
 
     static float pow(float a, float b) {
@@ -3990,7 +3990,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::pow, Float512VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::pow, Float512VectorTests::strictpow);
     }
 
 
@@ -4017,7 +4017,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::ATAN2, Float512VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::ATAN2, Float512VectorTests::strictATAN2);
     }
 
 
@@ -4033,7 +4033,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::POW, Float512VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::POW, Float512VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -4047,7 +4047,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float512VectorTests::pow, Float512VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float512VectorTests::pow, Float512VectorTests::strictpow);
     }
 
 
@@ -4076,7 +4076,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Float512VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Float512VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat512VectorTests(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4092,7 +4092,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Float512VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Float512VectorTests::fma);
     }
 
 
@@ -4115,7 +4115,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Float512VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Float512VectorTests::FMA);
     }
 
 
@@ -4134,7 +4134,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             FloatVector bv = FloatVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Float512VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Float512VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpProvider")
@@ -4149,7 +4149,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             FloatVector cv = FloatVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Float512VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Float512VectorTests::FMA);
     }
 
 
@@ -4169,7 +4169,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Float512VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Float512VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpMaskProvider")
@@ -4188,7 +4188,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Float512VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Float512VectorTests::FMA);
     }
 
 
@@ -4206,7 +4206,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float512VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float512VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat512VectorTestsDoubleBroadcastSmokeTest(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4220,7 +4220,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float512VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float512VectorTests::fma);
     }
 
 
@@ -4239,7 +4239,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Float512VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Float512VectorTests::FMA);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::NEG);
+        assertArraysEquals(r, a, Float512VectorTests::NEG);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4280,7 +4280,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::neg);
+        assertArraysEquals(r, a, Float512VectorTests::neg);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4298,7 +4298,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Float512VectorTests::NEG);
     }
 
     static float ABS(float a) {
@@ -4321,7 +4321,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::ABS);
+        assertArraysEquals(r, a, Float512VectorTests::ABS);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4336,7 +4336,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::abs);
+        assertArraysEquals(r, a, Float512VectorTests::abs);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4354,7 +4354,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Float512VectorTests::ABS);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::SQRT);
+        assertArraysEquals(r, a, Float512VectorTests::SQRT);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4401,7 +4401,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float512VectorTests::sqrt);
+        assertArraysEquals(r, a, Float512VectorTests::sqrt);
     }
 
 
@@ -4421,7 +4421,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float512VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Float512VectorTests::SQRT);
     }
 
     static float[] gather(float a[], int ix, int[] b, int iy) {
@@ -4446,7 +4446,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::gather);
+        assertArraysEquals(r, a, b, Float512VectorTests::gather);
     }
     static float[] gatherMasked(float a[], int ix, boolean[] mask, int[] b, int iy) {
         float[] res = new float[SPECIES.length()];
@@ -4474,7 +4474,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::gatherMasked);
     }
 
     static float[] scatter(float a[], int ix, int[] b, int iy) {
@@ -4499,7 +4499,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Float512VectorTests::scatter);
     }
 
     static float[] scatterMasked(float r[], float a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4537,7 +4537,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Float512VectorTests::scatterMasked);
     }
 
 
@@ -4579,8 +4579,8 @@ public class Float512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4590,8 +4590,8 @@ public class Float512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4601,8 +4601,8 @@ public class Float512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4668,7 +4668,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Float512VectorTests::ADDReduceLong, Float512VectorTests::ADDReduceAllLong);
     }
 
@@ -4709,7 +4709,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Float512VectorTests::ADDReduceLongMasked, Float512VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4721,7 +4721,7 @@ public class Float512VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -4739,7 +4739,7 @@ public class Float512VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float512VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float512VectorTests::blend);
     }
 
 
@@ -4756,7 +4756,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpSelectFromMaskProvider")
@@ -4775,7 +4775,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4852,7 +4852,7 @@ public class Float512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Float512VectorTests::beq);
+        assertArraysEquals(r, a, b, Float512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(float[] a, float[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "floatProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new float[a.length];
@@ -483,7 +461,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -68,7 +68,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a[i]);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Float64VectorTests extends AbstractVectorTest {
         float apply(float[] a);
     }
 
-    static void assertReductionArraysEquals(float[] a, float[] b, float c,
+    static void assertReductionArraysEquals(float[] r, float rc, float[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Float64VectorTests extends AbstractVectorTest {
         float apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(float[] a, float[] b, float c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(float[] r, float rc, float[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Float64VectorTests extends AbstractVectorTest {
         long apply(float[] a);
     }
 
-    static void assertReductionLongArraysEquals(float[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, float[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Float64VectorTests extends AbstractVectorTest {
         long apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(float[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, float[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Float64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(float[] a, float[] b, float element, int index) {
+    static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[]a, float[]r) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -613,7 +613,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -627,7 +627,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -641,7 +641,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -671,7 +671,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float apply(float[] a, int b);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FBinArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -686,7 +686,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -713,7 +713,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] r, float[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -723,7 +723,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -734,7 +734,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -744,7 +744,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(r, a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -761,7 +761,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -771,7 +771,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -781,7 +781,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -791,7 +791,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -802,7 +802,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -812,7 +812,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -823,7 +823,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -833,7 +833,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -845,7 +845,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -855,7 +855,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -897,7 +897,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(float[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -943,7 +943,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(float[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -954,7 +954,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1406,7 +1406,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Float64VectorTests::ADD);
     }
     static float add(float a, float b) {
         return (float)(a + b);
@@ -1424,7 +1424,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::add);
+        assertArraysEquals(r, a, b, Float64VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::add);
     }
     static float SUB(float a, float b) {
         return (float)(a - b);
@@ -1482,7 +1482,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Float64VectorTests::SUB);
     }
     static float sub(float a, float b) {
         return (float)(a - b);
@@ -1500,7 +1500,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::sub);
+        assertArraysEquals(r, a, b, Float64VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1520,7 +1520,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::SUB);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1538,7 +1538,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::sub);
     }
     static float MUL(float a, float b) {
         return (float)(a * b);
@@ -1558,7 +1558,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Float64VectorTests::MUL);
     }
     static float mul(float a, float b) {
         return (float)(a * b);
@@ -1576,7 +1576,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::mul);
+        assertArraysEquals(r, a, b, Float64VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::MUL);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1614,7 +1614,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::mul);
     }
 
     static float DIV(float a, float b) {
@@ -1635,7 +1635,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Float64VectorTests::DIV);
     }
     static float div(float a, float b) {
         return (float)(a / b);
@@ -1653,7 +1653,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::div);
+        assertArraysEquals(r, a, b, Float64VectorTests::div);
     }
 
 
@@ -1675,7 +1675,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::DIV);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1693,7 +1693,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::div);
     }
 
 
@@ -1716,7 +1716,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Float64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1736,7 +1736,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::FIRST_NONZERO);
     }
 
 
@@ -1758,7 +1758,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1775,7 +1775,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Float64VectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1789,7 +1789,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1806,7 +1806,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Float64VectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1820,7 +1820,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1837,7 +1837,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Float64VectorTests::mul);
     }
 
 
@@ -1852,7 +1852,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::div);
     }
 
 
@@ -1871,7 +1871,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Float64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Float64VectorTests::div);
     }
 
 
@@ -1894,7 +1894,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Float64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Float64VectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1911,7 +1911,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float64VectorTests::ADD);
     }
 
 
@@ -1967,7 +1967,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Float64VectorTests::MIN);
     }
     static float min(float a, float b) {
         return (float)(Math.min(a, b));
@@ -1985,7 +1985,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::min);
+        assertArraysEquals(r, a, b, Float64VectorTests::min);
     }
     static float MAX(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2005,7 +2005,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Float64VectorTests::MAX);
     }
     static float max(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2023,7 +2023,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::max);
+        assertArraysEquals(r, a, b, Float64VectorTests::max);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2037,7 +2037,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::MIN);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2051,7 +2051,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::min);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2065,7 +2065,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::MAX);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2079,7 +2079,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Float64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Float64VectorTests::max);
     }
 
 
@@ -2131,7 +2131,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float64VectorTests::ADDReduce, Float64VectorTests::ADDReduceAll);
     }
     static float ADDReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2175,7 +2175,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float64VectorTests::ADDReduceMasked, Float64VectorTests::ADDReduceAllMasked);
     }
     static float MULReduce(float[] a, int idx) {
@@ -2216,7 +2216,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float64VectorTests::MULReduce, Float64VectorTests::MULReduceAll);
     }
     static float MULReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2260,7 +2260,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float64VectorTests::MULReduceMasked, Float64VectorTests::MULReduceAllMasked);
     }
     static float MINReduce(float[] a, int idx) {
@@ -2301,7 +2301,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float64VectorTests::MINReduce, Float64VectorTests::MINReduceAll);
     }
     static float MINReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2346,7 +2346,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float64VectorTests::MINReduceMasked, Float64VectorTests::MINReduceAllMasked);
     }
     static float MAXReduce(float[] a, int idx) {
@@ -2387,7 +2387,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Float64VectorTests::MAXReduce, Float64VectorTests::MAXReduceAll);
     }
     static float MAXReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2432,7 +2432,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Float64VectorTests::MAXReduceMasked, Float64VectorTests::MAXReduceAllMasked);
     }
 
@@ -2452,7 +2452,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (float)4, 0);
+        assertInsertArraysEquals(r, a, (float)4, 0);
     }
     static boolean testIS_DEFAULT(float a) {
         return bits(a)==0;
@@ -3118,7 +3118,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::blend);
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleProvider")
@@ -3135,7 +3135,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleMaskProvider")
@@ -3153,7 +3153,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "floatUnaryOpProvider")
     static void getFloat64VectorTests(IntFunction<float[]> fa) {
@@ -3308,7 +3308,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::get);
+        assertArraysEquals(r, a, Float64VectorTests::get);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -3322,7 +3322,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3369,7 +3369,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Float64VectorTests::sliceUnary);
     }
     static float[] sliceBinary(float[] a, float[] b, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3398,7 +3398,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Float64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Float64VectorTests::sliceBinary);
     }
     static float[] slice(float[] a, float[] b, int origin, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3431,7 +3431,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Float64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Float64VectorTests::slice);
     }
     static float[] unsliceUnary(float[] a, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3458,7 +3458,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Float64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Float64VectorTests::unsliceUnary);
     }
     static float[] unsliceBinary(float[] a, float[] b, int origin, int part, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3497,7 +3497,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Float64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Float64VectorTests::unsliceBinary);
     }
     static float[] unslice(float[] a, float[] b, int origin, int part, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3553,7 +3553,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Float64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Float64VectorTests::unslice);
     }
 
     static float SIN(float a) {
@@ -3576,7 +3576,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::SIN, Float64VectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::SIN, Float64VectorTests::strictSIN);
     }
 
 
@@ -3600,7 +3600,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::EXP, Float64VectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::EXP, Float64VectorTests::strictEXP);
     }
 
 
@@ -3624,7 +3624,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::LOG1P, Float64VectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::LOG1P, Float64VectorTests::strictLOG1P);
     }
 
 
@@ -3648,7 +3648,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::LOG, Float64VectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::LOG, Float64VectorTests::strictLOG);
     }
 
 
@@ -3672,7 +3672,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::LOG10, Float64VectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::LOG10, Float64VectorTests::strictLOG10);
     }
 
 
@@ -3696,7 +3696,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::EXPM1, Float64VectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::EXPM1, Float64VectorTests::strictEXPM1);
     }
 
 
@@ -3720,7 +3720,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::COS, Float64VectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::COS, Float64VectorTests::strictCOS);
     }
 
 
@@ -3744,7 +3744,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::TAN, Float64VectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::TAN, Float64VectorTests::strictTAN);
     }
 
 
@@ -3768,7 +3768,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::SINH, Float64VectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::SINH, Float64VectorTests::strictSINH);
     }
 
 
@@ -3792,7 +3792,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::COSH, Float64VectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::COSH, Float64VectorTests::strictCOSH);
     }
 
 
@@ -3816,7 +3816,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::TANH, Float64VectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::TANH, Float64VectorTests::strictTANH);
     }
 
 
@@ -3840,7 +3840,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::ASIN, Float64VectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::ASIN, Float64VectorTests::strictASIN);
     }
 
 
@@ -3864,7 +3864,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::ACOS, Float64VectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::ACOS, Float64VectorTests::strictACOS);
     }
 
 
@@ -3888,7 +3888,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::ATAN, Float64VectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::ATAN, Float64VectorTests::strictATAN);
     }
 
 
@@ -3912,7 +3912,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, Float64VectorTests::CBRT, Float64VectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, Float64VectorTests::CBRT, Float64VectorTests::strictCBRT);
     }
 
 
@@ -3938,7 +3938,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::HYPOT, Float64VectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::HYPOT, Float64VectorTests::strictHYPOT);
     }
 
 
@@ -3965,7 +3965,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::POW, Float64VectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::POW, Float64VectorTests::strictPOW);
     }
 
     static float pow(float a, float b) {
@@ -3990,7 +3990,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::pow, Float64VectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::pow, Float64VectorTests::strictpow);
     }
 
 
@@ -4017,7 +4017,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::ATAN2, Float64VectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::ATAN2, Float64VectorTests::strictATAN2);
     }
 
 
@@ -4033,7 +4033,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::POW, Float64VectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::POW, Float64VectorTests::strictPOW);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -4047,7 +4047,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, Float64VectorTests::pow, Float64VectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, Float64VectorTests::pow, Float64VectorTests::strictpow);
     }
 
 
@@ -4076,7 +4076,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Float64VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, Float64VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat64VectorTests(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4092,7 +4092,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Float64VectorTests::fma);
+        assertArraysEquals(r, a, b, c, Float64VectorTests::fma);
     }
 
 
@@ -4115,7 +4115,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Float64VectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, Float64VectorTests::FMA);
     }
 
 
@@ -4134,7 +4134,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             FloatVector bv = FloatVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Float64VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, Float64VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpProvider")
@@ -4149,7 +4149,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             FloatVector cv = FloatVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Float64VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, Float64VectorTests::FMA);
     }
 
 
@@ -4169,7 +4169,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Float64VectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Float64VectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpMaskProvider")
@@ -4188,7 +4188,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Float64VectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Float64VectorTests::FMA);
     }
 
 
@@ -4206,7 +4206,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float64VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float64VectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloat64VectorTestsDoubleBroadcastSmokeTest(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4220,7 +4220,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Float64VectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Float64VectorTests::fma);
     }
 
 
@@ -4239,7 +4239,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Float64VectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Float64VectorTests::FMA);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::NEG);
+        assertArraysEquals(r, a, Float64VectorTests::NEG);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4280,7 +4280,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::neg);
+        assertArraysEquals(r, a, Float64VectorTests::neg);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4298,7 +4298,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Float64VectorTests::NEG);
     }
 
     static float ABS(float a) {
@@ -4321,7 +4321,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::ABS);
+        assertArraysEquals(r, a, Float64VectorTests::ABS);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4336,7 +4336,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::abs);
+        assertArraysEquals(r, a, Float64VectorTests::abs);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4354,7 +4354,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Float64VectorTests::ABS);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::SQRT);
+        assertArraysEquals(r, a, Float64VectorTests::SQRT);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4401,7 +4401,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Float64VectorTests::sqrt);
+        assertArraysEquals(r, a, Float64VectorTests::sqrt);
     }
 
 
@@ -4421,7 +4421,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Float64VectorTests::SQRT);
+        assertArraysEquals(r, a, mask, Float64VectorTests::SQRT);
     }
 
     static float[] gather(float a[], int ix, int[] b, int iy) {
@@ -4446,7 +4446,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::gather);
+        assertArraysEquals(r, a, b, Float64VectorTests::gather);
     }
     static float[] gatherMasked(float a[], int ix, boolean[] mask, int[] b, int iy) {
         float[] res = new float[SPECIES.length()];
@@ -4474,7 +4474,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::gatherMasked);
     }
 
     static float[] scatter(float a[], int ix, int[] b, int iy) {
@@ -4499,7 +4499,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Float64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Float64VectorTests::scatter);
     }
 
     static float[] scatterMasked(float r[], float a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4537,7 +4537,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Float64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Float64VectorTests::scatterMasked);
     }
 
 
@@ -4579,8 +4579,8 @@ public class Float64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4590,8 +4590,8 @@ public class Float64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4601,8 +4601,8 @@ public class Float64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4668,7 +4668,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Float64VectorTests::ADDReduceLong, Float64VectorTests::ADDReduceAllLong);
     }
 
@@ -4709,7 +4709,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Float64VectorTests::ADDReduceLongMasked, Float64VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4721,7 +4721,7 @@ public class Float64VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -4739,7 +4739,7 @@ public class Float64VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Float64VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Float64VectorTests::blend);
     }
 
 
@@ -4756,7 +4756,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpSelectFromMaskProvider")
@@ -4775,7 +4775,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4852,7 +4852,7 @@ public class Float64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Float64VectorTests::beq);
+        assertArraysEquals(r, a, b, Float64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -67,47 +67,25 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (float) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (float) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(float[] a, float[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (float) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -410,7 +388,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "floatProviderForIOOBE")
@@ -481,7 +459,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new float[a.length];
@@ -492,7 +470,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatMaskProviderForIOOBE")
@@ -565,7 +543,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -589,7 +567,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -676,7 +654,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -691,7 +669,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -807,7 +785,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
@@ -888,7 +866,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -899,7 +877,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
@@ -976,7 +954,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -987,7 +965,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -73,7 +73,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float a);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FUnArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a[i]);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(float[] r, float[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float apply(float[] a);
     }
 
-    static void assertReductionArraysEquals(float[] a, float[] b, float c,
+    static void assertReductionArraysEquals(float[] r, float rc, float[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(float[] a, float[] b, float c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(float[] r, float rc, float[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -167,17 +167,17 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         long apply(float[] a);
     }
 
-    static void assertReductionLongArraysEquals(float[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, float[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -189,17 +189,17 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         long apply(float[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(float[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, float[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -207,37 +207,37 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(float[] a, float[] b, float element, int index) {
+    static void assertInsertArraysEquals(float[] r, float[] a, float element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -251,7 +251,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -265,7 +265,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(float[] a, float[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(float[] r, float[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -285,7 +285,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(float[] a, float[] r, float[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(float[] r, float[] a, float[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -305,7 +305,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[]a, float[]r) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -334,7 +334,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -345,7 +345,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -357,7 +357,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -369,11 +369,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -384,11 +384,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -402,11 +402,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -420,7 +420,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, FBinOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -434,11 +434,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(float[] a, float[] b, float[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(float[] r, float[] a, float[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -464,7 +464,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -475,11 +475,11 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -491,7 +491,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -504,7 +504,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,12 +517,12 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -538,12 +538,12 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,12 +574,12 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(float[] a, float[] b, float[] c, float[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(float[] r, float[] a, float[] b, float[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -618,7 +618,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -632,7 +632,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -646,7 +646,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp(float[] a, float[] b, float[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp(float[] r, float[] a, float[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -676,7 +676,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float apply(float[] a, int b);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, FBinArrayOp f) {
+    static void assertArraysEquals(float[] r, float[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -691,7 +691,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -718,7 +718,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] r, float[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -728,7 +728,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -739,7 +739,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, int[] b, float[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -749,7 +749,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(r, a, i, mask, b, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -766,7 +766,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(float[] r, float[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -776,7 +776,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -786,7 +786,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -796,7 +796,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -807,7 +807,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -817,7 +817,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -828,7 +828,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -838,7 +838,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -850,7 +850,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         float[] apply(float[] a, float[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(float[] a, float[] b, float[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(float[] r, float[] a, float[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -860,7 +860,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             float[] ref = f.apply(a, b, origin, part, mask, i);
             float[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -902,7 +902,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(float[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -948,7 +948,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     );
 
 
-    static void assertArraysEquals(float[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -959,7 +959,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(float[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, float[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1411,7 +1411,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::ADD);
     }
     static float add(float a, float b) {
         return (float)(a + b);
@@ -1429,7 +1429,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::add);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1449,7 +1449,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1467,7 +1467,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::add);
     }
     static float SUB(float a, float b) {
         return (float)(a - b);
@@ -1487,7 +1487,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::SUB);
     }
     static float sub(float a, float b) {
         return (float)(a - b);
@@ -1505,7 +1505,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1525,7 +1525,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1543,7 +1543,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::sub);
     }
     static float MUL(float a, float b) {
         return (float)(a * b);
@@ -1563,7 +1563,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::MUL);
     }
     static float mul(float a, float b) {
         return (float)(a * b);
@@ -1581,7 +1581,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1601,7 +1601,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1619,7 +1619,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::mul);
     }
 
     static float DIV(float a, float b) {
@@ -1640,7 +1640,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::DIV);
     }
     static float div(float a, float b) {
         return (float)(a / b);
@@ -1658,7 +1658,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.div(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::div);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::div);
     }
 
 
@@ -1680,7 +1680,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1698,7 +1698,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.div(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::div);
     }
 
 
@@ -1721,7 +1721,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1741,7 +1741,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::FIRST_NONZERO);
     }
 
 
@@ -1763,7 +1763,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1780,7 +1780,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, FloatMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, FloatMaxVectorTests::add);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1794,7 +1794,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1811,7 +1811,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, FloatMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, FloatMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -1825,7 +1825,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1842,7 +1842,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, FloatMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, FloatMaxVectorTests::mul);
     }
 
 
@@ -1857,7 +1857,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::div);
     }
 
 
@@ -1876,7 +1876,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, FloatMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, FloatMaxVectorTests::div);
     }
 
 
@@ -1899,7 +1899,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, FloatMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, FloatMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -1916,7 +1916,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, FloatMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, FloatMaxVectorTests::ADD);
     }
 
 
@@ -1972,7 +1972,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::MIN);
     }
     static float min(float a, float b) {
         return (float)(Math.min(a, b));
@@ -1990,7 +1990,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::min);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::min);
     }
     static float MAX(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2010,7 +2010,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::MAX);
     }
     static float max(float a, float b) {
         return (float)(Math.max(a, b));
@@ -2028,7 +2028,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::max);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::max);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2042,7 +2042,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2056,7 +2056,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::min);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2070,7 +2070,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -2084,7 +2084,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, FloatMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, FloatMaxVectorTests::max);
     }
 
 
@@ -2136,7 +2136,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 FloatMaxVectorTests::ADDReduce, FloatMaxVectorTests::ADDReduceAll);
     }
     static float ADDReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2180,7 +2180,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 FloatMaxVectorTests::ADDReduceMasked, FloatMaxVectorTests::ADDReduceAllMasked);
     }
     static float MULReduce(float[] a, int idx) {
@@ -2221,7 +2221,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 FloatMaxVectorTests::MULReduce, FloatMaxVectorTests::MULReduceAll);
     }
     static float MULReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2265,7 +2265,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 FloatMaxVectorTests::MULReduceMasked, FloatMaxVectorTests::MULReduceAllMasked);
     }
     static float MINReduce(float[] a, int idx) {
@@ -2306,7 +2306,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 FloatMaxVectorTests::MINReduce, FloatMaxVectorTests::MINReduceAll);
     }
     static float MINReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2351,7 +2351,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 FloatMaxVectorTests::MINReduceMasked, FloatMaxVectorTests::MINReduceAllMasked);
     }
     static float MAXReduce(float[] a, int idx) {
@@ -2392,7 +2392,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 FloatMaxVectorTests::MAXReduce, FloatMaxVectorTests::MAXReduceAll);
     }
     static float MAXReduceMasked(float[] a, int idx, boolean[] mask) {
@@ -2437,7 +2437,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 FloatMaxVectorTests::MAXReduceMasked, FloatMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -2457,7 +2457,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (float)4, 0);
+        assertInsertArraysEquals(r, a, (float)4, 0);
     }
     static boolean testIS_DEFAULT(float a) {
         return bits(a)==0;
@@ -3123,7 +3123,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleProvider")
@@ -3140,7 +3140,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpShuffleMaskProvider")
@@ -3158,7 +3158,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "floatUnaryOpProvider")
     static void getFloatMaxVectorTests(IntFunction<float[]> fa) {
@@ -3313,7 +3313,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::get);
+        assertArraysEquals(r, a, FloatMaxVectorTests::get);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -3327,7 +3327,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3374,7 +3374,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, FloatMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, FloatMaxVectorTests::sliceUnary);
     }
     static float[] sliceBinary(float[] a, float[] b, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3403,7 +3403,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, FloatMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, FloatMaxVectorTests::sliceBinary);
     }
     static float[] slice(float[] a, float[] b, int origin, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3436,7 +3436,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, FloatMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, FloatMaxVectorTests::slice);
     }
     static float[] unsliceUnary(float[] a, int origin, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3463,7 +3463,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, FloatMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, FloatMaxVectorTests::unsliceUnary);
     }
     static float[] unsliceBinary(float[] a, float[] b, int origin, int part, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3502,7 +3502,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, FloatMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, FloatMaxVectorTests::unsliceBinary);
     }
     static float[] unslice(float[] a, float[] b, int origin, int part, boolean[] mask, int idx) {
         float[] res = new float[SPECIES.length()];
@@ -3558,7 +3558,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, FloatMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, FloatMaxVectorTests::unslice);
     }
 
     static float SIN(float a) {
@@ -3581,7 +3581,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::SIN, FloatMaxVectorTests::strictSIN);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::SIN, FloatMaxVectorTests::strictSIN);
     }
 
 
@@ -3605,7 +3605,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::EXP, FloatMaxVectorTests::strictEXP);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::EXP, FloatMaxVectorTests::strictEXP);
     }
 
 
@@ -3629,7 +3629,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::LOG1P, FloatMaxVectorTests::strictLOG1P);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::LOG1P, FloatMaxVectorTests::strictLOG1P);
     }
 
 
@@ -3653,7 +3653,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::LOG, FloatMaxVectorTests::strictLOG);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::LOG, FloatMaxVectorTests::strictLOG);
     }
 
 
@@ -3677,7 +3677,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::LOG10, FloatMaxVectorTests::strictLOG10);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::LOG10, FloatMaxVectorTests::strictLOG10);
     }
 
 
@@ -3701,7 +3701,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::EXPM1, FloatMaxVectorTests::strictEXPM1);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::EXPM1, FloatMaxVectorTests::strictEXPM1);
     }
 
 
@@ -3725,7 +3725,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::COS, FloatMaxVectorTests::strictCOS);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::COS, FloatMaxVectorTests::strictCOS);
     }
 
 
@@ -3749,7 +3749,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::TAN, FloatMaxVectorTests::strictTAN);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::TAN, FloatMaxVectorTests::strictTAN);
     }
 
 
@@ -3773,7 +3773,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::SINH, FloatMaxVectorTests::strictSINH);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::SINH, FloatMaxVectorTests::strictSINH);
     }
 
 
@@ -3797,7 +3797,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::COSH, FloatMaxVectorTests::strictCOSH);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::COSH, FloatMaxVectorTests::strictCOSH);
     }
 
 
@@ -3821,7 +3821,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::TANH, FloatMaxVectorTests::strictTANH);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::TANH, FloatMaxVectorTests::strictTANH);
     }
 
 
@@ -3845,7 +3845,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::ASIN, FloatMaxVectorTests::strictASIN);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::ASIN, FloatMaxVectorTests::strictASIN);
     }
 
 
@@ -3869,7 +3869,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::ACOS, FloatMaxVectorTests::strictACOS);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::ACOS, FloatMaxVectorTests::strictACOS);
     }
 
 
@@ -3893,7 +3893,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::ATAN, FloatMaxVectorTests::strictATAN);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::ATAN, FloatMaxVectorTests::strictATAN);
     }
 
 
@@ -3917,7 +3917,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, r, FloatMaxVectorTests::CBRT, FloatMaxVectorTests::strictCBRT);
+        assertArraysEqualsWithinOneUlp(r, a, FloatMaxVectorTests::CBRT, FloatMaxVectorTests::strictCBRT);
     }
 
 
@@ -3943,7 +3943,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::HYPOT, FloatMaxVectorTests::strictHYPOT);
+        assertArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::HYPOT, FloatMaxVectorTests::strictHYPOT);
     }
 
 
@@ -3970,7 +3970,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::POW, FloatMaxVectorTests::strictPOW);
+        assertArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::POW, FloatMaxVectorTests::strictPOW);
     }
 
     static float pow(float a, float b) {
@@ -3995,7 +3995,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::pow, FloatMaxVectorTests::strictpow);
+        assertArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::pow, FloatMaxVectorTests::strictpow);
     }
 
 
@@ -4022,7 +4022,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::ATAN2, FloatMaxVectorTests::strictATAN2);
+        assertArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::ATAN2, FloatMaxVectorTests::strictATAN2);
     }
 
 
@@ -4038,7 +4038,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.POW, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::POW, FloatMaxVectorTests::strictPOW);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::POW, FloatMaxVectorTests::strictPOW);
     }
 
     @Test(dataProvider = "floatBinaryOpProvider")
@@ -4052,7 +4052,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.pow(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, FloatMaxVectorTests::pow, FloatMaxVectorTests::strictpow);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, FloatMaxVectorTests::pow, FloatMaxVectorTests::strictpow);
     }
 
 
@@ -4081,7 +4081,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, FloatMaxVectorTests::FMA);
+        assertArraysEquals(r, a, b, c, FloatMaxVectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloatMaxVectorTests(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4097,7 +4097,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.fma(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, FloatMaxVectorTests::fma);
+        assertArraysEquals(r, a, b, c, FloatMaxVectorTests::fma);
     }
 
 
@@ -4120,7 +4120,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, FloatMaxVectorTests::FMA);
+        assertArraysEquals(r, a, b, c, mask, FloatMaxVectorTests::FMA);
     }
 
 
@@ -4139,7 +4139,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             FloatVector bv = FloatVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.FMA, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, FloatMaxVectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, FloatMaxVectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpProvider")
@@ -4154,7 +4154,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             FloatVector cv = FloatVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.FMA, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, FloatMaxVectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, FloatMaxVectorTests::FMA);
     }
 
 
@@ -4174,7 +4174,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, FloatMaxVectorTests::FMA);
+        assertBroadcastArraysEquals(r, a, b, c, mask, FloatMaxVectorTests::FMA);
     }
 
     @Test(dataProvider = "floatTernaryOpMaskProvider")
@@ -4193,7 +4193,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FloatMaxVectorTests::FMA);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FloatMaxVectorTests::FMA);
     }
 
 
@@ -4211,7 +4211,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, FloatMaxVectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, FloatMaxVectorTests::FMA);
     }
     @Test(dataProvider = "floatTernaryOpProvider")
     static void fmaFloatMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<float[]> fa, IntFunction<float[]> fb, IntFunction<float[]> fc) {
@@ -4225,7 +4225,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.fma(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, FloatMaxVectorTests::fma);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, FloatMaxVectorTests::fma);
     }
 
 
@@ -4244,7 +4244,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.FMA, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FloatMaxVectorTests::FMA);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FloatMaxVectorTests::FMA);
     }
 
 
@@ -4270,7 +4270,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::NEG);
+        assertArraysEquals(r, a, FloatMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4285,7 +4285,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::neg);
+        assertArraysEquals(r, a, FloatMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4303,7 +4303,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, FloatMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, FloatMaxVectorTests::NEG);
     }
 
     static float ABS(float a) {
@@ -4326,7 +4326,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::ABS);
+        assertArraysEquals(r, a, FloatMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4341,7 +4341,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::abs);
+        assertArraysEquals(r, a, FloatMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "floatUnaryOpMaskProvider")
@@ -4359,7 +4359,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, FloatMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, FloatMaxVectorTests::ABS);
     }
 
 
@@ -4391,7 +4391,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::SQRT);
+        assertArraysEquals(r, a, FloatMaxVectorTests::SQRT);
     }
 
     @Test(dataProvider = "floatUnaryOpProvider")
@@ -4406,7 +4406,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, FloatMaxVectorTests::sqrt);
+        assertArraysEquals(r, a, FloatMaxVectorTests::sqrt);
     }
 
 
@@ -4426,7 +4426,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, FloatMaxVectorTests::SQRT);
+        assertArraysEquals(r, a, mask, FloatMaxVectorTests::SQRT);
     }
 
     static float[] gather(float a[], int ix, int[] b, int iy) {
@@ -4451,7 +4451,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::gather);
     }
     static float[] gatherMasked(float a[], int ix, boolean[] mask, int[] b, int iy) {
         float[] res = new float[SPECIES.length()];
@@ -4479,7 +4479,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::gatherMasked);
     }
 
     static float[] scatter(float a[], int ix, int[] b, int iy) {
@@ -4504,7 +4504,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::scatter);
     }
 
     static float[] scatterMasked(float r[], float a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4542,7 +4542,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, FloatMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, FloatMaxVectorTests::scatterMasked);
     }
 
 
@@ -4584,8 +4584,8 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4595,8 +4595,8 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4606,8 +4606,8 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector av = FloatVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4673,7 +4673,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 FloatMaxVectorTests::ADDReduceLong, FloatMaxVectorTests::ADDReduceAllLong);
     }
 
@@ -4714,7 +4714,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 FloatMaxVectorTests::ADDReduceLongMasked, FloatMaxVectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4726,7 +4726,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             FloatVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "floatBinaryOpMaskProvider")
@@ -4744,7 +4744,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, FloatMaxVectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, FloatMaxVectorTests::blend);
     }
 
 
@@ -4761,7 +4761,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "floatUnaryOpSelectFromMaskProvider")
@@ -4780,7 +4780,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4857,7 +4857,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, FloatMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, FloatMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(int[] a, int[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "intProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new int[a.length];
@@ -483,7 +461,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -68,7 +68,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a[i]);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Int128VectorTests extends AbstractVectorTest {
         int apply(int[] a);
     }
 
-    static void assertReductionArraysEquals(int[] a, int[] b, int c,
+    static void assertReductionArraysEquals(int[] r, int rc, int[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Int128VectorTests extends AbstractVectorTest {
         int apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(int[] a, int[] b, int c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(int[] r, int rc, int[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Int128VectorTests extends AbstractVectorTest {
         long apply(int[] a);
     }
 
-    static void assertReductionLongArraysEquals(int[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, int[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Int128VectorTests extends AbstractVectorTest {
         long apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(int[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, int[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Int128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(int[] a, int[] b, int element, int index) {
+    static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[]a, int[]r) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int apply(int[] a, int b);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FBinArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] r, int[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(r, a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(int[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Int128VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(int[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1254,7 +1254,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Int128VectorTests::ADD);
     }
     static int add(int a, int b) {
         return (int)(a + b);
@@ -1272,7 +1272,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::add);
+        assertArraysEquals(r, a, b, Int128VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1292,7 +1292,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1310,7 +1310,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::add);
     }
     static int SUB(int a, int b) {
         return (int)(a - b);
@@ -1330,7 +1330,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Int128VectorTests::SUB);
     }
     static int sub(int a, int b) {
         return (int)(a - b);
@@ -1348,7 +1348,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::sub);
+        assertArraysEquals(r, a, b, Int128VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1368,7 +1368,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::SUB);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1386,7 +1386,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::sub);
     }
     static int MUL(int a, int b) {
         return (int)(a * b);
@@ -1406,7 +1406,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Int128VectorTests::MUL);
     }
     static int mul(int a, int b) {
         return (int)(a * b);
@@ -1424,7 +1424,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::mul);
+        assertArraysEquals(r, a, b, Int128VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::MUL);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::mul);
     }
 
 
@@ -1487,7 +1487,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Int128VectorTests::DIV);
     }
     static int div(int a, int b) {
         return (int)(a / b);
@@ -1509,7 +1509,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::div);
+        assertArraysEquals(r, a, b, Int128VectorTests::div);
     }
 
 
@@ -1533,7 +1533,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::DIV);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1555,7 +1555,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::div);
     }
 
     static int FIRST_NONZERO(int a, int b) {
@@ -1576,7 +1576,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Int128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::FIRST_NONZERO);
     }
 
     static int AND(int a, int b) {
@@ -1617,7 +1617,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::AND);
+        assertArraysEquals(r, a, b, Int128VectorTests::AND);
     }
     static int and(int a, int b) {
         return (int)(a & b);
@@ -1635,7 +1635,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::and);
+        assertArraysEquals(r, a, b, Int128VectorTests::and);
     }
 
 
@@ -1657,7 +1657,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::AND);
     }
 
 
@@ -1679,7 +1679,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Int128VectorTests::AND_NOT);
     }
 
 
@@ -1701,7 +1701,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::AND_NOT);
     }
 
 
@@ -1723,7 +1723,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::OR);
+        assertArraysEquals(r, a, b, Int128VectorTests::OR);
     }
     static int or(int a, int b) {
         return (int)(a | b);
@@ -1741,7 +1741,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::or);
+        assertArraysEquals(r, a, b, Int128VectorTests::or);
     }
 
 
@@ -1763,7 +1763,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::OR);
     }
 
 
@@ -1785,7 +1785,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::XOR);
+        assertArraysEquals(r, a, b, Int128VectorTests::XOR);
     }
 
 
@@ -1807,7 +1807,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::XOR);
     }
 
 
@@ -1822,7 +1822,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1839,7 +1839,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1853,7 +1853,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1870,7 +1870,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1884,7 +1884,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::mul);
     }
 
 
@@ -1920,7 +1920,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::div);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::div);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::OR);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1971,7 +1971,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::or);
     }
 
 
@@ -1990,7 +1990,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::OR);
     }
 
 
@@ -2006,7 +2006,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::AND);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2020,7 +2020,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::and);
     }
 
 
@@ -2039,7 +2039,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Int128VectorTests::AND);
     }
 
 
@@ -2055,7 +2055,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Int128VectorTests::OR);
     }
 
 
@@ -2074,7 +2074,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int128VectorTests::OR);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Int128VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -2106,7 +2106,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int128VectorTests::ADD);
     }
 
     static int LSHL(int a, int b) {
@@ -2127,7 +2127,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Int128VectorTests::LSHL);
     }
 
 
@@ -2149,7 +2149,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::LSHL);
     }
 
 
@@ -2175,7 +2175,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Int128VectorTests::ASHR);
     }
 
 
@@ -2197,7 +2197,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::ASHR);
     }
 
 
@@ -2223,7 +2223,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Int128VectorTests::LSHR);
     }
 
 
@@ -2245,7 +2245,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::LSHR);
     }
 
 
@@ -2270,7 +2270,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Int128VectorTests::LSHL_unary);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int128VectorTests::LSHL_unary);
     }
 
 
@@ -2316,7 +2316,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Int128VectorTests::LSHR_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int128VectorTests::LSHR_unary);
     }
 
 
@@ -2362,7 +2362,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Int128VectorTests::ASHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int128VectorTests::ASHR_unary);
     }
 
 
@@ -2408,7 +2408,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Int128VectorTests::MIN);
     }
     static int min(int a, int b) {
         return (int)(Math.min(a, b));
@@ -2426,7 +2426,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::min);
+        assertArraysEquals(r, a, b, Int128VectorTests::min);
     }
     static int MAX(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2446,7 +2446,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Int128VectorTests::MAX);
     }
     static int max(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2464,7 +2464,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::max);
+        assertArraysEquals(r, a, b, Int128VectorTests::max);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2478,7 +2478,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::MIN);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2492,7 +2492,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::min);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2506,7 +2506,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::MAX);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2520,7 +2520,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Int128VectorTests::max);
     }
 
     static int ANDReduce(int[] a, int idx) {
@@ -2563,7 +2563,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::ANDReduce, Int128VectorTests::ANDReduceAll);
     }
 
@@ -2611,7 +2611,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::ANDReduceMasked, Int128VectorTests::ANDReduceAllMasked);
     }
 
@@ -2656,7 +2656,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::ORReduce, Int128VectorTests::ORReduceAll);
     }
 
@@ -2704,7 +2704,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::ORReduceMasked, Int128VectorTests::ORReduceAllMasked);
     }
 
@@ -2749,7 +2749,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::XORReduce, Int128VectorTests::XORReduceAll);
     }
 
@@ -2797,7 +2797,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::XORReduceMasked, Int128VectorTests::XORReduceAllMasked);
     }
 
@@ -2839,7 +2839,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::ADDReduce, Int128VectorTests::ADDReduceAll);
     }
     static int ADDReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2883,7 +2883,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::ADDReduceMasked, Int128VectorTests::ADDReduceAllMasked);
     }
     static int MULReduce(int[] a, int idx) {
@@ -2924,7 +2924,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::MULReduce, Int128VectorTests::MULReduceAll);
     }
     static int MULReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2968,7 +2968,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::MULReduceMasked, Int128VectorTests::MULReduceAllMasked);
     }
     static int MINReduce(int[] a, int idx) {
@@ -3009,7 +3009,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::MINReduce, Int128VectorTests::MINReduceAll);
     }
     static int MINReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3054,7 +3054,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::MINReduceMasked, Int128VectorTests::MINReduceAllMasked);
     }
     static int MAXReduce(int[] a, int idx) {
@@ -3095,7 +3095,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int128VectorTests::MAXReduce, Int128VectorTests::MAXReduceAll);
     }
     static int MAXReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3140,7 +3140,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::MAXReduceMasked, Int128VectorTests::MAXReduceAllMasked);
     }
 
@@ -3166,7 +3166,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int128VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Int128VectorTests::anyTrue);
     }
 
 
@@ -3192,7 +3192,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int128VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Int128VectorTests::allTrue);
     }
 
 
@@ -3208,7 +3208,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (int)4, 0);
+        assertInsertArraysEquals(r, a, (int)4, 0);
     }
     static boolean testIS_DEFAULT(int a) {
         return bits(a)==0;
@@ -3757,7 +3757,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::blend);
     }
 
     @Test(dataProvider = "intUnaryOpShuffleProvider")
@@ -3774,7 +3774,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -3792,7 +3792,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "intUnaryOpProvider")
     static void getInt128VectorTests(IntFunction<int[]> fa) {
@@ -3947,7 +3947,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::get);
+        assertArraysEquals(r, a, Int128VectorTests::get);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -3961,7 +3961,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4008,7 +4008,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Int128VectorTests::sliceUnary);
     }
     static int[] sliceBinary(int[] a, int[] b, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4037,7 +4037,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Int128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Int128VectorTests::sliceBinary);
     }
     static int[] slice(int[] a, int[] b, int origin, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4070,7 +4070,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Int128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Int128VectorTests::slice);
     }
     static int[] unsliceUnary(int[] a, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4097,7 +4097,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Int128VectorTests::unsliceUnary);
     }
     static int[] unsliceBinary(int[] a, int[] b, int origin, int part, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4136,7 +4136,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Int128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Int128VectorTests::unsliceBinary);
     }
     static int[] unslice(int[] a, int[] b, int origin, int part, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4192,7 +4192,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Int128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Int128VectorTests::unslice);
     }
 
 
@@ -4241,7 +4241,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Int128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Int128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt128VectorTests(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4257,7 +4257,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Int128VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Int128VectorTests::bitwiseBlend);
     }
 
 
@@ -4280,7 +4280,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Int128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Int128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4298,7 +4298,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Int128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4313,7 +4313,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt128VectorTestsBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4327,7 +4327,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int128VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Int128VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4342,7 +4342,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int128VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int128VectorTests::bitwiseBlend);
     }
 
 
@@ -4362,7 +4362,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Int128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Int128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpMaskProvider")
@@ -4381,7 +4381,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Int128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Int128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4399,7 +4399,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt128VectorTestsDoubleBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4413,7 +4413,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int128VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int128VectorTests::bitwiseBlend);
     }
 
 
@@ -4432,7 +4432,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Int128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Int128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::NEG);
+        assertArraysEquals(r, a, Int128VectorTests::NEG);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4471,7 +4471,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::neg);
+        assertArraysEquals(r, a, Int128VectorTests::neg);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4489,7 +4489,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Int128VectorTests::NEG);
     }
 
     static int ABS(int a) {
@@ -4512,7 +4512,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::ABS);
+        assertArraysEquals(r, a, Int128VectorTests::ABS);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4527,7 +4527,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::abs);
+        assertArraysEquals(r, a, Int128VectorTests::abs);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4545,7 +4545,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Int128VectorTests::ABS);
     }
 
 
@@ -4571,7 +4571,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::NOT);
+        assertArraysEquals(r, a, Int128VectorTests::NOT);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4586,7 +4586,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::not);
+        assertArraysEquals(r, a, Int128VectorTests::not);
     }
 
 
@@ -4606,7 +4606,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int128VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Int128VectorTests::NOT);
     }
 
 
@@ -4629,7 +4629,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int128VectorTests::ZOMO);
+        assertArraysEquals(r, a, Int128VectorTests::ZOMO);
     }
 
 
@@ -4649,7 +4649,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int128VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Int128VectorTests::ZOMO);
     }
 
 
@@ -4677,7 +4677,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::gather);
+        assertArraysEquals(r, a, b, Int128VectorTests::gather);
     }
     static int[] gatherMasked(int a[], int ix, boolean[] mask, int[] b, int iy) {
         int[] res = new int[SPECIES.length()];
@@ -4705,7 +4705,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::gatherMasked);
     }
 
     static int[] scatter(int a[], int ix, int[] b, int iy) {
@@ -4730,7 +4730,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Int128VectorTests::scatter);
     }
 
     static int[] scatterMasked(int r[], int a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4768,7 +4768,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Int128VectorTests::scatterMasked);
     }
 
 
@@ -4810,8 +4810,8 @@ public class Int128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4821,8 +4821,8 @@ public class Int128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4832,8 +4832,8 @@ public class Int128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4899,7 +4899,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Int128VectorTests::ADDReduceLong, Int128VectorTests::ADDReduceAllLong);
     }
 
@@ -4940,7 +4940,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Int128VectorTests::ADDReduceLongMasked, Int128VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4952,7 +4952,7 @@ public class Int128VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -4970,7 +4970,7 @@ public class Int128VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int128VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int128VectorTests::blend);
     }
 
 
@@ -4987,7 +4987,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -5006,7 +5006,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5083,7 +5083,7 @@ public class Int128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Int128VectorTests::beq);
+        assertArraysEquals(r, a, b, Int128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(int[] a, int[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "intProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new int[a.length];
@@ -483,7 +461,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -68,7 +68,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a[i]);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Int256VectorTests extends AbstractVectorTest {
         int apply(int[] a);
     }
 
-    static void assertReductionArraysEquals(int[] a, int[] b, int c,
+    static void assertReductionArraysEquals(int[] r, int rc, int[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Int256VectorTests extends AbstractVectorTest {
         int apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(int[] a, int[] b, int c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(int[] r, int rc, int[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Int256VectorTests extends AbstractVectorTest {
         long apply(int[] a);
     }
 
-    static void assertReductionLongArraysEquals(int[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, int[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Int256VectorTests extends AbstractVectorTest {
         long apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(int[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, int[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Int256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(int[] a, int[] b, int element, int index) {
+    static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[]a, int[]r) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int apply(int[] a, int b);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FBinArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] r, int[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(r, a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(int[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Int256VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(int[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1254,7 +1254,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Int256VectorTests::ADD);
     }
     static int add(int a, int b) {
         return (int)(a + b);
@@ -1272,7 +1272,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::add);
+        assertArraysEquals(r, a, b, Int256VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1292,7 +1292,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1310,7 +1310,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::add);
     }
     static int SUB(int a, int b) {
         return (int)(a - b);
@@ -1330,7 +1330,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Int256VectorTests::SUB);
     }
     static int sub(int a, int b) {
         return (int)(a - b);
@@ -1348,7 +1348,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::sub);
+        assertArraysEquals(r, a, b, Int256VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1368,7 +1368,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::SUB);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1386,7 +1386,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::sub);
     }
     static int MUL(int a, int b) {
         return (int)(a * b);
@@ -1406,7 +1406,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Int256VectorTests::MUL);
     }
     static int mul(int a, int b) {
         return (int)(a * b);
@@ -1424,7 +1424,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::mul);
+        assertArraysEquals(r, a, b, Int256VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::MUL);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::mul);
     }
 
 
@@ -1487,7 +1487,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Int256VectorTests::DIV);
     }
     static int div(int a, int b) {
         return (int)(a / b);
@@ -1509,7 +1509,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::div);
+        assertArraysEquals(r, a, b, Int256VectorTests::div);
     }
 
 
@@ -1533,7 +1533,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::DIV);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1555,7 +1555,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::div);
     }
 
     static int FIRST_NONZERO(int a, int b) {
@@ -1576,7 +1576,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Int256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::FIRST_NONZERO);
     }
 
     static int AND(int a, int b) {
@@ -1617,7 +1617,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::AND);
+        assertArraysEquals(r, a, b, Int256VectorTests::AND);
     }
     static int and(int a, int b) {
         return (int)(a & b);
@@ -1635,7 +1635,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::and);
+        assertArraysEquals(r, a, b, Int256VectorTests::and);
     }
 
 
@@ -1657,7 +1657,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::AND);
     }
 
 
@@ -1679,7 +1679,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Int256VectorTests::AND_NOT);
     }
 
 
@@ -1701,7 +1701,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::AND_NOT);
     }
 
 
@@ -1723,7 +1723,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::OR);
+        assertArraysEquals(r, a, b, Int256VectorTests::OR);
     }
     static int or(int a, int b) {
         return (int)(a | b);
@@ -1741,7 +1741,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::or);
+        assertArraysEquals(r, a, b, Int256VectorTests::or);
     }
 
 
@@ -1763,7 +1763,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::OR);
     }
 
 
@@ -1785,7 +1785,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::XOR);
+        assertArraysEquals(r, a, b, Int256VectorTests::XOR);
     }
 
 
@@ -1807,7 +1807,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::XOR);
     }
 
 
@@ -1822,7 +1822,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1839,7 +1839,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1853,7 +1853,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1870,7 +1870,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1884,7 +1884,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::mul);
     }
 
 
@@ -1920,7 +1920,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::div);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::div);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::OR);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1971,7 +1971,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::or);
     }
 
 
@@ -1990,7 +1990,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::OR);
     }
 
 
@@ -2006,7 +2006,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::AND);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2020,7 +2020,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::and);
     }
 
 
@@ -2039,7 +2039,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Int256VectorTests::AND);
     }
 
 
@@ -2055,7 +2055,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Int256VectorTests::OR);
     }
 
 
@@ -2074,7 +2074,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int256VectorTests::OR);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Int256VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -2106,7 +2106,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int256VectorTests::ADD);
     }
 
     static int LSHL(int a, int b) {
@@ -2127,7 +2127,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Int256VectorTests::LSHL);
     }
 
 
@@ -2149,7 +2149,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::LSHL);
     }
 
 
@@ -2175,7 +2175,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Int256VectorTests::ASHR);
     }
 
 
@@ -2197,7 +2197,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::ASHR);
     }
 
 
@@ -2223,7 +2223,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Int256VectorTests::LSHR);
     }
 
 
@@ -2245,7 +2245,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::LSHR);
     }
 
 
@@ -2270,7 +2270,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Int256VectorTests::LSHL_unary);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int256VectorTests::LSHL_unary);
     }
 
 
@@ -2316,7 +2316,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Int256VectorTests::LSHR_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int256VectorTests::LSHR_unary);
     }
 
 
@@ -2362,7 +2362,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Int256VectorTests::ASHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int256VectorTests::ASHR_unary);
     }
 
 
@@ -2408,7 +2408,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Int256VectorTests::MIN);
     }
     static int min(int a, int b) {
         return (int)(Math.min(a, b));
@@ -2426,7 +2426,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::min);
+        assertArraysEquals(r, a, b, Int256VectorTests::min);
     }
     static int MAX(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2446,7 +2446,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Int256VectorTests::MAX);
     }
     static int max(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2464,7 +2464,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::max);
+        assertArraysEquals(r, a, b, Int256VectorTests::max);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2478,7 +2478,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::MIN);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2492,7 +2492,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::min);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2506,7 +2506,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::MAX);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2520,7 +2520,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Int256VectorTests::max);
     }
 
     static int ANDReduce(int[] a, int idx) {
@@ -2563,7 +2563,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::ANDReduce, Int256VectorTests::ANDReduceAll);
     }
 
@@ -2611,7 +2611,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::ANDReduceMasked, Int256VectorTests::ANDReduceAllMasked);
     }
 
@@ -2656,7 +2656,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::ORReduce, Int256VectorTests::ORReduceAll);
     }
 
@@ -2704,7 +2704,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::ORReduceMasked, Int256VectorTests::ORReduceAllMasked);
     }
 
@@ -2749,7 +2749,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::XORReduce, Int256VectorTests::XORReduceAll);
     }
 
@@ -2797,7 +2797,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::XORReduceMasked, Int256VectorTests::XORReduceAllMasked);
     }
 
@@ -2839,7 +2839,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::ADDReduce, Int256VectorTests::ADDReduceAll);
     }
     static int ADDReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2883,7 +2883,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::ADDReduceMasked, Int256VectorTests::ADDReduceAllMasked);
     }
     static int MULReduce(int[] a, int idx) {
@@ -2924,7 +2924,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::MULReduce, Int256VectorTests::MULReduceAll);
     }
     static int MULReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2968,7 +2968,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::MULReduceMasked, Int256VectorTests::MULReduceAllMasked);
     }
     static int MINReduce(int[] a, int idx) {
@@ -3009,7 +3009,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::MINReduce, Int256VectorTests::MINReduceAll);
     }
     static int MINReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3054,7 +3054,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::MINReduceMasked, Int256VectorTests::MINReduceAllMasked);
     }
     static int MAXReduce(int[] a, int idx) {
@@ -3095,7 +3095,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int256VectorTests::MAXReduce, Int256VectorTests::MAXReduceAll);
     }
     static int MAXReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3140,7 +3140,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::MAXReduceMasked, Int256VectorTests::MAXReduceAllMasked);
     }
 
@@ -3166,7 +3166,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int256VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Int256VectorTests::anyTrue);
     }
 
 
@@ -3192,7 +3192,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int256VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Int256VectorTests::allTrue);
     }
 
 
@@ -3208,7 +3208,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (int)4, 0);
+        assertInsertArraysEquals(r, a, (int)4, 0);
     }
     static boolean testIS_DEFAULT(int a) {
         return bits(a)==0;
@@ -3757,7 +3757,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::blend);
     }
 
     @Test(dataProvider = "intUnaryOpShuffleProvider")
@@ -3774,7 +3774,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -3792,7 +3792,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "intUnaryOpProvider")
     static void getInt256VectorTests(IntFunction<int[]> fa) {
@@ -3947,7 +3947,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::get);
+        assertArraysEquals(r, a, Int256VectorTests::get);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -3961,7 +3961,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4008,7 +4008,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Int256VectorTests::sliceUnary);
     }
     static int[] sliceBinary(int[] a, int[] b, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4037,7 +4037,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Int256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Int256VectorTests::sliceBinary);
     }
     static int[] slice(int[] a, int[] b, int origin, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4070,7 +4070,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Int256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Int256VectorTests::slice);
     }
     static int[] unsliceUnary(int[] a, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4097,7 +4097,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Int256VectorTests::unsliceUnary);
     }
     static int[] unsliceBinary(int[] a, int[] b, int origin, int part, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4136,7 +4136,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Int256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Int256VectorTests::unsliceBinary);
     }
     static int[] unslice(int[] a, int[] b, int origin, int part, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4192,7 +4192,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Int256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Int256VectorTests::unslice);
     }
 
 
@@ -4241,7 +4241,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Int256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Int256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt256VectorTests(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4257,7 +4257,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Int256VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Int256VectorTests::bitwiseBlend);
     }
 
 
@@ -4280,7 +4280,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Int256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Int256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4298,7 +4298,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Int256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4313,7 +4313,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt256VectorTestsBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4327,7 +4327,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int256VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Int256VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4342,7 +4342,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int256VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int256VectorTests::bitwiseBlend);
     }
 
 
@@ -4362,7 +4362,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Int256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Int256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpMaskProvider")
@@ -4381,7 +4381,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Int256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Int256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4399,7 +4399,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt256VectorTestsDoubleBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4413,7 +4413,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int256VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int256VectorTests::bitwiseBlend);
     }
 
 
@@ -4432,7 +4432,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Int256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Int256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::NEG);
+        assertArraysEquals(r, a, Int256VectorTests::NEG);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4471,7 +4471,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::neg);
+        assertArraysEquals(r, a, Int256VectorTests::neg);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4489,7 +4489,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Int256VectorTests::NEG);
     }
 
     static int ABS(int a) {
@@ -4512,7 +4512,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::ABS);
+        assertArraysEquals(r, a, Int256VectorTests::ABS);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4527,7 +4527,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::abs);
+        assertArraysEquals(r, a, Int256VectorTests::abs);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4545,7 +4545,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Int256VectorTests::ABS);
     }
 
 
@@ -4571,7 +4571,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::NOT);
+        assertArraysEquals(r, a, Int256VectorTests::NOT);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4586,7 +4586,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::not);
+        assertArraysEquals(r, a, Int256VectorTests::not);
     }
 
 
@@ -4606,7 +4606,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int256VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Int256VectorTests::NOT);
     }
 
 
@@ -4629,7 +4629,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int256VectorTests::ZOMO);
+        assertArraysEquals(r, a, Int256VectorTests::ZOMO);
     }
 
 
@@ -4649,7 +4649,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int256VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Int256VectorTests::ZOMO);
     }
 
 
@@ -4677,7 +4677,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::gather);
+        assertArraysEquals(r, a, b, Int256VectorTests::gather);
     }
     static int[] gatherMasked(int a[], int ix, boolean[] mask, int[] b, int iy) {
         int[] res = new int[SPECIES.length()];
@@ -4705,7 +4705,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::gatherMasked);
     }
 
     static int[] scatter(int a[], int ix, int[] b, int iy) {
@@ -4730,7 +4730,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Int256VectorTests::scatter);
     }
 
     static int[] scatterMasked(int r[], int a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4768,7 +4768,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Int256VectorTests::scatterMasked);
     }
 
 
@@ -4810,8 +4810,8 @@ public class Int256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4821,8 +4821,8 @@ public class Int256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4832,8 +4832,8 @@ public class Int256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4899,7 +4899,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Int256VectorTests::ADDReduceLong, Int256VectorTests::ADDReduceAllLong);
     }
 
@@ -4940,7 +4940,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Int256VectorTests::ADDReduceLongMasked, Int256VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4952,7 +4952,7 @@ public class Int256VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -4970,7 +4970,7 @@ public class Int256VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int256VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int256VectorTests::blend);
     }
 
 
@@ -4987,7 +4987,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -5006,7 +5006,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5083,7 +5083,7 @@ public class Int256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Int256VectorTests::beq);
+        assertArraysEquals(r, a, b, Int256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(int[] a, int[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "intProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new int[a.length];
@@ -483,7 +461,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -68,7 +68,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a[i]);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Int512VectorTests extends AbstractVectorTest {
         int apply(int[] a);
     }
 
-    static void assertReductionArraysEquals(int[] a, int[] b, int c,
+    static void assertReductionArraysEquals(int[] r, int rc, int[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Int512VectorTests extends AbstractVectorTest {
         int apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(int[] a, int[] b, int c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(int[] r, int rc, int[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Int512VectorTests extends AbstractVectorTest {
         long apply(int[] a);
     }
 
-    static void assertReductionLongArraysEquals(int[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, int[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Int512VectorTests extends AbstractVectorTest {
         long apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(int[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, int[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Int512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(int[] a, int[] b, int element, int index) {
+    static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[]a, int[]r) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int apply(int[] a, int b);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FBinArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] r, int[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(r, a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(int[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Int512VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(int[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1254,7 +1254,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Int512VectorTests::ADD);
     }
     static int add(int a, int b) {
         return (int)(a + b);
@@ -1272,7 +1272,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::add);
+        assertArraysEquals(r, a, b, Int512VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1292,7 +1292,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1310,7 +1310,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::add);
     }
     static int SUB(int a, int b) {
         return (int)(a - b);
@@ -1330,7 +1330,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Int512VectorTests::SUB);
     }
     static int sub(int a, int b) {
         return (int)(a - b);
@@ -1348,7 +1348,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::sub);
+        assertArraysEquals(r, a, b, Int512VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1368,7 +1368,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::SUB);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1386,7 +1386,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::sub);
     }
     static int MUL(int a, int b) {
         return (int)(a * b);
@@ -1406,7 +1406,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Int512VectorTests::MUL);
     }
     static int mul(int a, int b) {
         return (int)(a * b);
@@ -1424,7 +1424,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::mul);
+        assertArraysEquals(r, a, b, Int512VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::MUL);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::mul);
     }
 
 
@@ -1487,7 +1487,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Int512VectorTests::DIV);
     }
     static int div(int a, int b) {
         return (int)(a / b);
@@ -1509,7 +1509,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::div);
+        assertArraysEquals(r, a, b, Int512VectorTests::div);
     }
 
 
@@ -1533,7 +1533,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::DIV);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1555,7 +1555,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::div);
     }
 
     static int FIRST_NONZERO(int a, int b) {
@@ -1576,7 +1576,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Int512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::FIRST_NONZERO);
     }
 
     static int AND(int a, int b) {
@@ -1617,7 +1617,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::AND);
+        assertArraysEquals(r, a, b, Int512VectorTests::AND);
     }
     static int and(int a, int b) {
         return (int)(a & b);
@@ -1635,7 +1635,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::and);
+        assertArraysEquals(r, a, b, Int512VectorTests::and);
     }
 
 
@@ -1657,7 +1657,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::AND);
     }
 
 
@@ -1679,7 +1679,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Int512VectorTests::AND_NOT);
     }
 
 
@@ -1701,7 +1701,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::AND_NOT);
     }
 
 
@@ -1723,7 +1723,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::OR);
+        assertArraysEquals(r, a, b, Int512VectorTests::OR);
     }
     static int or(int a, int b) {
         return (int)(a | b);
@@ -1741,7 +1741,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::or);
+        assertArraysEquals(r, a, b, Int512VectorTests::or);
     }
 
 
@@ -1763,7 +1763,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::OR);
     }
 
 
@@ -1785,7 +1785,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::XOR);
+        assertArraysEquals(r, a, b, Int512VectorTests::XOR);
     }
 
 
@@ -1807,7 +1807,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::XOR);
     }
 
 
@@ -1822,7 +1822,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1839,7 +1839,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1853,7 +1853,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1870,7 +1870,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1884,7 +1884,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::mul);
     }
 
 
@@ -1920,7 +1920,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::div);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::div);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::OR);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1971,7 +1971,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::or);
     }
 
 
@@ -1990,7 +1990,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::OR);
     }
 
 
@@ -2006,7 +2006,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::AND);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2020,7 +2020,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::and);
     }
 
 
@@ -2039,7 +2039,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Int512VectorTests::AND);
     }
 
 
@@ -2055,7 +2055,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Int512VectorTests::OR);
     }
 
 
@@ -2074,7 +2074,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int512VectorTests::OR);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Int512VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -2106,7 +2106,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int512VectorTests::ADD);
     }
 
     static int LSHL(int a, int b) {
@@ -2127,7 +2127,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Int512VectorTests::LSHL);
     }
 
 
@@ -2149,7 +2149,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::LSHL);
     }
 
 
@@ -2175,7 +2175,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Int512VectorTests::ASHR);
     }
 
 
@@ -2197,7 +2197,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::ASHR);
     }
 
 
@@ -2223,7 +2223,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Int512VectorTests::LSHR);
     }
 
 
@@ -2245,7 +2245,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::LSHR);
     }
 
 
@@ -2270,7 +2270,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Int512VectorTests::LSHL_unary);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int512VectorTests::LSHL_unary);
     }
 
 
@@ -2316,7 +2316,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Int512VectorTests::LSHR_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int512VectorTests::LSHR_unary);
     }
 
 
@@ -2362,7 +2362,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Int512VectorTests::ASHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int512VectorTests::ASHR_unary);
     }
 
 
@@ -2408,7 +2408,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Int512VectorTests::MIN);
     }
     static int min(int a, int b) {
         return (int)(Math.min(a, b));
@@ -2426,7 +2426,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::min);
+        assertArraysEquals(r, a, b, Int512VectorTests::min);
     }
     static int MAX(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2446,7 +2446,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Int512VectorTests::MAX);
     }
     static int max(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2464,7 +2464,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::max);
+        assertArraysEquals(r, a, b, Int512VectorTests::max);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2478,7 +2478,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::MIN);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2492,7 +2492,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::min);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2506,7 +2506,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::MAX);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2520,7 +2520,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Int512VectorTests::max);
     }
 
     static int ANDReduce(int[] a, int idx) {
@@ -2563,7 +2563,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::ANDReduce, Int512VectorTests::ANDReduceAll);
     }
 
@@ -2611,7 +2611,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::ANDReduceMasked, Int512VectorTests::ANDReduceAllMasked);
     }
 
@@ -2656,7 +2656,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::ORReduce, Int512VectorTests::ORReduceAll);
     }
 
@@ -2704,7 +2704,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::ORReduceMasked, Int512VectorTests::ORReduceAllMasked);
     }
 
@@ -2749,7 +2749,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::XORReduce, Int512VectorTests::XORReduceAll);
     }
 
@@ -2797,7 +2797,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::XORReduceMasked, Int512VectorTests::XORReduceAllMasked);
     }
 
@@ -2839,7 +2839,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::ADDReduce, Int512VectorTests::ADDReduceAll);
     }
     static int ADDReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2883,7 +2883,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::ADDReduceMasked, Int512VectorTests::ADDReduceAllMasked);
     }
     static int MULReduce(int[] a, int idx) {
@@ -2924,7 +2924,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::MULReduce, Int512VectorTests::MULReduceAll);
     }
     static int MULReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2968,7 +2968,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::MULReduceMasked, Int512VectorTests::MULReduceAllMasked);
     }
     static int MINReduce(int[] a, int idx) {
@@ -3009,7 +3009,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::MINReduce, Int512VectorTests::MINReduceAll);
     }
     static int MINReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3054,7 +3054,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::MINReduceMasked, Int512VectorTests::MINReduceAllMasked);
     }
     static int MAXReduce(int[] a, int idx) {
@@ -3095,7 +3095,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int512VectorTests::MAXReduce, Int512VectorTests::MAXReduceAll);
     }
     static int MAXReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3140,7 +3140,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::MAXReduceMasked, Int512VectorTests::MAXReduceAllMasked);
     }
 
@@ -3166,7 +3166,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int512VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Int512VectorTests::anyTrue);
     }
 
 
@@ -3192,7 +3192,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int512VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Int512VectorTests::allTrue);
     }
 
 
@@ -3208,7 +3208,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (int)4, 0);
+        assertInsertArraysEquals(r, a, (int)4, 0);
     }
     static boolean testIS_DEFAULT(int a) {
         return bits(a)==0;
@@ -3757,7 +3757,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::blend);
     }
 
     @Test(dataProvider = "intUnaryOpShuffleProvider")
@@ -3774,7 +3774,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -3792,7 +3792,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "intUnaryOpProvider")
     static void getInt512VectorTests(IntFunction<int[]> fa) {
@@ -3947,7 +3947,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::get);
+        assertArraysEquals(r, a, Int512VectorTests::get);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -3961,7 +3961,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4008,7 +4008,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Int512VectorTests::sliceUnary);
     }
     static int[] sliceBinary(int[] a, int[] b, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4037,7 +4037,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Int512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Int512VectorTests::sliceBinary);
     }
     static int[] slice(int[] a, int[] b, int origin, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4070,7 +4070,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Int512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Int512VectorTests::slice);
     }
     static int[] unsliceUnary(int[] a, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4097,7 +4097,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Int512VectorTests::unsliceUnary);
     }
     static int[] unsliceBinary(int[] a, int[] b, int origin, int part, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4136,7 +4136,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Int512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Int512VectorTests::unsliceBinary);
     }
     static int[] unslice(int[] a, int[] b, int origin, int part, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4192,7 +4192,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Int512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Int512VectorTests::unslice);
     }
 
 
@@ -4241,7 +4241,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Int512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Int512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt512VectorTests(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4257,7 +4257,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Int512VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Int512VectorTests::bitwiseBlend);
     }
 
 
@@ -4280,7 +4280,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Int512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Int512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4298,7 +4298,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Int512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4313,7 +4313,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt512VectorTestsBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4327,7 +4327,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int512VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Int512VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4342,7 +4342,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int512VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int512VectorTests::bitwiseBlend);
     }
 
 
@@ -4362,7 +4362,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Int512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Int512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpMaskProvider")
@@ -4381,7 +4381,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Int512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Int512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4399,7 +4399,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt512VectorTestsDoubleBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4413,7 +4413,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int512VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int512VectorTests::bitwiseBlend);
     }
 
 
@@ -4432,7 +4432,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Int512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Int512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::NEG);
+        assertArraysEquals(r, a, Int512VectorTests::NEG);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4471,7 +4471,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::neg);
+        assertArraysEquals(r, a, Int512VectorTests::neg);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4489,7 +4489,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Int512VectorTests::NEG);
     }
 
     static int ABS(int a) {
@@ -4512,7 +4512,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::ABS);
+        assertArraysEquals(r, a, Int512VectorTests::ABS);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4527,7 +4527,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::abs);
+        assertArraysEquals(r, a, Int512VectorTests::abs);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4545,7 +4545,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Int512VectorTests::ABS);
     }
 
 
@@ -4571,7 +4571,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::NOT);
+        assertArraysEquals(r, a, Int512VectorTests::NOT);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4586,7 +4586,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::not);
+        assertArraysEquals(r, a, Int512VectorTests::not);
     }
 
 
@@ -4606,7 +4606,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int512VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Int512VectorTests::NOT);
     }
 
 
@@ -4629,7 +4629,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int512VectorTests::ZOMO);
+        assertArraysEquals(r, a, Int512VectorTests::ZOMO);
     }
 
 
@@ -4649,7 +4649,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int512VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Int512VectorTests::ZOMO);
     }
 
 
@@ -4677,7 +4677,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::gather);
+        assertArraysEquals(r, a, b, Int512VectorTests::gather);
     }
     static int[] gatherMasked(int a[], int ix, boolean[] mask, int[] b, int iy) {
         int[] res = new int[SPECIES.length()];
@@ -4705,7 +4705,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::gatherMasked);
     }
 
     static int[] scatter(int a[], int ix, int[] b, int iy) {
@@ -4730,7 +4730,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Int512VectorTests::scatter);
     }
 
     static int[] scatterMasked(int r[], int a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4768,7 +4768,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Int512VectorTests::scatterMasked);
     }
 
 
@@ -4810,8 +4810,8 @@ public class Int512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4821,8 +4821,8 @@ public class Int512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4832,8 +4832,8 @@ public class Int512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4899,7 +4899,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Int512VectorTests::ADDReduceLong, Int512VectorTests::ADDReduceAllLong);
     }
 
@@ -4940,7 +4940,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Int512VectorTests::ADDReduceLongMasked, Int512VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4952,7 +4952,7 @@ public class Int512VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -4970,7 +4970,7 @@ public class Int512VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int512VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int512VectorTests::blend);
     }
 
 
@@ -4987,7 +4987,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -5006,7 +5006,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5083,7 +5083,7 @@ public class Int512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Int512VectorTests::beq);
+        assertArraysEquals(r, a, b, Int512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(int[] a, int[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "intProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new int[a.length];
@@ -483,7 +461,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -68,7 +68,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a[i]);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Int64VectorTests extends AbstractVectorTest {
         int apply(int[] a);
     }
 
-    static void assertReductionArraysEquals(int[] a, int[] b, int c,
+    static void assertReductionArraysEquals(int[] r, int rc, int[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Int64VectorTests extends AbstractVectorTest {
         int apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(int[] a, int[] b, int c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(int[] r, int rc, int[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Int64VectorTests extends AbstractVectorTest {
         long apply(int[] a);
     }
 
-    static void assertReductionLongArraysEquals(int[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, int[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Int64VectorTests extends AbstractVectorTest {
         long apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(int[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, int[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Int64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(int[] a, int[] b, int element, int index) {
+    static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[]a, int[]r) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int apply(int[] a, int b);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FBinArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] r, int[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(r, a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(int[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Int64VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(int[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1254,7 +1254,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Int64VectorTests::ADD);
     }
     static int add(int a, int b) {
         return (int)(a + b);
@@ -1272,7 +1272,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::add);
+        assertArraysEquals(r, a, b, Int64VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1292,7 +1292,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1310,7 +1310,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::add);
     }
     static int SUB(int a, int b) {
         return (int)(a - b);
@@ -1330,7 +1330,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Int64VectorTests::SUB);
     }
     static int sub(int a, int b) {
         return (int)(a - b);
@@ -1348,7 +1348,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::sub);
+        assertArraysEquals(r, a, b, Int64VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1368,7 +1368,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::SUB);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1386,7 +1386,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::sub);
     }
     static int MUL(int a, int b) {
         return (int)(a * b);
@@ -1406,7 +1406,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Int64VectorTests::MUL);
     }
     static int mul(int a, int b) {
         return (int)(a * b);
@@ -1424,7 +1424,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::mul);
+        assertArraysEquals(r, a, b, Int64VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1444,7 +1444,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::MUL);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1462,7 +1462,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::mul);
     }
 
 
@@ -1487,7 +1487,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Int64VectorTests::DIV);
     }
     static int div(int a, int b) {
         return (int)(a / b);
@@ -1509,7 +1509,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::div);
+        assertArraysEquals(r, a, b, Int64VectorTests::div);
     }
 
 
@@ -1533,7 +1533,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::DIV);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1555,7 +1555,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::div);
     }
 
     static int FIRST_NONZERO(int a, int b) {
@@ -1576,7 +1576,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Int64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1596,7 +1596,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::FIRST_NONZERO);
     }
 
     static int AND(int a, int b) {
@@ -1617,7 +1617,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::AND);
+        assertArraysEquals(r, a, b, Int64VectorTests::AND);
     }
     static int and(int a, int b) {
         return (int)(a & b);
@@ -1635,7 +1635,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::and);
+        assertArraysEquals(r, a, b, Int64VectorTests::and);
     }
 
 
@@ -1657,7 +1657,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::AND);
     }
 
 
@@ -1679,7 +1679,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Int64VectorTests::AND_NOT);
     }
 
 
@@ -1701,7 +1701,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::AND_NOT);
     }
 
 
@@ -1723,7 +1723,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::OR);
+        assertArraysEquals(r, a, b, Int64VectorTests::OR);
     }
     static int or(int a, int b) {
         return (int)(a | b);
@@ -1741,7 +1741,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::or);
+        assertArraysEquals(r, a, b, Int64VectorTests::or);
     }
 
 
@@ -1763,7 +1763,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::OR);
     }
 
 
@@ -1785,7 +1785,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::XOR);
+        assertArraysEquals(r, a, b, Int64VectorTests::XOR);
     }
 
 
@@ -1807,7 +1807,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::XOR);
     }
 
 
@@ -1822,7 +1822,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1839,7 +1839,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1853,7 +1853,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1870,7 +1870,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1884,7 +1884,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1901,7 +1901,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::mul);
     }
 
 
@@ -1920,7 +1920,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::div);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::div);
     }
 
 
@@ -1957,7 +1957,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::OR);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1971,7 +1971,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::or);
     }
 
 
@@ -1990,7 +1990,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::OR);
     }
 
 
@@ -2006,7 +2006,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::AND);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2020,7 +2020,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::and);
     }
 
 
@@ -2039,7 +2039,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Int64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Int64VectorTests::AND);
     }
 
 
@@ -2055,7 +2055,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Int64VectorTests::OR);
     }
 
 
@@ -2074,7 +2074,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int64VectorTests::OR);
     }
 
 
@@ -2089,7 +2089,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Int64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Int64VectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -2106,7 +2106,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int64VectorTests::ADD);
     }
 
     static int LSHL(int a, int b) {
@@ -2127,7 +2127,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Int64VectorTests::LSHL);
     }
 
 
@@ -2149,7 +2149,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::LSHL);
     }
 
 
@@ -2175,7 +2175,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Int64VectorTests::ASHR);
     }
 
 
@@ -2197,7 +2197,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::ASHR);
     }
 
 
@@ -2223,7 +2223,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Int64VectorTests::LSHR);
     }
 
 
@@ -2245,7 +2245,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::LSHR);
     }
 
 
@@ -2270,7 +2270,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Int64VectorTests::LSHL_unary);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int64VectorTests::LSHL_unary);
     }
 
 
@@ -2316,7 +2316,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Int64VectorTests::LSHR_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int64VectorTests::LSHR_unary);
     }
 
 
@@ -2362,7 +2362,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Int64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Int64VectorTests::ASHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Int64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Int64VectorTests::ASHR_unary);
     }
 
 
@@ -2408,7 +2408,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Int64VectorTests::MIN);
     }
     static int min(int a, int b) {
         return (int)(Math.min(a, b));
@@ -2426,7 +2426,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::min);
+        assertArraysEquals(r, a, b, Int64VectorTests::min);
     }
     static int MAX(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2446,7 +2446,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Int64VectorTests::MAX);
     }
     static int max(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2464,7 +2464,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::max);
+        assertArraysEquals(r, a, b, Int64VectorTests::max);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2478,7 +2478,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::MIN);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2492,7 +2492,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::min);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2506,7 +2506,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::MAX);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2520,7 +2520,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Int64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Int64VectorTests::max);
     }
 
     static int ANDReduce(int[] a, int idx) {
@@ -2563,7 +2563,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::ANDReduce, Int64VectorTests::ANDReduceAll);
     }
 
@@ -2611,7 +2611,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::ANDReduceMasked, Int64VectorTests::ANDReduceAllMasked);
     }
 
@@ -2656,7 +2656,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::ORReduce, Int64VectorTests::ORReduceAll);
     }
 
@@ -2704,7 +2704,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::ORReduceMasked, Int64VectorTests::ORReduceAllMasked);
     }
 
@@ -2749,7 +2749,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::XORReduce, Int64VectorTests::XORReduceAll);
     }
 
@@ -2797,7 +2797,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::XORReduceMasked, Int64VectorTests::XORReduceAllMasked);
     }
 
@@ -2839,7 +2839,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::ADDReduce, Int64VectorTests::ADDReduceAll);
     }
     static int ADDReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2883,7 +2883,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::ADDReduceMasked, Int64VectorTests::ADDReduceAllMasked);
     }
     static int MULReduce(int[] a, int idx) {
@@ -2924,7 +2924,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::MULReduce, Int64VectorTests::MULReduceAll);
     }
     static int MULReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2968,7 +2968,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::MULReduceMasked, Int64VectorTests::MULReduceAllMasked);
     }
     static int MINReduce(int[] a, int idx) {
@@ -3009,7 +3009,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::MINReduce, Int64VectorTests::MINReduceAll);
     }
     static int MINReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3054,7 +3054,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::MINReduceMasked, Int64VectorTests::MINReduceAllMasked);
     }
     static int MAXReduce(int[] a, int idx) {
@@ -3095,7 +3095,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Int64VectorTests::MAXReduce, Int64VectorTests::MAXReduceAll);
     }
     static int MAXReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3140,7 +3140,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::MAXReduceMasked, Int64VectorTests::MAXReduceAllMasked);
     }
 
@@ -3166,7 +3166,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int64VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Int64VectorTests::anyTrue);
     }
 
 
@@ -3192,7 +3192,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Int64VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Int64VectorTests::allTrue);
     }
 
 
@@ -3208,7 +3208,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (int)4, 0);
+        assertInsertArraysEquals(r, a, (int)4, 0);
     }
     static boolean testIS_DEFAULT(int a) {
         return bits(a)==0;
@@ -3757,7 +3757,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::blend);
     }
 
     @Test(dataProvider = "intUnaryOpShuffleProvider")
@@ -3774,7 +3774,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -3792,7 +3792,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "intUnaryOpProvider")
     static void getInt64VectorTests(IntFunction<int[]> fa) {
@@ -3947,7 +3947,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::get);
+        assertArraysEquals(r, a, Int64VectorTests::get);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -3961,7 +3961,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4008,7 +4008,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Int64VectorTests::sliceUnary);
     }
     static int[] sliceBinary(int[] a, int[] b, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4037,7 +4037,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Int64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Int64VectorTests::sliceBinary);
     }
     static int[] slice(int[] a, int[] b, int origin, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4070,7 +4070,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Int64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Int64VectorTests::slice);
     }
     static int[] unsliceUnary(int[] a, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4097,7 +4097,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Int64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Int64VectorTests::unsliceUnary);
     }
     static int[] unsliceBinary(int[] a, int[] b, int origin, int part, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4136,7 +4136,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Int64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Int64VectorTests::unsliceBinary);
     }
     static int[] unslice(int[] a, int[] b, int origin, int part, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4192,7 +4192,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Int64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Int64VectorTests::unslice);
     }
 
 
@@ -4241,7 +4241,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Int64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Int64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt64VectorTests(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4257,7 +4257,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Int64VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Int64VectorTests::bitwiseBlend);
     }
 
 
@@ -4280,7 +4280,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Int64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Int64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4298,7 +4298,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Int64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4313,7 +4313,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt64VectorTestsBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4327,7 +4327,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Int64VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Int64VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4342,7 +4342,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Int64VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Int64VectorTests::bitwiseBlend);
     }
 
 
@@ -4362,7 +4362,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Int64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Int64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpMaskProvider")
@@ -4381,7 +4381,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Int64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Int64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4399,7 +4399,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendInt64VectorTestsDoubleBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4413,7 +4413,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Int64VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Int64VectorTests::bitwiseBlend);
     }
 
 
@@ -4432,7 +4432,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Int64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Int64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::NEG);
+        assertArraysEquals(r, a, Int64VectorTests::NEG);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4471,7 +4471,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::neg);
+        assertArraysEquals(r, a, Int64VectorTests::neg);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4489,7 +4489,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Int64VectorTests::NEG);
     }
 
     static int ABS(int a) {
@@ -4512,7 +4512,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::ABS);
+        assertArraysEquals(r, a, Int64VectorTests::ABS);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4527,7 +4527,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::abs);
+        assertArraysEquals(r, a, Int64VectorTests::abs);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4545,7 +4545,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Int64VectorTests::ABS);
     }
 
 
@@ -4571,7 +4571,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::NOT);
+        assertArraysEquals(r, a, Int64VectorTests::NOT);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4586,7 +4586,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::not);
+        assertArraysEquals(r, a, Int64VectorTests::not);
     }
 
 
@@ -4606,7 +4606,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int64VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Int64VectorTests::NOT);
     }
 
 
@@ -4629,7 +4629,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Int64VectorTests::ZOMO);
+        assertArraysEquals(r, a, Int64VectorTests::ZOMO);
     }
 
 
@@ -4649,7 +4649,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Int64VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Int64VectorTests::ZOMO);
     }
 
 
@@ -4677,7 +4677,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::gather);
+        assertArraysEquals(r, a, b, Int64VectorTests::gather);
     }
     static int[] gatherMasked(int a[], int ix, boolean[] mask, int[] b, int iy) {
         int[] res = new int[SPECIES.length()];
@@ -4705,7 +4705,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::gatherMasked);
     }
 
     static int[] scatter(int a[], int ix, int[] b, int iy) {
@@ -4730,7 +4730,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Int64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Int64VectorTests::scatter);
     }
 
     static int[] scatterMasked(int r[], int a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4768,7 +4768,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Int64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Int64VectorTests::scatterMasked);
     }
 
 
@@ -4810,8 +4810,8 @@ public class Int64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4821,8 +4821,8 @@ public class Int64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4832,8 +4832,8 @@ public class Int64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4899,7 +4899,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Int64VectorTests::ADDReduceLong, Int64VectorTests::ADDReduceAllLong);
     }
 
@@ -4940,7 +4940,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Int64VectorTests::ADDReduceLongMasked, Int64VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4952,7 +4952,7 @@ public class Int64VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -4970,7 +4970,7 @@ public class Int64VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Int64VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Int64VectorTests::blend);
     }
 
 
@@ -4987,7 +4987,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -5006,7 +5006,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5083,7 +5083,7 @@ public class Int64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Int64VectorTests::beq);
+        assertArraysEquals(r, a, b, Int64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -67,47 +67,25 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (int) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (int) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(int[] a, int[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (int) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -410,7 +388,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "intProviderForIOOBE")
@@ -481,7 +459,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new int[a.length];
@@ -492,7 +470,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intMaskProviderForIOOBE")
@@ -565,7 +543,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -589,7 +567,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -676,7 +654,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -691,7 +669,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -807,7 +785,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "intByteProviderForIOOBE")
@@ -888,7 +866,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -899,7 +877,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
@@ -976,7 +954,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -987,7 +965,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -73,7 +73,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int a);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FUnArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a[i]);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(int[] r, int[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int apply(int[] a);
     }
 
-    static void assertReductionArraysEquals(int[] a, int[] b, int c,
+    static void assertReductionArraysEquals(int[] r, int rc, int[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(int[] a, int[] b, int c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(int[] r, int rc, int[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -167,17 +167,17 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         long apply(int[] a);
     }
 
-    static void assertReductionLongArraysEquals(int[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, int[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -189,17 +189,17 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         long apply(int[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(int[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, int[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -207,37 +207,37 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(int[] a, int[] b, int element, int index) {
+    static void assertInsertArraysEquals(int[] r, int[] a, int element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -251,7 +251,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -265,7 +265,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -285,7 +285,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(int[] a, int[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(int[] r, int[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -305,7 +305,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[]a, int[]r) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -334,7 +334,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -345,7 +345,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -357,7 +357,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -369,11 +369,11 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -384,11 +384,11 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -402,11 +402,11 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -420,7 +420,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, FBinOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -434,11 +434,11 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -464,7 +464,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -475,11 +475,11 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -491,7 +491,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -504,7 +504,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,12 +517,12 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -538,12 +538,12 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,12 +574,12 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(int[] a, int[] b, int[] c, int[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(int[] r, int[] a, int[] b, int[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -602,7 +602,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int apply(int[] a, int b);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, FBinArrayOp f) {
+    static void assertArraysEquals(int[] r, int[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -617,7 +617,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -644,7 +644,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] r, int[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -665,7 +665,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -675,7 +675,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(r, a, i, mask, b, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -692,7 +692,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(int[] r, int[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -702,7 +702,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -712,7 +712,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -722,7 +722,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -733,7 +733,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -743,7 +743,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -754,7 +754,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -764,7 +764,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -776,7 +776,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         int[] apply(int[] a, int[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(int[] a, int[] b, int[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(int[] r, int[] a, int[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -786,7 +786,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             int[] ref = f.apply(a, b, origin, part, mask, i);
             int[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -795,7 +795,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(int[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -808,7 +808,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(int[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -819,7 +819,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(int[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, int[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1259,7 +1259,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::ADD);
     }
     static int add(int a, int b) {
         return (int)(a + b);
@@ -1277,7 +1277,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::add);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1297,7 +1297,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1315,7 +1315,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::add);
     }
     static int SUB(int a, int b) {
         return (int)(a - b);
@@ -1335,7 +1335,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::SUB);
     }
     static int sub(int a, int b) {
         return (int)(a - b);
@@ -1353,7 +1353,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1373,7 +1373,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1391,7 +1391,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::sub);
     }
     static int MUL(int a, int b) {
         return (int)(a * b);
@@ -1411,7 +1411,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::MUL);
     }
     static int mul(int a, int b) {
         return (int)(a * b);
@@ -1429,7 +1429,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1449,7 +1449,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1467,7 +1467,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::mul);
     }
 
 
@@ -1492,7 +1492,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::DIV);
     }
     static int div(int a, int b) {
         return (int)(a / b);
@@ -1514,7 +1514,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::div);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::div);
     }
 
 
@@ -1538,7 +1538,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1560,7 +1560,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::div);
     }
 
     static int FIRST_NONZERO(int a, int b) {
@@ -1581,7 +1581,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1601,7 +1601,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::FIRST_NONZERO);
     }
 
     static int AND(int a, int b) {
@@ -1622,7 +1622,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::AND);
     }
     static int and(int a, int b) {
         return (int)(a & b);
@@ -1640,7 +1640,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::and);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::and);
     }
 
 
@@ -1662,7 +1662,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::AND);
     }
 
 
@@ -1684,7 +1684,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::AND_NOT);
     }
 
 
@@ -1706,7 +1706,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::AND_NOT);
     }
 
 
@@ -1728,7 +1728,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::OR);
     }
     static int or(int a, int b) {
         return (int)(a | b);
@@ -1746,7 +1746,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::or);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::or);
     }
 
 
@@ -1768,7 +1768,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::OR);
     }
 
 
@@ -1790,7 +1790,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::XOR);
     }
 
 
@@ -1812,7 +1812,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::XOR);
     }
 
 
@@ -1827,7 +1827,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1844,7 +1844,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::add);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1858,7 +1858,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1875,7 +1875,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1889,7 +1889,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -1906,7 +1906,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::mul);
     }
 
 
@@ -1925,7 +1925,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::div);
     }
 
 
@@ -1946,7 +1946,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::div);
     }
 
 
@@ -1962,7 +1962,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::OR);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -1976,7 +1976,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::or);
     }
 
 
@@ -1995,7 +1995,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::OR);
     }
 
 
@@ -2011,7 +2011,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::AND);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2025,7 +2025,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::and);
     }
 
 
@@ -2044,7 +2044,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, IntMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, IntMaxVectorTests::AND);
     }
 
 
@@ -2060,7 +2060,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, IntMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, IntMaxVectorTests::OR);
     }
 
 
@@ -2079,7 +2079,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, IntMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, IntMaxVectorTests::OR);
     }
 
 
@@ -2094,7 +2094,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, IntMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, IntMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -2111,7 +2111,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, IntMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, IntMaxVectorTests::ADD);
     }
 
     static int LSHL(int a, int b) {
@@ -2132,7 +2132,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::LSHL);
     }
 
 
@@ -2154,7 +2154,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::LSHL);
     }
 
 
@@ -2180,7 +2180,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::ASHR);
     }
 
 
@@ -2202,7 +2202,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::ASHR);
     }
 
 
@@ -2228,7 +2228,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::LSHR);
     }
 
 
@@ -2250,7 +2250,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::LSHR);
     }
 
 
@@ -2275,7 +2275,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, IntMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, IntMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2296,7 +2296,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, IntMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, IntMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2321,7 +2321,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, IntMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, IntMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2342,7 +2342,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, IntMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, IntMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2367,7 +2367,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, IntMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, IntMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2388,7 +2388,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, IntMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, IntMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2413,7 +2413,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::MIN);
     }
     static int min(int a, int b) {
         return (int)(Math.min(a, b));
@@ -2431,7 +2431,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::min);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::min);
     }
     static int MAX(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2451,7 +2451,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::MAX);
     }
     static int max(int a, int b) {
         return (int)(Math.max(a, b));
@@ -2469,7 +2469,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::max);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::max);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2483,7 +2483,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2497,7 +2497,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::min);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2511,7 +2511,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "intBinaryOpProvider")
@@ -2525,7 +2525,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, IntMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, IntMaxVectorTests::max);
     }
 
     static int ANDReduce(int[] a, int idx) {
@@ -2568,7 +2568,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::ANDReduce, IntMaxVectorTests::ANDReduceAll);
     }
 
@@ -2616,7 +2616,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::ANDReduceMasked, IntMaxVectorTests::ANDReduceAllMasked);
     }
 
@@ -2661,7 +2661,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::ORReduce, IntMaxVectorTests::ORReduceAll);
     }
 
@@ -2709,7 +2709,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::ORReduceMasked, IntMaxVectorTests::ORReduceAllMasked);
     }
 
@@ -2754,7 +2754,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::XORReduce, IntMaxVectorTests::XORReduceAll);
     }
 
@@ -2802,7 +2802,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::XORReduceMasked, IntMaxVectorTests::XORReduceAllMasked);
     }
 
@@ -2844,7 +2844,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::ADDReduce, IntMaxVectorTests::ADDReduceAll);
     }
     static int ADDReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2888,7 +2888,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::ADDReduceMasked, IntMaxVectorTests::ADDReduceAllMasked);
     }
     static int MULReduce(int[] a, int idx) {
@@ -2929,7 +2929,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::MULReduce, IntMaxVectorTests::MULReduceAll);
     }
     static int MULReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -2973,7 +2973,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::MULReduceMasked, IntMaxVectorTests::MULReduceAllMasked);
     }
     static int MINReduce(int[] a, int idx) {
@@ -3014,7 +3014,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::MINReduce, IntMaxVectorTests::MINReduceAll);
     }
     static int MINReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3059,7 +3059,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::MINReduceMasked, IntMaxVectorTests::MINReduceAllMasked);
     }
     static int MAXReduce(int[] a, int idx) {
@@ -3100,7 +3100,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 IntMaxVectorTests::MAXReduce, IntMaxVectorTests::MAXReduceAll);
     }
     static int MAXReduceMasked(int[] a, int idx, boolean[] mask) {
@@ -3145,7 +3145,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::MAXReduceMasked, IntMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -3171,7 +3171,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, IntMaxVectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, IntMaxVectorTests::anyTrue);
     }
 
 
@@ -3197,7 +3197,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, IntMaxVectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, IntMaxVectorTests::allTrue);
     }
 
 
@@ -3213,7 +3213,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (int)4, 0);
+        assertInsertArraysEquals(r, a, (int)4, 0);
     }
     static boolean testIS_DEFAULT(int a) {
         return bits(a)==0;
@@ -3762,7 +3762,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "intUnaryOpShuffleProvider")
@@ -3779,7 +3779,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -3797,7 +3797,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "intUnaryOpProvider")
     static void getIntMaxVectorTests(IntFunction<int[]> fa) {
@@ -3952,7 +3952,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::get);
+        assertArraysEquals(r, a, IntMaxVectorTests::get);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -3966,7 +3966,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4013,7 +4013,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, IntMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, IntMaxVectorTests::sliceUnary);
     }
     static int[] sliceBinary(int[] a, int[] b, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4042,7 +4042,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, IntMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, IntMaxVectorTests::sliceBinary);
     }
     static int[] slice(int[] a, int[] b, int origin, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4075,7 +4075,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, IntMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, IntMaxVectorTests::slice);
     }
     static int[] unsliceUnary(int[] a, int origin, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4102,7 +4102,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, IntMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, IntMaxVectorTests::unsliceUnary);
     }
     static int[] unsliceBinary(int[] a, int[] b, int origin, int part, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4141,7 +4141,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, IntMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, IntMaxVectorTests::unsliceBinary);
     }
     static int[] unslice(int[] a, int[] b, int origin, int part, boolean[] mask, int idx) {
         int[] res = new int[SPECIES.length()];
@@ -4197,7 +4197,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, IntMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, IntMaxVectorTests::unslice);
     }
 
 
@@ -4246,7 +4246,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, IntMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, IntMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendIntMaxVectorTests(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4262,7 +4262,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, IntMaxVectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, IntMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4285,7 +4285,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, IntMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, IntMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4303,7 +4303,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4318,7 +4318,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendIntMaxVectorTestsBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4332,7 +4332,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             IntVector bv = IntVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "intTernaryOpProvider")
@@ -4347,7 +4347,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             IntVector cv = IntVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4367,7 +4367,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, IntMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, IntMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "intTernaryOpMaskProvider")
@@ -4386,7 +4386,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, IntMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, IntMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4404,7 +4404,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "intTernaryOpProvider")
     static void bitwiseBlendIntMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<int[]> fa, IntFunction<int[]> fb, IntFunction<int[]> fc) {
@@ -4418,7 +4418,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, IntMaxVectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, IntMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4437,7 +4437,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, IntMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, IntMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4461,7 +4461,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::NEG);
+        assertArraysEquals(r, a, IntMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4476,7 +4476,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::neg);
+        assertArraysEquals(r, a, IntMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4494,7 +4494,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, IntMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, IntMaxVectorTests::NEG);
     }
 
     static int ABS(int a) {
@@ -4517,7 +4517,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::ABS);
+        assertArraysEquals(r, a, IntMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4532,7 +4532,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::abs);
+        assertArraysEquals(r, a, IntMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "intUnaryOpMaskProvider")
@@ -4550,7 +4550,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, IntMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, IntMaxVectorTests::ABS);
     }
 
 
@@ -4576,7 +4576,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::NOT);
+        assertArraysEquals(r, a, IntMaxVectorTests::NOT);
     }
 
     @Test(dataProvider = "intUnaryOpProvider")
@@ -4591,7 +4591,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::not);
+        assertArraysEquals(r, a, IntMaxVectorTests::not);
     }
 
 
@@ -4611,7 +4611,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, IntMaxVectorTests::NOT);
+        assertArraysEquals(r, a, mask, IntMaxVectorTests::NOT);
     }
 
 
@@ -4634,7 +4634,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, IntMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, IntMaxVectorTests::ZOMO);
     }
 
 
@@ -4654,7 +4654,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, IntMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, IntMaxVectorTests::ZOMO);
     }
 
 
@@ -4682,7 +4682,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::gather);
     }
     static int[] gatherMasked(int a[], int ix, boolean[] mask, int[] b, int iy) {
         int[] res = new int[SPECIES.length()];
@@ -4710,7 +4710,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::gatherMasked);
     }
 
     static int[] scatter(int a[], int ix, int[] b, int iy) {
@@ -4735,7 +4735,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, IntMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::scatter);
     }
 
     static int[] scatterMasked(int r[], int a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4773,7 +4773,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, IntMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, IntMaxVectorTests::scatterMasked);
     }
 
 
@@ -4815,8 +4815,8 @@ public class IntMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4826,8 +4826,8 @@ public class IntMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4837,8 +4837,8 @@ public class IntMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector av = IntVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4904,7 +4904,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 IntMaxVectorTests::ADDReduceLong, IntMaxVectorTests::ADDReduceAllLong);
     }
 
@@ -4945,7 +4945,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 IntMaxVectorTests::ADDReduceLongMasked, IntMaxVectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4957,7 +4957,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             IntVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "intBinaryOpMaskProvider")
@@ -4975,7 +4975,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, IntMaxVectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, IntMaxVectorTests::blend);
     }
 
 
@@ -4992,7 +4992,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "intUnaryOpShuffleMaskProvider")
@@ -5011,7 +5011,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5088,7 +5088,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, IntMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, IntMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(long[] a, long[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "longProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new long[a.length];
@@ -483,7 +461,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -68,7 +68,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a[i]);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Long128VectorTests extends AbstractVectorTest {
         long apply(long[] a);
     }
 
-    static void assertReductionArraysEquals(long[] a, long[] b, long c,
+    static void assertReductionArraysEquals(long[] r, long rc, long[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Long128VectorTests extends AbstractVectorTest {
         long apply(long[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(long[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(long[] r, long rc, long[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -159,37 +159,37 @@ public class Long128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(long[] a, long[] b, long element, int index) {
+    static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -203,7 +203,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -217,7 +217,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -237,7 +237,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -257,7 +257,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[]a, long[]r) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -286,7 +286,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -297,7 +297,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -309,7 +309,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -321,11 +321,11 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -336,11 +336,11 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -354,11 +354,11 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -372,7 +372,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -386,11 +386,11 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -416,7 +416,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -427,11 +427,11 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -443,7 +443,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -456,7 +456,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -469,12 +469,12 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -490,12 +490,12 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -511,7 +511,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -526,12 +526,12 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long apply(long[] a, int b);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FBinArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,7 +569,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -596,7 +596,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] r, long[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -606,7 +606,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -617,7 +617,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -627,7 +627,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(r, a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -644,7 +644,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -664,7 +664,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -674,7 +674,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -685,7 +685,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -695,7 +695,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -706,7 +706,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -716,7 +716,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -728,7 +728,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -780,7 +780,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(long[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -793,7 +793,7 @@ public class Long128VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(long[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -804,7 +804,7 @@ public class Long128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1275,7 +1275,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Long128VectorTests::ADD);
     }
     static long add(long a, long b) {
         return (long)(a + b);
@@ -1293,7 +1293,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::add);
+        assertArraysEquals(r, a, b, Long128VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1313,7 +1313,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1331,7 +1331,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::add);
     }
     static long SUB(long a, long b) {
         return (long)(a - b);
@@ -1351,7 +1351,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Long128VectorTests::SUB);
     }
     static long sub(long a, long b) {
         return (long)(a - b);
@@ -1369,7 +1369,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::sub);
+        assertArraysEquals(r, a, b, Long128VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1389,7 +1389,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::SUB);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1407,7 +1407,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::sub);
     }
     static long MUL(long a, long b) {
         return (long)(a * b);
@@ -1427,7 +1427,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Long128VectorTests::MUL);
     }
     static long mul(long a, long b) {
         return (long)(a * b);
@@ -1445,7 +1445,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::mul);
+        assertArraysEquals(r, a, b, Long128VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1465,7 +1465,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::MUL);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1483,7 +1483,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::mul);
     }
 
 
@@ -1508,7 +1508,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Long128VectorTests::DIV);
     }
     static long div(long a, long b) {
         return (long)(a / b);
@@ -1530,7 +1530,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::div);
+        assertArraysEquals(r, a, b, Long128VectorTests::div);
     }
 
 
@@ -1554,7 +1554,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::DIV);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1576,7 +1576,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::div);
     }
 
     static long FIRST_NONZERO(long a, long b) {
@@ -1597,7 +1597,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Long128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1617,7 +1617,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::FIRST_NONZERO);
     }
 
     static long AND(long a, long b) {
@@ -1638,7 +1638,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::AND);
+        assertArraysEquals(r, a, b, Long128VectorTests::AND);
     }
     static long and(long a, long b) {
         return (long)(a & b);
@@ -1656,7 +1656,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::and);
+        assertArraysEquals(r, a, b, Long128VectorTests::and);
     }
 
 
@@ -1678,7 +1678,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::AND);
     }
 
 
@@ -1700,7 +1700,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Long128VectorTests::AND_NOT);
     }
 
 
@@ -1722,7 +1722,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::AND_NOT);
     }
 
 
@@ -1744,7 +1744,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::OR);
+        assertArraysEquals(r, a, b, Long128VectorTests::OR);
     }
     static long or(long a, long b) {
         return (long)(a | b);
@@ -1762,7 +1762,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::or);
+        assertArraysEquals(r, a, b, Long128VectorTests::or);
     }
 
 
@@ -1784,7 +1784,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::OR);
     }
 
 
@@ -1806,7 +1806,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::XOR);
+        assertArraysEquals(r, a, b, Long128VectorTests::XOR);
     }
 
 
@@ -1828,7 +1828,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::XOR);
     }
 
 
@@ -1843,7 +1843,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1860,7 +1860,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1874,7 +1874,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1891,7 +1891,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1905,7 +1905,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1922,7 +1922,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::mul);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::div);
     }
 
 
@@ -1962,7 +1962,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::div);
     }
 
 
@@ -1978,7 +1978,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::OR);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1992,7 +1992,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::or);
     }
 
 
@@ -2011,7 +2011,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::OR);
     }
 
 
@@ -2027,7 +2027,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::AND);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::and);
     }
 
 
@@ -2060,7 +2060,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Long128VectorTests::AND);
     }
 
 
@@ -2076,7 +2076,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Long128VectorTests::OR);
     }
 
 
@@ -2095,7 +2095,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long128VectorTests::OR);
     }
 
 
@@ -2110,7 +2110,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Long128VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -2127,7 +2127,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long128VectorTests::ADD);
     }
 
     static long LSHL(long a, long b) {
@@ -2148,7 +2148,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Long128VectorTests::LSHL);
     }
 
 
@@ -2170,7 +2170,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::LSHL);
     }
 
 
@@ -2196,7 +2196,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Long128VectorTests::ASHR);
     }
 
 
@@ -2218,7 +2218,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::ASHR);
     }
 
 
@@ -2244,7 +2244,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Long128VectorTests::LSHR);
     }
 
 
@@ -2266,7 +2266,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::LSHR);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Long128VectorTests::LSHL_unary);
     }
 
 
@@ -2312,7 +2312,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long128VectorTests::LSHL_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Long128VectorTests::LSHR_unary);
     }
 
 
@@ -2358,7 +2358,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long128VectorTests::LSHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Long128VectorTests::ASHR_unary);
     }
 
 
@@ -2404,7 +2404,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long128VectorTests::ASHR_unary);
     }
 
 
@@ -2429,7 +2429,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Long128VectorTests::MIN);
     }
     static long min(long a, long b) {
         return (long)(Math.min(a, b));
@@ -2447,7 +2447,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::min);
+        assertArraysEquals(r, a, b, Long128VectorTests::min);
     }
     static long MAX(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2467,7 +2467,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Long128VectorTests::MAX);
     }
     static long max(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2485,7 +2485,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::max);
+        assertArraysEquals(r, a, b, Long128VectorTests::max);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2499,7 +2499,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::MIN);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2513,7 +2513,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::min);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2527,7 +2527,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::MAX);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2541,7 +2541,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Long128VectorTests::max);
     }
 
     static long ANDReduce(long[] a, int idx) {
@@ -2584,7 +2584,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::ANDReduce, Long128VectorTests::ANDReduceAll);
     }
 
@@ -2632,7 +2632,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::ANDReduceMasked, Long128VectorTests::ANDReduceAllMasked);
     }
 
@@ -2677,7 +2677,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::ORReduce, Long128VectorTests::ORReduceAll);
     }
 
@@ -2725,7 +2725,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::ORReduceMasked, Long128VectorTests::ORReduceAllMasked);
     }
 
@@ -2770,7 +2770,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::XORReduce, Long128VectorTests::XORReduceAll);
     }
 
@@ -2818,7 +2818,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::XORReduceMasked, Long128VectorTests::XORReduceAllMasked);
     }
 
@@ -2860,7 +2860,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::ADDReduce, Long128VectorTests::ADDReduceAll);
     }
     static long ADDReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2904,7 +2904,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::ADDReduceMasked, Long128VectorTests::ADDReduceAllMasked);
     }
     static long MULReduce(long[] a, int idx) {
@@ -2945,7 +2945,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::MULReduce, Long128VectorTests::MULReduceAll);
     }
     static long MULReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2989,7 +2989,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::MULReduceMasked, Long128VectorTests::MULReduceAllMasked);
     }
     static long MINReduce(long[] a, int idx) {
@@ -3030,7 +3030,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::MINReduce, Long128VectorTests::MINReduceAll);
     }
     static long MINReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3075,7 +3075,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::MINReduceMasked, Long128VectorTests::MINReduceAllMasked);
     }
     static long MAXReduce(long[] a, int idx) {
@@ -3116,7 +3116,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::MAXReduce, Long128VectorTests::MAXReduceAll);
     }
     static long MAXReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3161,7 +3161,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::MAXReduceMasked, Long128VectorTests::MAXReduceAllMasked);
     }
 
@@ -3187,7 +3187,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long128VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Long128VectorTests::anyTrue);
     }
 
 
@@ -3213,7 +3213,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long128VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Long128VectorTests::allTrue);
     }
 
 
@@ -3229,7 +3229,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (long)4, 0);
+        assertInsertArraysEquals(r, a, (long)4, 0);
     }
     static boolean testIS_DEFAULT(long a) {
         return bits(a)==0;
@@ -3706,7 +3706,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::blend);
     }
 
     @Test(dataProvider = "longUnaryOpShuffleProvider")
@@ -3723,7 +3723,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpShuffleMaskProvider")
@@ -3741,7 +3741,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "longUnaryOpProvider")
     static void getLong128VectorTests(IntFunction<long[]> fa) {
@@ -3896,7 +3896,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::get);
+        assertArraysEquals(r, a, Long128VectorTests::get);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -3910,7 +3910,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3957,7 +3957,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Long128VectorTests::sliceUnary);
     }
     static long[] sliceBinary(long[] a, long[] b, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -3986,7 +3986,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Long128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Long128VectorTests::sliceBinary);
     }
     static long[] slice(long[] a, long[] b, int origin, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4019,7 +4019,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Long128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Long128VectorTests::slice);
     }
     static long[] unsliceUnary(long[] a, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4046,7 +4046,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Long128VectorTests::unsliceUnary);
     }
     static long[] unsliceBinary(long[] a, long[] b, int origin, int part, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4085,7 +4085,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Long128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Long128VectorTests::unsliceBinary);
     }
     static long[] unslice(long[] a, long[] b, int origin, int part, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4141,7 +4141,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Long128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Long128VectorTests::unslice);
     }
 
 
@@ -4190,7 +4190,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Long128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Long128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong128VectorTests(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4206,7 +4206,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Long128VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Long128VectorTests::bitwiseBlend);
     }
 
 
@@ -4229,7 +4229,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Long128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Long128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4247,7 +4247,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Long128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4262,7 +4262,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong128VectorTestsBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4276,7 +4276,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long128VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Long128VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4291,7 +4291,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long128VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long128VectorTests::bitwiseBlend);
     }
 
 
@@ -4311,7 +4311,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Long128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Long128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Long128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Long128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4348,7 +4348,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong128VectorTestsDoubleBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4362,7 +4362,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long128VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long128VectorTests::bitwiseBlend);
     }
 
 
@@ -4381,7 +4381,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Long128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Long128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4405,7 +4405,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::NEG);
+        assertArraysEquals(r, a, Long128VectorTests::NEG);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4420,7 +4420,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::neg);
+        assertArraysEquals(r, a, Long128VectorTests::neg);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4438,7 +4438,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Long128VectorTests::NEG);
     }
 
     static long ABS(long a) {
@@ -4461,7 +4461,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::ABS);
+        assertArraysEquals(r, a, Long128VectorTests::ABS);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4476,7 +4476,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::abs);
+        assertArraysEquals(r, a, Long128VectorTests::abs);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4494,7 +4494,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Long128VectorTests::ABS);
     }
 
 
@@ -4520,7 +4520,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::NOT);
+        assertArraysEquals(r, a, Long128VectorTests::NOT);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4535,7 +4535,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::not);
+        assertArraysEquals(r, a, Long128VectorTests::not);
     }
 
 
@@ -4555,7 +4555,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long128VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Long128VectorTests::NOT);
     }
 
 
@@ -4578,7 +4578,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long128VectorTests::ZOMO);
+        assertArraysEquals(r, a, Long128VectorTests::ZOMO);
     }
 
 
@@ -4598,7 +4598,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long128VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Long128VectorTests::ZOMO);
     }
 
 
@@ -4626,7 +4626,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::gather);
+        assertArraysEquals(r, a, b, Long128VectorTests::gather);
     }
     static long[] gatherMasked(long a[], int ix, boolean[] mask, int[] b, int iy) {
         long[] res = new long[SPECIES.length()];
@@ -4654,7 +4654,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::gatherMasked);
     }
 
     static long[] scatter(long a[], int ix, int[] b, int iy) {
@@ -4679,7 +4679,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Long128VectorTests::scatter);
     }
 
     static long[] scatterMasked(long r[], long a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4717,7 +4717,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Long128VectorTests::scatterMasked);
     }
 
 
@@ -4759,8 +4759,8 @@ public class Long128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4770,8 +4770,8 @@ public class Long128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4781,8 +4781,8 @@ public class Long128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4831,7 +4831,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long128VectorTests::ADDReduce, Long128VectorTests::ADDReduceAll);
     }
 
@@ -4853,7 +4853,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long128VectorTests::ADDReduceMasked, Long128VectorTests::ADDReduceAllMasked);
     }
 
@@ -4870,7 +4870,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpSelectFromMaskProvider")
@@ -4889,7 +4889,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4966,7 +4966,7 @@ public class Long128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Long128VectorTests::beq);
+        assertArraysEquals(r, a, b, Long128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(long[] a, long[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "longProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new long[a.length];
@@ -483,7 +461,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -68,7 +68,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a[i]);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Long256VectorTests extends AbstractVectorTest {
         long apply(long[] a);
     }
 
-    static void assertReductionArraysEquals(long[] a, long[] b, long c,
+    static void assertReductionArraysEquals(long[] r, long rc, long[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Long256VectorTests extends AbstractVectorTest {
         long apply(long[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(long[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(long[] r, long rc, long[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -159,37 +159,37 @@ public class Long256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(long[] a, long[] b, long element, int index) {
+    static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -203,7 +203,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -217,7 +217,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -237,7 +237,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -257,7 +257,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[]a, long[]r) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -286,7 +286,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -297,7 +297,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -309,7 +309,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -321,11 +321,11 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -336,11 +336,11 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -354,11 +354,11 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -372,7 +372,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -386,11 +386,11 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -416,7 +416,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -427,11 +427,11 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -443,7 +443,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -456,7 +456,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -469,12 +469,12 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -490,12 +490,12 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -511,7 +511,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -526,12 +526,12 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long apply(long[] a, int b);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FBinArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,7 +569,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -596,7 +596,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] r, long[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -606,7 +606,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -617,7 +617,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -627,7 +627,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(r, a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -644,7 +644,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -664,7 +664,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -674,7 +674,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -685,7 +685,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -695,7 +695,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -706,7 +706,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -716,7 +716,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -728,7 +728,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -780,7 +780,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(long[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -793,7 +793,7 @@ public class Long256VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(long[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -804,7 +804,7 @@ public class Long256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1275,7 +1275,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Long256VectorTests::ADD);
     }
     static long add(long a, long b) {
         return (long)(a + b);
@@ -1293,7 +1293,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::add);
+        assertArraysEquals(r, a, b, Long256VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1313,7 +1313,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1331,7 +1331,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::add);
     }
     static long SUB(long a, long b) {
         return (long)(a - b);
@@ -1351,7 +1351,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Long256VectorTests::SUB);
     }
     static long sub(long a, long b) {
         return (long)(a - b);
@@ -1369,7 +1369,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::sub);
+        assertArraysEquals(r, a, b, Long256VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1389,7 +1389,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::SUB);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1407,7 +1407,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::sub);
     }
     static long MUL(long a, long b) {
         return (long)(a * b);
@@ -1427,7 +1427,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Long256VectorTests::MUL);
     }
     static long mul(long a, long b) {
         return (long)(a * b);
@@ -1445,7 +1445,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::mul);
+        assertArraysEquals(r, a, b, Long256VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1465,7 +1465,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::MUL);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1483,7 +1483,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::mul);
     }
 
 
@@ -1508,7 +1508,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Long256VectorTests::DIV);
     }
     static long div(long a, long b) {
         return (long)(a / b);
@@ -1530,7 +1530,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::div);
+        assertArraysEquals(r, a, b, Long256VectorTests::div);
     }
 
 
@@ -1554,7 +1554,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::DIV);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1576,7 +1576,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::div);
     }
 
     static long FIRST_NONZERO(long a, long b) {
@@ -1597,7 +1597,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Long256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1617,7 +1617,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::FIRST_NONZERO);
     }
 
     static long AND(long a, long b) {
@@ -1638,7 +1638,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::AND);
+        assertArraysEquals(r, a, b, Long256VectorTests::AND);
     }
     static long and(long a, long b) {
         return (long)(a & b);
@@ -1656,7 +1656,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::and);
+        assertArraysEquals(r, a, b, Long256VectorTests::and);
     }
 
 
@@ -1678,7 +1678,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::AND);
     }
 
 
@@ -1700,7 +1700,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Long256VectorTests::AND_NOT);
     }
 
 
@@ -1722,7 +1722,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::AND_NOT);
     }
 
 
@@ -1744,7 +1744,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::OR);
+        assertArraysEquals(r, a, b, Long256VectorTests::OR);
     }
     static long or(long a, long b) {
         return (long)(a | b);
@@ -1762,7 +1762,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::or);
+        assertArraysEquals(r, a, b, Long256VectorTests::or);
     }
 
 
@@ -1784,7 +1784,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::OR);
     }
 
 
@@ -1806,7 +1806,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::XOR);
+        assertArraysEquals(r, a, b, Long256VectorTests::XOR);
     }
 
 
@@ -1828,7 +1828,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::XOR);
     }
 
 
@@ -1843,7 +1843,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1860,7 +1860,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1874,7 +1874,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1891,7 +1891,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1905,7 +1905,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1922,7 +1922,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::mul);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::div);
     }
 
 
@@ -1962,7 +1962,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::div);
     }
 
 
@@ -1978,7 +1978,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::OR);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1992,7 +1992,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::or);
     }
 
 
@@ -2011,7 +2011,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::OR);
     }
 
 
@@ -2027,7 +2027,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::AND);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::and);
     }
 
 
@@ -2060,7 +2060,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Long256VectorTests::AND);
     }
 
 
@@ -2076,7 +2076,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Long256VectorTests::OR);
     }
 
 
@@ -2095,7 +2095,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long256VectorTests::OR);
     }
 
 
@@ -2110,7 +2110,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Long256VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -2127,7 +2127,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long256VectorTests::ADD);
     }
 
     static long LSHL(long a, long b) {
@@ -2148,7 +2148,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Long256VectorTests::LSHL);
     }
 
 
@@ -2170,7 +2170,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::LSHL);
     }
 
 
@@ -2196,7 +2196,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Long256VectorTests::ASHR);
     }
 
 
@@ -2218,7 +2218,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::ASHR);
     }
 
 
@@ -2244,7 +2244,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Long256VectorTests::LSHR);
     }
 
 
@@ -2266,7 +2266,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::LSHR);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Long256VectorTests::LSHL_unary);
     }
 
 
@@ -2312,7 +2312,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long256VectorTests::LSHL_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Long256VectorTests::LSHR_unary);
     }
 
 
@@ -2358,7 +2358,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long256VectorTests::LSHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Long256VectorTests::ASHR_unary);
     }
 
 
@@ -2404,7 +2404,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long256VectorTests::ASHR_unary);
     }
 
 
@@ -2429,7 +2429,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Long256VectorTests::MIN);
     }
     static long min(long a, long b) {
         return (long)(Math.min(a, b));
@@ -2447,7 +2447,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::min);
+        assertArraysEquals(r, a, b, Long256VectorTests::min);
     }
     static long MAX(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2467,7 +2467,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Long256VectorTests::MAX);
     }
     static long max(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2485,7 +2485,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::max);
+        assertArraysEquals(r, a, b, Long256VectorTests::max);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2499,7 +2499,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::MIN);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2513,7 +2513,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::min);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2527,7 +2527,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::MAX);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2541,7 +2541,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Long256VectorTests::max);
     }
 
     static long ANDReduce(long[] a, int idx) {
@@ -2584,7 +2584,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::ANDReduce, Long256VectorTests::ANDReduceAll);
     }
 
@@ -2632,7 +2632,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::ANDReduceMasked, Long256VectorTests::ANDReduceAllMasked);
     }
 
@@ -2677,7 +2677,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::ORReduce, Long256VectorTests::ORReduceAll);
     }
 
@@ -2725,7 +2725,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::ORReduceMasked, Long256VectorTests::ORReduceAllMasked);
     }
 
@@ -2770,7 +2770,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::XORReduce, Long256VectorTests::XORReduceAll);
     }
 
@@ -2818,7 +2818,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::XORReduceMasked, Long256VectorTests::XORReduceAllMasked);
     }
 
@@ -2860,7 +2860,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::ADDReduce, Long256VectorTests::ADDReduceAll);
     }
     static long ADDReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2904,7 +2904,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::ADDReduceMasked, Long256VectorTests::ADDReduceAllMasked);
     }
     static long MULReduce(long[] a, int idx) {
@@ -2945,7 +2945,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::MULReduce, Long256VectorTests::MULReduceAll);
     }
     static long MULReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2989,7 +2989,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::MULReduceMasked, Long256VectorTests::MULReduceAllMasked);
     }
     static long MINReduce(long[] a, int idx) {
@@ -3030,7 +3030,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::MINReduce, Long256VectorTests::MINReduceAll);
     }
     static long MINReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3075,7 +3075,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::MINReduceMasked, Long256VectorTests::MINReduceAllMasked);
     }
     static long MAXReduce(long[] a, int idx) {
@@ -3116,7 +3116,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::MAXReduce, Long256VectorTests::MAXReduceAll);
     }
     static long MAXReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3161,7 +3161,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::MAXReduceMasked, Long256VectorTests::MAXReduceAllMasked);
     }
 
@@ -3187,7 +3187,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long256VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Long256VectorTests::anyTrue);
     }
 
 
@@ -3213,7 +3213,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long256VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Long256VectorTests::allTrue);
     }
 
 
@@ -3229,7 +3229,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (long)4, 0);
+        assertInsertArraysEquals(r, a, (long)4, 0);
     }
     static boolean testIS_DEFAULT(long a) {
         return bits(a)==0;
@@ -3706,7 +3706,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::blend);
     }
 
     @Test(dataProvider = "longUnaryOpShuffleProvider")
@@ -3723,7 +3723,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpShuffleMaskProvider")
@@ -3741,7 +3741,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "longUnaryOpProvider")
     static void getLong256VectorTests(IntFunction<long[]> fa) {
@@ -3896,7 +3896,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::get);
+        assertArraysEquals(r, a, Long256VectorTests::get);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -3910,7 +3910,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3957,7 +3957,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Long256VectorTests::sliceUnary);
     }
     static long[] sliceBinary(long[] a, long[] b, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -3986,7 +3986,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Long256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Long256VectorTests::sliceBinary);
     }
     static long[] slice(long[] a, long[] b, int origin, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4019,7 +4019,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Long256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Long256VectorTests::slice);
     }
     static long[] unsliceUnary(long[] a, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4046,7 +4046,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Long256VectorTests::unsliceUnary);
     }
     static long[] unsliceBinary(long[] a, long[] b, int origin, int part, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4085,7 +4085,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Long256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Long256VectorTests::unsliceBinary);
     }
     static long[] unslice(long[] a, long[] b, int origin, int part, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4141,7 +4141,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Long256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Long256VectorTests::unslice);
     }
 
 
@@ -4190,7 +4190,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Long256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Long256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong256VectorTests(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4206,7 +4206,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Long256VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Long256VectorTests::bitwiseBlend);
     }
 
 
@@ -4229,7 +4229,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Long256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Long256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4247,7 +4247,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Long256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4262,7 +4262,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong256VectorTestsBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4276,7 +4276,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long256VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Long256VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4291,7 +4291,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long256VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long256VectorTests::bitwiseBlend);
     }
 
 
@@ -4311,7 +4311,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Long256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Long256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Long256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Long256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4348,7 +4348,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong256VectorTestsDoubleBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4362,7 +4362,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long256VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long256VectorTests::bitwiseBlend);
     }
 
 
@@ -4381,7 +4381,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Long256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Long256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4405,7 +4405,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::NEG);
+        assertArraysEquals(r, a, Long256VectorTests::NEG);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4420,7 +4420,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::neg);
+        assertArraysEquals(r, a, Long256VectorTests::neg);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4438,7 +4438,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Long256VectorTests::NEG);
     }
 
     static long ABS(long a) {
@@ -4461,7 +4461,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::ABS);
+        assertArraysEquals(r, a, Long256VectorTests::ABS);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4476,7 +4476,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::abs);
+        assertArraysEquals(r, a, Long256VectorTests::abs);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4494,7 +4494,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Long256VectorTests::ABS);
     }
 
 
@@ -4520,7 +4520,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::NOT);
+        assertArraysEquals(r, a, Long256VectorTests::NOT);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4535,7 +4535,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::not);
+        assertArraysEquals(r, a, Long256VectorTests::not);
     }
 
 
@@ -4555,7 +4555,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long256VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Long256VectorTests::NOT);
     }
 
 
@@ -4578,7 +4578,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long256VectorTests::ZOMO);
+        assertArraysEquals(r, a, Long256VectorTests::ZOMO);
     }
 
 
@@ -4598,7 +4598,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long256VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Long256VectorTests::ZOMO);
     }
 
 
@@ -4626,7 +4626,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::gather);
+        assertArraysEquals(r, a, b, Long256VectorTests::gather);
     }
     static long[] gatherMasked(long a[], int ix, boolean[] mask, int[] b, int iy) {
         long[] res = new long[SPECIES.length()];
@@ -4654,7 +4654,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::gatherMasked);
     }
 
     static long[] scatter(long a[], int ix, int[] b, int iy) {
@@ -4679,7 +4679,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Long256VectorTests::scatter);
     }
 
     static long[] scatterMasked(long r[], long a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4717,7 +4717,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Long256VectorTests::scatterMasked);
     }
 
 
@@ -4759,8 +4759,8 @@ public class Long256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4770,8 +4770,8 @@ public class Long256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4781,8 +4781,8 @@ public class Long256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4831,7 +4831,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long256VectorTests::ADDReduce, Long256VectorTests::ADDReduceAll);
     }
 
@@ -4853,7 +4853,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long256VectorTests::ADDReduceMasked, Long256VectorTests::ADDReduceAllMasked);
     }
 
@@ -4870,7 +4870,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpSelectFromMaskProvider")
@@ -4889,7 +4889,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4966,7 +4966,7 @@ public class Long256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Long256VectorTests::beq);
+        assertArraysEquals(r, a, b, Long256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(long[] a, long[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "longProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new long[a.length];
@@ -483,7 +461,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -68,7 +68,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a[i]);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Long512VectorTests extends AbstractVectorTest {
         long apply(long[] a);
     }
 
-    static void assertReductionArraysEquals(long[] a, long[] b, long c,
+    static void assertReductionArraysEquals(long[] r, long rc, long[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Long512VectorTests extends AbstractVectorTest {
         long apply(long[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(long[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(long[] r, long rc, long[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -159,37 +159,37 @@ public class Long512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(long[] a, long[] b, long element, int index) {
+    static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -203,7 +203,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -217,7 +217,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -237,7 +237,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -257,7 +257,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[]a, long[]r) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -286,7 +286,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -297,7 +297,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -309,7 +309,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -321,11 +321,11 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -336,11 +336,11 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -354,11 +354,11 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -372,7 +372,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -386,11 +386,11 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -416,7 +416,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -427,11 +427,11 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -443,7 +443,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -456,7 +456,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -469,12 +469,12 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -490,12 +490,12 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -511,7 +511,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -526,12 +526,12 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long apply(long[] a, int b);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FBinArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,7 +569,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -596,7 +596,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] r, long[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -606,7 +606,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -617,7 +617,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -627,7 +627,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(r, a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -644,7 +644,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -664,7 +664,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -674,7 +674,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -685,7 +685,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -695,7 +695,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -706,7 +706,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -716,7 +716,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -728,7 +728,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -780,7 +780,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(long[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -793,7 +793,7 @@ public class Long512VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(long[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -804,7 +804,7 @@ public class Long512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1275,7 +1275,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Long512VectorTests::ADD);
     }
     static long add(long a, long b) {
         return (long)(a + b);
@@ -1293,7 +1293,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::add);
+        assertArraysEquals(r, a, b, Long512VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1313,7 +1313,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1331,7 +1331,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::add);
     }
     static long SUB(long a, long b) {
         return (long)(a - b);
@@ -1351,7 +1351,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Long512VectorTests::SUB);
     }
     static long sub(long a, long b) {
         return (long)(a - b);
@@ -1369,7 +1369,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::sub);
+        assertArraysEquals(r, a, b, Long512VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1389,7 +1389,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::SUB);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1407,7 +1407,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::sub);
     }
     static long MUL(long a, long b) {
         return (long)(a * b);
@@ -1427,7 +1427,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Long512VectorTests::MUL);
     }
     static long mul(long a, long b) {
         return (long)(a * b);
@@ -1445,7 +1445,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::mul);
+        assertArraysEquals(r, a, b, Long512VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1465,7 +1465,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::MUL);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1483,7 +1483,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::mul);
     }
 
 
@@ -1508,7 +1508,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Long512VectorTests::DIV);
     }
     static long div(long a, long b) {
         return (long)(a / b);
@@ -1530,7 +1530,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::div);
+        assertArraysEquals(r, a, b, Long512VectorTests::div);
     }
 
 
@@ -1554,7 +1554,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::DIV);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1576,7 +1576,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::div);
     }
 
     static long FIRST_NONZERO(long a, long b) {
@@ -1597,7 +1597,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Long512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1617,7 +1617,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::FIRST_NONZERO);
     }
 
     static long AND(long a, long b) {
@@ -1638,7 +1638,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::AND);
+        assertArraysEquals(r, a, b, Long512VectorTests::AND);
     }
     static long and(long a, long b) {
         return (long)(a & b);
@@ -1656,7 +1656,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::and);
+        assertArraysEquals(r, a, b, Long512VectorTests::and);
     }
 
 
@@ -1678,7 +1678,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::AND);
     }
 
 
@@ -1700,7 +1700,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Long512VectorTests::AND_NOT);
     }
 
 
@@ -1722,7 +1722,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::AND_NOT);
     }
 
 
@@ -1744,7 +1744,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::OR);
+        assertArraysEquals(r, a, b, Long512VectorTests::OR);
     }
     static long or(long a, long b) {
         return (long)(a | b);
@@ -1762,7 +1762,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::or);
+        assertArraysEquals(r, a, b, Long512VectorTests::or);
     }
 
 
@@ -1784,7 +1784,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::OR);
     }
 
 
@@ -1806,7 +1806,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::XOR);
+        assertArraysEquals(r, a, b, Long512VectorTests::XOR);
     }
 
 
@@ -1828,7 +1828,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::XOR);
     }
 
 
@@ -1843,7 +1843,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1860,7 +1860,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1874,7 +1874,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1891,7 +1891,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1905,7 +1905,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1922,7 +1922,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::mul);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::div);
     }
 
 
@@ -1962,7 +1962,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::div);
     }
 
 
@@ -1978,7 +1978,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::OR);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1992,7 +1992,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::or);
     }
 
 
@@ -2011,7 +2011,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::OR);
     }
 
 
@@ -2027,7 +2027,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::AND);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::and);
     }
 
 
@@ -2060,7 +2060,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Long512VectorTests::AND);
     }
 
 
@@ -2076,7 +2076,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Long512VectorTests::OR);
     }
 
 
@@ -2095,7 +2095,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long512VectorTests::OR);
     }
 
 
@@ -2110,7 +2110,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Long512VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -2127,7 +2127,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long512VectorTests::ADD);
     }
 
     static long LSHL(long a, long b) {
@@ -2148,7 +2148,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Long512VectorTests::LSHL);
     }
 
 
@@ -2170,7 +2170,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::LSHL);
     }
 
 
@@ -2196,7 +2196,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Long512VectorTests::ASHR);
     }
 
 
@@ -2218,7 +2218,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::ASHR);
     }
 
 
@@ -2244,7 +2244,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Long512VectorTests::LSHR);
     }
 
 
@@ -2266,7 +2266,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::LSHR);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Long512VectorTests::LSHL_unary);
     }
 
 
@@ -2312,7 +2312,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long512VectorTests::LSHL_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Long512VectorTests::LSHR_unary);
     }
 
 
@@ -2358,7 +2358,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long512VectorTests::LSHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Long512VectorTests::ASHR_unary);
     }
 
 
@@ -2404,7 +2404,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long512VectorTests::ASHR_unary);
     }
 
 
@@ -2429,7 +2429,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Long512VectorTests::MIN);
     }
     static long min(long a, long b) {
         return (long)(Math.min(a, b));
@@ -2447,7 +2447,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::min);
+        assertArraysEquals(r, a, b, Long512VectorTests::min);
     }
     static long MAX(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2467,7 +2467,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Long512VectorTests::MAX);
     }
     static long max(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2485,7 +2485,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::max);
+        assertArraysEquals(r, a, b, Long512VectorTests::max);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2499,7 +2499,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::MIN);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2513,7 +2513,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::min);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2527,7 +2527,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::MAX);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2541,7 +2541,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Long512VectorTests::max);
     }
 
     static long ANDReduce(long[] a, int idx) {
@@ -2584,7 +2584,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::ANDReduce, Long512VectorTests::ANDReduceAll);
     }
 
@@ -2632,7 +2632,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::ANDReduceMasked, Long512VectorTests::ANDReduceAllMasked);
     }
 
@@ -2677,7 +2677,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::ORReduce, Long512VectorTests::ORReduceAll);
     }
 
@@ -2725,7 +2725,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::ORReduceMasked, Long512VectorTests::ORReduceAllMasked);
     }
 
@@ -2770,7 +2770,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::XORReduce, Long512VectorTests::XORReduceAll);
     }
 
@@ -2818,7 +2818,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::XORReduceMasked, Long512VectorTests::XORReduceAllMasked);
     }
 
@@ -2860,7 +2860,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::ADDReduce, Long512VectorTests::ADDReduceAll);
     }
     static long ADDReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2904,7 +2904,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::ADDReduceMasked, Long512VectorTests::ADDReduceAllMasked);
     }
     static long MULReduce(long[] a, int idx) {
@@ -2945,7 +2945,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::MULReduce, Long512VectorTests::MULReduceAll);
     }
     static long MULReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2989,7 +2989,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::MULReduceMasked, Long512VectorTests::MULReduceAllMasked);
     }
     static long MINReduce(long[] a, int idx) {
@@ -3030,7 +3030,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::MINReduce, Long512VectorTests::MINReduceAll);
     }
     static long MINReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3075,7 +3075,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::MINReduceMasked, Long512VectorTests::MINReduceAllMasked);
     }
     static long MAXReduce(long[] a, int idx) {
@@ -3116,7 +3116,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::MAXReduce, Long512VectorTests::MAXReduceAll);
     }
     static long MAXReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3161,7 +3161,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::MAXReduceMasked, Long512VectorTests::MAXReduceAllMasked);
     }
 
@@ -3187,7 +3187,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long512VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Long512VectorTests::anyTrue);
     }
 
 
@@ -3213,7 +3213,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long512VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Long512VectorTests::allTrue);
     }
 
 
@@ -3229,7 +3229,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (long)4, 0);
+        assertInsertArraysEquals(r, a, (long)4, 0);
     }
     static boolean testIS_DEFAULT(long a) {
         return bits(a)==0;
@@ -3706,7 +3706,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::blend);
     }
 
     @Test(dataProvider = "longUnaryOpShuffleProvider")
@@ -3723,7 +3723,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpShuffleMaskProvider")
@@ -3741,7 +3741,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "longUnaryOpProvider")
     static void getLong512VectorTests(IntFunction<long[]> fa) {
@@ -3896,7 +3896,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::get);
+        assertArraysEquals(r, a, Long512VectorTests::get);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -3910,7 +3910,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3957,7 +3957,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Long512VectorTests::sliceUnary);
     }
     static long[] sliceBinary(long[] a, long[] b, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -3986,7 +3986,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Long512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Long512VectorTests::sliceBinary);
     }
     static long[] slice(long[] a, long[] b, int origin, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4019,7 +4019,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Long512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Long512VectorTests::slice);
     }
     static long[] unsliceUnary(long[] a, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4046,7 +4046,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Long512VectorTests::unsliceUnary);
     }
     static long[] unsliceBinary(long[] a, long[] b, int origin, int part, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4085,7 +4085,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Long512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Long512VectorTests::unsliceBinary);
     }
     static long[] unslice(long[] a, long[] b, int origin, int part, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4141,7 +4141,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Long512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Long512VectorTests::unslice);
     }
 
 
@@ -4190,7 +4190,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Long512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Long512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong512VectorTests(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4206,7 +4206,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Long512VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Long512VectorTests::bitwiseBlend);
     }
 
 
@@ -4229,7 +4229,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Long512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Long512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4247,7 +4247,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Long512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4262,7 +4262,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong512VectorTestsBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4276,7 +4276,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long512VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Long512VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4291,7 +4291,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long512VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long512VectorTests::bitwiseBlend);
     }
 
 
@@ -4311,7 +4311,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Long512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Long512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Long512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Long512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4348,7 +4348,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong512VectorTestsDoubleBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4362,7 +4362,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long512VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long512VectorTests::bitwiseBlend);
     }
 
 
@@ -4381,7 +4381,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Long512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Long512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4405,7 +4405,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::NEG);
+        assertArraysEquals(r, a, Long512VectorTests::NEG);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4420,7 +4420,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::neg);
+        assertArraysEquals(r, a, Long512VectorTests::neg);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4438,7 +4438,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Long512VectorTests::NEG);
     }
 
     static long ABS(long a) {
@@ -4461,7 +4461,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::ABS);
+        assertArraysEquals(r, a, Long512VectorTests::ABS);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4476,7 +4476,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::abs);
+        assertArraysEquals(r, a, Long512VectorTests::abs);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4494,7 +4494,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Long512VectorTests::ABS);
     }
 
 
@@ -4520,7 +4520,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::NOT);
+        assertArraysEquals(r, a, Long512VectorTests::NOT);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4535,7 +4535,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::not);
+        assertArraysEquals(r, a, Long512VectorTests::not);
     }
 
 
@@ -4555,7 +4555,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long512VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Long512VectorTests::NOT);
     }
 
 
@@ -4578,7 +4578,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long512VectorTests::ZOMO);
+        assertArraysEquals(r, a, Long512VectorTests::ZOMO);
     }
 
 
@@ -4598,7 +4598,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long512VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Long512VectorTests::ZOMO);
     }
 
 
@@ -4626,7 +4626,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::gather);
+        assertArraysEquals(r, a, b, Long512VectorTests::gather);
     }
     static long[] gatherMasked(long a[], int ix, boolean[] mask, int[] b, int iy) {
         long[] res = new long[SPECIES.length()];
@@ -4654,7 +4654,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::gatherMasked);
     }
 
     static long[] scatter(long a[], int ix, int[] b, int iy) {
@@ -4679,7 +4679,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Long512VectorTests::scatter);
     }
 
     static long[] scatterMasked(long r[], long a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4717,7 +4717,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Long512VectorTests::scatterMasked);
     }
 
 
@@ -4759,8 +4759,8 @@ public class Long512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4770,8 +4770,8 @@ public class Long512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4781,8 +4781,8 @@ public class Long512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4831,7 +4831,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long512VectorTests::ADDReduce, Long512VectorTests::ADDReduceAll);
     }
 
@@ -4853,7 +4853,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long512VectorTests::ADDReduceMasked, Long512VectorTests::ADDReduceAllMasked);
     }
 
@@ -4870,7 +4870,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpSelectFromMaskProvider")
@@ -4889,7 +4889,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4966,7 +4966,7 @@ public class Long512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Long512VectorTests::beq);
+        assertArraysEquals(r, a, b, Long512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(long[] a, long[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "longProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new long[a.length];
@@ -483,7 +461,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -68,7 +68,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a[i]);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Long64VectorTests extends AbstractVectorTest {
         long apply(long[] a);
     }
 
-    static void assertReductionArraysEquals(long[] a, long[] b, long c,
+    static void assertReductionArraysEquals(long[] r, long rc, long[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Long64VectorTests extends AbstractVectorTest {
         long apply(long[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(long[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(long[] r, long rc, long[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -159,37 +159,37 @@ public class Long64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(long[] a, long[] b, long element, int index) {
+    static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -203,7 +203,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -217,7 +217,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -237,7 +237,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -257,7 +257,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[]a, long[]r) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -286,7 +286,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -297,7 +297,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -309,7 +309,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -321,11 +321,11 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -336,11 +336,11 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -354,11 +354,11 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -372,7 +372,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -386,11 +386,11 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -416,7 +416,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -427,11 +427,11 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -443,7 +443,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -456,7 +456,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -469,12 +469,12 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -490,12 +490,12 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -511,7 +511,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -526,12 +526,12 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long apply(long[] a, int b);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FBinArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,7 +569,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -596,7 +596,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] r, long[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -606,7 +606,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -617,7 +617,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -627,7 +627,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(r, a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -644,7 +644,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -664,7 +664,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -674,7 +674,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -685,7 +685,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -695,7 +695,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -706,7 +706,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -716,7 +716,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -728,7 +728,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -780,7 +780,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(long[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -793,7 +793,7 @@ public class Long64VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(long[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -804,7 +804,7 @@ public class Long64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1275,7 +1275,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Long64VectorTests::ADD);
     }
     static long add(long a, long b) {
         return (long)(a + b);
@@ -1293,7 +1293,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::add);
+        assertArraysEquals(r, a, b, Long64VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1313,7 +1313,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1331,7 +1331,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::add);
     }
     static long SUB(long a, long b) {
         return (long)(a - b);
@@ -1351,7 +1351,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Long64VectorTests::SUB);
     }
     static long sub(long a, long b) {
         return (long)(a - b);
@@ -1369,7 +1369,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::sub);
+        assertArraysEquals(r, a, b, Long64VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1389,7 +1389,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::SUB);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1407,7 +1407,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::sub);
     }
     static long MUL(long a, long b) {
         return (long)(a * b);
@@ -1427,7 +1427,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Long64VectorTests::MUL);
     }
     static long mul(long a, long b) {
         return (long)(a * b);
@@ -1445,7 +1445,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::mul);
+        assertArraysEquals(r, a, b, Long64VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1465,7 +1465,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::MUL);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1483,7 +1483,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::mul);
     }
 
 
@@ -1508,7 +1508,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Long64VectorTests::DIV);
     }
     static long div(long a, long b) {
         return (long)(a / b);
@@ -1530,7 +1530,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::div);
+        assertArraysEquals(r, a, b, Long64VectorTests::div);
     }
 
 
@@ -1554,7 +1554,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::DIV);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1576,7 +1576,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::div);
     }
 
     static long FIRST_NONZERO(long a, long b) {
@@ -1597,7 +1597,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Long64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1617,7 +1617,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::FIRST_NONZERO);
     }
 
     static long AND(long a, long b) {
@@ -1638,7 +1638,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::AND);
+        assertArraysEquals(r, a, b, Long64VectorTests::AND);
     }
     static long and(long a, long b) {
         return (long)(a & b);
@@ -1656,7 +1656,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::and);
+        assertArraysEquals(r, a, b, Long64VectorTests::and);
     }
 
 
@@ -1678,7 +1678,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::AND);
     }
 
 
@@ -1700,7 +1700,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Long64VectorTests::AND_NOT);
     }
 
 
@@ -1722,7 +1722,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::AND_NOT);
     }
 
 
@@ -1744,7 +1744,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::OR);
+        assertArraysEquals(r, a, b, Long64VectorTests::OR);
     }
     static long or(long a, long b) {
         return (long)(a | b);
@@ -1762,7 +1762,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::or);
+        assertArraysEquals(r, a, b, Long64VectorTests::or);
     }
 
 
@@ -1784,7 +1784,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::OR);
     }
 
 
@@ -1806,7 +1806,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::XOR);
+        assertArraysEquals(r, a, b, Long64VectorTests::XOR);
     }
 
 
@@ -1828,7 +1828,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::XOR);
     }
 
 
@@ -1843,7 +1843,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1860,7 +1860,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1874,7 +1874,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1891,7 +1891,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1905,7 +1905,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1922,7 +1922,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::mul);
     }
 
 
@@ -1941,7 +1941,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::div);
     }
 
 
@@ -1962,7 +1962,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::div);
     }
 
 
@@ -1978,7 +1978,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::OR);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1992,7 +1992,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::or);
     }
 
 
@@ -2011,7 +2011,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::OR);
     }
 
 
@@ -2027,7 +2027,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::AND);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2041,7 +2041,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::and);
     }
 
 
@@ -2060,7 +2060,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Long64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Long64VectorTests::AND);
     }
 
 
@@ -2076,7 +2076,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Long64VectorTests::OR);
     }
 
 
@@ -2095,7 +2095,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long64VectorTests::OR);
     }
 
 
@@ -2110,7 +2110,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Long64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Long64VectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -2127,7 +2127,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Long64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Long64VectorTests::ADD);
     }
 
     static long LSHL(long a, long b) {
@@ -2148,7 +2148,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Long64VectorTests::LSHL);
     }
 
 
@@ -2170,7 +2170,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::LSHL);
     }
 
 
@@ -2196,7 +2196,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Long64VectorTests::ASHR);
     }
 
 
@@ -2218,7 +2218,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::ASHR);
     }
 
 
@@ -2244,7 +2244,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Long64VectorTests::LSHR);
     }
 
 
@@ -2266,7 +2266,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::LSHR);
     }
 
 
@@ -2291,7 +2291,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Long64VectorTests::LSHL_unary);
     }
 
 
@@ -2312,7 +2312,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long64VectorTests::LSHL_unary);
     }
 
 
@@ -2337,7 +2337,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Long64VectorTests::LSHR_unary);
     }
 
 
@@ -2358,7 +2358,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long64VectorTests::LSHR_unary);
     }
 
 
@@ -2383,7 +2383,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Long64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Long64VectorTests::ASHR_unary);
     }
 
 
@@ -2404,7 +2404,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Long64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Long64VectorTests::ASHR_unary);
     }
 
 
@@ -2429,7 +2429,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Long64VectorTests::MIN);
     }
     static long min(long a, long b) {
         return (long)(Math.min(a, b));
@@ -2447,7 +2447,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::min);
+        assertArraysEquals(r, a, b, Long64VectorTests::min);
     }
     static long MAX(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2467,7 +2467,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Long64VectorTests::MAX);
     }
     static long max(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2485,7 +2485,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::max);
+        assertArraysEquals(r, a, b, Long64VectorTests::max);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2499,7 +2499,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::MIN);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2513,7 +2513,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::min);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2527,7 +2527,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::MAX);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2541,7 +2541,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Long64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Long64VectorTests::max);
     }
 
     static long ANDReduce(long[] a, int idx) {
@@ -2584,7 +2584,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::ANDReduce, Long64VectorTests::ANDReduceAll);
     }
 
@@ -2632,7 +2632,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::ANDReduceMasked, Long64VectorTests::ANDReduceAllMasked);
     }
 
@@ -2677,7 +2677,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::ORReduce, Long64VectorTests::ORReduceAll);
     }
 
@@ -2725,7 +2725,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::ORReduceMasked, Long64VectorTests::ORReduceAllMasked);
     }
 
@@ -2770,7 +2770,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::XORReduce, Long64VectorTests::XORReduceAll);
     }
 
@@ -2818,7 +2818,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::XORReduceMasked, Long64VectorTests::XORReduceAllMasked);
     }
 
@@ -2860,7 +2860,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::ADDReduce, Long64VectorTests::ADDReduceAll);
     }
     static long ADDReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2904,7 +2904,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::ADDReduceMasked, Long64VectorTests::ADDReduceAllMasked);
     }
     static long MULReduce(long[] a, int idx) {
@@ -2945,7 +2945,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::MULReduce, Long64VectorTests::MULReduceAll);
     }
     static long MULReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2989,7 +2989,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::MULReduceMasked, Long64VectorTests::MULReduceAllMasked);
     }
     static long MINReduce(long[] a, int idx) {
@@ -3030,7 +3030,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::MINReduce, Long64VectorTests::MINReduceAll);
     }
     static long MINReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3075,7 +3075,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::MINReduceMasked, Long64VectorTests::MINReduceAllMasked);
     }
     static long MAXReduce(long[] a, int idx) {
@@ -3116,7 +3116,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::MAXReduce, Long64VectorTests::MAXReduceAll);
     }
     static long MAXReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3161,7 +3161,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::MAXReduceMasked, Long64VectorTests::MAXReduceAllMasked);
     }
 
@@ -3187,7 +3187,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long64VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Long64VectorTests::anyTrue);
     }
 
 
@@ -3213,7 +3213,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Long64VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Long64VectorTests::allTrue);
     }
 
 
@@ -3229,7 +3229,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (long)4, 0);
+        assertInsertArraysEquals(r, a, (long)4, 0);
     }
     static boolean testIS_DEFAULT(long a) {
         return bits(a)==0;
@@ -3706,7 +3706,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::blend);
     }
 
     @Test(dataProvider = "longUnaryOpShuffleProvider")
@@ -3723,7 +3723,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpShuffleMaskProvider")
@@ -3741,7 +3741,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "longUnaryOpProvider")
     static void getLong64VectorTests(IntFunction<long[]> fa) {
@@ -3896,7 +3896,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::get);
+        assertArraysEquals(r, a, Long64VectorTests::get);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -3910,7 +3910,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3957,7 +3957,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Long64VectorTests::sliceUnary);
     }
     static long[] sliceBinary(long[] a, long[] b, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -3986,7 +3986,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Long64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Long64VectorTests::sliceBinary);
     }
     static long[] slice(long[] a, long[] b, int origin, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4019,7 +4019,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Long64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Long64VectorTests::slice);
     }
     static long[] unsliceUnary(long[] a, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4046,7 +4046,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Long64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Long64VectorTests::unsliceUnary);
     }
     static long[] unsliceBinary(long[] a, long[] b, int origin, int part, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4085,7 +4085,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Long64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Long64VectorTests::unsliceBinary);
     }
     static long[] unslice(long[] a, long[] b, int origin, int part, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4141,7 +4141,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Long64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Long64VectorTests::unslice);
     }
 
 
@@ -4190,7 +4190,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Long64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Long64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong64VectorTests(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4206,7 +4206,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Long64VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Long64VectorTests::bitwiseBlend);
     }
 
 
@@ -4229,7 +4229,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Long64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Long64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4247,7 +4247,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Long64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4262,7 +4262,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong64VectorTestsBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4276,7 +4276,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Long64VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Long64VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4291,7 +4291,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Long64VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Long64VectorTests::bitwiseBlend);
     }
 
 
@@ -4311,7 +4311,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Long64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Long64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpMaskProvider")
@@ -4330,7 +4330,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Long64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Long64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4348,7 +4348,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLong64VectorTestsDoubleBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4362,7 +4362,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Long64VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Long64VectorTests::bitwiseBlend);
     }
 
 
@@ -4381,7 +4381,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Long64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Long64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4405,7 +4405,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::NEG);
+        assertArraysEquals(r, a, Long64VectorTests::NEG);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4420,7 +4420,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::neg);
+        assertArraysEquals(r, a, Long64VectorTests::neg);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4438,7 +4438,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Long64VectorTests::NEG);
     }
 
     static long ABS(long a) {
@@ -4461,7 +4461,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::ABS);
+        assertArraysEquals(r, a, Long64VectorTests::ABS);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4476,7 +4476,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::abs);
+        assertArraysEquals(r, a, Long64VectorTests::abs);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4494,7 +4494,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Long64VectorTests::ABS);
     }
 
 
@@ -4520,7 +4520,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::NOT);
+        assertArraysEquals(r, a, Long64VectorTests::NOT);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4535,7 +4535,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::not);
+        assertArraysEquals(r, a, Long64VectorTests::not);
     }
 
 
@@ -4555,7 +4555,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long64VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Long64VectorTests::NOT);
     }
 
 
@@ -4578,7 +4578,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Long64VectorTests::ZOMO);
+        assertArraysEquals(r, a, Long64VectorTests::ZOMO);
     }
 
 
@@ -4598,7 +4598,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Long64VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Long64VectorTests::ZOMO);
     }
 
 
@@ -4626,7 +4626,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::gather);
+        assertArraysEquals(r, a, b, Long64VectorTests::gather);
     }
     static long[] gatherMasked(long a[], int ix, boolean[] mask, int[] b, int iy) {
         long[] res = new long[SPECIES.length()];
@@ -4654,7 +4654,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::gatherMasked);
     }
 
     static long[] scatter(long a[], int ix, int[] b, int iy) {
@@ -4679,7 +4679,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Long64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Long64VectorTests::scatter);
     }
 
     static long[] scatterMasked(long r[], long a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4717,7 +4717,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Long64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Long64VectorTests::scatterMasked);
     }
 
 
@@ -4759,8 +4759,8 @@ public class Long64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4770,8 +4770,8 @@ public class Long64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4781,8 +4781,8 @@ public class Long64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4831,7 +4831,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Long64VectorTests::ADDReduce, Long64VectorTests::ADDReduceAll);
     }
 
@@ -4853,7 +4853,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Long64VectorTests::ADDReduceMasked, Long64VectorTests::ADDReduceAllMasked);
     }
 
@@ -4870,7 +4870,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpSelectFromMaskProvider")
@@ -4889,7 +4889,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4966,7 +4966,7 @@ public class Long64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Long64VectorTests::beq);
+        assertArraysEquals(r, a, b, Long64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -67,47 +67,25 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (long) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (long) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(long[] a, long[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (long) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -410,7 +388,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "longProviderForIOOBE")
@@ -481,7 +459,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new long[a.length];
@@ -492,7 +470,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longMaskProviderForIOOBE")
@@ -565,7 +543,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -589,7 +567,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -676,7 +654,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -691,7 +669,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -807,7 +785,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "longByteProviderForIOOBE")
@@ -888,7 +866,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -899,7 +877,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
@@ -976,7 +954,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -987,7 +965,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -73,7 +73,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long a);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FUnArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a[i]);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(long[] r, long[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long apply(long[] a);
     }
 
-    static void assertReductionArraysEquals(long[] a, long[] b, long c,
+    static void assertReductionArraysEquals(long[] r, long rc, long[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long apply(long[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(long[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(long[] r, long rc, long[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -164,37 +164,37 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(long[] a, long[] b, long element, int index) {
+    static void assertInsertArraysEquals(long[] r, long[] a, long element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -208,7 +208,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -222,7 +222,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(long[] a, long[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(long[] r, long[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -242,7 +242,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(long[] a, long[] r, long[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(long[] r, long[] a, long[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -262,7 +262,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[]a, long[]r) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -291,7 +291,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -302,7 +302,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -314,7 +314,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -326,11 +326,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -341,11 +341,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -359,11 +359,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -377,7 +377,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, FBinOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -391,11 +391,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(long[] a, long[] b, long[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(long[] r, long[] a, long[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -421,7 +421,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -432,11 +432,11 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -448,7 +448,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -461,7 +461,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -474,12 +474,12 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -495,12 +495,12 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -516,7 +516,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -531,12 +531,12 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(long[] a, long[] b, long[] c, long[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(long[] r, long[] a, long[] b, long[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long apply(long[] a, int b);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, FBinArrayOp f) {
+    static void assertArraysEquals(long[] r, long[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,7 +574,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -601,7 +601,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] r, long[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -611,7 +611,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -622,7 +622,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, int[] b, long[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -632,7 +632,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(r, a, i, mask, b, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -649,7 +649,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(long[] r, long[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -659,7 +659,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -669,7 +669,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -679,7 +679,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -690,7 +690,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -700,7 +700,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -711,7 +711,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -721,7 +721,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -733,7 +733,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         long[] apply(long[] a, long[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(long[] a, long[] b, long[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(long[] r, long[] a, long[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -743,7 +743,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             long[] ref = f.apply(a, b, origin, part, mask, i);
             long[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -785,7 +785,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             })
     );
 
-    static void assertArraysEquals(long[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -798,7 +798,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(long[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -809,7 +809,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(long[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, long[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1280,7 +1280,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::ADD);
     }
     static long add(long a, long b) {
         return (long)(a + b);
@@ -1298,7 +1298,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::add);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1318,7 +1318,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1336,7 +1336,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::add);
     }
     static long SUB(long a, long b) {
         return (long)(a - b);
@@ -1356,7 +1356,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::SUB);
     }
     static long sub(long a, long b) {
         return (long)(a - b);
@@ -1374,7 +1374,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1394,7 +1394,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1412,7 +1412,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::sub);
     }
     static long MUL(long a, long b) {
         return (long)(a * b);
@@ -1432,7 +1432,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::MUL);
     }
     static long mul(long a, long b) {
         return (long)(a * b);
@@ -1450,7 +1450,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1470,7 +1470,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1488,7 +1488,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::mul);
     }
 
 
@@ -1513,7 +1513,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::DIV);
     }
     static long div(long a, long b) {
         return (long)(a / b);
@@ -1535,7 +1535,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::div);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::div);
     }
 
 
@@ -1559,7 +1559,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1581,7 +1581,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::div);
     }
 
     static long FIRST_NONZERO(long a, long b) {
@@ -1602,7 +1602,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1622,7 +1622,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::FIRST_NONZERO);
     }
 
     static long AND(long a, long b) {
@@ -1643,7 +1643,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::AND);
     }
     static long and(long a, long b) {
         return (long)(a & b);
@@ -1661,7 +1661,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::and);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::and);
     }
 
 
@@ -1683,7 +1683,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::AND);
     }
 
 
@@ -1705,7 +1705,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::AND_NOT);
     }
 
 
@@ -1727,7 +1727,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::AND_NOT);
     }
 
 
@@ -1749,7 +1749,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::OR);
     }
     static long or(long a, long b) {
         return (long)(a | b);
@@ -1767,7 +1767,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::or);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::or);
     }
 
 
@@ -1789,7 +1789,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::OR);
     }
 
 
@@ -1811,7 +1811,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::XOR);
     }
 
 
@@ -1833,7 +1833,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::XOR);
     }
 
 
@@ -1848,7 +1848,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1865,7 +1865,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::add);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1879,7 +1879,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1896,7 +1896,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1910,7 +1910,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -1927,7 +1927,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::mul);
     }
 
 
@@ -1946,7 +1946,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::div);
     }
 
 
@@ -1967,7 +1967,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::div);
     }
 
 
@@ -1983,7 +1983,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::OR);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -1997,7 +1997,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::or);
     }
 
 
@@ -2016,7 +2016,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::OR);
     }
 
 
@@ -2032,7 +2032,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::AND);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2046,7 +2046,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::and);
     }
 
 
@@ -2065,7 +2065,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, LongMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, LongMaxVectorTests::AND);
     }
 
 
@@ -2081,7 +2081,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, LongMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, LongMaxVectorTests::OR);
     }
 
 
@@ -2100,7 +2100,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, LongMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, LongMaxVectorTests::OR);
     }
 
 
@@ -2115,7 +2115,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, LongMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, LongMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "longBinaryOpMaskProvider")
@@ -2132,7 +2132,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, LongMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, LongMaxVectorTests::ADD);
     }
 
     static long LSHL(long a, long b) {
@@ -2153,7 +2153,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::LSHL);
     }
 
 
@@ -2175,7 +2175,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::LSHL);
     }
 
 
@@ -2201,7 +2201,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::ASHR);
     }
 
 
@@ -2223,7 +2223,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::ASHR);
     }
 
 
@@ -2249,7 +2249,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::LSHR);
     }
 
 
@@ -2271,7 +2271,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::LSHR);
     }
 
 
@@ -2296,7 +2296,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, LongMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, LongMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2317,7 +2317,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, LongMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, LongMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2342,7 +2342,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, LongMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, LongMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2363,7 +2363,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, LongMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, LongMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2388,7 +2388,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, LongMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, LongMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2409,7 +2409,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, LongMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, LongMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2434,7 +2434,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::MIN);
     }
     static long min(long a, long b) {
         return (long)(Math.min(a, b));
@@ -2452,7 +2452,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::min);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::min);
     }
     static long MAX(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2472,7 +2472,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::MAX);
     }
     static long max(long a, long b) {
         return (long)(Math.max(a, b));
@@ -2490,7 +2490,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::max);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::max);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2504,7 +2504,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2518,7 +2518,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::min);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2532,7 +2532,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "longBinaryOpProvider")
@@ -2546,7 +2546,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, LongMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, LongMaxVectorTests::max);
     }
 
     static long ANDReduce(long[] a, int idx) {
@@ -2589,7 +2589,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::ANDReduce, LongMaxVectorTests::ANDReduceAll);
     }
 
@@ -2637,7 +2637,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::ANDReduceMasked, LongMaxVectorTests::ANDReduceAllMasked);
     }
 
@@ -2682,7 +2682,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::ORReduce, LongMaxVectorTests::ORReduceAll);
     }
 
@@ -2730,7 +2730,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::ORReduceMasked, LongMaxVectorTests::ORReduceAllMasked);
     }
 
@@ -2775,7 +2775,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::XORReduce, LongMaxVectorTests::XORReduceAll);
     }
 
@@ -2823,7 +2823,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::XORReduceMasked, LongMaxVectorTests::XORReduceAllMasked);
     }
 
@@ -2865,7 +2865,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::ADDReduce, LongMaxVectorTests::ADDReduceAll);
     }
     static long ADDReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2909,7 +2909,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::ADDReduceMasked, LongMaxVectorTests::ADDReduceAllMasked);
     }
     static long MULReduce(long[] a, int idx) {
@@ -2950,7 +2950,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::MULReduce, LongMaxVectorTests::MULReduceAll);
     }
     static long MULReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -2994,7 +2994,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::MULReduceMasked, LongMaxVectorTests::MULReduceAllMasked);
     }
     static long MINReduce(long[] a, int idx) {
@@ -3035,7 +3035,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::MINReduce, LongMaxVectorTests::MINReduceAll);
     }
     static long MINReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3080,7 +3080,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::MINReduceMasked, LongMaxVectorTests::MINReduceAllMasked);
     }
     static long MAXReduce(long[] a, int idx) {
@@ -3121,7 +3121,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::MAXReduce, LongMaxVectorTests::MAXReduceAll);
     }
     static long MAXReduceMasked(long[] a, int idx, boolean[] mask) {
@@ -3166,7 +3166,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::MAXReduceMasked, LongMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -3192,7 +3192,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, LongMaxVectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, LongMaxVectorTests::anyTrue);
     }
 
 
@@ -3218,7 +3218,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, LongMaxVectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, LongMaxVectorTests::allTrue);
     }
 
 
@@ -3234,7 +3234,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (long)4, 0);
+        assertInsertArraysEquals(r, a, (long)4, 0);
     }
     static boolean testIS_DEFAULT(long a) {
         return bits(a)==0;
@@ -3711,7 +3711,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "longUnaryOpShuffleProvider")
@@ -3728,7 +3728,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpShuffleMaskProvider")
@@ -3746,7 +3746,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "longUnaryOpProvider")
     static void getLongMaxVectorTests(IntFunction<long[]> fa) {
@@ -3901,7 +3901,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::get);
+        assertArraysEquals(r, a, LongMaxVectorTests::get);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -3915,7 +3915,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -3962,7 +3962,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, LongMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, LongMaxVectorTests::sliceUnary);
     }
     static long[] sliceBinary(long[] a, long[] b, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -3991,7 +3991,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, LongMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, LongMaxVectorTests::sliceBinary);
     }
     static long[] slice(long[] a, long[] b, int origin, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4024,7 +4024,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, LongMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, LongMaxVectorTests::slice);
     }
     static long[] unsliceUnary(long[] a, int origin, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4051,7 +4051,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, LongMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, LongMaxVectorTests::unsliceUnary);
     }
     static long[] unsliceBinary(long[] a, long[] b, int origin, int part, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4090,7 +4090,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, LongMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, LongMaxVectorTests::unsliceBinary);
     }
     static long[] unslice(long[] a, long[] b, int origin, int part, boolean[] mask, int idx) {
         long[] res = new long[SPECIES.length()];
@@ -4146,7 +4146,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, LongMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, LongMaxVectorTests::unslice);
     }
 
 
@@ -4195,7 +4195,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, LongMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, LongMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLongMaxVectorTests(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4211,7 +4211,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, LongMaxVectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, LongMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4234,7 +4234,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, LongMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, LongMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4252,7 +4252,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4267,7 +4267,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLongMaxVectorTestsBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4281,7 +4281,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             LongVector bv = LongVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "longTernaryOpProvider")
@@ -4296,7 +4296,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             LongVector cv = LongVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4316,7 +4316,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, LongMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, LongMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "longTernaryOpMaskProvider")
@@ -4335,7 +4335,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, LongMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, LongMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4353,7 +4353,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "longTernaryOpProvider")
     static void bitwiseBlendLongMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<long[]> fa, IntFunction<long[]> fb, IntFunction<long[]> fc) {
@@ -4367,7 +4367,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, LongMaxVectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, LongMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4386,7 +4386,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, LongMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, LongMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4410,7 +4410,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::NEG);
+        assertArraysEquals(r, a, LongMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4425,7 +4425,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::neg);
+        assertArraysEquals(r, a, LongMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4443,7 +4443,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, LongMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, LongMaxVectorTests::NEG);
     }
 
     static long ABS(long a) {
@@ -4466,7 +4466,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::ABS);
+        assertArraysEquals(r, a, LongMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4481,7 +4481,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::abs);
+        assertArraysEquals(r, a, LongMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "longUnaryOpMaskProvider")
@@ -4499,7 +4499,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, LongMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, LongMaxVectorTests::ABS);
     }
 
 
@@ -4525,7 +4525,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::NOT);
+        assertArraysEquals(r, a, LongMaxVectorTests::NOT);
     }
 
     @Test(dataProvider = "longUnaryOpProvider")
@@ -4540,7 +4540,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::not);
+        assertArraysEquals(r, a, LongMaxVectorTests::not);
     }
 
 
@@ -4560,7 +4560,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, LongMaxVectorTests::NOT);
+        assertArraysEquals(r, a, mask, LongMaxVectorTests::NOT);
     }
 
 
@@ -4583,7 +4583,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, LongMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, LongMaxVectorTests::ZOMO);
     }
 
 
@@ -4603,7 +4603,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, LongMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, LongMaxVectorTests::ZOMO);
     }
 
 
@@ -4631,7 +4631,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::gather);
     }
     static long[] gatherMasked(long a[], int ix, boolean[] mask, int[] b, int iy) {
         long[] res = new long[SPECIES.length()];
@@ -4659,7 +4659,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::gatherMasked);
     }
 
     static long[] scatter(long a[], int ix, int[] b, int iy) {
@@ -4684,7 +4684,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, LongMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::scatter);
     }
 
     static long[] scatterMasked(long r[], long a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4722,7 +4722,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, LongMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, LongMaxVectorTests::scatterMasked);
     }
 
 
@@ -4764,8 +4764,8 @@ public class LongMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4775,8 +4775,8 @@ public class LongMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4786,8 +4786,8 @@ public class LongMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             LongVector av = LongVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4836,7 +4836,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 LongMaxVectorTests::ADDReduce, LongMaxVectorTests::ADDReduceAll);
     }
 
@@ -4858,7 +4858,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 LongMaxVectorTests::ADDReduceMasked, LongMaxVectorTests::ADDReduceAllMasked);
     }
 
@@ -4875,7 +4875,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "longUnaryOpSelectFromMaskProvider")
@@ -4894,7 +4894,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -4971,7 +4971,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, LongMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, LongMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (128 / 8));
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(short[] a, short[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "shortProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new short[a.length];
@@ -483,7 +461,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -68,7 +68,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a[i]);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Short128VectorTests extends AbstractVectorTest {
         short apply(short[] a);
     }
 
-    static void assertReductionArraysEquals(short[] a, short[] b, short c,
+    static void assertReductionArraysEquals(short[] r, short rc, short[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Short128VectorTests extends AbstractVectorTest {
         short apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(short[] a, short[] b, short c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(short[] r, short rc, short[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Short128VectorTests extends AbstractVectorTest {
         long apply(short[] a);
     }
 
-    static void assertReductionLongArraysEquals(short[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, short[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Short128VectorTests extends AbstractVectorTest {
         long apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(short[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, short[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Short128VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(short[] a, short[] b, short element, int index) {
+    static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[]a, short[]r) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short apply(short[] a, int b);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FBinArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] r, short[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(r, a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(short[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Short128VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(short[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1278,7 +1278,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::ADD);
+        assertArraysEquals(r, a, b, Short128VectorTests::ADD);
     }
     static short add(short a, short b) {
         return (short)(a + b);
@@ -1296,7 +1296,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::add);
+        assertArraysEquals(r, a, b, Short128VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1316,7 +1316,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1334,7 +1334,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::add);
     }
     static short SUB(short a, short b) {
         return (short)(a - b);
@@ -1354,7 +1354,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::SUB);
+        assertArraysEquals(r, a, b, Short128VectorTests::SUB);
     }
     static short sub(short a, short b) {
         return (short)(a - b);
@@ -1372,7 +1372,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::sub);
+        assertArraysEquals(r, a, b, Short128VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1392,7 +1392,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::SUB);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1410,7 +1410,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::sub);
     }
     static short MUL(short a, short b) {
         return (short)(a * b);
@@ -1430,7 +1430,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::MUL);
+        assertArraysEquals(r, a, b, Short128VectorTests::MUL);
     }
     static short mul(short a, short b) {
         return (short)(a * b);
@@ -1448,7 +1448,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::mul);
+        assertArraysEquals(r, a, b, Short128VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1468,7 +1468,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::MUL);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1486,7 +1486,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::mul);
     }
 
 
@@ -1511,7 +1511,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::DIV);
+        assertArraysEquals(r, a, b, Short128VectorTests::DIV);
     }
     static short div(short a, short b) {
         return (short)(a / b);
@@ -1533,7 +1533,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::div);
+        assertArraysEquals(r, a, b, Short128VectorTests::div);
     }
 
 
@@ -1557,7 +1557,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::DIV);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1579,7 +1579,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::div);
     }
 
     static short FIRST_NONZERO(short a, short b) {
@@ -1600,7 +1600,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Short128VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1620,7 +1620,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::FIRST_NONZERO);
     }
 
     static short AND(short a, short b) {
@@ -1641,7 +1641,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::AND);
+        assertArraysEquals(r, a, b, Short128VectorTests::AND);
     }
     static short and(short a, short b) {
         return (short)(a & b);
@@ -1659,7 +1659,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::and);
+        assertArraysEquals(r, a, b, Short128VectorTests::and);
     }
 
 
@@ -1681,7 +1681,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::AND);
     }
 
 
@@ -1703,7 +1703,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Short128VectorTests::AND_NOT);
     }
 
 
@@ -1725,7 +1725,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::AND_NOT);
     }
 
 
@@ -1747,7 +1747,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::OR);
+        assertArraysEquals(r, a, b, Short128VectorTests::OR);
     }
     static short or(short a, short b) {
         return (short)(a | b);
@@ -1765,7 +1765,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::or);
+        assertArraysEquals(r, a, b, Short128VectorTests::or);
     }
 
 
@@ -1787,7 +1787,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::OR);
     }
 
 
@@ -1809,7 +1809,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::XOR);
+        assertArraysEquals(r, a, b, Short128VectorTests::XOR);
     }
 
 
@@ -1831,7 +1831,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::XOR);
     }
 
 
@@ -1846,7 +1846,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1863,7 +1863,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1877,7 +1877,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1894,7 +1894,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1908,7 +1908,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1925,7 +1925,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::mul);
     }
 
 
@@ -1944,7 +1944,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::div);
     }
 
 
@@ -1965,7 +1965,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::div);
     }
 
 
@@ -1981,7 +1981,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::OR);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1995,7 +1995,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::or);
     }
 
 
@@ -2014,7 +2014,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::OR);
     }
 
 
@@ -2030,7 +2030,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::AND);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2044,7 +2044,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::and);
     }
 
 
@@ -2063,7 +2063,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short128VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Short128VectorTests::AND);
     }
 
 
@@ -2079,7 +2079,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Short128VectorTests::OR);
     }
 
 
@@ -2098,7 +2098,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short128VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short128VectorTests::OR);
     }
 
 
@@ -2113,7 +2113,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Short128VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -2130,7 +2130,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short128VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short128VectorTests::ADD);
     }
 
 
@@ -2155,7 +2155,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Short128VectorTests::LSHL);
     }
 
 
@@ -2177,7 +2177,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::LSHL);
     }
 
 
@@ -2203,7 +2203,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Short128VectorTests::ASHR);
     }
 
 
@@ -2225,7 +2225,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::ASHR);
     }
 
 
@@ -2251,7 +2251,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Short128VectorTests::LSHR);
     }
 
 
@@ -2273,7 +2273,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::LSHR);
     }
 
 
@@ -2298,7 +2298,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Short128VectorTests::LSHL_unary);
     }
 
 
@@ -2319,7 +2319,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short128VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short128VectorTests::LSHL_unary);
     }
 
 
@@ -2344,7 +2344,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Short128VectorTests::LSHR_unary);
     }
 
 
@@ -2365,7 +2365,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short128VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short128VectorTests::LSHR_unary);
     }
 
 
@@ -2390,7 +2390,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Short128VectorTests::ASHR_unary);
     }
 
 
@@ -2411,7 +2411,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short128VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short128VectorTests::ASHR_unary);
     }
 
     static short MIN(short a, short b) {
@@ -2432,7 +2432,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::MIN);
+        assertArraysEquals(r, a, b, Short128VectorTests::MIN);
     }
     static short min(short a, short b) {
         return (short)(Math.min(a, b));
@@ -2450,7 +2450,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::min);
+        assertArraysEquals(r, a, b, Short128VectorTests::min);
     }
     static short MAX(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2470,7 +2470,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::MAX);
+        assertArraysEquals(r, a, b, Short128VectorTests::MAX);
     }
     static short max(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2488,7 +2488,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::max);
+        assertArraysEquals(r, a, b, Short128VectorTests::max);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2502,7 +2502,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::MIN);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2516,7 +2516,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::min);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2530,7 +2530,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::MAX);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2544,7 +2544,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short128VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Short128VectorTests::max);
     }
 
     static short ANDReduce(short[] a, int idx) {
@@ -2587,7 +2587,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::ANDReduce, Short128VectorTests::ANDReduceAll);
     }
 
@@ -2635,7 +2635,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::ANDReduceMasked, Short128VectorTests::ANDReduceAllMasked);
     }
 
@@ -2680,7 +2680,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::ORReduce, Short128VectorTests::ORReduceAll);
     }
 
@@ -2728,7 +2728,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::ORReduceMasked, Short128VectorTests::ORReduceAllMasked);
     }
 
@@ -2773,7 +2773,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::XORReduce, Short128VectorTests::XORReduceAll);
     }
 
@@ -2821,7 +2821,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::XORReduceMasked, Short128VectorTests::XORReduceAllMasked);
     }
 
@@ -2863,7 +2863,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::ADDReduce, Short128VectorTests::ADDReduceAll);
     }
     static short ADDReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2907,7 +2907,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::ADDReduceMasked, Short128VectorTests::ADDReduceAllMasked);
     }
     static short MULReduce(short[] a, int idx) {
@@ -2948,7 +2948,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::MULReduce, Short128VectorTests::MULReduceAll);
     }
     static short MULReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2992,7 +2992,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::MULReduceMasked, Short128VectorTests::MULReduceAllMasked);
     }
     static short MINReduce(short[] a, int idx) {
@@ -3033,7 +3033,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::MINReduce, Short128VectorTests::MINReduceAll);
     }
     static short MINReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3078,7 +3078,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::MINReduceMasked, Short128VectorTests::MINReduceAllMasked);
     }
     static short MAXReduce(short[] a, int idx) {
@@ -3119,7 +3119,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short128VectorTests::MAXReduce, Short128VectorTests::MAXReduceAll);
     }
     static short MAXReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3164,7 +3164,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::MAXReduceMasked, Short128VectorTests::MAXReduceAllMasked);
     }
 
@@ -3190,7 +3190,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short128VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Short128VectorTests::anyTrue);
     }
 
 
@@ -3216,7 +3216,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short128VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Short128VectorTests::allTrue);
     }
 
 
@@ -3232,7 +3232,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (short)4, 0);
+        assertInsertArraysEquals(r, a, (short)4, 0);
     }
     static boolean testIS_DEFAULT(short a) {
         return bits(a)==0;
@@ -3781,7 +3781,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::blend);
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleProvider")
@@ -3798,7 +3798,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleMaskProvider")
@@ -3816,7 +3816,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "shortUnaryOpProvider")
     static void getShort128VectorTests(IntFunction<short[]> fa) {
@@ -3971,7 +3971,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::get);
+        assertArraysEquals(r, a, Short128VectorTests::get);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -3985,7 +3985,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4032,7 +4032,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short128VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Short128VectorTests::sliceUnary);
     }
     static short[] sliceBinary(short[] a, short[] b, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4061,7 +4061,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Short128VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Short128VectorTests::sliceBinary);
     }
     static short[] slice(short[] a, short[] b, int origin, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4094,7 +4094,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Short128VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Short128VectorTests::slice);
     }
     static short[] unsliceUnary(short[] a, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4121,7 +4121,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short128VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Short128VectorTests::unsliceUnary);
     }
     static short[] unsliceBinary(short[] a, short[] b, int origin, int part, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4160,7 +4160,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Short128VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Short128VectorTests::unsliceBinary);
     }
     static short[] unslice(short[] a, short[] b, int origin, int part, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4216,7 +4216,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Short128VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Short128VectorTests::unslice);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Short128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Short128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort128VectorTests(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4281,7 +4281,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Short128VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Short128VectorTests::bitwiseBlend);
     }
 
 
@@ -4304,7 +4304,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Short128VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Short128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4322,7 +4322,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Short128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4337,7 +4337,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort128VectorTestsBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4351,7 +4351,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short128VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Short128VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4366,7 +4366,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short128VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short128VectorTests::bitwiseBlend);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Short128VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Short128VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpMaskProvider")
@@ -4405,7 +4405,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Short128VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Short128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4423,7 +4423,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short128VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort128VectorTestsDoubleBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4437,7 +4437,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short128VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short128VectorTests::bitwiseBlend);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Short128VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Short128VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4480,7 +4480,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::NEG);
+        assertArraysEquals(r, a, Short128VectorTests::NEG);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4495,7 +4495,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::neg);
+        assertArraysEquals(r, a, Short128VectorTests::neg);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4513,7 +4513,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short128VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Short128VectorTests::NEG);
     }
 
     static short ABS(short a) {
@@ -4536,7 +4536,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::ABS);
+        assertArraysEquals(r, a, Short128VectorTests::ABS);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4551,7 +4551,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::abs);
+        assertArraysEquals(r, a, Short128VectorTests::abs);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4569,7 +4569,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short128VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Short128VectorTests::ABS);
     }
 
 
@@ -4595,7 +4595,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::NOT);
+        assertArraysEquals(r, a, Short128VectorTests::NOT);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4610,7 +4610,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::not);
+        assertArraysEquals(r, a, Short128VectorTests::not);
     }
 
 
@@ -4630,7 +4630,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short128VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Short128VectorTests::NOT);
     }
 
 
@@ -4653,7 +4653,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short128VectorTests::ZOMO);
+        assertArraysEquals(r, a, Short128VectorTests::ZOMO);
     }
 
 
@@ -4673,7 +4673,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short128VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Short128VectorTests::ZOMO);
     }
 
 
@@ -4701,7 +4701,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::gather);
+        assertArraysEquals(r, a, b, Short128VectorTests::gather);
     }
     static short[] gatherMasked(short a[], int ix, boolean[] mask, int[] b, int iy) {
         short[] res = new short[SPECIES.length()];
@@ -4729,7 +4729,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::gatherMasked);
     }
 
     static short[] scatter(short a[], int ix, int[] b, int iy) {
@@ -4754,7 +4754,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short128VectorTests::scatter);
+        assertArraysEquals(r, a, b, Short128VectorTests::scatter);
     }
 
     static short[] scatterMasked(short r[], short a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4792,7 +4792,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short128VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Short128VectorTests::scatterMasked);
     }
 
 
@@ -4834,8 +4834,8 @@ public class Short128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4845,8 +4845,8 @@ public class Short128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4856,8 +4856,8 @@ public class Short128VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4923,7 +4923,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Short128VectorTests::ADDReduceLong, Short128VectorTests::ADDReduceAllLong);
     }
 
@@ -4964,7 +4964,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Short128VectorTests::ADDReduceLongMasked, Short128VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4976,7 +4976,7 @@ public class Short128VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -4994,7 +4994,7 @@ public class Short128VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short128VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short128VectorTests::blend);
     }
 
 
@@ -5011,7 +5011,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpSelectFromMaskProvider")
@@ -5030,7 +5030,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5107,7 +5107,7 @@ public class Short128VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Short128VectorTests::beq);
+        assertArraysEquals(r, a, b, Short128VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (256 / 8));
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(short[] a, short[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "shortProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new short[a.length];
@@ -483,7 +461,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -68,7 +68,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a[i]);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Short256VectorTests extends AbstractVectorTest {
         short apply(short[] a);
     }
 
-    static void assertReductionArraysEquals(short[] a, short[] b, short c,
+    static void assertReductionArraysEquals(short[] r, short rc, short[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Short256VectorTests extends AbstractVectorTest {
         short apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(short[] a, short[] b, short c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(short[] r, short rc, short[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Short256VectorTests extends AbstractVectorTest {
         long apply(short[] a);
     }
 
-    static void assertReductionLongArraysEquals(short[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, short[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Short256VectorTests extends AbstractVectorTest {
         long apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(short[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, short[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Short256VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(short[] a, short[] b, short element, int index) {
+    static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[]a, short[]r) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short apply(short[] a, int b);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FBinArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] r, short[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(r, a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(short[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Short256VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(short[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1278,7 +1278,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::ADD);
+        assertArraysEquals(r, a, b, Short256VectorTests::ADD);
     }
     static short add(short a, short b) {
         return (short)(a + b);
@@ -1296,7 +1296,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::add);
+        assertArraysEquals(r, a, b, Short256VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1316,7 +1316,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1334,7 +1334,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::add);
     }
     static short SUB(short a, short b) {
         return (short)(a - b);
@@ -1354,7 +1354,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::SUB);
+        assertArraysEquals(r, a, b, Short256VectorTests::SUB);
     }
     static short sub(short a, short b) {
         return (short)(a - b);
@@ -1372,7 +1372,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::sub);
+        assertArraysEquals(r, a, b, Short256VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1392,7 +1392,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::SUB);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1410,7 +1410,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::sub);
     }
     static short MUL(short a, short b) {
         return (short)(a * b);
@@ -1430,7 +1430,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::MUL);
+        assertArraysEquals(r, a, b, Short256VectorTests::MUL);
     }
     static short mul(short a, short b) {
         return (short)(a * b);
@@ -1448,7 +1448,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::mul);
+        assertArraysEquals(r, a, b, Short256VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1468,7 +1468,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::MUL);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1486,7 +1486,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::mul);
     }
 
 
@@ -1511,7 +1511,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::DIV);
+        assertArraysEquals(r, a, b, Short256VectorTests::DIV);
     }
     static short div(short a, short b) {
         return (short)(a / b);
@@ -1533,7 +1533,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::div);
+        assertArraysEquals(r, a, b, Short256VectorTests::div);
     }
 
 
@@ -1557,7 +1557,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::DIV);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1579,7 +1579,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::div);
     }
 
     static short FIRST_NONZERO(short a, short b) {
@@ -1600,7 +1600,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Short256VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1620,7 +1620,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::FIRST_NONZERO);
     }
 
     static short AND(short a, short b) {
@@ -1641,7 +1641,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::AND);
+        assertArraysEquals(r, a, b, Short256VectorTests::AND);
     }
     static short and(short a, short b) {
         return (short)(a & b);
@@ -1659,7 +1659,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::and);
+        assertArraysEquals(r, a, b, Short256VectorTests::and);
     }
 
 
@@ -1681,7 +1681,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::AND);
     }
 
 
@@ -1703,7 +1703,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Short256VectorTests::AND_NOT);
     }
 
 
@@ -1725,7 +1725,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::AND_NOT);
     }
 
 
@@ -1747,7 +1747,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::OR);
+        assertArraysEquals(r, a, b, Short256VectorTests::OR);
     }
     static short or(short a, short b) {
         return (short)(a | b);
@@ -1765,7 +1765,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::or);
+        assertArraysEquals(r, a, b, Short256VectorTests::or);
     }
 
 
@@ -1787,7 +1787,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::OR);
     }
 
 
@@ -1809,7 +1809,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::XOR);
+        assertArraysEquals(r, a, b, Short256VectorTests::XOR);
     }
 
 
@@ -1831,7 +1831,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::XOR);
     }
 
 
@@ -1846,7 +1846,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1863,7 +1863,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1877,7 +1877,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1894,7 +1894,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1908,7 +1908,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1925,7 +1925,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::mul);
     }
 
 
@@ -1944,7 +1944,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::div);
     }
 
 
@@ -1965,7 +1965,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::div);
     }
 
 
@@ -1981,7 +1981,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::OR);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1995,7 +1995,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::or);
     }
 
 
@@ -2014,7 +2014,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::OR);
     }
 
 
@@ -2030,7 +2030,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::AND);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2044,7 +2044,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::and);
     }
 
 
@@ -2063,7 +2063,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short256VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Short256VectorTests::AND);
     }
 
 
@@ -2079,7 +2079,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Short256VectorTests::OR);
     }
 
 
@@ -2098,7 +2098,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short256VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short256VectorTests::OR);
     }
 
 
@@ -2113,7 +2113,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Short256VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -2130,7 +2130,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short256VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short256VectorTests::ADD);
     }
 
 
@@ -2155,7 +2155,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Short256VectorTests::LSHL);
     }
 
 
@@ -2177,7 +2177,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::LSHL);
     }
 
 
@@ -2203,7 +2203,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Short256VectorTests::ASHR);
     }
 
 
@@ -2225,7 +2225,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::ASHR);
     }
 
 
@@ -2251,7 +2251,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Short256VectorTests::LSHR);
     }
 
 
@@ -2273,7 +2273,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::LSHR);
     }
 
 
@@ -2298,7 +2298,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Short256VectorTests::LSHL_unary);
     }
 
 
@@ -2319,7 +2319,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short256VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short256VectorTests::LSHL_unary);
     }
 
 
@@ -2344,7 +2344,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Short256VectorTests::LSHR_unary);
     }
 
 
@@ -2365,7 +2365,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short256VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short256VectorTests::LSHR_unary);
     }
 
 
@@ -2390,7 +2390,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Short256VectorTests::ASHR_unary);
     }
 
 
@@ -2411,7 +2411,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short256VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short256VectorTests::ASHR_unary);
     }
 
     static short MIN(short a, short b) {
@@ -2432,7 +2432,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::MIN);
+        assertArraysEquals(r, a, b, Short256VectorTests::MIN);
     }
     static short min(short a, short b) {
         return (short)(Math.min(a, b));
@@ -2450,7 +2450,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::min);
+        assertArraysEquals(r, a, b, Short256VectorTests::min);
     }
     static short MAX(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2470,7 +2470,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::MAX);
+        assertArraysEquals(r, a, b, Short256VectorTests::MAX);
     }
     static short max(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2488,7 +2488,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::max);
+        assertArraysEquals(r, a, b, Short256VectorTests::max);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2502,7 +2502,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::MIN);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2516,7 +2516,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::min);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2530,7 +2530,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::MAX);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2544,7 +2544,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short256VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Short256VectorTests::max);
     }
 
     static short ANDReduce(short[] a, int idx) {
@@ -2587,7 +2587,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::ANDReduce, Short256VectorTests::ANDReduceAll);
     }
 
@@ -2635,7 +2635,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::ANDReduceMasked, Short256VectorTests::ANDReduceAllMasked);
     }
 
@@ -2680,7 +2680,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::ORReduce, Short256VectorTests::ORReduceAll);
     }
 
@@ -2728,7 +2728,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::ORReduceMasked, Short256VectorTests::ORReduceAllMasked);
     }
 
@@ -2773,7 +2773,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::XORReduce, Short256VectorTests::XORReduceAll);
     }
 
@@ -2821,7 +2821,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::XORReduceMasked, Short256VectorTests::XORReduceAllMasked);
     }
 
@@ -2863,7 +2863,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::ADDReduce, Short256VectorTests::ADDReduceAll);
     }
     static short ADDReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2907,7 +2907,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::ADDReduceMasked, Short256VectorTests::ADDReduceAllMasked);
     }
     static short MULReduce(short[] a, int idx) {
@@ -2948,7 +2948,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::MULReduce, Short256VectorTests::MULReduceAll);
     }
     static short MULReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2992,7 +2992,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::MULReduceMasked, Short256VectorTests::MULReduceAllMasked);
     }
     static short MINReduce(short[] a, int idx) {
@@ -3033,7 +3033,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::MINReduce, Short256VectorTests::MINReduceAll);
     }
     static short MINReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3078,7 +3078,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::MINReduceMasked, Short256VectorTests::MINReduceAllMasked);
     }
     static short MAXReduce(short[] a, int idx) {
@@ -3119,7 +3119,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short256VectorTests::MAXReduce, Short256VectorTests::MAXReduceAll);
     }
     static short MAXReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3164,7 +3164,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::MAXReduceMasked, Short256VectorTests::MAXReduceAllMasked);
     }
 
@@ -3190,7 +3190,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short256VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Short256VectorTests::anyTrue);
     }
 
 
@@ -3216,7 +3216,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short256VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Short256VectorTests::allTrue);
     }
 
 
@@ -3232,7 +3232,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (short)4, 0);
+        assertInsertArraysEquals(r, a, (short)4, 0);
     }
     static boolean testIS_DEFAULT(short a) {
         return bits(a)==0;
@@ -3781,7 +3781,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::blend);
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleProvider")
@@ -3798,7 +3798,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleMaskProvider")
@@ -3816,7 +3816,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "shortUnaryOpProvider")
     static void getShort256VectorTests(IntFunction<short[]> fa) {
@@ -3971,7 +3971,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::get);
+        assertArraysEquals(r, a, Short256VectorTests::get);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -3985,7 +3985,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4032,7 +4032,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short256VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Short256VectorTests::sliceUnary);
     }
     static short[] sliceBinary(short[] a, short[] b, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4061,7 +4061,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Short256VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Short256VectorTests::sliceBinary);
     }
     static short[] slice(short[] a, short[] b, int origin, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4094,7 +4094,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Short256VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Short256VectorTests::slice);
     }
     static short[] unsliceUnary(short[] a, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4121,7 +4121,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short256VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Short256VectorTests::unsliceUnary);
     }
     static short[] unsliceBinary(short[] a, short[] b, int origin, int part, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4160,7 +4160,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Short256VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Short256VectorTests::unsliceBinary);
     }
     static short[] unslice(short[] a, short[] b, int origin, int part, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4216,7 +4216,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Short256VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Short256VectorTests::unslice);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Short256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Short256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort256VectorTests(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4281,7 +4281,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Short256VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Short256VectorTests::bitwiseBlend);
     }
 
 
@@ -4304,7 +4304,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Short256VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Short256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4322,7 +4322,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Short256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4337,7 +4337,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort256VectorTestsBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4351,7 +4351,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short256VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Short256VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4366,7 +4366,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short256VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short256VectorTests::bitwiseBlend);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Short256VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Short256VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpMaskProvider")
@@ -4405,7 +4405,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Short256VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Short256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4423,7 +4423,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short256VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort256VectorTestsDoubleBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4437,7 +4437,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short256VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short256VectorTests::bitwiseBlend);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Short256VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Short256VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4480,7 +4480,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::NEG);
+        assertArraysEquals(r, a, Short256VectorTests::NEG);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4495,7 +4495,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::neg);
+        assertArraysEquals(r, a, Short256VectorTests::neg);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4513,7 +4513,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short256VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Short256VectorTests::NEG);
     }
 
     static short ABS(short a) {
@@ -4536,7 +4536,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::ABS);
+        assertArraysEquals(r, a, Short256VectorTests::ABS);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4551,7 +4551,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::abs);
+        assertArraysEquals(r, a, Short256VectorTests::abs);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4569,7 +4569,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short256VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Short256VectorTests::ABS);
     }
 
 
@@ -4595,7 +4595,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::NOT);
+        assertArraysEquals(r, a, Short256VectorTests::NOT);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4610,7 +4610,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::not);
+        assertArraysEquals(r, a, Short256VectorTests::not);
     }
 
 
@@ -4630,7 +4630,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short256VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Short256VectorTests::NOT);
     }
 
 
@@ -4653,7 +4653,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short256VectorTests::ZOMO);
+        assertArraysEquals(r, a, Short256VectorTests::ZOMO);
     }
 
 
@@ -4673,7 +4673,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short256VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Short256VectorTests::ZOMO);
     }
 
 
@@ -4701,7 +4701,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::gather);
+        assertArraysEquals(r, a, b, Short256VectorTests::gather);
     }
     static short[] gatherMasked(short a[], int ix, boolean[] mask, int[] b, int iy) {
         short[] res = new short[SPECIES.length()];
@@ -4729,7 +4729,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::gatherMasked);
     }
 
     static short[] scatter(short a[], int ix, int[] b, int iy) {
@@ -4754,7 +4754,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short256VectorTests::scatter);
+        assertArraysEquals(r, a, b, Short256VectorTests::scatter);
     }
 
     static short[] scatterMasked(short r[], short a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4792,7 +4792,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short256VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Short256VectorTests::scatterMasked);
     }
 
 
@@ -4834,8 +4834,8 @@ public class Short256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4845,8 +4845,8 @@ public class Short256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4856,8 +4856,8 @@ public class Short256VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4923,7 +4923,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Short256VectorTests::ADDReduceLong, Short256VectorTests::ADDReduceAllLong);
     }
 
@@ -4964,7 +4964,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Short256VectorTests::ADDReduceLongMasked, Short256VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4976,7 +4976,7 @@ public class Short256VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -4994,7 +4994,7 @@ public class Short256VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short256VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short256VectorTests::blend);
     }
 
 
@@ -5011,7 +5011,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpSelectFromMaskProvider")
@@ -5030,7 +5030,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5107,7 +5107,7 @@ public class Short256VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Short256VectorTests::beq);
+        assertArraysEquals(r, a, b, Short256VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (512 / 8));
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(short[] a, short[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "shortProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new short[a.length];
@@ -483,7 +461,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -68,7 +68,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a[i]);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Short512VectorTests extends AbstractVectorTest {
         short apply(short[] a);
     }
 
-    static void assertReductionArraysEquals(short[] a, short[] b, short c,
+    static void assertReductionArraysEquals(short[] r, short rc, short[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Short512VectorTests extends AbstractVectorTest {
         short apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(short[] a, short[] b, short c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(short[] r, short rc, short[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Short512VectorTests extends AbstractVectorTest {
         long apply(short[] a);
     }
 
-    static void assertReductionLongArraysEquals(short[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, short[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Short512VectorTests extends AbstractVectorTest {
         long apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(short[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, short[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Short512VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(short[] a, short[] b, short element, int index) {
+    static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[]a, short[]r) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short apply(short[] a, int b);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FBinArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] r, short[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(r, a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(short[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Short512VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(short[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1278,7 +1278,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::ADD);
+        assertArraysEquals(r, a, b, Short512VectorTests::ADD);
     }
     static short add(short a, short b) {
         return (short)(a + b);
@@ -1296,7 +1296,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::add);
+        assertArraysEquals(r, a, b, Short512VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1316,7 +1316,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1334,7 +1334,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::add);
     }
     static short SUB(short a, short b) {
         return (short)(a - b);
@@ -1354,7 +1354,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::SUB);
+        assertArraysEquals(r, a, b, Short512VectorTests::SUB);
     }
     static short sub(short a, short b) {
         return (short)(a - b);
@@ -1372,7 +1372,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::sub);
+        assertArraysEquals(r, a, b, Short512VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1392,7 +1392,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::SUB);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1410,7 +1410,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::sub);
     }
     static short MUL(short a, short b) {
         return (short)(a * b);
@@ -1430,7 +1430,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::MUL);
+        assertArraysEquals(r, a, b, Short512VectorTests::MUL);
     }
     static short mul(short a, short b) {
         return (short)(a * b);
@@ -1448,7 +1448,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::mul);
+        assertArraysEquals(r, a, b, Short512VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1468,7 +1468,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::MUL);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1486,7 +1486,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::mul);
     }
 
 
@@ -1511,7 +1511,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::DIV);
+        assertArraysEquals(r, a, b, Short512VectorTests::DIV);
     }
     static short div(short a, short b) {
         return (short)(a / b);
@@ -1533,7 +1533,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::div);
+        assertArraysEquals(r, a, b, Short512VectorTests::div);
     }
 
 
@@ -1557,7 +1557,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::DIV);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1579,7 +1579,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::div);
     }
 
     static short FIRST_NONZERO(short a, short b) {
@@ -1600,7 +1600,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Short512VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1620,7 +1620,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::FIRST_NONZERO);
     }
 
     static short AND(short a, short b) {
@@ -1641,7 +1641,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::AND);
+        assertArraysEquals(r, a, b, Short512VectorTests::AND);
     }
     static short and(short a, short b) {
         return (short)(a & b);
@@ -1659,7 +1659,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::and);
+        assertArraysEquals(r, a, b, Short512VectorTests::and);
     }
 
 
@@ -1681,7 +1681,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::AND);
     }
 
 
@@ -1703,7 +1703,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Short512VectorTests::AND_NOT);
     }
 
 
@@ -1725,7 +1725,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::AND_NOT);
     }
 
 
@@ -1747,7 +1747,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::OR);
+        assertArraysEquals(r, a, b, Short512VectorTests::OR);
     }
     static short or(short a, short b) {
         return (short)(a | b);
@@ -1765,7 +1765,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::or);
+        assertArraysEquals(r, a, b, Short512VectorTests::or);
     }
 
 
@@ -1787,7 +1787,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::OR);
     }
 
 
@@ -1809,7 +1809,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::XOR);
+        assertArraysEquals(r, a, b, Short512VectorTests::XOR);
     }
 
 
@@ -1831,7 +1831,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::XOR);
     }
 
 
@@ -1846,7 +1846,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1863,7 +1863,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1877,7 +1877,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1894,7 +1894,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1908,7 +1908,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1925,7 +1925,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::mul);
     }
 
 
@@ -1944,7 +1944,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::div);
     }
 
 
@@ -1965,7 +1965,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::div);
     }
 
 
@@ -1981,7 +1981,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::OR);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1995,7 +1995,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::or);
     }
 
 
@@ -2014,7 +2014,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::OR);
     }
 
 
@@ -2030,7 +2030,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::AND);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2044,7 +2044,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::and);
     }
 
 
@@ -2063,7 +2063,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short512VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Short512VectorTests::AND);
     }
 
 
@@ -2079,7 +2079,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Short512VectorTests::OR);
     }
 
 
@@ -2098,7 +2098,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short512VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short512VectorTests::OR);
     }
 
 
@@ -2113,7 +2113,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Short512VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -2130,7 +2130,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short512VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short512VectorTests::ADD);
     }
 
 
@@ -2155,7 +2155,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Short512VectorTests::LSHL);
     }
 
 
@@ -2177,7 +2177,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::LSHL);
     }
 
 
@@ -2203,7 +2203,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Short512VectorTests::ASHR);
     }
 
 
@@ -2225,7 +2225,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::ASHR);
     }
 
 
@@ -2251,7 +2251,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Short512VectorTests::LSHR);
     }
 
 
@@ -2273,7 +2273,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::LSHR);
     }
 
 
@@ -2298,7 +2298,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Short512VectorTests::LSHL_unary);
     }
 
 
@@ -2319,7 +2319,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short512VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short512VectorTests::LSHL_unary);
     }
 
 
@@ -2344,7 +2344,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Short512VectorTests::LSHR_unary);
     }
 
 
@@ -2365,7 +2365,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short512VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short512VectorTests::LSHR_unary);
     }
 
 
@@ -2390,7 +2390,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Short512VectorTests::ASHR_unary);
     }
 
 
@@ -2411,7 +2411,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short512VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short512VectorTests::ASHR_unary);
     }
 
     static short MIN(short a, short b) {
@@ -2432,7 +2432,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::MIN);
+        assertArraysEquals(r, a, b, Short512VectorTests::MIN);
     }
     static short min(short a, short b) {
         return (short)(Math.min(a, b));
@@ -2450,7 +2450,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::min);
+        assertArraysEquals(r, a, b, Short512VectorTests::min);
     }
     static short MAX(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2470,7 +2470,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::MAX);
+        assertArraysEquals(r, a, b, Short512VectorTests::MAX);
     }
     static short max(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2488,7 +2488,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::max);
+        assertArraysEquals(r, a, b, Short512VectorTests::max);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2502,7 +2502,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::MIN);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2516,7 +2516,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::min);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2530,7 +2530,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::MAX);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2544,7 +2544,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short512VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Short512VectorTests::max);
     }
 
     static short ANDReduce(short[] a, int idx) {
@@ -2587,7 +2587,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::ANDReduce, Short512VectorTests::ANDReduceAll);
     }
 
@@ -2635,7 +2635,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::ANDReduceMasked, Short512VectorTests::ANDReduceAllMasked);
     }
 
@@ -2680,7 +2680,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::ORReduce, Short512VectorTests::ORReduceAll);
     }
 
@@ -2728,7 +2728,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::ORReduceMasked, Short512VectorTests::ORReduceAllMasked);
     }
 
@@ -2773,7 +2773,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::XORReduce, Short512VectorTests::XORReduceAll);
     }
 
@@ -2821,7 +2821,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::XORReduceMasked, Short512VectorTests::XORReduceAllMasked);
     }
 
@@ -2863,7 +2863,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::ADDReduce, Short512VectorTests::ADDReduceAll);
     }
     static short ADDReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2907,7 +2907,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::ADDReduceMasked, Short512VectorTests::ADDReduceAllMasked);
     }
     static short MULReduce(short[] a, int idx) {
@@ -2948,7 +2948,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::MULReduce, Short512VectorTests::MULReduceAll);
     }
     static short MULReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2992,7 +2992,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::MULReduceMasked, Short512VectorTests::MULReduceAllMasked);
     }
     static short MINReduce(short[] a, int idx) {
@@ -3033,7 +3033,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::MINReduce, Short512VectorTests::MINReduceAll);
     }
     static short MINReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3078,7 +3078,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::MINReduceMasked, Short512VectorTests::MINReduceAllMasked);
     }
     static short MAXReduce(short[] a, int idx) {
@@ -3119,7 +3119,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short512VectorTests::MAXReduce, Short512VectorTests::MAXReduceAll);
     }
     static short MAXReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3164,7 +3164,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::MAXReduceMasked, Short512VectorTests::MAXReduceAllMasked);
     }
 
@@ -3190,7 +3190,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short512VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Short512VectorTests::anyTrue);
     }
 
 
@@ -3216,7 +3216,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short512VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Short512VectorTests::allTrue);
     }
 
 
@@ -3232,7 +3232,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (short)4, 0);
+        assertInsertArraysEquals(r, a, (short)4, 0);
     }
     static boolean testIS_DEFAULT(short a) {
         return bits(a)==0;
@@ -3781,7 +3781,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::blend);
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleProvider")
@@ -3798,7 +3798,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleMaskProvider")
@@ -3816,7 +3816,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "shortUnaryOpProvider")
     static void getShort512VectorTests(IntFunction<short[]> fa) {
@@ -3971,7 +3971,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::get);
+        assertArraysEquals(r, a, Short512VectorTests::get);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -3985,7 +3985,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4032,7 +4032,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short512VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Short512VectorTests::sliceUnary);
     }
     static short[] sliceBinary(short[] a, short[] b, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4061,7 +4061,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Short512VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Short512VectorTests::sliceBinary);
     }
     static short[] slice(short[] a, short[] b, int origin, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4094,7 +4094,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Short512VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Short512VectorTests::slice);
     }
     static short[] unsliceUnary(short[] a, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4121,7 +4121,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short512VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Short512VectorTests::unsliceUnary);
     }
     static short[] unsliceBinary(short[] a, short[] b, int origin, int part, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4160,7 +4160,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Short512VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Short512VectorTests::unsliceBinary);
     }
     static short[] unslice(short[] a, short[] b, int origin, int part, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4216,7 +4216,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Short512VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Short512VectorTests::unslice);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Short512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Short512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort512VectorTests(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4281,7 +4281,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Short512VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Short512VectorTests::bitwiseBlend);
     }
 
 
@@ -4304,7 +4304,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Short512VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Short512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4322,7 +4322,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Short512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4337,7 +4337,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort512VectorTestsBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4351,7 +4351,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short512VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Short512VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4366,7 +4366,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short512VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short512VectorTests::bitwiseBlend);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Short512VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Short512VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpMaskProvider")
@@ -4405,7 +4405,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Short512VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Short512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4423,7 +4423,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short512VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort512VectorTestsDoubleBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4437,7 +4437,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short512VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short512VectorTests::bitwiseBlend);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Short512VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Short512VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4480,7 +4480,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::NEG);
+        assertArraysEquals(r, a, Short512VectorTests::NEG);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4495,7 +4495,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::neg);
+        assertArraysEquals(r, a, Short512VectorTests::neg);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4513,7 +4513,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short512VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Short512VectorTests::NEG);
     }
 
     static short ABS(short a) {
@@ -4536,7 +4536,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::ABS);
+        assertArraysEquals(r, a, Short512VectorTests::ABS);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4551,7 +4551,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::abs);
+        assertArraysEquals(r, a, Short512VectorTests::abs);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4569,7 +4569,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short512VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Short512VectorTests::ABS);
     }
 
 
@@ -4595,7 +4595,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::NOT);
+        assertArraysEquals(r, a, Short512VectorTests::NOT);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4610,7 +4610,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::not);
+        assertArraysEquals(r, a, Short512VectorTests::not);
     }
 
 
@@ -4630,7 +4630,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short512VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Short512VectorTests::NOT);
     }
 
 
@@ -4653,7 +4653,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short512VectorTests::ZOMO);
+        assertArraysEquals(r, a, Short512VectorTests::ZOMO);
     }
 
 
@@ -4673,7 +4673,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short512VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Short512VectorTests::ZOMO);
     }
 
 
@@ -4701,7 +4701,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::gather);
+        assertArraysEquals(r, a, b, Short512VectorTests::gather);
     }
     static short[] gatherMasked(short a[], int ix, boolean[] mask, int[] b, int iy) {
         short[] res = new short[SPECIES.length()];
@@ -4729,7 +4729,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::gatherMasked);
     }
 
     static short[] scatter(short a[], int ix, int[] b, int iy) {
@@ -4754,7 +4754,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short512VectorTests::scatter);
+        assertArraysEquals(r, a, b, Short512VectorTests::scatter);
     }
 
     static short[] scatterMasked(short r[], short a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4792,7 +4792,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short512VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Short512VectorTests::scatterMasked);
     }
 
 
@@ -4834,8 +4834,8 @@ public class Short512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4845,8 +4845,8 @@ public class Short512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4856,8 +4856,8 @@ public class Short512VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4923,7 +4923,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Short512VectorTests::ADDReduceLong, Short512VectorTests::ADDReduceAllLong);
     }
 
@@ -4964,7 +4964,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Short512VectorTests::ADDReduceLongMasked, Short512VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4976,7 +4976,7 @@ public class Short512VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -4994,7 +4994,7 @@ public class Short512VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short512VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short512VectorTests::blend);
     }
 
 
@@ -5011,7 +5011,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpSelectFromMaskProvider")
@@ -5030,7 +5030,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5107,7 +5107,7 @@ public class Short512VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Short512VectorTests::beq);
+        assertArraysEquals(r, a, b, Short512VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -58,47 +58,25 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (64 / 8));
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(short[] a, short[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -401,7 +379,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "shortProviderForIOOBE")
@@ -472,7 +450,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new short[a.length];
@@ -483,7 +461,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortMaskProviderForIOOBE")
@@ -556,7 +534,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -580,7 +558,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -667,7 +645,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -682,7 +660,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -798,7 +776,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -879,7 +857,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -890,7 +868,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -967,7 +945,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -978,7 +956,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -68,7 +68,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -83,7 +83,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -93,13 +93,13 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a[i]);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -118,17 +118,17 @@ public class Short64VectorTests extends AbstractVectorTest {
         short apply(short[] a);
     }
 
-    static void assertReductionArraysEquals(short[] a, short[] b, short c,
+    static void assertReductionArraysEquals(short[] r, short rc, short[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -140,17 +140,17 @@ public class Short64VectorTests extends AbstractVectorTest {
         short apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(short[] a, short[] b, short c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(short[] r, short rc, short[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -162,17 +162,17 @@ public class Short64VectorTests extends AbstractVectorTest {
         long apply(short[] a);
     }
 
-    static void assertReductionLongArraysEquals(short[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, short[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -184,17 +184,17 @@ public class Short64VectorTests extends AbstractVectorTest {
         long apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(short[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, short[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -202,37 +202,37 @@ public class Short64VectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(short[] a, short[] b, short element, int index) {
+    static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -246,7 +246,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -260,7 +260,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -280,7 +280,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -300,7 +300,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[]a, short[]r) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -329,7 +329,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -340,7 +340,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -352,7 +352,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -364,11 +364,11 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -379,11 +379,11 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -397,11 +397,11 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -415,7 +415,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -429,11 +429,11 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -459,7 +459,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -470,11 +470,11 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -486,7 +486,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -499,7 +499,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -512,12 +512,12 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -533,12 +533,12 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -554,7 +554,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -569,12 +569,12 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -597,7 +597,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short apply(short[] a, int b);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FBinArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -612,7 +612,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -639,7 +639,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] r, short[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -649,7 +649,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -660,7 +660,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -670,7 +670,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(r, a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -687,7 +687,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -697,7 +697,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -707,7 +707,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -717,7 +717,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -728,7 +728,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -738,7 +738,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -749,7 +749,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -759,7 +759,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -771,7 +771,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -781,7 +781,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -790,7 +790,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(short[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -803,7 +803,7 @@ public class Short64VectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(short[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -814,7 +814,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1278,7 +1278,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::ADD);
+        assertArraysEquals(r, a, b, Short64VectorTests::ADD);
     }
     static short add(short a, short b) {
         return (short)(a + b);
@@ -1296,7 +1296,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::add);
+        assertArraysEquals(r, a, b, Short64VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1316,7 +1316,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1334,7 +1334,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::add);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::add);
     }
     static short SUB(short a, short b) {
         return (short)(a - b);
@@ -1354,7 +1354,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::SUB);
+        assertArraysEquals(r, a, b, Short64VectorTests::SUB);
     }
     static short sub(short a, short b) {
         return (short)(a - b);
@@ -1372,7 +1372,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::sub);
+        assertArraysEquals(r, a, b, Short64VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1392,7 +1392,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::SUB);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1410,7 +1410,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::sub);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::sub);
     }
     static short MUL(short a, short b) {
         return (short)(a * b);
@@ -1430,7 +1430,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::MUL);
+        assertArraysEquals(r, a, b, Short64VectorTests::MUL);
     }
     static short mul(short a, short b) {
         return (short)(a * b);
@@ -1448,7 +1448,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::mul);
+        assertArraysEquals(r, a, b, Short64VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1468,7 +1468,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::MUL);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1486,7 +1486,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::mul);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::mul);
     }
 
 
@@ -1511,7 +1511,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::DIV);
+        assertArraysEquals(r, a, b, Short64VectorTests::DIV);
     }
     static short div(short a, short b) {
         return (short)(a / b);
@@ -1533,7 +1533,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::div);
+        assertArraysEquals(r, a, b, Short64VectorTests::div);
     }
 
 
@@ -1557,7 +1557,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::DIV);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1579,7 +1579,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::div);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::div);
     }
 
     static short FIRST_NONZERO(short a, short b) {
@@ -1600,7 +1600,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, Short64VectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1620,7 +1620,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::FIRST_NONZERO);
     }
 
     static short AND(short a, short b) {
@@ -1641,7 +1641,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::AND);
+        assertArraysEquals(r, a, b, Short64VectorTests::AND);
     }
     static short and(short a, short b) {
         return (short)(a & b);
@@ -1659,7 +1659,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::and);
+        assertArraysEquals(r, a, b, Short64VectorTests::and);
     }
 
 
@@ -1681,7 +1681,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::AND);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::AND);
     }
 
 
@@ -1703,7 +1703,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, Short64VectorTests::AND_NOT);
     }
 
 
@@ -1725,7 +1725,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::AND_NOT);
     }
 
 
@@ -1747,7 +1747,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::OR);
+        assertArraysEquals(r, a, b, Short64VectorTests::OR);
     }
     static short or(short a, short b) {
         return (short)(a | b);
@@ -1765,7 +1765,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::or);
+        assertArraysEquals(r, a, b, Short64VectorTests::or);
     }
 
 
@@ -1787,7 +1787,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::OR);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::OR);
     }
 
 
@@ -1809,7 +1809,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::XOR);
+        assertArraysEquals(r, a, b, Short64VectorTests::XOR);
     }
 
 
@@ -1831,7 +1831,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::XOR);
     }
 
 
@@ -1846,7 +1846,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1863,7 +1863,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1877,7 +1877,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1894,7 +1894,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1908,7 +1908,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1925,7 +1925,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::mul);
     }
 
 
@@ -1944,7 +1944,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::div);
     }
 
 
@@ -1965,7 +1965,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::div);
     }
 
 
@@ -1981,7 +1981,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::OR);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1995,7 +1995,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::or);
     }
 
 
@@ -2014,7 +2014,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::OR);
     }
 
 
@@ -2030,7 +2030,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::AND);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2044,7 +2044,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::and);
     }
 
 
@@ -2063,7 +2063,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, Short64VectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, Short64VectorTests::AND);
     }
 
 
@@ -2079,7 +2079,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, Short64VectorTests::OR);
     }
 
 
@@ -2098,7 +2098,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short64VectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short64VectorTests::OR);
     }
 
 
@@ -2113,7 +2113,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, Short64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, Short64VectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -2130,7 +2130,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short64VectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short64VectorTests::ADD);
     }
 
 
@@ -2155,7 +2155,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, Short64VectorTests::LSHL);
     }
 
 
@@ -2177,7 +2177,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::LSHL);
     }
 
 
@@ -2203,7 +2203,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, Short64VectorTests::ASHR);
     }
 
 
@@ -2225,7 +2225,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::ASHR);
     }
 
 
@@ -2251,7 +2251,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, Short64VectorTests::LSHR);
     }
 
 
@@ -2273,7 +2273,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::LSHR);
     }
 
 
@@ -2298,7 +2298,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, Short64VectorTests::LSHL_unary);
     }
 
 
@@ -2319,7 +2319,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short64VectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short64VectorTests::LSHL_unary);
     }
 
 
@@ -2344,7 +2344,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, Short64VectorTests::LSHR_unary);
     }
 
 
@@ -2365,7 +2365,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short64VectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short64VectorTests::LSHR_unary);
     }
 
 
@@ -2390,7 +2390,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, Short64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, Short64VectorTests::ASHR_unary);
     }
 
 
@@ -2411,7 +2411,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, Short64VectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, Short64VectorTests::ASHR_unary);
     }
 
     static short MIN(short a, short b) {
@@ -2432,7 +2432,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::MIN);
+        assertArraysEquals(r, a, b, Short64VectorTests::MIN);
     }
     static short min(short a, short b) {
         return (short)(Math.min(a, b));
@@ -2450,7 +2450,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::min);
+        assertArraysEquals(r, a, b, Short64VectorTests::min);
     }
     static short MAX(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2470,7 +2470,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::MAX);
+        assertArraysEquals(r, a, b, Short64VectorTests::MAX);
     }
     static short max(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2488,7 +2488,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::max);
+        assertArraysEquals(r, a, b, Short64VectorTests::max);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2502,7 +2502,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::MIN);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2516,7 +2516,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::min);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2530,7 +2530,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::MAX);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2544,7 +2544,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, Short64VectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, Short64VectorTests::max);
     }
 
     static short ANDReduce(short[] a, int idx) {
@@ -2587,7 +2587,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::ANDReduce, Short64VectorTests::ANDReduceAll);
     }
 
@@ -2635,7 +2635,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::ANDReduceMasked, Short64VectorTests::ANDReduceAllMasked);
     }
 
@@ -2680,7 +2680,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::ORReduce, Short64VectorTests::ORReduceAll);
     }
 
@@ -2728,7 +2728,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::ORReduceMasked, Short64VectorTests::ORReduceAllMasked);
     }
 
@@ -2773,7 +2773,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::XORReduce, Short64VectorTests::XORReduceAll);
     }
 
@@ -2821,7 +2821,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::XORReduceMasked, Short64VectorTests::XORReduceAllMasked);
     }
 
@@ -2863,7 +2863,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::ADDReduce, Short64VectorTests::ADDReduceAll);
     }
     static short ADDReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2907,7 +2907,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::ADDReduceMasked, Short64VectorTests::ADDReduceAllMasked);
     }
     static short MULReduce(short[] a, int idx) {
@@ -2948,7 +2948,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::MULReduce, Short64VectorTests::MULReduceAll);
     }
     static short MULReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2992,7 +2992,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::MULReduceMasked, Short64VectorTests::MULReduceAllMasked);
     }
     static short MINReduce(short[] a, int idx) {
@@ -3033,7 +3033,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::MINReduce, Short64VectorTests::MINReduceAll);
     }
     static short MINReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3078,7 +3078,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::MINReduceMasked, Short64VectorTests::MINReduceAllMasked);
     }
     static short MAXReduce(short[] a, int idx) {
@@ -3119,7 +3119,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 Short64VectorTests::MAXReduce, Short64VectorTests::MAXReduceAll);
     }
     static short MAXReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3164,7 +3164,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::MAXReduceMasked, Short64VectorTests::MAXReduceAllMasked);
     }
 
@@ -3190,7 +3190,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short64VectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, Short64VectorTests::anyTrue);
     }
 
 
@@ -3216,7 +3216,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, Short64VectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, Short64VectorTests::allTrue);
     }
 
 
@@ -3232,7 +3232,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (short)4, 0);
+        assertInsertArraysEquals(r, a, (short)4, 0);
     }
     static boolean testIS_DEFAULT(short a) {
         return bits(a)==0;
@@ -3781,7 +3781,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::blend);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::blend);
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleProvider")
@@ -3798,7 +3798,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleMaskProvider")
@@ -3816,7 +3816,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "shortUnaryOpProvider")
     static void getShort64VectorTests(IntFunction<short[]> fa) {
@@ -3971,7 +3971,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::get);
+        assertArraysEquals(r, a, Short64VectorTests::get);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -3985,7 +3985,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4032,7 +4032,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short64VectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, Short64VectorTests::sliceUnary);
     }
     static short[] sliceBinary(short[] a, short[] b, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4061,7 +4061,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, Short64VectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, Short64VectorTests::sliceBinary);
     }
     static short[] slice(short[] a, short[] b, int origin, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4094,7 +4094,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, Short64VectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, Short64VectorTests::slice);
     }
     static short[] unsliceUnary(short[] a, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4121,7 +4121,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, Short64VectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, Short64VectorTests::unsliceUnary);
     }
     static short[] unsliceBinary(short[] a, short[] b, int origin, int part, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4160,7 +4160,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, Short64VectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, Short64VectorTests::unsliceBinary);
     }
     static short[] unslice(short[] a, short[] b, int origin, int part, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4216,7 +4216,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, Short64VectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, Short64VectorTests::unslice);
     }
 
 
@@ -4265,7 +4265,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, Short64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, Short64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort64VectorTests(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4281,7 +4281,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, Short64VectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, Short64VectorTests::bitwiseBlend);
     }
 
 
@@ -4304,7 +4304,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, Short64VectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, Short64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4322,7 +4322,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, Short64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4337,7 +4337,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort64VectorTestsBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4351,7 +4351,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, Short64VectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, Short64VectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4366,7 +4366,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, Short64VectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, Short64VectorTests::bitwiseBlend);
     }
 
 
@@ -4386,7 +4386,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, Short64VectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, Short64VectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpMaskProvider")
@@ -4405,7 +4405,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, Short64VectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, Short64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4423,7 +4423,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short64VectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShort64VectorTestsDoubleBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4437,7 +4437,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, Short64VectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, Short64VectorTests::bitwiseBlend);
     }
 
 
@@ -4456,7 +4456,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, Short64VectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, Short64VectorTests::BITWISE_BLEND);
     }
 
 
@@ -4480,7 +4480,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::NEG);
+        assertArraysEquals(r, a, Short64VectorTests::NEG);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4495,7 +4495,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::neg);
+        assertArraysEquals(r, a, Short64VectorTests::neg);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4513,7 +4513,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short64VectorTests::NEG);
+        assertArraysEquals(r, a, mask, Short64VectorTests::NEG);
     }
 
     static short ABS(short a) {
@@ -4536,7 +4536,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::ABS);
+        assertArraysEquals(r, a, Short64VectorTests::ABS);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4551,7 +4551,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::abs);
+        assertArraysEquals(r, a, Short64VectorTests::abs);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4569,7 +4569,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short64VectorTests::ABS);
+        assertArraysEquals(r, a, mask, Short64VectorTests::ABS);
     }
 
 
@@ -4595,7 +4595,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::NOT);
+        assertArraysEquals(r, a, Short64VectorTests::NOT);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4610,7 +4610,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::not);
+        assertArraysEquals(r, a, Short64VectorTests::not);
     }
 
 
@@ -4630,7 +4630,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short64VectorTests::NOT);
+        assertArraysEquals(r, a, mask, Short64VectorTests::NOT);
     }
 
 
@@ -4653,7 +4653,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, Short64VectorTests::ZOMO);
+        assertArraysEquals(r, a, Short64VectorTests::ZOMO);
     }
 
 
@@ -4673,7 +4673,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, Short64VectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, Short64VectorTests::ZOMO);
     }
 
 
@@ -4701,7 +4701,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::gather);
+        assertArraysEquals(r, a, b, Short64VectorTests::gather);
     }
     static short[] gatherMasked(short a[], int ix, boolean[] mask, int[] b, int iy) {
         short[] res = new short[SPECIES.length()];
@@ -4729,7 +4729,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::gatherMasked);
     }
 
     static short[] scatter(short a[], int ix, int[] b, int iy) {
@@ -4754,7 +4754,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, Short64VectorTests::scatter);
+        assertArraysEquals(r, a, b, Short64VectorTests::scatter);
     }
 
     static short[] scatterMasked(short r[], short a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4792,7 +4792,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, Short64VectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, Short64VectorTests::scatterMasked);
     }
 
 
@@ -4834,8 +4834,8 @@ public class Short64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4845,8 +4845,8 @@ public class Short64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4856,8 +4856,8 @@ public class Short64VectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4923,7 +4923,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 Short64VectorTests::ADDReduceLong, Short64VectorTests::ADDReduceAllLong);
     }
 
@@ -4964,7 +4964,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 Short64VectorTests::ADDReduceLongMasked, Short64VectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4976,7 +4976,7 @@ public class Short64VectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -4994,7 +4994,7 @@ public class Short64VectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, Short64VectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, Short64VectorTests::blend);
     }
 
 
@@ -5011,7 +5011,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpSelectFromMaskProvider")
@@ -5030,7 +5030,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5107,7 +5107,7 @@ public class Short64VectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, Short64VectorTests::beq);
+        assertArraysEquals(r, a, b, Short64VectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -67,47 +67,25 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * (Max / 8));
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : (short) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : (short) 0, "at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int[] im) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(short[] a, short[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : (short) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 
@@ -410,7 +388,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "shortProviderForIOOBE")
@@ -481,7 +459,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new short[a.length];
@@ -492,7 +470,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortMaskProviderForIOOBE")
@@ -565,7 +543,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -589,7 +567,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -676,7 +654,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -691,7 +669,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -807,7 +785,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
@@ -888,7 +866,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -899,7 +877,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
@@ -976,7 +954,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -987,7 +965,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -73,7 +73,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -88,7 +88,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short a);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FUnArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -98,13 +98,13 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a[i]);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals(short[] r, short[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -123,17 +123,17 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short apply(short[] a);
     }
 
-    static void assertReductionArraysEquals(short[] a, short[] b, short c,
+    static void assertReductionArraysEquals(short[] r, short rc, short[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -145,17 +145,17 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked(short[] a, short[] b, short c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked(short[] r, short rc, short[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -167,17 +167,17 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         long apply(short[] a);
     }
 
-    static void assertReductionLongArraysEquals(short[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, short[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -189,17 +189,17 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         long apply(short[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked(short[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, short[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -207,37 +207,37 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals(short[] a, short[] b, short element, int index) {
+    static void assertInsertArraysEquals(short[] r, short[] a, short element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -251,7 +251,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -265,7 +265,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals(short[] a, short[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals(short[] r, short[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -285,7 +285,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals(short[] a, short[] r, short[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals(short[] r, short[] a, short[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -305,7 +305,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[]a, short[]r) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -334,7 +334,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -345,7 +345,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -357,7 +357,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -369,11 +369,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -384,11 +384,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -402,11 +402,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -420,7 +420,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, FBinOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -434,11 +434,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals(short[] a, short[] b, short[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals(short[] r, short[] a, short[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -464,7 +464,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -475,11 +475,11 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -491,7 +491,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -504,7 +504,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,12 +517,12 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -538,12 +538,12 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -559,7 +559,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -574,12 +574,12 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals(short[] a, short[] b, short[] c, short[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals(short[] r, short[] a, short[] b, short[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -602,7 +602,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short apply(short[] a, int b);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, FBinArrayOp f) {
+    static void assertArraysEquals(short[] r, short[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -617,7 +617,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, FGatherScatterOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -644,7 +644,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] r, short[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -654,7 +654,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -665,7 +665,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, int[] b, short[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -675,7 +675,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(r, a, i, mask, b, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -692,7 +692,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals(short[] r, short[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -702,7 +702,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -712,7 +712,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -722,7 +722,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -733,7 +733,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -743,7 +743,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -754,7 +754,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -764,7 +764,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -776,7 +776,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         short[] apply(short[] a, short[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals(short[] a, short[] b, short[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals(short[] r, short[] a, short[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -786,7 +786,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         } catch (AssertionError e) {
             short[] ref = f.apply(a, b, origin, part, mask, i);
             short[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -795,7 +795,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     }
 
 
-    static void assertArraysEquals(short[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -808,7 +808,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
 
 
 
-    static void assertArraysEquals(short[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -819,7 +819,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals(short[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, short[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1283,7 +1283,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::ADD);
     }
     static short add(short a, short b) {
         return (short)(a + b);
@@ -1301,7 +1301,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.add(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::add);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1321,7 +1321,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::ADD);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1339,7 +1339,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.add(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::add);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::add);
     }
     static short SUB(short a, short b) {
         return (short)(a - b);
@@ -1359,7 +1359,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::SUB);
     }
     static short sub(short a, short b) {
         return (short)(a - b);
@@ -1377,7 +1377,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.sub(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1397,7 +1397,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::SUB);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::SUB);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1415,7 +1415,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.sub(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::sub);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::sub);
     }
     static short MUL(short a, short b) {
         return (short)(a * b);
@@ -1435,7 +1435,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::MUL);
     }
     static short mul(short a, short b) {
         return (short)(a * b);
@@ -1453,7 +1453,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.mul(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1473,7 +1473,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::MUL);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::MUL);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1491,7 +1491,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.mul(bv, vmask).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::mul);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::mul);
     }
 
 
@@ -1516,7 +1516,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::DIV);
     }
     static short div(short a, short b) {
         return (short)(a / b);
@@ -1538,7 +1538,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::div);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::div);
     }
 
 
@@ -1562,7 +1562,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::DIV);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::DIV);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1584,7 +1584,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::div);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::div);
     }
 
     static short FIRST_NONZERO(short a, short b) {
@@ -1605,7 +1605,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::FIRST_NONZERO);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1625,7 +1625,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::FIRST_NONZERO);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::FIRST_NONZERO);
     }
 
     static short AND(short a, short b) {
@@ -1646,7 +1646,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::AND);
     }
     static short and(short a, short b) {
         return (short)(a & b);
@@ -1664,7 +1664,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.and(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::and);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::and);
     }
 
 
@@ -1686,7 +1686,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::AND);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::AND);
     }
 
 
@@ -1708,7 +1708,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::AND_NOT);
     }
 
 
@@ -1730,7 +1730,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::AND_NOT);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::AND_NOT);
     }
 
 
@@ -1752,7 +1752,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::OR);
     }
     static short or(short a, short b) {
         return (short)(a | b);
@@ -1770,7 +1770,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.or(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::or);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::or);
     }
 
 
@@ -1792,7 +1792,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::OR);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::OR);
     }
 
 
@@ -1814,7 +1814,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::XOR);
     }
 
 
@@ -1836,7 +1836,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::XOR);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::XOR);
     }
 
 
@@ -1851,7 +1851,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.add(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1868,7 +1868,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.add(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::add);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::add);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1882,7 +1882,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1899,7 +1899,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.sub(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::sub);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::sub);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -1913,7 +1913,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::mul);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -1930,7 +1930,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.mul(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::mul);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::mul);
     }
 
 
@@ -1949,7 +1949,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.div(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::div);
     }
 
 
@@ -1970,7 +1970,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.div(b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::div);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::div);
     }
 
 
@@ -1986,7 +1986,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::OR);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2000,7 +2000,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.or(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::or);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::or);
     }
 
 
@@ -2019,7 +2019,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::OR);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::OR);
     }
 
 
@@ -2035,7 +2035,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::AND);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2049,7 +2049,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.and(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::and);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::and);
     }
 
 
@@ -2068,7 +2068,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.AND, b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, mask, ShortMaxVectorTests::AND);
+        assertBroadcastArraysEquals(r, a, b, mask, ShortMaxVectorTests::AND);
     }
 
 
@@ -2084,7 +2084,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, ShortMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, ShortMaxVectorTests::OR);
     }
 
 
@@ -2103,7 +2103,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.OR, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, ShortMaxVectorTests::OR);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ShortMaxVectorTests::OR);
     }
 
 
@@ -2118,7 +2118,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i]).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, ShortMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, ShortMaxVectorTests::ADD);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -2135,7 +2135,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.ADD, (long)b[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastLongArraysEquals(a, b, r, mask, ShortMaxVectorTests::ADD);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ShortMaxVectorTests::ADD);
     }
 
 
@@ -2160,7 +2160,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::LSHL);
     }
 
 
@@ -2182,7 +2182,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::LSHL);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::LSHL);
     }
 
 
@@ -2208,7 +2208,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::ASHR);
     }
 
 
@@ -2230,7 +2230,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::ASHR);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::ASHR);
     }
 
 
@@ -2256,7 +2256,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::LSHR);
     }
 
 
@@ -2278,7 +2278,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::LSHR);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::LSHR);
     }
 
 
@@ -2303,7 +2303,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ShortMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, ShortMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2324,7 +2324,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ShortMaxVectorTests::LSHL_unary);
+        assertShiftArraysEquals(r, a, b, mask, ShortMaxVectorTests::LSHL_unary);
     }
 
 
@@ -2349,7 +2349,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ShortMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, ShortMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2370,7 +2370,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ShortMaxVectorTests::LSHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, ShortMaxVectorTests::LSHR_unary);
     }
 
 
@@ -2395,7 +2395,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, ShortMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, ShortMaxVectorTests::ASHR_unary);
     }
 
 
@@ -2416,7 +2416,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertShiftArraysEquals(a, b, r, mask, ShortMaxVectorTests::ASHR_unary);
+        assertShiftArraysEquals(r, a, b, mask, ShortMaxVectorTests::ASHR_unary);
     }
 
     static short MIN(short a, short b) {
@@ -2437,7 +2437,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::MIN);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::MIN);
     }
     static short min(short a, short b) {
         return (short)(Math.min(a, b));
@@ -2455,7 +2455,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.min(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::min);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::min);
     }
     static short MAX(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2475,7 +2475,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::MAX);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::MAX);
     }
     static short max(short a, short b) {
         return (short)(Math.max(a, b));
@@ -2493,7 +2493,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.max(bv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::max);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::max);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2507,7 +2507,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MIN, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::MIN);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::MIN);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2521,7 +2521,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.min(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::min);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::min);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2535,7 +2535,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.MAX, b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::MAX);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::MAX);
     }
 
     @Test(dataProvider = "shortBinaryOpProvider")
@@ -2549,7 +2549,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.max(b[i]).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, r, ShortMaxVectorTests::max);
+        assertBroadcastArraysEquals(r, a, b, ShortMaxVectorTests::max);
     }
 
     static short ANDReduce(short[] a, int idx) {
@@ -2592,7 +2592,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::ANDReduce, ShortMaxVectorTests::ANDReduceAll);
     }
 
@@ -2640,7 +2640,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::ANDReduceMasked, ShortMaxVectorTests::ANDReduceAllMasked);
     }
 
@@ -2685,7 +2685,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::ORReduce, ShortMaxVectorTests::ORReduceAll);
     }
 
@@ -2733,7 +2733,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::ORReduceMasked, ShortMaxVectorTests::ORReduceAllMasked);
     }
 
@@ -2778,7 +2778,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::XORReduce, ShortMaxVectorTests::XORReduceAll);
     }
 
@@ -2826,7 +2826,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::XORReduceMasked, ShortMaxVectorTests::XORReduceAllMasked);
     }
 
@@ -2868,7 +2868,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::ADDReduce, ShortMaxVectorTests::ADDReduceAll);
     }
     static short ADDReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2912,7 +2912,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::ADDReduceMasked, ShortMaxVectorTests::ADDReduceAllMasked);
     }
     static short MULReduce(short[] a, int idx) {
@@ -2953,7 +2953,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::MULReduce, ShortMaxVectorTests::MULReduceAll);
     }
     static short MULReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -2997,7 +2997,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::MULReduceMasked, ShortMaxVectorTests::MULReduceAllMasked);
     }
     static short MINReduce(short[] a, int idx) {
@@ -3038,7 +3038,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::MINReduce, ShortMaxVectorTests::MINReduceAll);
     }
     static short MINReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3083,7 +3083,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::MINReduceMasked, ShortMaxVectorTests::MINReduceAllMasked);
     }
     static short MAXReduce(short[] a, int idx) {
@@ -3124,7 +3124,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 ShortMaxVectorTests::MAXReduce, ShortMaxVectorTests::MAXReduceAll);
     }
     static short MAXReduceMasked(short[] a, int idx, boolean[] mask) {
@@ -3169,7 +3169,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::MAXReduceMasked, ShortMaxVectorTests::MAXReduceAllMasked);
     }
 
@@ -3195,7 +3195,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, ShortMaxVectorTests::anyTrue);
+        assertReductionBoolArraysEquals(r, mask, ShortMaxVectorTests::anyTrue);
     }
 
 
@@ -3221,7 +3221,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertReductionBoolArraysEquals(mask, r, ShortMaxVectorTests::allTrue);
+        assertReductionBoolArraysEquals(r, mask, ShortMaxVectorTests::allTrue);
     }
 
 
@@ -3237,7 +3237,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertInsertArraysEquals(a, r, (short)4, 0);
+        assertInsertArraysEquals(r, a, (short)4, 0);
     }
     static boolean testIS_DEFAULT(short a) {
         return bits(a)==0;
@@ -3786,7 +3786,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::blend);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::blend);
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleProvider")
@@ -3803,7 +3803,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpShuffleMaskProvider")
@@ -3821,7 +3821,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }
     @Test(dataProvider = "shortUnaryOpProvider")
     static void getShortMaxVectorTests(IntFunction<short[]> fa) {
@@ -3976,7 +3976,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::get);
+        assertArraysEquals(r, a, ShortMaxVectorTests::get);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -3990,7 +3990,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 
@@ -4037,7 +4037,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, ShortMaxVectorTests::sliceUnary);
+        assertArraysEquals(r, a, origin, ShortMaxVectorTests::sliceUnary);
     }
     static short[] sliceBinary(short[] a, short[] b, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4066,7 +4066,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, ShortMaxVectorTests::sliceBinary);
+        assertArraysEquals(r, a, b, origin, ShortMaxVectorTests::sliceBinary);
     }
     static short[] slice(short[] a, short[] b, int origin, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4099,7 +4099,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, mask, ShortMaxVectorTests::slice);
+        assertArraysEquals(r, a, b, origin, mask, ShortMaxVectorTests::slice);
     }
     static short[] unsliceUnary(short[] a, int origin, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4126,7 +4126,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, origin, ShortMaxVectorTests::unsliceUnary);
+        assertArraysEquals(r, a, origin, ShortMaxVectorTests::unsliceUnary);
     }
     static short[] unsliceBinary(short[] a, short[] b, int origin, int part, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4165,7 +4165,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, ShortMaxVectorTests::unsliceBinary);
+        assertArraysEquals(r, a, b, origin, part, ShortMaxVectorTests::unsliceBinary);
     }
     static short[] unslice(short[] a, short[] b, int origin, int part, boolean[] mask, int idx) {
         short[] res = new short[SPECIES.length()];
@@ -4221,7 +4221,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, origin, part, mask, ShortMaxVectorTests::unslice);
+        assertArraysEquals(r, a, b, origin, part, mask, ShortMaxVectorTests::unslice);
     }
 
 
@@ -4270,7 +4270,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, ShortMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, ShortMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShortMaxVectorTests(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4286,7 +4286,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(bv, cv).intoArray(r, i);
         }
 
-        assertArraysEquals(a, b, c, r, ShortMaxVectorTests::bitwiseBlend);
+        assertArraysEquals(r, a, b, c, ShortMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4309,7 +4309,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, c, r, mask, ShortMaxVectorTests::BITWISE_BLEND);
+        assertArraysEquals(r, a, b, c, mask, ShortMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4327,7 +4327,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4342,7 +4342,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShortMaxVectorTestsBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4356,7 +4356,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
             av.bitwiseBlend(bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::bitwiseBlend);
+        assertBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::bitwiseBlend);
     }
 
     @Test(dataProvider = "shortTernaryOpProvider")
@@ -4371,7 +4371,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ShortVector cv = ShortVector.fromArray(SPECIES, c, i);
             av.bitwiseBlend(b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::bitwiseBlend);
+        assertAltBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4391,7 +4391,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, ShortMaxVectorTests::BITWISE_BLEND);
+        assertBroadcastArraysEquals(r, a, b, c, mask, ShortMaxVectorTests::BITWISE_BLEND);
     }
 
     @Test(dataProvider = "shortTernaryOpMaskProvider")
@@ -4410,7 +4410,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, ShortMaxVectorTests::BITWISE_BLEND);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, ShortMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4428,7 +4428,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::BITWISE_BLEND);
     }
     @Test(dataProvider = "shortTernaryOpProvider")
     static void bitwiseBlendShortMaxVectorTestsDoubleBroadcastSmokeTest(IntFunction<short[]> fa, IntFunction<short[]> fb, IntFunction<short[]> fc) {
@@ -4442,7 +4442,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.bitwiseBlend(b[i], c[i]).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, ShortMaxVectorTests::bitwiseBlend);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, ShortMaxVectorTests::bitwiseBlend);
     }
 
 
@@ -4461,7 +4461,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             av.lanewise(VectorOperators.BITWISE_BLEND, b[i], c[i], vmask).intoArray(r, i);
         }
 
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, ShortMaxVectorTests::BITWISE_BLEND);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, ShortMaxVectorTests::BITWISE_BLEND);
     }
 
 
@@ -4485,7 +4485,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::NEG);
+        assertArraysEquals(r, a, ShortMaxVectorTests::NEG);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4500,7 +4500,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::neg);
+        assertArraysEquals(r, a, ShortMaxVectorTests::neg);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4518,7 +4518,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ShortMaxVectorTests::NEG);
+        assertArraysEquals(r, a, mask, ShortMaxVectorTests::NEG);
     }
 
     static short ABS(short a) {
@@ -4541,7 +4541,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::ABS);
+        assertArraysEquals(r, a, ShortMaxVectorTests::ABS);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4556,7 +4556,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::abs);
+        assertArraysEquals(r, a, ShortMaxVectorTests::abs);
     }
 
     @Test(dataProvider = "shortUnaryOpMaskProvider")
@@ -4574,7 +4574,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ShortMaxVectorTests::ABS);
+        assertArraysEquals(r, a, mask, ShortMaxVectorTests::ABS);
     }
 
 
@@ -4600,7 +4600,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::NOT);
+        assertArraysEquals(r, a, ShortMaxVectorTests::NOT);
     }
 
     @Test(dataProvider = "shortUnaryOpProvider")
@@ -4615,7 +4615,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::not);
+        assertArraysEquals(r, a, ShortMaxVectorTests::not);
     }
 
 
@@ -4635,7 +4635,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ShortMaxVectorTests::NOT);
+        assertArraysEquals(r, a, mask, ShortMaxVectorTests::NOT);
     }
 
 
@@ -4658,7 +4658,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, ShortMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, ShortMaxVectorTests::ZOMO);
     }
 
 
@@ -4678,7 +4678,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, r, mask, ShortMaxVectorTests::ZOMO);
+        assertArraysEquals(r, a, mask, ShortMaxVectorTests::ZOMO);
     }
 
 
@@ -4706,7 +4706,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::gather);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::gather);
     }
     static short[] gatherMasked(short a[], int ix, boolean[] mask, int[] b, int iy) {
         short[] res = new short[SPECIES.length()];
@@ -4734,7 +4734,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::gatherMasked);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::gatherMasked);
     }
 
     static short[] scatter(short a[], int ix, int[] b, int iy) {
@@ -4759,7 +4759,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::scatter);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::scatter);
     }
 
     static short[] scatterMasked(short r[], short a[], int ix, boolean[] mask, int[] b, int iy) {
@@ -4797,7 +4797,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             }
         }
 
-        assertArraysEquals(a, b, r, mask, ShortMaxVectorTests::scatterMasked);
+        assertArraysEquals(r, a, b, mask, ShortMaxVectorTests::scatterMasked);
     }
 
 
@@ -4839,8 +4839,8 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4850,8 +4850,8 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4861,8 +4861,8 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector av = ShortVector.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -4928,7 +4928,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 ShortMaxVectorTests::ADDReduceLong, ShortMaxVectorTests::ADDReduceAllLong);
     }
 
@@ -4969,7 +4969,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 ShortMaxVectorTests::ADDReduceLongMasked, ShortMaxVectorTests::ADDReduceAllLongMasked);
     }
 
@@ -4981,7 +4981,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             ShortVector.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "shortBinaryOpMaskProvider")
@@ -4999,7 +4999,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, ShortMaxVectorTests::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, ShortMaxVectorTests::blend);
     }
 
 
@@ -5016,7 +5016,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "shortUnaryOpSelectFromMaskProvider")
@@ -5035,7 +5035,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -5112,7 +5112,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, ShortMaxVectorTests::beq);
+        assertArraysEquals(r, a, b, ShortMaxVectorTests::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
@@ -416,7 +416,7 @@ public class VectorReshapeTests {
                            ", origin=" + origin);
         System.out.println("expect: "+Arrays.toString(expected));
         System.out.println("output: "+Arrays.toString(output));
-        Assert.assertEquals(expected, output);
+        Assert.assertEquals(output, expected);
     }
 
     @Test(dataProvider = "byteUnaryOpProvider")

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Long-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Long-op.template
@@ -2,5 +2,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$BroadcastLongSmokeTest(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertBroadcastLongArraysEquals(a, b, r, $vectorteststype$::[[TEST]]);
+        assertBroadcastLongArraysEquals(r, a, b, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Masked-Long-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Masked-Long-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]$vectorteststype$BroadcastMaskedLongSmokeTest(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
                                           IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertBroadcastLongArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]]);
+        assertBroadcastLongArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-Masked-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]$vectorteststype$BroadcastMaskedSmokeTest(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
                                           IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertBroadcastArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]]);
+        assertBroadcastArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-op-math.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-op-math.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$BroadcastSmokeTest(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertBroadcastArraysEqualsWithinOneUlp(a, b, r, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
+        assertBroadcastArraysEqualsWithinOneUlp(r, a, b, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Broadcast-op.template
@@ -2,5 +2,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$BroadcastSmokeTest(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertBroadcastArraysEquals(a, b, r, $vectorteststype$::[[TEST]]);
+        assertBroadcastArraysEquals(r, a, b, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-Masked-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
                                           IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-op-math.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-op-math.template
@@ -9,6 +9,6 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertArraysEqualsWithinOneUlp(a, b, r, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
+        assertArraysEqualsWithinOneUlp(r, a, b, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Binary-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Binary-op.template
@@ -5,5 +5,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Blend-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Blend-op.template
@@ -7,5 +7,5 @@
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
                                           IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, mask, $vectorteststype$::blend);
+        assertArraysEquals(r, a, b, mask, $vectorteststype$::blend);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-BoolReduction-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-BoolReduction-op.template
@@ -1,5 +1,5 @@
     @Test(dataProvider = "boolUnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertReductionBoolArraysEquals(mask, r, $vectorteststype$::[[TEST]]);
+        assertReductionBoolArraysEquals(r, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Broadcast.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Broadcast.template
@@ -2,7 +2,7 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void Broadcast$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Gather-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Gather-Masked-op.template
@@ -12,6 +12,6 @@
     @Test(dataProvider = "$type$UnaryMaskedOpIndexProvider")
     static void [[TEST]][[TEST_TYPE]]$vectorteststype$(IntFunction<$type$[]> fa, BiFunction<Integer,Integer,int[]> fs, IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]][[TEST_TYPE]]);
+        assertArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]][[TEST_TYPE]]);
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Gather-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Gather-op.template
@@ -10,5 +10,5 @@
     @Test(dataProvider = "$type$UnaryOpIndexProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa, BiFunction<Integer,Integer,int[]> fs) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Get-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Get-op.template
@@ -1,5 +1,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void get$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEquals(a, r, $vectorteststype$::get);
+        assertArraysEquals(r, a, $vectorteststype$::get);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Masked-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]Masked$vectorteststype$(IntFunction<$type$[]> fa,
                                                 IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, r, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -45,8 +45,8 @@
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             $abstractvectortype$ av = $abstractvectortype$.fromArray(SPECIES, a, i);
-            int [] r = av.toIntArray();
-            assertArraysEquals(a, r, i);
+            int[] r = av.toIntArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -60,8 +60,8 @@
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             $abstractvectortype$ av = $abstractvectortype$.fromArray(SPECIES, a, i);
-            long [] r = av.toLongArray();
-            assertArraysEquals(a, r, i);
+            long[] r = av.toLongArray();
+            assertArraysEquals(r, a, i);
         }
     }
 
@@ -72,8 +72,8 @@
 
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             $abstractvectortype$ av = $abstractvectortype$.fromArray(SPECIES, a, i);
-            double [] r = av.toDoubleArray();
-            assertArraysEquals(a, r, i);
+            double[] r = av.toDoubleArray();
+            assertArraysEquals(r, a, i);
         }
     }
 #end[!Double]
@@ -115,7 +115,7 @@
             $abstractvectortype$ av = $abstractvectortype$.fromArray(SPECIES, a, i);
             av.reinterpretAsBytes().intoArray(r, i);
         }
-        assertArraysEquals(a, r, 0);
+        assertArraysEquals(r, a, 0);
     }
 #end[byte]
 
@@ -154,7 +154,7 @@
             ra += r[i];
         }
 
-        assertReductionLongArraysEquals(a, r, ra,
+        assertReductionLongArraysEquals(r, ra, a,
                 $vectorteststype$::ADDReduceLong, $vectorteststype$::ADDReduceAllLong);
     }
 
@@ -195,7 +195,7 @@
             ra += r[i];
         }
 
-        assertReductionLongArraysEqualsMasked(a, r, ra, mask,
+        assertReductionLongArraysEqualsMasked(r, ra, a, mask,
                 $vectorteststype$::ADDReduceLongMasked, $vectorteststype$::ADDReduceAllLongMasked);
     }
 
@@ -211,7 +211,7 @@
         for (int i = 0; i < a.length; i += SPECIES.length()) {
             $abstractvectortype$.broadcast(SPECIES, (long)a[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, r);
+        assertBroadcastArraysEquals(r, a);
     }
 
     @Test(dataProvider = "$type$BinaryOpMaskProvider")
@@ -229,7 +229,7 @@
                 av.blend((long)b[i], vmask).intoArray(r, i);
             }
         }
-        assertBroadcastLongArraysEquals(a, b, r, mask, $vectorteststype$::blend);
+        assertBroadcastLongArraysEquals(r, a, b, mask, $vectorteststype$::blend);
     }
 #end[!Long]
 
@@ -250,7 +250,7 @@
             ra += r[i];
         }
 
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 $vectorteststype$::ADDReduce, $vectorteststype$::ADDReduceAll);
     }
 
@@ -272,7 +272,7 @@
             ra += r[i];
         }
 
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 $vectorteststype$::ADDReduceMasked, $vectorteststype$::ADDReduceAllMasked);
     }
 #end[Long]
@@ -294,7 +294,7 @@
             bv.selectFrom(av).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, SPECIES.length());
     }
 
 #if[Int]
@@ -317,7 +317,7 @@
             bv.selectFrom(av, vmask).intoArray(r, i);
         }
 
-        assertSelectFromArraysEquals(a, r, order, mask, SPECIES.length());
+        assertSelectFromArraysEquals(r, a, order, mask, SPECIES.length());
     }
 
     @Test(dataProvider = "shuffleProvider")
@@ -394,7 +394,7 @@
             var cv = av.eq(bv);
             cv.intoArray(r, i);
         }
-        assertArraysEquals(a, b, r, $vectorteststype$::beq);
+        assertArraysEquals(r, a, b, $vectorteststype$::beq);
     }
 
     @Test(dataProvider = "maskProvider")

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Rearrange.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Rearrange.template
@@ -3,7 +3,7 @@
     static void Rearrange$vectorteststype$(IntFunction<$type$[]> fa,
                                            BiFunction<Integer,Integer,int[]> fs) {
 [[KERNEL]]
-        assertRearrangeArraysEquals(a, r, order, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, SPECIES.length());
     }
 
     @Test(dataProvider = "$type$UnaryOpShuffleMaskProvider")
@@ -21,5 +21,5 @@
             av.rearrange(VectorShuffle.fromArray(SPECIES, order, i), vmask).intoArray(r, i);
         }
 
-        assertRearrangeArraysEquals(a, r, order, mask, SPECIES.length());
+        assertRearrangeArraysEquals(r, a, order, mask, SPECIES.length());
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-Max-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-Max-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpMaskProvider")
     static void [[TEST]]Reduce$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 $vectorteststype$::[[TEST]]ReduceMasked, $vectorteststype$::[[TEST]]ReduceAllMasked);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-Min-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-Min-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpMaskProvider")
     static void [[TEST]]Reduce$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 $vectorteststype$::[[TEST]]ReduceMasked, $vectorteststype$::[[TEST]]ReduceAllMasked);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Masked-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpMaskProvider")
     static void [[TEST]]Reduce$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertReductionArraysEqualsMasked(a, r, ra, mask,
+        assertReductionArraysEqualsMasked(r, ra, a, mask,
                 $vectorteststype$::[[TEST]]ReduceMasked, $vectorteststype$::[[TEST]]ReduceAllMasked);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Max-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Max-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]Reduce$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 $vectorteststype$::[[TEST]]Reduce, $vectorteststype$::[[TEST]]ReduceAll);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Min-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-Min-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]Reduce$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 $vectorteststype$::[[TEST]]Reduce, $vectorteststype$::[[TEST]]ReduceAll);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Reduction-op.template
@@ -1,6 +1,6 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]Reduce$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertReductionArraysEquals(a, r, ra,
+        assertReductionArraysEquals(r, ra, a,
                 $vectorteststype$::[[TEST]]Reduce, $vectorteststype$::[[TEST]]ReduceAll);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Scatter-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Scatter-Masked-op.template
@@ -21,6 +21,6 @@
     @Test(dataProvider = "scatterMaskedOpIndexProvider")
     static void [[TEST]][[TEST_TYPE]]$vectorteststype$(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb, BiFunction<Integer,Integer,int[]> fs, IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]][[TEST_TYPE]]);
+        assertArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]][[TEST_TYPE]]);
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Scatter-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Scatter-op.template
@@ -10,6 +10,6 @@
     @Test(dataProvider = "$type$UnaryOpIndexProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa, BiFunction<Integer,Integer,int[]> fs) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, $vectorteststype$::[[TEST]]);
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Shift-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Shift-Masked-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]$vectorteststype$Shift(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
                                           IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertShiftArraysEquals(a, b, r, mask, $vectorteststype$::[[TEST]]_unary);
+        assertShiftArraysEquals(r, a, b, mask, $vectorteststype$::[[TEST]]_unary);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Shift-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Shift-op.template
@@ -5,5 +5,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$Shift(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertShiftArraysEquals(a, b, r, $vectorteststype$::[[TEST]]_unary);
+        assertShiftArraysEquals(r, a, b, $vectorteststype$::[[TEST]]_unary);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Single-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Single-op.template
@@ -8,5 +8,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEquals(a, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Slice-Masked-bop.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Slice-Masked-bop.template
@@ -15,5 +15,5 @@
     static void [[TEST]]$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
     IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, origin, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, origin, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Slice-bop.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Slice-bop.template
@@ -14,5 +14,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$Binary(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, origin, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, origin, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Slice-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Slice-op.template
@@ -12,5 +12,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEquals(a, r, origin, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, origin, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Broadcast-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Broadcast-Masked-op.template
@@ -14,7 +14,7 @@
             av.lanewise(VectorOperators.[[TEST]], bv, c[i], vmask).intoArray(r, i);
         }
 
-        assertBroadcastArraysEquals(a, b, c, r, mask, $vectorteststype$::[[TEST]]);
+        assertBroadcastArraysEquals(r, a, b, c, mask, $vectorteststype$::[[TEST]]);
     }
 
     @Test(dataProvider = "$type$TernaryOpMaskProvider")
@@ -33,5 +33,5 @@
             av.lanewise(VectorOperators.[[TEST]], b[i], cv, vmask).intoArray(r, i);
         }
 
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, $vectorteststype$::[[TEST]]);
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Broadcast-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Broadcast-op.template
@@ -10,7 +10,7 @@
             $abstractvectortype$ bv = $abstractvectortype$.fromArray(SPECIES, b, i);
             av.lanewise(VectorOperators.[[TEST]], bv, c[i]).intoArray(r, i);
         }
-        assertBroadcastArraysEquals(a, b, c, r, $vectorteststype$::[[TEST]]);
+        assertBroadcastArraysEquals(r, a, b, c, $vectorteststype$::[[TEST]]);
     }
 
     @Test(dataProvider = "$type$TernaryOpProvider")
@@ -25,5 +25,5 @@
             $abstractvectortype$ cv = $abstractvectortype$.fromArray(SPECIES, c, i);
             av.lanewise(VectorOperators.[[TEST]], b[i], cv).intoArray(r, i);
         }
-        assertAltBroadcastArraysEquals(a, b, c, r, $vectorteststype$::[[TEST]]);
+        assertAltBroadcastArraysEquals(r, a, b, c, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Double-Broadcast-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Double-Broadcast-Masked-op.template
@@ -11,5 +11,5 @@
         final int INVOC_COUNT = count;
 #end[double]
 [[KERNEL]]
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, $vectorteststype$::[[TEST]]);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Double-Broadcast-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Double-Broadcast-op.template
@@ -10,5 +10,5 @@
         final int INVOC_COUNT = count;
 #end[double]
 [[KERNEL]]
-        assertDoubleBroadcastArraysEquals(a, b, c, r, $vectorteststype$::[[TEST]]);
+        assertDoubleBroadcastArraysEquals(r, a, b, c, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-Masked-op.template
@@ -11,5 +11,5 @@
         final int INVOC_COUNT = count;
 #end[double]
 [[KERNEL]]
-        assertArraysEquals(a, b, c, r, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, c, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Ternary-op.template
@@ -10,5 +10,5 @@
         final int INVOC_COUNT = count;
 #end[double]
 [[KERNEL]]
-        assertArraysEquals(a, b, c, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, c, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unary-Masked-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unary-Masked-op.template
@@ -3,5 +3,5 @@
     static void [[TEST]]Masked$vectorteststype$(IntFunction<$type$[]> fa,
                                                 IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, r, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unary-op-math.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unary-op-math.template
@@ -9,5 +9,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEqualsWithinOneUlp(a, r, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
+        assertArraysEqualsWithinOneUlp(r, a, $vectorteststype$::[[TEST]], $vectorteststype$::strict[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unary-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unary-op.template
@@ -2,5 +2,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEquals(a, r, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-Masked-bop.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-Masked-bop.template
@@ -38,5 +38,5 @@
     static void [[TEST]]$vectorteststype$Masked(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb,
     IntFunction<boolean[]> fm) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, origin, part, mask, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, origin, part, mask, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-bop.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-bop.template
@@ -23,5 +23,5 @@
     @Test(dataProvider = "$type$BinaryOpProvider")
     static void [[TEST]]$vectorteststype$Binary(IntFunction<$type$[]> fa, IntFunction<$type$[]> fb) {
 [[KERNEL]]
-        assertArraysEquals(a, b, r, origin, part, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, b, origin, part, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Unslice-op.template
@@ -14,5 +14,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void [[TEST]]$vectorteststype$(IntFunction<$type$[]> fa) {
 [[KERNEL]]
-        assertArraysEquals(a, r, origin, $vectorteststype$::[[TEST]]);
+        assertArraysEquals(r, a, origin, $vectorteststype$::[[TEST]]);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-With-Op.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-With-Op.template
@@ -2,5 +2,5 @@
     @Test(dataProvider = "$type$UnaryOpProvider")
     static void with$vectorteststype$(IntFunction<$type$ []> fa) {
 [[KERNEL]]
-        assertInsertArraysEquals(a, r, ($type$)4, 0);
+        assertInsertArraysEquals(r, a, ($type$)4, 0);
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -97,7 +97,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$ apply($type$ a);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] r, FUnOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -112,7 +112,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$ a);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] r, FUnArrayOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, FUnArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -122,13 +122,13 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a[i]);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] r, boolean[] mask, FUnOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, boolean[] mask, FUnOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -147,17 +147,17 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$ apply($type$[] a);
     }
 
-    static void assertReductionArraysEquals($type$[] a, $type$[] b, $type$ c,
+    static void assertReductionArraysEquals($type$[] r, $type$ rc, $type$[] a,
                                             FReductionOp f, FReductionAllOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -169,17 +169,17 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$ apply($type$[] a, boolean[] mask);
     }
 
-    static void assertReductionArraysEqualsMasked($type$[] a, $type$[] b, $type$ c, boolean[] mask,
+    static void assertReductionArraysEqualsMasked($type$[] r, $type$ rc, $type$[] a, boolean[] mask,
                                             FReductionMaskedOp f, FReductionAllMaskedOp fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 
@@ -192,17 +192,17 @@ public class $vectorteststype$ extends AbstractVectorTest {
         long apply($type$[] a);
     }
 
-    static void assertReductionLongArraysEquals($type$[] a, long[] b, long c,
+    static void assertReductionLongArraysEquals(long[] r, long rc, $type$[] a,
                                             FReductionOpLong f, FReductionAllOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a));
+            Assert.assertEquals(rc, fa.apply(a));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
@@ -214,17 +214,17 @@ public class $vectorteststype$ extends AbstractVectorTest {
         long apply($type$[] a, boolean[] mask);
     }
 
-    static void assertReductionLongArraysEqualsMasked($type$[] a, long[] b, long c, boolean[] mask,
+    static void assertReductionLongArraysEqualsMasked(long[] r, long rc, $type$[] a, boolean[] mask,
                                             FReductionMaskedOpLong f, FReductionAllMaskedOpLong fa) {
         int i = 0;
         try {
-            Assert.assertEquals(c, fa.apply(a, mask));
+            Assert.assertEquals(rc, fa.apply(a, mask));
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i, mask));
+                Assert.assertEquals(r[i], f.apply(a, i, mask));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(c, fa.apply(a, mask), "Final result is incorrect!");
-            Assert.assertEquals(b[i], f.apply(a, i, mask), "at index #" + i);
+            Assert.assertEquals(rc, fa.apply(a, mask), "Final result is incorrect!");
+            Assert.assertEquals(r[i], f.apply(a, i, mask), "at index #" + i);
         }
     }
 #end[!Long]
@@ -233,37 +233,37 @@ public class $vectorteststype$ extends AbstractVectorTest {
         boolean apply(boolean[] a, int idx);
     }
 
-    static void assertReductionBoolArraysEquals(boolean[] a, boolean[] b, FBoolReductionOp f) {
+    static void assertReductionBoolArraysEquals(boolean[] r, boolean[] a, FBoolReductionOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
-                Assert.assertEquals(b[i], f.apply(a, i));
+                Assert.assertEquals(r[i], f.apply(a, i));
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(b[i], f.apply(a, i), "at index #" + i);
+            Assert.assertEquals(r[i], f.apply(a, i), "at index #" + i);
         }
     }
 
-    static void assertInsertArraysEquals($type$[] a, $type$[] b, $type$ element, int index) {
+    static void assertInsertArraysEquals($type$[] r, $type$[] a, $type$ element, int index) {
         int i = 0;
         try {
             for (; i < a.length; i += 1) {
                 if(i%SPECIES.length() == index) {
-                    Assert.assertEquals(b[i], element);
+                    Assert.assertEquals(r[i], element);
                 } else {
-                    Assert.assertEquals(b[i], a[i]);
+                    Assert.assertEquals(r[i], a[i]);
                 }
             }
         } catch (AssertionError e) {
             if (i%SPECIES.length() == index) {
-                Assert.assertEquals(b[i], element, "at index #" + i);
+                Assert.assertEquals(r[i], element, "at index #" + i);
             } else {
-                Assert.assertEquals(b[i], a[i], "at index #" + i);
+                Assert.assertEquals(r[i], a[i], "at index #" + i);
             }
         }
     }
 
-    static void assertRearrangeArraysEquals($type$[] a, $type$[] r, int[] order, int vector_len) {
+    static void assertRearrangeArraysEquals($type$[] r, $type$[] a, int[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -277,7 +277,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals($type$[] a, $type$[] r, $type$[] order, int vector_len) {
+    static void assertSelectFromArraysEquals($type$[] r, $type$[] a, $type$[] order, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -291,7 +291,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertRearrangeArraysEquals($type$[] a, $type$[] r, int[] order, boolean[] mask, int vector_len) {
+    static void assertRearrangeArraysEquals($type$[] r, $type$[] a, int[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -311,7 +311,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertSelectFromArraysEquals($type$[] a, $type$[] r, $type$[] order, boolean[] mask, int vector_len) {
+    static void assertSelectFromArraysEquals($type$[] r, $type$[] a, $type$[] order, boolean[] mask, int vector_len) {
         int i = 0, j = 0;
         try {
             for (; i < a.length; i += vector_len) {
@@ -331,7 +331,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals($type$[]a, $type$[]r) {
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a) {
         int i = 0;
         for (; i < a.length; i += SPECIES.length()) {
             int idx = i;
@@ -360,7 +360,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, FBinOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -371,7 +371,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] r, FBinOp f) {
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -383,7 +383,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals($type$[] a, $type$[] b, $type$[] r, FBinOp f) {
+    static void assertBroadcastLongArraysEquals($type$[] r, $type$[] a, $type$[] b, FBinOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -395,11 +395,11 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinOp f) {
-        assertArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinOp f) {
+        assertArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -410,11 +410,11 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -428,11 +428,11 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastLongArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinOp f) {
-        assertBroadcastLongArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertBroadcastLongArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinOp f) {
+        assertBroadcastLongArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertBroadcastLongArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertBroadcastLongArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -446,7 +446,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals($type$[] a, $type$[] b, $type$[] r, FBinOp f) {
+    static void assertShiftArraysEquals($type$[] r, $type$[] a, $type$[] b, FBinOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -460,11 +460,11 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertShiftArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinOp f) {
-        assertShiftArraysEquals(a, b, r, mask, FBinMaskOp.lift(f));
+    static void assertShiftArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinOp f) {
+        assertShiftArraysEquals(r, a, b, mask, FBinMaskOp.lift(f));
     }
 
-    static void assertShiftArraysEquals($type$[] a, $type$[] b, $type$[] r, boolean[] mask, FBinMaskOp f) {
+    static void assertShiftArraysEquals($type$[] r, $type$[] a, $type$[] b, boolean[] mask, FBinMaskOp f) {
         int i = 0;
         int j = 0;
         try {
@@ -490,7 +490,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, FTernOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -501,11 +501,11 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask, FTernOp f) {
-        assertArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask, FTernOp f) {
+        assertArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask, FTernMaskOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask, FTernMaskOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -517,7 +517,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, FTernOp f) {
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -530,7 +530,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, FTernOp f) {
+    static void assertAltBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -543,12 +543,12 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                             FTernOp f) {
-        assertBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -564,12 +564,12 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertAltBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                             FTernOp f) {
-        assertAltBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertAltBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertAltBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertAltBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                             FTernMaskOp f) {
         int i = 0;
         try {
@@ -585,7 +585,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, FTernOp f) {
+    static void assertDoubleBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, FTernOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -600,12 +600,12 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertDoubleBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                                   FTernOp f) {
-        assertDoubleBroadcastArraysEquals(a, b, c, r, mask, FTernMaskOp.lift(f));
+        assertDoubleBroadcastArraysEquals(r, a, b, c, mask, FTernMaskOp.lift(f));
     }
 
-    static void assertDoubleBroadcastArraysEquals($type$[] a, $type$[] b, $type$[] c, $type$[] r, boolean[] mask,
+    static void assertDoubleBroadcastArraysEquals($type$[] r, $type$[] a, $type$[] b, $type$[] c, boolean[] mask,
                                                   FTernMaskOp f) {
         int i = 0;
         try {
@@ -645,7 +645,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         return true;
     }
 
-    static void assertArraysEqualsWithinOneUlp($type$[] a, $type$[] r, FUnOp mathf, FUnOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp($type$[] r, $type$[] a, FUnOp mathf, FUnOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -659,7 +659,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEqualsWithinOneUlp($type$[] a, $type$[] b, $type$[] r, FBinOp mathf, FBinOp strictmathf) {
+    static void assertArraysEqualsWithinOneUlp($type$[] r, $type$[] a, $type$[] b, FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
             // Check that result is within 1 ulp of strict math or equivalent to math implementation.
@@ -673,7 +673,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertBroadcastArraysEqualsWithinOneUlp($type$[] a, $type$[] b, $type$[] r,
+    static void assertBroadcastArraysEqualsWithinOneUlp($type$[] r, $type$[] a, $type$[] b,
                                                         FBinOp mathf, FBinOp strictmathf) {
         int i = 0;
         try {
@@ -704,7 +704,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$ apply($type$[] a, int b);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] r, FBinArrayOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, FBinArrayOp f) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
@@ -719,7 +719,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, int ix, int[] b, int iy);
     }
 
-    static void assertArraysEquals($type$[] a, int[] b, $type$[] r, FGatherScatterOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, int[] b, FGatherScatterOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -746,7 +746,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] r, $type$[] a, int ix, boolean[] mask, int[] b, int iy);
     }
 
-    static void assertArraysEquals($type$[] a, int[] b, $type$[] r, boolean[] mask, FGatherMaskedOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, int[] b, boolean[] mask, FGatherMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -756,7 +756,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, i, mask, b, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -767,7 +767,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         }
     }
 
-    static void assertArraysEquals($type$[] a, int[] b, $type$[] r, boolean[] mask, FScatterMaskedOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, int[] b, boolean[] mask, FScatterMaskedOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -777,7 +777,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(r, a, i, mask, b, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res,
+            Assert.assertEquals(res, ref,
               "(ref: " + Arrays.toString(ref) + ", res: " + Arrays.toString(res) + ", a: "
               + Arrays.toString(Arrays.copyOfRange(a, i, i+SPECIES.length()))
               + ", b: "
@@ -794,7 +794,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, int origin, int idx);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] r, int origin, FLaneOp f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, int origin, FLaneOp f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -804,7 +804,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, origin, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i);
         }
@@ -814,7 +814,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, $type$[] b, int origin, int idx);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, int origin, FLaneBop f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, int origin, FLaneBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -824,7 +824,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, b, origin, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -835,7 +835,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, $type$[] b, int origin, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, int origin, boolean[] mask, FLaneMaskedBop f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, int origin, boolean[] mask, FLaneMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -845,7 +845,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, b, origin, mask, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin);
@@ -856,7 +856,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, $type$[] b, int origin, int part, int idx);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, int origin, int part, FLanePartBop f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, int origin, int part, FLanePartBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -866,7 +866,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, b, origin, part, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -878,7 +878,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         $type$[] apply($type$[] a, $type$[] b, int origin, int part, boolean[] mask, int idx);
     }
 
-    static void assertArraysEquals($type$[] a, $type$[] b, $type$[] r, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
+    static void assertArraysEquals($type$[] r, $type$[] a, $type$[] b, int origin, int part, boolean[] mask, FLanePartMaskedBop f) {
         int i = 0;
         try {
             for (; i < a.length; i += SPECIES.length()) {
@@ -888,7 +888,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         } catch (AssertionError e) {
             $type$[] ref = f.apply(a, b, origin, part, mask, i);
             $type$[] res = Arrays.copyOfRange(r, i, i+SPECIES.length());
-            Assert.assertEquals(ref, res, "(ref: " + Arrays.toString(ref)
+            Assert.assertEquals(res, ref, "(ref: " + Arrays.toString(ref)
               + ", res: " + Arrays.toString(res)
               + "), at index #" + i
               + ", at origin #" + origin
@@ -934,7 +934,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
 #end[!byteOrShort]
 #end[!Int]
 
-    static void assertArraysEquals($type$[] a, int[] r, int offs) {
+    static void assertArraysEquals(int[] r, $type$[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -984,7 +984,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
 #end[!Long]
 
 #if[byte]
-    static void assertArraysEquals($type$[] a, $type$[] r, int offs) {
+    static void assertArraysEquals($type$[] r, $type$[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -996,7 +996,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
     }
 #end[byte]
 
-    static void assertArraysEquals($type$[] a, long[] r, int offs) {
+    static void assertArraysEquals(long[] r, $type$[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {
@@ -1008,7 +1008,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
     }
 
 #if[!Double]
-    static void assertArraysEquals($type$[] a, double[] r, int offs) {
+    static void assertArraysEquals(double[] r, $type$[] a, int offs) {
         int i = 0;
         try {
             for (; i < r.length; i++) {

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -84,48 +84,26 @@ public class $vectorteststype$ extends AbstractVectorTest {
 
     static final int BUFFER_SIZE = Integer.getInteger("jdk.incubator.vector.test.buffer-size", BUFFER_REPS * ($bits$ / 8));
 
-    static void assertArraysEquals($type$[] a, $type$[] r, boolean[] mask) {
+    static void assertArraysEquals($type$[] r, $type$[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : ($type$) 0, r[i]);
+                Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : ($type$) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[i] : ($type$) 0, r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals($type$[] a, $type$[] r, int[] im) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(a[im[i]], r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(a[im[i]], r[i], "at index #" + i);
-        }
-    }
-
-    static void assertArraysEquals($type$[] a, $type$[] r, int[] im, boolean[] mask) {
-        int i = 0;
-        try {
-            for (; i < a.length; i++) {
-                Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : ($type$) 0, r[i]);
-            }
-        } catch (AssertionError e) {
-            Assert.assertEquals(mask[i % SPECIES.length()] ? a[im[i]] : ($type$) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[i % SPECIES.length()] ? a[i] : ($type$) 0, "at index #" + i);
         }
     }
 
 #if[!byte]
-    static void assertArraysEquals(byte[] a, byte[] r, boolean[] mask) {
+    static void assertArraysEquals(byte[] r, byte[] a, boolean[] mask) {
         int i = 0;
         try {
             for (; i < a.length; i++) {
-                Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i]);
+                Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0);
             }
         } catch (AssertionError e) {
-            Assert.assertEquals(mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, r[i], "at index #" + i);
+            Assert.assertEquals(r[i], mask[(i*8/SPECIES.elementSize()) % SPECIES.length()] ? a[i] : (byte) 0, "at index #" + i);
         }
     }
 #end[!byte]
@@ -433,7 +411,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test(dataProvider = "$type$ProviderForIOOBE")
@@ -504,7 +482,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 av.intoArray(r, i);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new $type$[a.length];
@@ -515,7 +493,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 av.intoArray(r, i, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "$type$MaskProviderForIOOBE")
@@ -588,7 +566,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(mask, r);
+        Assert.assertEquals(r, mask);
     }
 
 
@@ -612,7 +590,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        Assert.assertEquals(a, r, "Buffers not equal");
+        Assert.assertEquals(r, a, "Buffers not equal");
     }
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
@@ -699,7 +677,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
 
 
         r = fb.apply(a.limit());
@@ -714,7 +692,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
         Assert.assertEquals(a.limit(), l, "Input buffer limit changed");
         Assert.assertEquals(r.position(), 0, "Result buffer position changed");
         Assert.assertEquals(r.limit(), l, "Result buffer limit changed");
-        assertArraysEquals(_a, bufferToArray(r), mask);
+        assertArraysEquals(bufferToArray(r), _a, mask);
     }
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
@@ -830,7 +808,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo);
             }
         }
-        Assert.assertEquals(a, r, "Byte arrays not equal");
+        Assert.assertEquals(r, a, "Byte arrays not equal");
     }
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
@@ -911,7 +889,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
               av.intoByteArray(r, i, bo);
           }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
 
 
         r = new byte[a.length];
@@ -922,7 +900,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 av.intoByteArray(r, i, bo, vmask);
             }
         }
-        assertArraysEquals(a, r, mask);
+        assertArraysEquals(r, a, mask);
     }
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
@@ -999,7 +977,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 vmask.intoArray(r, i);
             }
         }
-        Assert.assertEquals(a, r);
+        Assert.assertEquals(r, a);
     }
 
     @Test
@@ -1010,7 +988,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
             int [] r = shuffle.toArray();
 
             int [] a = expectedShuffle(SPECIES.length(), fn);
-            Assert.assertEquals(a, r);
+            Assert.assertEquals(r, a);
        }
     }
 }


### PR DESCRIPTION
Some vector api tests have incorrect output messages if assertion fails. The root cause is the improper use of `"org.testng.Assert.assertEqual()"`, whose definition with int type is:
```
assertEquals(int actual, int expected, String message);
```

The method needs the actual value be used as the first argument and expected value as the second one. But in some vector api tests, the two arguments are swapped.

For example, here is part of the fail log in VectorReshapeTests we met:
```
 expect: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 output: [1, 2, 3, 4, 5, 6, 7, 8, 1, 0, 0, 0, 0, 0, 0, 0]
 test VectorReshapeTests.testRebracket128(byte(i)): failure
 java.lang.AssertionError: arrays differ firstly at element [8]; expected value is <1> but was <9>.
   at org.testng.Assert.fail(Assert.java:94)
   at org.testng.Assert.assertEquals(Assert.java:774)
   ...
```

The assertion error should be `"...expected value is <9> but was <1>."`

This does not influence on the test effectiveness. However, the incorrect message is confusing which might mislead people. The simple fix is just to swap the arguments back.

This patch also adjusts the arguments order of all the assertion methods to make the actual values used as the first one. Besides, it also removes two unused assertion methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258813](https://bugs.openjdk.java.net/browse/JDK-8258813): [TESTBUG] Fix incorrect Vector API test output message


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to c3fb298644cb549c79ed9853241534cb42cba4d2
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1922/head:pull/1922`
`$ git checkout pull/1922`
