### PR TITLE
8250564: Remove terminally deprecated constructor in GSSUtil

### DIFF
--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -84,8 +84,7 @@ public class URLDecoder {
     /**
      * Do not call.
      */
-    @Deprecated(since="16", forRemoval=true)
-    public URLDecoder() {}
+    private URLDecoder() {}
 
     // The platform default encoding
     static String dfltEncName = URLEncoder.dfltEncName;

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/GSSUtil.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/GSSUtil.java
@@ -37,8 +37,7 @@ public class GSSUtil {
     /**
      * Do not call.
      */
-    @Deprecated(since="16", forRemoval=true)
-    public GSSUtil() {}
+    private GSSUtil() {}
 
     /**
      * Use this method to convert a GSSName and GSSCredential into a

--- a/test/jdk/java/net/URLDecoder/B6463990.java
+++ b/test/jdk/java/net/URLDecoder/B6463990.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,7 @@ public class B6463990 {
     public static void main(String[] args) {
         boolean except = false;
         try {
-            URLDecoder ud = new java.net.URLDecoder();
-            String s = ud.decode("%-1", "iso-8859-1");
+            String s = URLDecoder.decode("%-1", "iso-8859-1");
             System.out.println((int) s.charAt(0));
         } catch (Exception e) {
             except = true;


### PR DESCRIPTION
Back in JDK 16, two unintended default constructors were identified and deprecated for removal. The time has come to remove them.

Please also review the corresponding CSRs:

JDK-8258521 Remove terminally deprecated constructor in GSSUtil 
https://bugs.openjdk.java.net/browse/JDK-8258521

 JDK-8258522 Remove terminally deprecated constructor in java.net.URLDecoder 
https://bugs.openjdk.java.net/browse/JDK-8258522

Calling a static method using an instance of a class, as done in the test B6463990.java, is a coding anti-pattern that generates a lint warning; that warning in enabled in the JDK build.

Thanks,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8250564](https://bugs.openjdk.java.net/browse/JDK-8250564): Remove terminally deprecated constructor in GSSUtil
 * [JDK-8250565](https://bugs.openjdk.java.net/browse/JDK-8250565): Remove terminally deprecated constructor in java.net.URLDecoder


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1948/head:pull/1948`
`$ git checkout pull/1948`
