### PR TITLE
8259042: Inconsistent use of general primitives loops

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/loops/Blit.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/Blit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.awt.image.ColorModel;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.lang.ref.WeakReference;
-import sun.java2d.loops.GraphicsPrimitive;
+
 import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
 import sun.java2d.pipe.SpanIterator;
@@ -114,9 +114,9 @@ public class Blit extends GraphicsPrimitive
         GraphicsPrimitiveMgr.registerGeneral(new Blit(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype)
     {
         /*
         System.out.println("Constructing general blit for:");

--- a/src/java.desktop/share/classes/sun/java2d/loops/BlitBg.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/BlitBg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,17 @@
 
 package sun.java2d.loops;
 
-import java.awt.Font;
+import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Composite;
-import java.awt.AlphaComposite;
-import java.awt.Transparency;
+import java.awt.Font;
+import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.WritableRaster;
-import java.awt.image.BufferedImage;
+
 import sun.awt.image.BufImgSurfaceData;
-import sun.java2d.loops.GraphicsPrimitive;
-import sun.java2d.SurfaceData;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
 
 /**
@@ -118,9 +117,9 @@ public class BlitBg extends GraphicsPrimitive
         GraphicsPrimitiveMgr.registerGeneral(new BlitBg(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype)
     {
         /*
         System.out.println("Constructing general blitbg for:");

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphList.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,10 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
-import sun.java2d.pipe.Region;
+import sun.font.GlyphList;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
-import sun.font.GlyphList;
+import sun.java2d.pipe.Region;
 
 /**
  *   DrawGlyphList - loops for SolidTextRenderer pipe.
@@ -77,9 +76,9 @@ public class DrawGlyphList extends GraphicsPrimitive {
                                 new DrawGlyphList(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype) {
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype) {
         return new General(srctype, comptype, dsttype);
     }
 

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListAA.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListAA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,10 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
-import sun.java2d.pipe.Region;
+import sun.font.GlyphList;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
-import sun.font.GlyphList;
+import sun.java2d.pipe.Region;
 
 /**
  *   DrawGlyphListAA - loops for AATextRenderer pipe
@@ -75,9 +74,9 @@ public class DrawGlyphListAA extends GraphicsPrimitive {
                                    new DrawGlyphListAA(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype) {
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype) {
         return new General(srctype, comptype, dsttype);
     }
 

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListLCD.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListLCD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,9 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
+import sun.font.GlyphList;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
-import sun.font.GlyphList;
 
 /**
  *   DrawGlyphListLCD- loops for LCDTextRenderer pipe
@@ -70,23 +69,6 @@ public class DrawGlyphListLCD extends GraphicsPrimitive {
 
     public native void DrawGlyphListLCD(SunGraphics2D sg2d, SurfaceData dest,
                                          GlyphList srcData);
-
-    static {
-        GraphicsPrimitiveMgr.registerGeneral(
-                                   new DrawGlyphListLCD(null, null, null));
-    }
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype) {
-        /* Do not return a General loop. SunGraphics2D determines whether
-         * to use LCD or standard AA text based on whether there is an
-         * installed loop.
-         * This can be uncommented once there is a General loop which can
-         * handle one byte per colour component masks properly.
-         */
-        return null;
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawGlyphListLCD(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawLine.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -73,15 +72,6 @@ public class DrawLine extends GraphicsPrimitive
      */
     public native void DrawLine(SunGraphics2D sg2d, SurfaceData dest,
                                 int x1, int y1, int x2, int y2);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: use FillSpans or converter object?
-        throw new InternalError("DrawLine not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawLine(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawParallelogram.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawParallelogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -81,15 +80,6 @@ public class DrawParallelogram extends GraphicsPrimitive
                                          double dx1, double dy1,
                                          double dx2, double dy2,
                                          double lw1, double lw2);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: iterate with a FillRect primitive?
-        throw new InternalError("DrawParallelogram not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawParallelogram(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawPath.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
+import java.awt.geom.Path2D;
+
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
-import java.awt.geom.Path2D;
 
 /**
  *   DrawPath
@@ -76,14 +76,6 @@ public class DrawPath extends GraphicsPrimitive {
     public native void DrawPath(SunGraphics2D sg2d, SurfaceData sData,
                                 int transX, int transY,
                                 Path2D.Float p2df);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        throw new InternalError("DrawPath not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawPath(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawPolygons.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawPolygons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -77,15 +76,6 @@ public class DrawPolygons extends GraphicsPrimitive
                                     int[] nPoints, int numPolys,
                                     int transX, int transY,
                                     boolean close);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: use FillSpans or converter object?
-        throw new InternalError("DrawPolygons not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawPolygons(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawRect.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawRect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -74,15 +73,6 @@ public class DrawRect extends GraphicsPrimitive
      */
     public native void DrawRect(SunGraphics2D sg2d, SurfaceData dest,
                                 int x1, int y1, int w, int h);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: use FillSpans or converter object?
-        throw new InternalError("DrawRect not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawRect(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/FillParallelogram.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/FillParallelogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -78,15 +77,6 @@ public class FillParallelogram extends GraphicsPrimitive
                                          double x0, double y0,
                                          double dx1, double dy1,
                                          double dx2, double dy2);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: iterate with a FillRect primitive?
-        throw new InternalError("FillParallelogram not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceFillParallelogram(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/FillPath.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/FillPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
+import java.awt.geom.Path2D;
+
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
-import java.awt.geom.Path2D;
 
 /**
  *   FillPath
@@ -76,14 +76,6 @@ public class FillPath extends GraphicsPrimitive {
     public native void FillPath(SunGraphics2D sg2d, SurfaceData sData,
                                 int transX, int transY,
                                 Path2D.Float p2df);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        throw new InternalError("FillPath not implemented for "+
-                                srctype+" with "+comptype);
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceFillPath(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/FillRect.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/FillRect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 
@@ -79,9 +78,9 @@ public class FillRect extends GraphicsPrimitive
         GraphicsPrimitiveMgr.registerGeneral(new FillRect(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype)
     {
         return new General(srctype, comptype, dsttype);
     }

--- a/src/java.desktop/share/classes/sun/java2d/loops/FillSpans.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/FillSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,9 @@
 
 package sun.java2d.loops;
 
-import sun.java2d.loops.GraphicsPrimitive;
-import sun.java2d.pipe.SpanIterator;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
+import sun.java2d.pipe.SpanIterator;
 
 /**
  * FillSpans
@@ -80,15 +79,6 @@ public class FillSpans extends GraphicsPrimitive
                           SpanIterator si)
     {
         FillSpans(sg2d, dest, sg2d.pixel, si.getNativeIterator(), si);
-    }
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        // REMIND: iterate with a FillRect primitive?
-        throw new InternalError("FillSpans not implemented for "+
-                                srctype+" with "+comptype);
     }
 
     public GraphicsPrimitive traceWrap() {

--- a/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitive.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,25 +29,24 @@
 
 package sun.java2d.loops;
 
-import java.awt.image.BufferedImage;
 import java.awt.AlphaComposite;
 import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.StringTokenizer;
+
 import sun.awt.image.BufImgSurfaceData;
 import sun.awt.util.ThreadGroupUtils;
 import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
-import java.lang.reflect.Field;
-import java.util.StringTokenizer;
-import java.util.Iterator;
-import java.util.HashMap;
-import java.util.Map;
-import java.io.PrintStream;
-import java.io.OutputStream;
-import java.io.FileOutputStream;
-import java.io.FileNotFoundException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import sun.security.action.GetPropertyAction;
 
 /**
@@ -312,9 +311,18 @@ public abstract class GraphicsPrimitive {
                 destType.equals(other.destType));
     }
 
-    public abstract GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                                    CompositeType comptype,
-                                                    SurfaceType dsttype);
+    /**
+     * Produces specific primitive loop if the current object is registered as a
+     * general loop, otherwise the {@code InternalError} is thrown.
+     *
+     * @see GraphicsPrimitiveMgr#registerGeneral
+     */
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype) {
+        throw new InternalError("%s not implemented for %s, comp: %s, dst: %s".
+                formatted(getClass().getName(), srctype, comptype, dsttype));
+    }
 
     public abstract GraphicsPrimitive traceWrap();
 

--- a/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveMgr.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveMgr.java
@@ -121,6 +121,12 @@ public final class GraphicsPrimitiveMgr {
         primitives = temp;
     }
 
+    /**
+     * Registers the general loop which will be used to produce specific
+     * primitives by the {@link GraphicsPrimitive#makePrimitive} function.
+     *
+     * @param gen the graphics primitive to be registered as the general loop
+     */
     public static synchronized void registerGeneral(GraphicsPrimitive gen) {
         if (generalPrimitives == null) {
             generalPrimitives = new GraphicsPrimitive[] {gen};

--- a/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveProxy.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,13 +63,6 @@ public class GraphicsPrimitiveProxy extends GraphicsPrimitive {
         super(methodSignature, primID, srctype, comptype, dsttype);
         this.owner = owner;
         this.relativeClassName = relativeClassName;
-    }
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype) {
-        // This should never happen.
-        throw new InternalError("makePrimitive called on a Proxy!");
     }
 
     //

--- a/src/java.desktop/share/classes/sun/java2d/loops/MaskBlit.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/MaskBlit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package sun.java2d.loops;
 
 import java.awt.Composite;
 import java.lang.ref.WeakReference;
-import sun.java2d.loops.GraphicsPrimitive;
+
 import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
 
@@ -112,9 +112,9 @@ public class MaskBlit extends GraphicsPrimitive
         GraphicsPrimitiveMgr.registerGeneral(new MaskBlit(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype)
     {
         /*
         new Throwable().printStackTrace();

--- a/src/java.desktop/share/classes/sun/java2d/loops/MaskFill.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/MaskFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ package sun.java2d.loops;
 
 import java.awt.Composite;
 import java.awt.image.BufferedImage;
+
 import sun.awt.image.BufImgSurfaceData;
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
@@ -144,9 +144,9 @@ public class MaskFill extends GraphicsPrimitive
         GraphicsPrimitiveMgr.registerGeneral(new MaskFill(null, null, null));
     }
 
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
+    protected GraphicsPrimitive makePrimitive(SurfaceType srctype,
+                                              CompositeType comptype,
+                                              SurfaceType dsttype)
     {
         if (SurfaceType.OpaqueColor.equals(srctype) ||
             SurfaceType.AnyColor.equals(srctype))

--- a/src/java.desktop/share/classes/sun/java2d/loops/ScaledBlit.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/ScaledBlit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package sun.java2d.loops;
 
 import java.awt.Composite;
-import sun.java2d.loops.GraphicsPrimitive;
+
 import sun.java2d.SurfaceData;
 import sun.java2d.pipe.Region;
 
@@ -103,23 +103,6 @@ public class ScaledBlit extends GraphicsPrimitive
                              int sx2, int sy2,
                              double dx1, double dy1,
                              double dx2, double dy2);
-
-    static {
-        GraphicsPrimitiveMgr.registerGeneral(new ScaledBlit(null, null, null));
-    }
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        /*
-        System.out.println("Constructing general blit for:");
-        System.out.println("src:  "+srctype);
-        System.out.println("comp: "+comptype);
-        System.out.println("dst:  "+dsttype);
-        */
-        return null;
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceScaledBlit(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/TransformBlit.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/TransformBlit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ package sun.java2d.loops;
 
 import java.awt.Composite;
 import java.awt.geom.AffineTransform;
+
 import sun.java2d.SurfaceData;
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.pipe.Region;
 
 /**
@@ -104,25 +104,6 @@ public class TransformBlit extends GraphicsPrimitive
                                  AffineTransform at, int hint,
                                  int srcx, int srcy, int dstx, int dsty,
                                  int width, int height);
-
-    // REMIND: do we have a general loop?
-    static {
-        GraphicsPrimitiveMgr.registerGeneral(new TransformBlit(null, null,
-                                                               null));
-    }
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        /*
-        System.out.println("Constructing general blit for:");
-        System.out.println("src:  "+srctype);
-        System.out.println("comp: "+comptype);
-        System.out.println("dst:  "+dsttype);
-        */
-        return null;
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceTransformBlit(this);

--- a/src/java.desktop/share/classes/sun/java2d/loops/TransformHelper.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/TransformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ package sun.java2d.loops;
 
 import java.awt.Composite;
 import java.awt.geom.AffineTransform;
+
 import sun.java2d.SurfaceData;
-import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.pipe.Region;
 
 /**
@@ -97,13 +97,6 @@ public class TransformHelper extends GraphicsPrimitive
                                  int sx1, int sy1, int sx2, int sy2,
                                  int dx1, int dy1, int dx2, int dy2,
                                  int[] edges, int dxoff, int dyoff);
-
-    public GraphicsPrimitive makePrimitive(SurfaceType srctype,
-                                           CompositeType comptype,
-                                           SurfaceType dsttype)
-    {
-        return null;
-    }
 
     public GraphicsPrimitive traceWrap() {
         return new TraceTransformHelper(this);


### PR DESCRIPTION
The java2d uses the primitives such as Blit loop for rendering differing things. Currently, not all possible variants of primitives are implemented, but it is possible to register some general loop that may produce the primitives for some specific src/comp/dst.

But we have some inconsistent here:
 - Some primitives register themselves as a general loop but always return null in the makePrimitive() method
 - Some primitives (which are not registered as general loops) return null or throw an error in the makePrimitive() method

After the fix:
 - The primitive will be registered as a general primitive only if it has a meaningful makePrimitive method
 - An attempt to call the makePrimitive for non registered general loop will cause an error