### PR TITLE
8193942: Regression automated test '/open/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -740,7 +740,6 @@ javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
-javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8193942 generic-all
 javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all

--- a/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java
+++ b/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java
@@ -44,7 +44,7 @@ public class ScaledFrameBackgroundTest {
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(50);
+            robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
@@ -54,10 +54,11 @@ public class ScaledFrameBackgroundTest {
                 panel.setBackground(BACKGROUND);
                 frame.getContentPane().add(panel);
                 frame.setVisible(true);
+                frame.setLocationRelativeTo(null);
             });
 
             robot.waitForIdle();
-            Thread.sleep(200);
+            robot.delay(1000);
 
             Rectangle[] rects = new Rectangle[1];
             SwingUtilities.invokeAndWait(() -> {
@@ -81,7 +82,7 @@ public class ScaledFrameBackgroundTest {
             color = robot.getPixelColor(x, y);
 
             if (!BACKGROUND.equals(color)) {
-                throw new RuntimeException("Wrong backgound color!");
+                throw new RuntimeException("Wrong backgound color!!");
             }
         } finally {
             if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());


### PR DESCRIPTION
This test use to fail in macos in mach5 nightly testing long time back. It used to fail in ubuntu17.10 due to unsupported wayland display mode. Recent run of this test on supported platforms does not fail.
Modified the test slightly to be consistent with other test regarding robot delays, moved frame to center of screen.
Mach5 job running several iterations of the test in all platforms is ok. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8193942](https://bugs.openjdk.java.net/browse/JDK-8193942): Regression automated test '/open/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java' fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1923/head:pull/1923`
`$ git checkout pull/1923`
