### PR TITLE
8215537: [TEST_BUG] java/awt/print/PrinterJob/LandscapeStackOverflow.java fails by timeout

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
+++ b/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
@@ -36,7 +36,6 @@ import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import javax.print.PrintService;
-import javax.print.PrintServiceLookup;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.standard.OrientationRequested;
@@ -44,21 +43,13 @@ import javax.print.attribute.standard.OrientationRequested;
 public class LandscapeStackOverflow {
 
     public static final void main( String[] parameters ) throws Exception {
-        PrintService defaultPrtSrv = PrintServiceLookup.lookupDefaultPrintService();
-        // If there is no default printer, search for non-default printservice
-        if (defaultPrtSrv == null) {
-            PrintService[] printService = PrinterJob.lookupPrintServices();
-            System.out.println("check printer name of service " + printService);
-            // If there is only a non-default one, set that as the printer for the job
-            if (printService.length == 1) {
-                System.out.println("set this printer service to print...");
-                defaultPrtSrv = printService[0];
-            }
+        PrintService[] printService = PrinterJob.lookupPrintServices();
+        if (printService.length == 0) {
+            throw new RuntimeException("no printer found");
         }
         PrinterJob printjob = PrinterJob.getPrinterJob();
-        printjob.setPrintService(defaultPrtSrv);
         if (printjob.getPrintService() == null) {
-            throw new RuntimeException("No printer found");
+            printjob.setPrintService(printService[0]);
         }
         printjob.setJobName( "Test Print Job" );
 

--- a/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
+++ b/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
@@ -35,6 +35,8 @@ import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.standard.OrientationRequested;
@@ -43,6 +45,11 @@ public class LandscapeStackOverflow {
 
     public static final void main( String[] parameters ) {
         PrinterJob printjob = PrinterJob.getPrinterJob();
+        PrintService defaultPrtSrv = PrintServiceLookup.lookupDefaultPrintService();
+        if (printjob.getPrintService() == null || defaultPrtSrv == null) {
+            System.out.println("No printers. Test cannot continue");
+            return;
+        }
         printjob.setJobName( "Test Print Job" );
 
         PrintRequestAttributeSet attributes = new HashPrintRequestAttributeSet();

--- a/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
+++ b/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
@@ -47,8 +47,7 @@ public class LandscapeStackOverflow {
         PrinterJob printjob = PrinterJob.getPrinterJob();
         PrintService defaultPrtSrv = PrintServiceLookup.lookupDefaultPrintService();
         if (printjob.getPrintService() == null || defaultPrtSrv == null) {
-            System.out.println("No printers. Test cannot continue");
-            return;
+            throw new RuntimeException("No printer found");
         }
         printjob.setJobName( "Test Print Job" );
 

--- a/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
+++ b/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
@@ -43,10 +43,21 @@ import javax.print.attribute.standard.OrientationRequested;
 
 public class LandscapeStackOverflow {
 
-    public static final void main( String[] parameters ) {
-        PrinterJob printjob = PrinterJob.getPrinterJob();
+    public static final void main( String[] parameters ) throws Exception {
         PrintService defaultPrtSrv = PrintServiceLookup.lookupDefaultPrintService();
-        if (printjob.getPrintService() == null || defaultPrtSrv == null) {
+	// If there is no default printer, search for non-default printservice
+        if (defaultPrtSrv == null) {
+            PrintService[] printService = PrinterJob.lookupPrintServices();
+            System.out.println("check printer name of service " + printService);
+            // If there is only a non-default one, set that as the printer for the job
+            if (printService.length == 1) {
+                System.out.println("set this printer service to print...");
+                defaultPrtSrv = printService[0];
+            }
+        }
+        PrinterJob printjob = PrinterJob.getPrinterJob();
+        printjob.setPrintService(defaultPrtSrv);
+        if (printjob.getPrintService() == null) {
             throw new RuntimeException("No printer found");
         }
         printjob.setJobName( "Test Print Job" );

--- a/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
+++ b/test/jdk/java/awt/print/PrinterJob/LandscapeStackOverflow.java
@@ -45,7 +45,7 @@ public class LandscapeStackOverflow {
 
     public static final void main( String[] parameters ) throws Exception {
         PrintService defaultPrtSrv = PrintServiceLookup.lookupDefaultPrintService();
-	// If there is no default printer, search for non-default printservice
+        // If there is no default printer, search for non-default printservice
         if (defaultPrtSrv == null) {
             PrintService[] printService = PrinterJob.lookupPrintServices();
             System.out.println("check printer name of service " + printService);


### PR DESCRIPTION
Test fails with timeout and it seems likely due to non-availability of printer in the test system. We should just update the test to check for default (or available) printers and return if there is no printer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8215537](https://bugs.openjdk.java.net/browse/JDK-8215537): [TEST_BUG] java/awt/print/PrinterJob/LandscapeStackOverflow.java fails by timeout


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1927/head:pull/1927`
`$ git checkout pull/1927`
