### PR TITLE
8259223: Simplify boolean expression in the SunJSSE provider

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
+++ b/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -890,7 +890,7 @@ enum CipherSuite {
         this.macAlg = macAlg;
         this.hashAlg = hashAlg;
 
-        this.exportable = (cipher == null ? false : cipher.exportable);
+        this.exportable = (cipher != null && cipher.exportable);
     }
 
     static CipherSuite nameOf(String ciperSuiteName) {

--- a/src/java.base/share/classes/sun/security/ssl/EphemeralKeyManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/EphemeralKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ final class EphemeralKeyManager {
          * Return the KeyPair or null if it is invalid.
          */
         private KeyPair getKeyPair() {
-            if (isValid() == false) {
+            if (!isValid()) {
                 keyPair = null;
                 return null;
             }

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,7 +325,7 @@ final class Finished {
         }
     }
 
-    // TLS 1.2
+    // TLS 1.3
     private static final
             class T13VerifyDataGenerator implements VerifyDataGenerator {
         private static final byte[] hkdfLabel = "tls13 finished".getBytes();

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -576,7 +576,7 @@ abstract class HandshakeContext implements ConnectionContext {
 
                     retval |= groupAvailable;
                 } else {
-                    retval |= true;
+                    retval = true;
                 }
             }
 

--- a/src/java.base/share/classes/sun/security/ssl/KeyManagerFactoryImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/KeyManagerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ abstract class KeyManagerFactoryImpl extends KeyManagerFactorySpi {
         @Override
         protected void engineInit(ManagerFactoryParameters params) throws
                 InvalidAlgorithmParameterException {
-            if (params instanceof KeyStoreBuilderParameters == false) {
+            if (!(params instanceof KeyStoreBuilderParameters)) {
                 throw new InvalidAlgorithmParameterException(
                 "Parameters must be instance of KeyStoreBuilderParameters");
             }

--- a/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
+++ b/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,7 +356,7 @@ enum ProtocolVersion {
      * TLS 1.1/DTLS 1.0 or newer version.
      */
     boolean useTLS11PlusSpec() {
-        return isDTLS ? true : (this.id >= TLS11.id);
+        return isDTLS || (this.id >= TLS11.id);
     }
 
     /**
@@ -364,7 +364,7 @@ enum ProtocolVersion {
      * newer version.
      */
     boolean useTLS10PlusSpec() {
-        return isDTLS ? true : (this.id >= TLS10.id);
+        return isDTLS || (this.id >= TLS10.id);
     }
 
     /**
@@ -372,7 +372,7 @@ enum ProtocolVersion {
      * newer version.
      */
     static boolean useTLS10PlusSpec(int id, boolean isDTLS) {
-        return isDTLS ? true : (id >= TLS10.id);
+        return isDTLS || (id >= TLS10.id);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -837,7 +837,7 @@ public final class SSLSocketImpl
     @Override
     public boolean isInputShutdown() {
         return conContext.isInboundClosed() &&
-                ((autoClose || !isLayered()) ? super.isInputShutdown(): true);
+                (!autoClose && isLayered() || super.isInputShutdown());
     }
 
     // Please don't synchronized this method.  Otherwise, the read and close
@@ -861,7 +861,7 @@ public final class SSLSocketImpl
     @Override
     public boolean isOutputShutdown() {
         return conContext.isOutboundClosed() &&
-                ((autoClose || !isLayered()) ? super.isOutputShutdown(): true);
+                (!autoClose && isLayered() || super.isOutputShutdown());
     }
 
     @Override

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,8 +364,8 @@ enum SignatureScheme {
                constraints.permits(SIGNATURE_PRIMITIVE_SET,
                         this.algorithm, (signAlgParams != null ?
                                 signAlgParams.parameters : null)) &&
-               (namedGroup != null ?
-                        namedGroup.isPermitted(constraints) : true);
+                        (namedGroup == null ||
+                            namedGroup.isPermitted(constraints));
     }
 
     // Get local supported algorithm collection complying to algorithm

--- a/src/java.base/share/classes/sun/security/ssl/SunX509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SunX509KeyManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ final class SunX509KeyManagerImpl extends X509ExtendedKeyManager {
                 continue;
             }
             Key key = ks.getKey(alias, password);
-            if (key instanceof PrivateKey == false) {
+            if (!(key instanceof PrivateKey)) {
                 continue;
             }
             Certificate[] certs = ks.getCertificateChain(alias);
@@ -334,7 +334,7 @@ final class SunX509KeyManagerImpl extends X509ExtendedKeyManager {
         if (issuers == null) {
             issuers = new X500Principal[0];
         }
-        if (issuers instanceof X500Principal[] == false) {
+        if (!(issuers instanceof X500Principal[])) {
             // normally, this will never happen but try to recover if it does
             issuers = convertPrincipals(issuers);
         }
@@ -375,7 +375,7 @@ final class SunX509KeyManagerImpl extends X509ExtendedKeyManager {
                         certs[0].getSigAlgName().toUpperCase(Locale.ENGLISH);
                     String pattern = "WITH" +
                         sigType.toUpperCase(Locale.ENGLISH);
-                    if (sigAlgName.contains(pattern) == false) {
+                    if (!sigAlgName.contains(pattern)) {
                         continue;
                     }
                 }

--- a/src/java.base/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,13 +155,13 @@ abstract class TrustManagerFactoryImpl extends TrustManagerFactorySpi {
         @Override
         X509TrustManager getInstance(ManagerFactoryParameters spec)
                 throws InvalidAlgorithmParameterException {
-            if (spec instanceof CertPathTrustManagerParameters == false) {
+            if (!(spec instanceof CertPathTrustManagerParameters)) {
                 throw new InvalidAlgorithmParameterException
                     ("Parameters must be CertPathTrustManagerParameters");
             }
             CertPathParameters params =
                 ((CertPathTrustManagerParameters)spec).getParameters();
-            if (params instanceof PKIXBuilderParameters == false) {
+            if (!(params instanceof PKIXBuilderParameters)) {
                 throw new InvalidAlgorithmParameterException
                     ("Encapsulated parameters must be PKIXBuilderParameters");
             }

--- a/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
@@ -614,7 +614,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             // exchange and not ephemeral ECDH. We leave it in
                             // for now until there are signs that this check
                             // causes problems for real world EC certificates.
-                            if ((this == SERVER) && (!getBit(ku, 4))) {
+                            if (this == SERVER && !getBit(ku, 4)) {
                                 return CheckResult.EXTENSION_MISMATCH;
                             }
                             break;
@@ -820,7 +820,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
             if (!preferred && checkResult == CheckResult.OK && keyIndex == 0) {
                 preferred = true;
             }
-            if (preferred && (!findAll)) {
+            if (preferred && !findAll) {
                 // if we have a good match and do not need all matches,
                 // return immediately
                 return Collections.singletonList(status);

--- a/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,7 +271,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
             KeyStore ks = builder.getKeyStore();
             Entry newEntry = ks.getEntry
                     (keyStoreAlias, builder.getProtectionParameter(alias));
-            if (newEntry instanceof PrivateKeyEntry == false) {
+            if (!(newEntry instanceof PrivateKeyEntry)) {
                 // unexpected type of entry
                 return null;
             }
@@ -581,7 +581,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             // require either signature bit
                             // or if server also allow key encipherment bit
                             if (!supportsDigitalSignature) {
-                                if (this == CLIENT || getBit(ku, 2) == false) {
+                                if (this == CLIENT || !getBit(ku, 2)) {
                                     return CheckResult.EXTENSION_MISMATCH;
                                 }
                             }
@@ -599,7 +599,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             break;
                         case "DH":
                             // require keyagreement bit
-                            if (getBit(ku, 4) == false) {
+                            if (!getBit(ku, 4)) {
                                 return CheckResult.EXTENSION_MISMATCH;
                             }
                             break;
@@ -614,7 +614,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             // exchange and not ephemeral ECDH. We leave it in
                             // for now until there are signs that this check
                             // causes problems for real world EC certificates.
-                            if ((this == SERVER) && (getBit(ku, 4) == false)) {
+                            if ((this == SERVER) && (!getBit(ku, 4))) {
                                 return CheckResult.EXTENSION_MISMATCH;
                             }
                             break;
@@ -748,7 +748,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
 
             boolean incompatible = false;
             for (Certificate cert : chain) {
-                if (cert instanceof X509Certificate == false) {
+                if (!(cert instanceof X509Certificate)) {
                     // not an X509Certificate, ignore this alias
                     incompatible = true;
                     break;
@@ -785,7 +785,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                         break;
                     }
                 }
-                if (found == false) {
+                if (!found) {
                     if (SSLLogger.isOn && SSLLogger.isOn("keymanager")) {
                         SSLLogger.fine(
                                 "Ignore alias " + alias
@@ -820,7 +820,7 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
             if (!preferred && checkResult == CheckResult.OK && keyIndex == 0) {
                 preferred = true;
             }
-            if (preferred && (findAll == false)) {
+            if (preferred && (!findAll)) {
                 // if we have a good match and do not need all matches,
                 // return immediately
                 return Collections.singletonList(status);


### PR DESCRIPTION
There are some boolean expressions that could be improved for better readability in the SunJSSE provider implementation. For example: 

```
- if (cert instanceof X509Certificate == false) { 
+ if (!(cert instanceof X509Certificate)) { 

- return isDTLS ? true : (id >= TLS10.id);
+ return isDTLS || (id >= TLS10.id);

```

Code cleanup, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8259223

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259223](https://bugs.openjdk.java.net/browse/JDK-8259223): Simplify boolean expression in the SunJSSE provider


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 93700102ef7d45c4a6e23e78c9dece0a16d037d0


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1942/head:pull/1942`
`$ git checkout pull/1942`
