### PR TITLE
8259049: Uninitialized variable after JDK-8257513

### DIFF
--- a/src/hotspot/share/opto/constantTable.cpp
+++ b/src/hotspot/share/opto/constantTable.cpp
@@ -150,7 +150,7 @@ bool ConstantTable::emit(CodeBuffer& cb) const {
              "must be: %d == %d", (int)(constant_addr - _masm.code()->consts()->start()), (int)(con.offset()));
 
       // Expand jump-table
-      address last_addr;
+      address last_addr = NULL;
       for (uint j = 1; j < n->outcnt(); j++) {
         last_addr = _masm.address_constant(dummy + j);
         if (last_addr == NULL) {


### PR DESCRIPTION
Fixing missing initialization to prevent possible compiler warnings. The initialization is not required for correctness, though.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259049](https://bugs.openjdk.java.net/browse/JDK-8259049): Uninitialized variable after JDK-8257513


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1930/head:pull/1930`
`$ git checkout pull/1930`
