### PR TITLE
8259045: Exception message from saproc.dll is garbled on Windows with Japanese locale

### DIFF
--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ else ifeq ($(call isTargetOs, macosx), true)
       -mstack-alignment=16 -fPIC
   LIBSA_EXTRA_SRC := $(SUPPORT_OUTPUTDIR)/gensrc/jdk.hotspot.agent
 else ifeq ($(call isTargetOs, windows), true)
-  SA_CFLAGS := -D_WINDOWS -D_DEBUG -D_CONSOLE -D_MBCS -EHsc
+  SA_CFLAGS := -D_WINDOWS -D_DEBUG -D_CONSOLE -EHsc
   ifeq ($(call isTargetCpu, x86_64), true)
     SA_CXXFLAGS := -DWIN64
   else
@@ -65,12 +65,13 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSA, \
     CFLAGS := $(CFLAGS_JDKLIB) $(SA_CFLAGS), \
     CXXFLAGS := $(CXXFLAGS_JDKLIB) $(SA_CFLAGS) $(SA_CXXFLAGS), \
     EXTRA_SRC := $(LIBSA_EXTRA_SRC), \
-    LDFLAGS := $(LDFLAGS_JDKLIB), \
+    LDFLAGS := $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(LIBCXX), \
+    LIBS_unix := -ljava, \
     LIBS_linux := $(LIBDL), \
     LIBS_macosx := -framework Foundation -framework JavaNativeFoundation \
         -framework JavaRuntimeSupport -framework Security -framework CoreFoundation, \
-    LIBS_windows := dbgeng.lib, \
+    LIBS_windows := dbgeng.lib $(WIN_JAVA_LIB), \
 ))
 
 TARGETS += $(BUILD_LIBSA)


### PR DESCRIPTION
I got garbled exception message as following when I run `livenmethods` CLHSDB command:

```
sun.jvm.hotspot.debugger.DebuggerException : ?w???????W
```

My Windows laptop is set Japanese Locale, garbled message was written in Japanese.
saproc.dll would throw exception via [ThrowNew()](https://docs.oracle.com/en/java/javase/15/docs/specs/jni/functions.html#thrownew) JNI function, but it accepts UTF-8 encoded message. However [FormatMessage()](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage) Windows API might not return UTF-8 encoded string on Japanese locale.

java.dll (libjava,so) provides good functions to resolve this issue. We can convert localized (non ascii) chars to UTF-8 string. I use them in this PR and remove `FormatMessage()` call from sadis.c.
And also I remove `-D_MBCS` from compiler option because [MBCS has been already deprecated](https://docs.microsoft.com/ja-jp/cpp/text/support-for-multibyte-character-sets-mbcss) - it does not seem to add to any other executables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259045](https://bugs.openjdk.java.net/browse/JDK-8259045): Exception message from saproc.dll is garbled on Windows with Japanese locale


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1928/head:pull/1928`
`$ git checkout pull/1928`
