### PR TITLE
8258896: Remove the JVM ForceFloatExceptions option

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4183,21 +4183,19 @@ jint os::init_2(void) {
 #endif
 
   // for debugging float code generation bugs
-  if (ForceFloatExceptions) {
-#ifndef  _WIN64
-    static long fp_control_word = 0;
-    __asm { fstcw fp_control_word }
-    // see Intel PPro Manual, Vol. 2, p 7-16
-    const long precision = 0x20;
-    const long underflow = 0x10;
-    const long overflow  = 0x08;
-    const long zero_div  = 0x04;
-    const long denorm    = 0x02;
-    const long invalid   = 0x01;
-    fp_control_word |= invalid;
-    __asm { fldcw fp_control_word }
+#if defined(_DEBUG) && !defined(_WIN64)
+  static long fp_control_word = 0;
+  __asm { fstcw fp_control_word }
+  // see Intel PPro Manual, Vol. 2, p 7-16
+  const long precision = 0x20;
+  const long underflow = 0x10;
+  const long overflow  = 0x08;
+  const long zero_div  = 0x04;
+  const long denorm    = 0x02;
+  const long invalid   = 0x01;
+  fp_control_word |= invalid;
+  __asm { fldcw fp_control_word }
 #endif
-  }
 
   // If stack_commit_size is 0, windows will reserve the default size,
   // but only commit a small portion of it.

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4187,11 +4187,6 @@ jint os::init_2(void) {
   static long fp_control_word = 0;
   __asm { fstcw fp_control_word }
   // see Intel PPro Manual, Vol. 2, p 7-16
-  const long precision = 0x20;
-  const long underflow = 0x10;
-  const long overflow  = 0x08;
-  const long zero_div  = 0x04;
-  const long denorm    = 0x02;
   const long invalid   = 0x01;
   fp_control_word |= invalid;
   __asm { fldcw fp_control_word }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4183,7 +4183,7 @@ jint os::init_2(void) {
 #endif
 
   // for debugging float code generation bugs
-#if defined(_DEBUG) && !defined(_WIN64)
+#if defined(ASSERT) && !defined(_WIN64)
   static long fp_control_word = 0;
   __asm { fstcw fp_control_word }
   // see Intel PPro Manual, Vol. 2, p 7-16

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -461,9 +461,6 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, BytecodeVerificationLocal, false, DIAGNOSTIC,               \
           "Enable the Java bytecode verifier for local classes")            \
-                                                                            \
-  develop(bool, ForceFloatExceptions, trueInDebug,                          \
-          "Force exceptions on FP stack under/overflow")                    \
                                                                             \
   develop(bool, VerifyStackAtCalls, false,                                  \
           "Verify that the stack pointer is unchanged after calls")         \


### PR DESCRIPTION
Please review this change to replace the JVM ForceFloatExceptions flag with #ifdef (_DEBUG).  The change was tested with tiers 1 and 2 on Linux, Windows, and Mac OS, and tiers 3-5 on Windows x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258896](https://bugs.openjdk.java.net/browse/JDK-8258896): Remove the JVM ForceFloatExceptions option


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to c85737e16b284de9c2c8084ffd106c477cc27050
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1932/head:pull/1932`
`$ git checkout pull/1932`
