### PR TITLE
8196466: javax/swing/JFileChooser/8062561/bug8062561.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -752,7 +752,6 @@ javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 li
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
-javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all


### PR DESCRIPTION
This test was marked for "windows only" in https://github.com/openjdk/jdk/commit/7cb9e5821e0e5bcc483bc7c587ea921e9b515e77 in JDK-8198333
but the test is redundantly problem listed for linux and mac. 
We can remove the test from ProblemList as it is being run in mach5 on windows without any issue and it will not run on linux,mac as 8062561 fix for which this test was created is windows specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196466](https://bugs.openjdk.java.net/browse/JDK-8196466): javax/swing/JFileChooser/8062561/bug8062561.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1924/head:pull/1924`
`$ git checkout pull/1924`
