### PR TITLE
8259236: C2 compilation fails with assert(is_power_of_2(value)) failed: value must be a power of 2: 8000000000000000

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -9600,7 +9600,7 @@ instruct btrL_mem_imm(memory dst, immL_NotPow2 con, rFlagsReg cr)
   ins_cost(125);
   format %{ "btrq    $dst, log2(not($con))\t# long" %}
   ins_encode %{
-    __ btrq($dst$$Address, log2i_exact(~$con$$constant));
+    __ btrq($dst$$Address, log2i_exact((julong)~$con$$constant));
   %}
   ins_pipe(ialu_mem_imm);
 %}


### PR DESCRIPTION
log2i_exact does not accept 0x8000000000000000 if the type is signed, which log2_long used before JDK-8257815 did. This adds a cast to julong, similar to what was previously done in btsL_mem_imm

Ran the test 10+ times in our CI without hitting the assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259236](https://bugs.openjdk.java.net/browse/JDK-8259236): C2 compilation fails with assert(is_power_of_2(value)) failed: value must be a power of 2: 8000000000000000


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1944/head:pull/1944`
`$ git checkout pull/1944`
