### PR TITLE
8259067: bootclasspath append takes out object lock

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -830,6 +830,7 @@ bool ClassLoader::contains_append_entry(const char* name) {
 // The boot append entries are added with a lock, and read lock free.
 void ClassLoader::add_to_boot_append_entries(ClassPathEntry *new_entry) {
   if (new_entry != NULL) {
+    MutexLocker ml(Bootclasspath_lock, Mutex::_no_safepoint_check_flag);
     if (_last_append_entry == NULL) {
       _last_append_entry = new_entry;
       assert(first_append_entry() == NULL, "boot loader's append class path entry list not empty");

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -834,7 +834,7 @@ void ClassLoader::add_to_boot_append_entries(ClassPathEntry *new_entry) {
     if (_last_append_entry == NULL) {
       _last_append_entry = new_entry;
       assert(first_append_entry() == NULL, "boot loader's append class path entry list not empty");
-      Atomic::store(&_first_append_entry_list, new_entry);
+      Atomic::release_store(&_first_append_entry_list, new_entry);
     } else {
       _last_append_entry->set_next(new_entry);
       _last_append_entry = new_entry;

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -53,7 +53,6 @@ public:
   ClassPathEntry* next() const;
   virtual ~ClassPathEntry() {}
   void set_next(ClassPathEntry* next);
-  bool cas_set_next(ClassPathEntry* next);
 
   virtual bool is_modules_image() const { return false; }
   virtual bool is_jar_file() const { return false; }

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -217,7 +217,7 @@ class ClassLoader: AllStatic {
   //    Note: boot loader append path does not support named modules.
   static ClassPathEntry* volatile _first_append_entry_list;
   static ClassPathEntry* first_append_entry() {
-    return Atomic::load(&_first_append_entry_list);
+    return Atomic::load_acquire(&_first_append_entry_list);
   }
 
   // Last entry in linked list of appended ClassPathEntry instances

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,8 @@ public:
   ClassPathEntry* next() const;
   virtual ~ClassPathEntry() {}
   void set_next(ClassPathEntry* next);
+  bool cas_set_next(ClassPathEntry* next);
+
   virtual bool is_modules_image() const { return false; }
   virtual bool is_jar_file() const { return false; }
   // Is this entry created from the "Class-path" attribute from a JAR Manifest?
@@ -214,9 +216,13 @@ class ClassLoader: AllStatic {
   // 3. the boot loader's append path
   //    [-Xbootclasspath/a]; [jvmti appended entries]
   //    Note: boot loader append path does not support named modules.
-  static ClassPathEntry* _first_append_entry;
+  static ClassPathEntry* volatile _first_append_entry_list;
+  static ClassPathEntry* first_append_entry() {
+    return Atomic::load(&_first_append_entry_list);
+  }
+
   // Last entry in linked list of appended ClassPathEntry instances
-  static ClassPathEntry* _last_append_entry;
+  static ClassPathEntry* volatile _last_append_entry;
 
   // Info used by CDS
   CDS_ONLY(static ClassPathEntry* _app_classpath_entries;)
@@ -234,7 +240,7 @@ class ClassLoader: AllStatic {
   CDS_ONLY(static ClassPathEntry* app_classpath_entries() {return _app_classpath_entries;})
   CDS_ONLY(static ClassPathEntry* module_path_entries() {return _module_path_entries;})
 
-  static bool has_bootclasspath_append() { return _first_append_entry != NULL; }
+  static bool has_bootclasspath_append() { return first_append_entry() != NULL; }
 
  protected:
   // Initialization:

--- a/src/hotspot/share/classfile/classLoader.inline.hpp
+++ b/src/hotspot/share/classfile/classLoader.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ inline ClassPathEntry* ClassLoader::classpath_entry(int n) {
     // the _jrt_entry is not included in the _first_append_entry
     // linked list, it must be accounted for when comparing the
     // class path vs. the shared archive class path.
-    ClassPathEntry* e = ClassLoader::_first_append_entry;
+    ClassPathEntry* e = first_append_entry();
     while (--n >= 1) {
       assert(e != NULL, "Not that many classpath entries.");
       e = e->next();
@@ -72,7 +72,7 @@ inline int ClassLoader::num_boot_classpath_entries() {
   Arguments::assert_is_dumping_archive();
   assert(has_jrt_entry(), "must have a java runtime image");
   int num_entries = 1; // count the runtime image
-  ClassPathEntry* e = ClassLoader::_first_append_entry;
+  ClassPathEntry* e = first_append_entry();
   while (e != NULL) {
     num_entries ++;
     e = e->next();
@@ -82,7 +82,7 @@ inline int ClassLoader::num_boot_classpath_entries() {
 
 inline ClassPathEntry* ClassLoader::get_next_boot_classpath_entry(ClassPathEntry* e) {
   if (e == ClassLoader::_jrt_entry) {
-    return ClassLoader::_first_append_entry;
+    return first_append_entry();
   } else {
     return e->next();
   }

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -658,13 +658,6 @@ JvmtiEnv::AddToBootstrapClassLoaderSearch(const char* segment) {
     if (zip_entry == NULL) {
       return JVMTI_ERROR_ILLEGAL_ARGUMENT;
     }
-
-    // lock the loader
-    Thread* thread = Thread::current();
-    HandleMark hm(thread);
-    Handle loader_lock = Handle(thread, SystemDictionary::system_loader_lock());
-
-    ObjectLocker ol(loader_lock, thread);
 
     // add the jar file to the bootclasspath
     log_info(class, load)("opened: %s", zip_entry->name());

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -659,8 +659,6 @@ JvmtiEnv::AddToBootstrapClassLoaderSearch(const char* segment) {
       return JVMTI_ERROR_ILLEGAL_ARGUMENT;
     }
 
-    MutexLocker ml(Bootclasspath_lock, Mutex::_no_safepoint_check_flag);
-
     // add the jar file to the bootclasspath
     log_info(class, load)("opened: %s", zip_entry->name());
 #if INCLUDE_CDS

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -659,6 +659,8 @@ JvmtiEnv::AddToBootstrapClassLoaderSearch(const char* segment) {
       return JVMTI_ERROR_ILLEGAL_ARGUMENT;
     }
 
+    MutexLocker ml(Bootclasspath_lock, Mutex::_no_safepoint_check_flag);
+
     // add the jar file to the bootclasspath
     log_info(class, load)("opened: %s", zip_entry->name());
 #if INCLUDE_CDS

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,7 @@ Mutex*   CDSLambda_lock               = NULL;
 Mutex*   DumpRegion_lock              = NULL;
 Mutex*   ClassListFile_lock           = NULL;
 #endif // INCLUDE_CDS
+Mutex*   Bootclasspath_lock           = NULL;
 
 #if INCLUDE_JVMCI
 Monitor* JVMCI_lock                   = NULL;
@@ -352,6 +353,7 @@ void mutex_init() {
   def(DumpRegion_lock              , PaddedMutex  , leaf,        true,  _safepoint_check_never);
   def(ClassListFile_lock           , PaddedMutex  , leaf,        true,  _safepoint_check_never);
 #endif // INCLUDE_CDS
+  def(Bootclasspath_lock           , PaddedMutex  , leaf,        false, _safepoint_check_never);
 
 #if INCLUDE_JVMCI
   def(JVMCI_lock                   , PaddedMonitor, nonleaf+2,   true,  _safepoint_check_always);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,6 +157,8 @@ extern Mutex*   CodeHeapStateAnalytics_lock;     // lock print functions against
 #if INCLUDE_JVMCI
 extern Monitor* JVMCI_lock;                      // Monitor to control initialization of JVMCI
 #endif
+
+extern Mutex*   Bootclasspath_lock;
 
 extern Mutex* tty_lock;                          // lock to synchronize output.
 


### PR DESCRIPTION
See CR for details.
I made the classpath append list lock-free.  Calling experts in Atomic operations...
Tested with tier1-6.
Thanks,
Coleen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259067](https://bugs.openjdk.java.net/browse/JDK-8259067): bootclasspath append takes out object lock


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 9b250606f60bc923f219263ca3415a28bc2d28ae
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 9b250606f60bc923f219263ca3415a28bc2d28ae
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 9b250606f60bc923f219263ca3415a28bc2d28ae
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1935/head:pull/1935`
`$ git checkout pull/1935`
