### PR TITLE
8259235: javac crashes while attributing super method invocation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3729,7 +3729,7 @@ public class Resolve {
         for (Type t1 : types.interfaces(t)) {
             boolean shouldAdd = true;
             for (Type t2 : types.directSupertypes(t)) {
-                if (t1 != t2 && types.isSubtypeNoCapture(t2, t1)) {
+                if (t1 != t2 && !t2.hasTag(ERROR) && types.isSubtypeNoCapture(t2, t1)) {
                     shouldAdd = false;
                 }
             }

--- a/test/langtools/tools/javac/recovery/SuperMethodCallBroken.java
+++ b/test/langtools/tools/javac/recovery/SuperMethodCallBroken.java
@@ -1,0 +1,15 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8259235
+ * @summary Invocation of a method from a superinterface in a class that has an erroneous supertype
+ *          should not crash javac.
+ * @compile/fail/ref=SuperMethodCallBroken.out -XDdev -XDrawDiagnostics SuperMethodCallBroken.java
+ */
+public abstract class SuperMethodCallBroken extends Undef implements I, java.util.List<String> {
+    public void test() {
+        I.super.test();
+    }
+}
+interface I {
+    public default void test() {}
+}

--- a/test/langtools/tools/javac/recovery/SuperMethodCallBroken.out
+++ b/test/langtools/tools/javac/recovery/SuperMethodCallBroken.out
@@ -1,0 +1,2 @@
+SuperMethodCallBroken.java:8:53: compiler.err.cant.resolve: kindname.class, Undef, , 
+1 error


### PR DESCRIPTION
Code like:
```
public class SuperMethodCallBroken extends Undef implements I {
    public void test() {
        I.super.test();
    }
}
interface I {
    public default void test() {}
}
```

crashes javac. The reason is that when `I.super` is being attributed, the interfaces of the enclosing class are pruned to remove subtypes - but `Undef` is erroneous and is a subtype of every type. So `I` is removed from the list of interfaces to check, and javac crashes then.

The proposed fix is to ignore erroneous supertypes when looking for subtypes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259235](https://bugs.openjdk.java.net/browse/JDK-8259235): javac crashes while attributing super method invocation


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1945/head:pull/1945`
`$ git checkout pull/1945`
