### PR TITLE
8259278: Optimize Vector API slice and unslice operations

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3006,6 +3006,16 @@ void MacroAssembler::vaddss(XMMRegister dst, XMMRegister nds, AddressLiteral src
   }
 }
 
+void MacroAssembler::vpaddb(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch) {
+  assert(UseAVX > 0, "requires some form of AVX");
+  if (reachable(src)) {
+    Assembler::vpaddb(dst, nds, as_Address(src), vector_len);
+  } else {
+    lea(rscratch, src);
+    Assembler::vpaddb(dst, nds, Address(rscratch, 0), vector_len);
+  }
+}
+
 void MacroAssembler::vpaddd(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch) {
   assert(UseAVX > 0, "requires some form of AVX");
   if (reachable(src)) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1241,6 +1241,7 @@ public:
 
   void vpaddb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpaddb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
+  void vpaddb(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch);
 
   void vpaddw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpaddw(XMMRegister dst, XMMRegister nds, Address src, int vector_len);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -607,6 +607,21 @@ class StubGenerator: public StubCodeGenerator {
     __ emit_data(0x37363534, relocInfo::none, 0);
     __ emit_data(0x3B3A3938, relocInfo::none, 0);
     __ emit_data(0x3F3E3D3C, relocInfo::none, 0);
+    return start;
+  }
+
+  address generate_vector_byte_shuffle_mask(const char *stub_name) {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", stub_name);
+    address start = __ pc();
+    __ emit_data(0x70707070, relocInfo::none, 0);
+    __ emit_data(0x70707070, relocInfo::none, 0);
+    __ emit_data(0x70707070, relocInfo::none, 0);
+    __ emit_data(0x70707070, relocInfo::none, 0);
+    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
+    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
+    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
+    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
     return start;
   }
 
@@ -3966,6 +3981,7 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::x86::_vector_64_bit_mask = generate_vector_custom_i32("vector_64_bit_mask", Assembler::AVX_512bit,
                                                                         0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
     StubRoutines::x86::_vector_int_shuffle_mask = generate_vector_mask("vector_int_shuffle_mask", 0x03020100);
+    StubRoutines::x86::_vector_byte_shuffle_mask = generate_vector_byte_shuffle_mask("vector_byte_shuffle_mask");
     StubRoutines::x86::_vector_short_shuffle_mask = generate_vector_mask("vector_short_shuffle_mask", 0x01000100);
     StubRoutines::x86::_vector_long_shuffle_mask = generate_vector_mask_long_double("vector_long_shuffle_mask", 0x00000001, 0x0);
     StubRoutines::x86::_vector_byte_perm_mask = generate_vector_byte_perm_mask("vector_byte_perm_mask");

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -808,6 +808,17 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  address generate_vector_byte_shuffle_mask(const char *stub_name) {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", stub_name);
+    address start = __ pc();
+    __ emit_data64(0x7070707070707070, relocInfo::none);
+    __ emit_data64(0x7070707070707070, relocInfo::none);
+    __ emit_data64(0xF0F0F0F0F0F0F0F0, relocInfo::none);
+    __ emit_data64(0xF0F0F0F0F0F0F0F0, relocInfo::none);
+    return start;
+  }
+
   address generate_fp_mask(const char *stub_name, int64_t mask) {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", stub_name);
@@ -6828,6 +6839,7 @@ address generate_avx_ghash_processBlocks() {
     StubRoutines::x86::_vector_64_bit_mask = generate_vector_custom_i32("vector_64_bit_mask", Assembler::AVX_512bit,
                                                                         0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
     StubRoutines::x86::_vector_int_shuffle_mask = generate_vector_mask("vector_int_shuffle_mask", 0x0302010003020100);
+    StubRoutines::x86::_vector_byte_shuffle_mask = generate_vector_byte_shuffle_mask("vector_byte_shuffle_mask");
     StubRoutines::x86::_vector_short_shuffle_mask = generate_vector_mask("vector_short_shuffle_mask", 0x0100010001000100);
     StubRoutines::x86::_vector_long_shuffle_mask = generate_vector_mask("vector_long_shuffle_mask", 0x0000000100000000);
     StubRoutines::x86::_vector_long_sign_mask = generate_vector_mask("vector_long_sign_mask", 0x8000000000000000);

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ address StubRoutines::x86::_vector_short_to_byte_mask = NULL;
 address StubRoutines::x86::_vector_int_to_byte_mask = NULL;
 address StubRoutines::x86::_vector_int_to_short_mask = NULL;
 address StubRoutines::x86::_vector_all_bits_set = NULL;
+address StubRoutines::x86::_vector_byte_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_short_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_int_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_long_shuffle_mask = NULL;

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,6 +149,7 @@ class x86 {
   static address _vector_32_bit_mask;
   static address _vector_64_bit_mask;
   static address _vector_int_shuffle_mask;
+  static address _vector_byte_shuffle_mask;
   static address _vector_short_shuffle_mask;
   static address _vector_long_shuffle_mask;
   static address _vector_iota_indices;
@@ -278,6 +279,10 @@ class x86 {
 
   static address vector_int_shuffle_mask() {
     return _vector_int_shuffle_mask;
+  }
+
+  static address vector_byte_shuffle_mask() {
+    return _vector_byte_shuffle_mask;
   }
 
   static address vector_short_shuffle_mask() {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1354,6 +1354,7 @@ Assembler::Width widthForType(BasicType bt) {
   static address vector_long_sign_mask() { return StubRoutines::x86::vector_long_sign_mask(); }
   static address vector_all_bits_set() { return StubRoutines::x86::vector_all_bits_set(); }
   static address vector_int_to_short_mask() { return StubRoutines::x86::vector_int_to_short_mask(); }
+  static address vector_byte_shufflemask() { return StubRoutines::x86::vector_byte_shuffle_mask(); }
   static address vector_short_shufflemask() { return StubRoutines::x86::vector_short_shuffle_mask(); }
   static address vector_int_shufflemask() { return StubRoutines::x86::vector_int_shuffle_mask(); }
   static address vector_long_shufflemask() { return StubRoutines::x86::vector_long_shuffle_mask(); }
@@ -1691,9 +1692,9 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
         return false; // Implementation limitation due to how shuffle is loaded
       } else if (size_in_bits == 256 && UseAVX < 2) {
         return false; // Implementation limitation
-      } else if (bt == T_BYTE && size_in_bits >= 256 && !VM_Version::supports_avx512_vbmi())  {
+      } else if (bt == T_BYTE && size_in_bits > 256 && !VM_Version::supports_avx512_vbmi())  {
         return false; // Implementation limitation
-      } else if (bt == T_SHORT && size_in_bits >= 256 && !VM_Version::supports_avx512bw())  {
+      } else if (bt == T_SHORT && size_in_bits > 256 && !VM_Version::supports_avx512bw())  {
         return false; // Implementation limitation
       }
       break;
@@ -7500,13 +7501,24 @@ instruct rearrangeB(vec dst, vec shuffle) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rearrangeB_avx(vec dst, vec src, vec shuffle) %{
+instruct rearrangeB_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
   predicate(vector_element_basic_type(n) == T_BYTE &&
             vector_length(n) == 32 && !VM_Version::supports_avx512_vbmi());
   match(Set dst (VectorRearrange src shuffle));
-  format %{ "vector_rearrange $dst, $shuffle, $src" %}
+  effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
+  format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
   ins_encode %{
-    __ vpshufb($dst$$XMMRegister, $shuffle$$XMMRegister, $src$$XMMRegister, Assembler::AVX_256bit);
+    assert(UseAVX >= 2, "required");
+    // Swap src into vtmp1
+    __ vperm2i128($vtmp1$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, 1);
+    // Shuffle swapped src to get entries from other 128 bit lane
+    __ vpshufb($vtmp1$$XMMRegister, $vtmp1$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
+    // Shuffle original src to get entries from self 128 bit lane
+    __ vpshufb($dst$$XMMRegister, $src$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
+    // Create a blend mask by setting high bits for entries coming from other lane in shuffle
+    __ vpaddb($vtmp2$$XMMRegister, $shuffle$$XMMRegister, ExternalAddress(vector_byte_shufflemask()), Assembler::AVX_256bit, $scratch$$Register);
+    // Perform the blend
+    __ vpblendvb($dst$$XMMRegister, $dst$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister, Assembler::AVX_256bit);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7527,26 +7539,40 @@ instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
 
 instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 8 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+            vector_length(n) <= 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
     // Create a byte shuffle mask from short shuffle mask
     // only byte shuffle instruction available on these platforms
+    int vlen_in_bytes = vector_length_in_bytes(this);
+    if (vlen_in_bytes <= 8) {
+      // Multiply each shuffle by two to get byte index
+      __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
+      __ psllw($vtmp$$XMMRegister, 1);
 
-    // Multiply each shuffle by two to get byte index
-    __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
-    __ psllw($vtmp$$XMMRegister, 1);
+      // Duplicate to create 2 copies of byte index
+      __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
+      __ psllw($dst$$XMMRegister, 8);
+      __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
 
-    // Duplicate to create 2 copies of byte index
-    __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
-    __ psllw($dst$$XMMRegister, 8);
-    __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
+      // Add one to get alternate byte index
+      __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
+      __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      // Multiply each shuffle by two to get byte index
+      __ vpmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister, vlen_enc);
+      __ vpsllw($vtmp$$XMMRegister, $vtmp$$XMMRegister, 1, vlen_enc);
 
-    // Add one to get alternate byte index
-    __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
-    __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
+      // Duplicate to create 2 copies of byte index
+      __ vpsllw($dst$$XMMRegister, $vtmp$$XMMRegister,  8, vlen_enc);
+      __ vpor($dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
+
+      // Add one to get alternate byte index
+      __ vpaddb($dst$$XMMRegister, $dst$$XMMRegister, ExternalAddress(vector_short_shufflemask()), vlen_enc, $scratch$$Register);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7559,6 +7585,28 @@ instruct rearrangeS(vec dst, vec shuffle) %{
   ins_encode %{
     assert(UseSSE >= 4, "required");
     __ pshufb($dst$$XMMRegister, $shuffle$$XMMRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct rearrangeS_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
+  predicate(vector_element_basic_type(n) == T_SHORT &&
+            vector_length(n) == 16 && !VM_Version::supports_avx512bw());
+  match(Set dst (VectorRearrange src shuffle));
+  effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
+  format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
+  ins_encode %{
+    assert(UseAVX >= 2, "required");
+    // Swap src into vtmp1
+    __ vperm2i128($vtmp1$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, 1);
+    // Shuffle swapped src to get entries from other 128 bit lane
+    __ vpshufb($vtmp1$$XMMRegister, $vtmp1$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
+    // Shuffle original src to get entries from self 128 bit lane
+    __ vpshufb($dst$$XMMRegister, $src$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
+    // Create a blend mask by setting high bits for entries coming from other lane in shuffle
+    __ vpaddb($vtmp2$$XMMRegister, $shuffle$$XMMRegister, ExternalAddress(vector_byte_shufflemask()), Assembler::AVX_256bit, $scratch$$Register);
+    // Perform the blend
+    __ vpblendvb($dst$$XMMRegister, $dst$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister, Assembler::AVX_256bit);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector slice(int origin, Vector<Byte> v) {
-        return (Byte128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte128Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Byte128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte128Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte128Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte128Vector unslice(int origin, Vector<Byte> w, int part) {
-        return (Byte128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte128Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Byte128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte128Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte128Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -381,41 +381,19 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector slice(int origin, Vector<Byte> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte128Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Byte128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte128Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte128Vector unslice(int origin, Vector<Byte> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte128Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Byte128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte128Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -381,41 +381,19 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector slice(int origin, Vector<Byte> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte256Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Byte256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte256Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte256Vector unslice(int origin, Vector<Byte> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte256Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Byte256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte256Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector slice(int origin, Vector<Byte> v) {
-        return (Byte256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte256Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Byte256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte256Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte256Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte256Vector unslice(int origin, Vector<Byte> w, int part) {
-        return (Byte256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte256Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Byte256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte256Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte256Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -381,41 +381,19 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector slice(int origin, Vector<Byte> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte512Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Byte512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte512Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte512Vector unslice(int origin, Vector<Byte> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte512Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Byte512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte512Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector slice(int origin, Vector<Byte> v) {
-        return (Byte512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte512Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Byte512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte512Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte512Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte512Vector unslice(int origin, Vector<Byte> w, int part) {
-        return (Byte512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte512Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Byte512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte512Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte512Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -381,41 +381,19 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector slice(int origin, Vector<Byte> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte64Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Byte64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte64Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Byte64Vector unslice(int origin, Vector<Byte> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte64Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Byte64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Byte64Shuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Byte64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector slice(int origin, Vector<Byte> v) {
-        return (Byte64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte64Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Byte64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte64Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte64Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Byte64Vector unslice(int origin, Vector<Byte> w, int part) {
-        return (Byte64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte64Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Byte64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Byte64Shuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Byte64Shuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -381,41 +381,19 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector slice(int origin, Vector<Byte> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ByteMaxShuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((ByteMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ByteMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public ByteMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ByteMaxShuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ByteMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public ByteMaxVector unslice(int origin, Vector<Byte> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ByteMaxShuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((ByteMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ByteMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ByteMaxShuffle Iota = iotaShuffle();
-            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ByteMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector slice(int origin, Vector<Byte> v) {
-        return (ByteMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ByteMaxShuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((ByteMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public ByteMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         ByteMaxShuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ByteMaxShuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public ByteMaxVector unslice(int origin, Vector<Byte> w, int part) {
-        return (ByteMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ByteMaxShuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((ByteMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         ByteMaxShuffle Iota = iotaShuffle();
-         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ByteMaxShuffle Iota = iotaShuffle();
+            VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1975,22 +1975,6 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     public abstract
     ByteVector slice(int origin, Vector<Byte> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    ByteVector sliceTemplate(int origin, Vector<Byte> v1) {
-        ByteVector that = (ByteVector) v1;
-        that.check(this);
-        byte[] a0 = this.vec();
-        byte[] a1 = that.vec();
-        byte[] res = new byte[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2020,38 +2004,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     /*package-private*/
     final
     @ForceInline
-    ByteVector
-    unsliceTemplate(int origin, Vector<Byte> w, int part) {
-        ByteVector that = (ByteVector) w;
-        that.check(this);
-        byte[] slice = this.vec();
-        byte[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Byte>>
     ByteVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Byte> w, int part, M m) {
         ByteVector that = (ByteVector) w;
         that.check(this);
-        ByteVector slice = that.sliceTemplate(origin, that);
+        ByteVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -375,41 +375,19 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector slice(int origin, Vector<Double> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double128Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Double128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Double128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double128Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Double128Vector unslice(int origin, Vector<Double> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double128Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Double128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double128Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector slice(int origin, Vector<Double> v) {
-        return (Double128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double128Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Double128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double128Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double128Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double128Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double128Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Double128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double128Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double128Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -375,41 +375,19 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector slice(int origin, Vector<Double> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double256Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Double256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Double256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double256Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Double256Vector unslice(int origin, Vector<Double> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double256Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Double256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double256Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector slice(int origin, Vector<Double> v) {
-        return (Double256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double256Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Double256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double256Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double256Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double256Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double256Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Double256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double256Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double256Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector slice(int origin, Vector<Double> v) {
-        return (Double512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double512Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Double512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double512Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double512Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double512Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double512Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Double512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double512Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double512Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -375,41 +375,19 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector slice(int origin, Vector<Double> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double512Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Double512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Double512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double512Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Double512Vector unslice(int origin, Vector<Double> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double512Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Double512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double512Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector slice(int origin, Vector<Double> v) {
-        return (Double64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double64Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Double64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double64Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double64Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Double64Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double64Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Double64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Double64Shuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Double64Shuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -375,41 +375,19 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector slice(int origin, Vector<Double> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double64Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Double64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Double64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double64Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Double64Vector unslice(int origin, Vector<Double> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double64Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Double64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Double64Shuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Double64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -375,41 +375,19 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector slice(int origin, Vector<Double> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            DoubleMaxShuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((DoubleMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (DoubleMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public DoubleMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            DoubleMaxShuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (DoubleMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public DoubleMaxVector unslice(int origin, Vector<Double> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            DoubleMaxShuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((DoubleMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (DoubleMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            DoubleMaxShuffle Iota = iotaShuffle();
-            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (DoubleMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector slice(int origin, Vector<Double> v) {
-        return (DoubleMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            DoubleMaxShuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((DoubleMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public DoubleMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         DoubleMaxShuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            DoubleMaxShuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public DoubleMaxVector unslice(int origin, Vector<Double> w, int part) {
-        return (DoubleMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            DoubleMaxShuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((DoubleMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         DoubleMaxShuffle Iota = iotaShuffle();
-         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            DoubleMaxShuffle Iota = iotaShuffle();
+            VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1888,22 +1888,6 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     public abstract
     DoubleVector slice(int origin, Vector<Double> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    DoubleVector sliceTemplate(int origin, Vector<Double> v1) {
-        DoubleVector that = (DoubleVector) v1;
-        that.check(this);
-        double[] a0 = this.vec();
-        double[] a1 = that.vec();
-        double[] res = new double[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1933,38 +1917,14 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /*package-private*/
     final
     @ForceInline
-    DoubleVector
-    unsliceTemplate(int origin, Vector<Double> w, int part) {
-        DoubleVector that = (DoubleVector) w;
-        that.check(this);
-        double[] slice = this.vec();
-        double[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Double>>
     DoubleVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Double> w, int part, M m) {
         DoubleVector that = (DoubleVector) w;
         that.check(this);
-        DoubleVector slice = that.sliceTemplate(origin, that);
+        DoubleVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -375,41 +375,19 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector slice(int origin, Vector<Float> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float128Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Float128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Float128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float128Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Float128Vector unslice(int origin, Vector<Float> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float128Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Float128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float128Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector slice(int origin, Vector<Float> v) {
-        return (Float128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float128Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Float128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float128Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float128Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float128Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float128Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Float128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float128Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float128Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector slice(int origin, Vector<Float> v) {
-        return (Float256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float256Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Float256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float256Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float256Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float256Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float256Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Float256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float256Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float256Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -375,41 +375,19 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector slice(int origin, Vector<Float> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float256Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Float256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Float256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float256Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Float256Vector unslice(int origin, Vector<Float> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float256Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Float256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float256Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -375,41 +375,19 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector slice(int origin, Vector<Float> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float512Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Float512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Float512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float512Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Float512Vector unslice(int origin, Vector<Float> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float512Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Float512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float512Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector slice(int origin, Vector<Float> v) {
-        return (Float512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float512Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Float512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float512Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float512Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float512Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float512Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Float512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float512Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float512Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -375,41 +375,19 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector slice(int origin, Vector<Float> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float64Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Float64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Float64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float64Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Float64Vector unslice(int origin, Vector<Float> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float64Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Float64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Float64Shuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Float64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector slice(int origin, Vector<Float> v) {
-        return (Float64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float64Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Float64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float64Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float64Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Float64Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float64Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Float64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Float64Shuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Float64Shuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -375,41 +375,19 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector slice(int origin, Vector<Float> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            FloatMaxShuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((FloatMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (FloatMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public FloatMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            FloatMaxShuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (FloatMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public FloatMaxVector unslice(int origin, Vector<Float> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            FloatMaxShuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((FloatMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (FloatMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -424,14 +402,7 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            FloatMaxShuffle Iota = iotaShuffle();
-            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (FloatMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -375,26 +375,41 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector slice(int origin, Vector<Float> v) {
-        return (FloatMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            FloatMaxShuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((FloatMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public FloatMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         FloatMaxShuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            FloatMaxShuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public FloatMaxVector unslice(int origin, Vector<Float> w, int part) {
-        return (FloatMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            FloatMaxShuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((FloatMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -409,14 +424,14 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         FloatMaxShuffle Iota = iotaShuffle();
-         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            FloatMaxShuffle Iota = iotaShuffle();
+            VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1900,22 +1900,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
     public abstract
     FloatVector slice(int origin, Vector<Float> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    FloatVector sliceTemplate(int origin, Vector<Float> v1) {
-        FloatVector that = (FloatVector) v1;
-        that.check(this);
-        float[] a0 = this.vec();
-        float[] a1 = that.vec();
-        float[] res = new float[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1945,38 +1929,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     final
     @ForceInline
-    FloatVector
-    unsliceTemplate(int origin, Vector<Float> w, int part) {
-        FloatVector that = (FloatVector) w;
-        that.check(this);
-        float[] slice = this.vec();
-        float[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Float>>
     FloatVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Float> w, int part, M m) {
         FloatVector that = (FloatVector) w;
         that.check(this);
-        FloatVector slice = that.sliceTemplate(origin, that);
+        FloatVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector slice(int origin, Vector<Integer> v) {
-        return (Int128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int128Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Int128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int128Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int128Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int128Vector unslice(int origin, Vector<Integer> w, int part) {
-        return (Int128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int128Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Int128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int128Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int128Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -381,41 +381,19 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector slice(int origin, Vector<Integer> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int128Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Int128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Int128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int128Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Int128Vector unslice(int origin, Vector<Integer> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int128Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Int128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int128Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -381,41 +381,19 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector slice(int origin, Vector<Integer> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int256Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Int256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Int256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int256Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Int256Vector unslice(int origin, Vector<Integer> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int256Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Int256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int256Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector slice(int origin, Vector<Integer> v) {
-        return (Int256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int256Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Int256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int256Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int256Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int256Vector unslice(int origin, Vector<Integer> w, int part) {
-        return (Int256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int256Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Int256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int256Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int256Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector slice(int origin, Vector<Integer> v) {
-        return (Int512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int512Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Int512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int512Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int512Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int512Vector unslice(int origin, Vector<Integer> w, int part) {
-        return (Int512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int512Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Int512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int512Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int512Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -381,41 +381,19 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector slice(int origin, Vector<Integer> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int512Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Int512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Int512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int512Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Int512Vector unslice(int origin, Vector<Integer> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int512Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Int512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int512Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector slice(int origin, Vector<Integer> v) {
-        return (Int64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int64Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Int64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int64Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int64Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Int64Vector unslice(int origin, Vector<Integer> w, int part) {
-        return (Int64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int64Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Int64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Int64Shuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Int64Shuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -381,41 +381,19 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector slice(int origin, Vector<Integer> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int64Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Int64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Int64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int64Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Int64Vector unslice(int origin, Vector<Integer> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int64Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Int64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Int64Shuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Int64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector slice(int origin, Vector<Integer> v) {
-        return (IntMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            IntMaxShuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((IntMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public IntMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         IntMaxShuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            IntMaxShuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public IntMaxVector unslice(int origin, Vector<Integer> w, int part) {
-        return (IntMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            IntMaxShuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((IntMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         IntMaxShuffle Iota = iotaShuffle();
-         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            IntMaxShuffle Iota = iotaShuffle();
+            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -381,41 +381,19 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector slice(int origin, Vector<Integer> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            IntMaxShuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((IntMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (IntMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public IntMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            IntMaxShuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (IntMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public IntMaxVector unslice(int origin, Vector<Integer> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            IntMaxShuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((IntMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (IntMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            IntMaxShuffle Iota = iotaShuffle();
-            VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (IntMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1974,22 +1974,6 @@ public abstract class IntVector extends AbstractVector<Integer> {
     public abstract
     IntVector slice(int origin, Vector<Integer> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    IntVector sliceTemplate(int origin, Vector<Integer> v1) {
-        IntVector that = (IntVector) v1;
-        that.check(this);
-        int[] a0 = this.vec();
-        int[] a1 = that.vec();
-        int[] res = new int[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2019,38 +2003,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
     /*package-private*/
     final
     @ForceInline
-    IntVector
-    unsliceTemplate(int origin, Vector<Integer> w, int part) {
-        IntVector that = (IntVector) w;
-        that.check(this);
-        int[] slice = this.vec();
-        int[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Integer>>
     IntVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Integer> w, int part, M m) {
         IntVector that = (IntVector) w;
         that.check(this);
-        IntVector slice = that.sliceTemplate(origin, that);
+        IntVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -371,41 +371,19 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector slice(int origin, Vector<Long> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long128Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Long128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Long128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long128Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Long128Vector unslice(int origin, Vector<Long> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long128Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Long128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -420,14 +398,7 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long128Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,26 +371,41 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector slice(int origin, Vector<Long> v) {
-        return (Long128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long128Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Long128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long128Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long128Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long128Vector unslice(int origin, Vector<Long> w, int part) {
-        return (Long128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long128Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Long128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -405,14 +420,14 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long128Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long128Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -371,41 +371,19 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector slice(int origin, Vector<Long> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long256Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Long256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Long256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long256Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Long256Vector unslice(int origin, Vector<Long> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long256Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Long256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -420,14 +398,7 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long256Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,26 +371,41 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector slice(int origin, Vector<Long> v) {
-        return (Long256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long256Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Long256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long256Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long256Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long256Vector unslice(int origin, Vector<Long> w, int part) {
-        return (Long256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long256Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Long256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -405,14 +420,14 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long256Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long256Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -371,41 +371,19 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector slice(int origin, Vector<Long> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long512Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Long512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Long512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long512Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Long512Vector unslice(int origin, Vector<Long> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long512Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Long512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -420,14 +398,7 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long512Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,26 +371,41 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector slice(int origin, Vector<Long> v) {
-        return (Long512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long512Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Long512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long512Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long512Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long512Vector unslice(int origin, Vector<Long> w, int part) {
-        return (Long512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long512Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Long512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -405,14 +420,14 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long512Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long512Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,26 +371,41 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector slice(int origin, Vector<Long> v) {
-        return (Long64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long64Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Long64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long64Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long64Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Long64Vector unslice(int origin, Vector<Long> w, int part) {
-        return (Long64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long64Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Long64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -405,14 +420,14 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Long64Shuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Long64Shuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -371,41 +371,19 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector slice(int origin, Vector<Long> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long64Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Long64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Long64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long64Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Long64Vector unslice(int origin, Vector<Long> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long64Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Long64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -420,14 +398,7 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Long64Shuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Long64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -371,41 +371,19 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector slice(int origin, Vector<Long> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            LongMaxShuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((LongMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (LongMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public LongMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            LongMaxShuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (LongMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public LongMaxVector unslice(int origin, Vector<Long> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            LongMaxShuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((LongMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (LongMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -420,14 +398,7 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            LongMaxShuffle Iota = iotaShuffle();
-            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (LongMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,26 +371,41 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector slice(int origin, Vector<Long> v) {
-        return (LongMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            LongMaxShuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((LongMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public LongMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         LongMaxShuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            LongMaxShuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public LongMaxVector unslice(int origin, Vector<Long> w, int part) {
-        return (LongMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            LongMaxShuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((LongMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -405,14 +420,14 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         LongMaxShuffle Iota = iotaShuffle();
-         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            LongMaxShuffle Iota = iotaShuffle();
+            VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1845,22 +1845,6 @@ public abstract class LongVector extends AbstractVector<Long> {
     public abstract
     LongVector slice(int origin, Vector<Long> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    LongVector sliceTemplate(int origin, Vector<Long> v1) {
-        LongVector that = (LongVector) v1;
-        that.check(this);
-        long[] a0 = this.vec();
-        long[] a1 = that.vec();
-        long[] res = new long[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1890,38 +1874,14 @@ public abstract class LongVector extends AbstractVector<Long> {
     /*package-private*/
     final
     @ForceInline
-    LongVector
-    unsliceTemplate(int origin, Vector<Long> w, int part) {
-        LongVector that = (LongVector) w;
-        that.check(this);
-        long[] slice = this.vec();
-        long[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Long>>
     LongVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Long> w, int part, M m) {
         LongVector that = (LongVector) w;
         that.check(this);
-        LongVector slice = that.sliceTemplate(origin, that);
+        LongVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1845,6 +1845,19 @@ public abstract class LongVector extends AbstractVector<Long> {
     public abstract
     LongVector slice(int origin, Vector<Long> v1);
 
+    /*package-private*/
+    final
+    @ForceInline
+    LongVector sliceTemplate(int origin, Vector<Long> v1) {
+        LongVector that = (LongVector) v1;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Long> Iota = iotaShuffle();
+        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return ((LongVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1864,6 +1877,17 @@ public abstract class LongVector extends AbstractVector<Long> {
     public abstract
     LongVector slice(int origin);
 
+    /*package-private*/
+    final
+    @ForceInline
+    LongVector sliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Long> Iota = iotaShuffle();
+        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1874,14 +1898,29 @@ public abstract class LongVector extends AbstractVector<Long> {
     /*package-private*/
     final
     @ForceInline
+    LongVector
+    unsliceTemplate(int origin, Vector<Long> w, int part) {
+        LongVector that = (LongVector) w;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Long> Iota = iotaShuffle();
+        VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                                  (broadcast((long)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return ((LongVector)w).blend(this.rearrange(Iota), BlendMask);
+    }
+
+    /*package-private*/
+    final
+    @ForceInline
     <M extends VectorMask<Long>>
     LongVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Long> w, int part, M m) {
         LongVector that = (LongVector) w;
         that.check(this);
-        LongVector slice = that.slice(origin, that);
+        LongVector slice = that.sliceTemplate(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unslice(origin, w, part);
+        return slice.unsliceTemplate(origin, w, part);
     }
 
     /**
@@ -1897,6 +1936,19 @@ public abstract class LongVector extends AbstractVector<Long> {
     @Override
     public abstract
     LongVector unslice(int origin);
+
+    /*package-private*/
+    final
+    @ForceInline
+    LongVector
+    unsliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Long> Iota = iotaShuffle();
+        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE,
+                                                                  (broadcast((long)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector slice(int origin, Vector<Short> v) {
-        return (Short128Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short128Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Short128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short128Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short128Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short128Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short128Vector unslice(int origin, Vector<Short> w, int part) {
-        return (Short128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short128Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Short128Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short128Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short128Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -381,41 +381,19 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector slice(int origin, Vector<Short> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short128Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Short128Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Short128Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short128Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Short128Vector unslice(int origin, Vector<Short> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short128Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Short128Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short128Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector slice(int origin, Vector<Short> v) {
-        return (Short256Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short256Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Short256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short256Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short256Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short256Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short256Vector unslice(int origin, Vector<Short> w, int part) {
-        return (Short256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short256Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Short256Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short256Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short256Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -381,41 +381,19 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector slice(int origin, Vector<Short> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short256Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Short256Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Short256Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short256Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Short256Vector unslice(int origin, Vector<Short> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short256Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Short256Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short256Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector slice(int origin, Vector<Short> v) {
-        return (Short512Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short512Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Short512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short512Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short512Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short512Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short512Vector unslice(int origin, Vector<Short> w, int part) {
-        return (Short512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short512Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Short512Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short512Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short512Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -381,41 +381,19 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector slice(int origin, Vector<Short> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short512Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Short512Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Short512Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short512Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Short512Vector unslice(int origin, Vector<Short> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short512Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Short512Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short512Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector slice(int origin, Vector<Short> v) {
-        return (Short64Vector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short64Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((Short64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short64Vector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short64Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short64Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public Short64Vector unslice(int origin, Vector<Short> w, int part) {
-        return (Short64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short64Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((Short64Vector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         Short64Shuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            Short64Shuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -381,41 +381,19 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector slice(int origin, Vector<Short> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short64Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((Short64Vector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public Short64Vector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short64Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public Short64Vector unslice(int origin, Vector<Short> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short64Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((Short64Vector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            Short64Shuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (Short64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,26 +381,41 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector slice(int origin, Vector<Short> v) {
-        return (ShortMaxVector) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ShortMaxShuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ((ShortMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public ShortMaxVector slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         ShortMaxShuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ShortMaxShuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public ShortMaxVector unslice(int origin, Vector<Short> w, int part) {
-        return (ShortMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ShortMaxShuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ((ShortMaxVector)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -415,14 +430,14 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         ShortMaxShuffle Iota = iotaShuffle();
-         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            ShortMaxShuffle Iota = iotaShuffle();
+            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -381,41 +381,19 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector slice(int origin, Vector<Short> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ShortMaxShuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ((ShortMaxVector)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ShortMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public ShortMaxVector slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ShortMaxShuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ShortMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public ShortMaxVector unslice(int origin, Vector<Short> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ShortMaxShuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ((ShortMaxVector)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ShortMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -430,14 +408,7 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            ShortMaxShuffle Iota = iotaShuffle();
-            VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return (ShortMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -1975,6 +1975,19 @@ public abstract class ShortVector extends AbstractVector<Short> {
     public abstract
     ShortVector slice(int origin, Vector<Short> v1);
 
+    /*package-private*/
+    final
+    @ForceInline
+    ShortVector sliceTemplate(int origin, Vector<Short> v1) {
+        ShortVector that = (ShortVector) v1;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Short> Iota = iotaShuffle();
+        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return ((ShortVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1994,6 +2007,17 @@ public abstract class ShortVector extends AbstractVector<Short> {
     public abstract
     ShortVector slice(int origin);
 
+    /*package-private*/
+    final
+    @ForceInline
+    ShortVector sliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Short> Iota = iotaShuffle();
+        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2004,14 +2028,29 @@ public abstract class ShortVector extends AbstractVector<Short> {
     /*package-private*/
     final
     @ForceInline
+    ShortVector
+    unsliceTemplate(int origin, Vector<Short> w, int part) {
+        ShortVector that = (ShortVector) w;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Short> Iota = iotaShuffle();
+        VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                                  (broadcast((short)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return ((ShortVector)w).blend(this.rearrange(Iota), BlendMask);
+    }
+
+    /*package-private*/
+    final
+    @ForceInline
     <M extends VectorMask<Short>>
     ShortVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Short> w, int part, M m) {
         ShortVector that = (ShortVector) w;
         that.check(this);
-        ShortVector slice = that.slice(origin, that);
+        ShortVector slice = that.sliceTemplate(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unslice(origin, w, part);
+        return slice.unsliceTemplate(origin, w, part);
     }
 
     /**
@@ -2027,6 +2066,19 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @Override
     public abstract
     ShortVector unslice(int origin);
+
+    /*package-private*/
+    final
+    @ForceInline
+    ShortVector
+    unsliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<Short> Iota = iotaShuffle();
+        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE,
+                                                                  (broadcast((short)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1975,22 +1975,6 @@ public abstract class ShortVector extends AbstractVector<Short> {
     public abstract
     ShortVector slice(int origin, Vector<Short> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    ShortVector sliceTemplate(int origin, Vector<Short> v1) {
-        ShortVector that = (ShortVector) v1;
-        that.check(this);
-        short[] a0 = this.vec();
-        short[] a1 = that.vec();
-        short[] res = new short[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2020,38 +2004,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
     /*package-private*/
     final
     @ForceInline
-    ShortVector
-    unsliceTemplate(int origin, Vector<Short> w, int part) {
-        ShortVector that = (ShortVector) w;
-        that.check(this);
-        short[] slice = this.vec();
-        short[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<Short>>
     ShortVector
     unsliceTemplate(Class<M> maskType, int origin, Vector<Short> w, int part, M m) {
         ShortVector that = (ShortVector) w;
         that.check(this);
-        ShortVector slice = that.sliceTemplate(origin, that);
+        ShortVector slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2244,22 +2244,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     public abstract
     $abstractvectortype$ slice(int origin, Vector<$Boxtype$> v1);
 
-    /*package-private*/
-    final
-    @ForceInline
-    $abstractvectortype$ sliceTemplate(int origin, Vector<$Boxtype$> v1) {
-        $abstractvectortype$ that = ($abstractvectortype$) v1;
-        that.check(this);
-        $type$[] a0 = this.vec();
-        $type$[] a1 = that.vec();
-        $type$[] res = new $type$[a0.length];
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        System.arraycopy(a0, origin, res, 0, firstPart);
-        System.arraycopy(a1, 0, res, firstPart, origin);
-        return vectorFactory(res);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2289,38 +2273,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /*package-private*/
     final
     @ForceInline
-    $abstractvectortype$
-    unsliceTemplate(int origin, Vector<$Boxtype$> w, int part) {
-        $abstractvectortype$ that = ($abstractvectortype$) w;
-        that.check(this);
-        $type$[] slice = this.vec();
-        $type$[] res = that.vec().clone();
-        int vlen = res.length;
-        int firstPart = vlen - origin;
-        switch (part) {
-        case 0:
-            System.arraycopy(slice, 0, res, origin, firstPart);
-            break;
-        case 1:
-            System.arraycopy(slice, firstPart, res, 0, origin);
-            break;
-        default:
-            throw wrongPartForSlice(part);
-        }
-        return vectorFactory(res);
-    }
-
-    /*package-private*/
-    final
-    @ForceInline
     <M extends VectorMask<$Boxtype$>>
     $abstractvectortype$
     unsliceTemplate(Class<M> maskType, int origin, Vector<$Boxtype$> w, int part, M m) {
         $abstractvectortype$ that = ($abstractvectortype$) w;
         that.check(this);
-        $abstractvectortype$ slice = that.sliceTemplate(origin, that);
+        $abstractvectortype$ slice = that.slice(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unsliceTemplate(origin, w, part);
+        return slice.unslice(origin, w, part);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -2244,6 +2244,19 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     public abstract
     $abstractvectortype$ slice(int origin, Vector<$Boxtype$> v1);
 
+    /*package-private*/
+    final
+    @ForceInline
+    $abstractvectortype$ sliceTemplate(int origin, Vector<$Boxtype$> v1) {
+        $abstractvectortype$ that = ($abstractvectortype$) v1;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
+        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return (($abstractvectortype$)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2263,6 +2276,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     public abstract
     $abstractvectortype$ slice(int origin);
 
+    /*package-private*/
+    final
+    @ForceInline
+    $abstractvectortype$ sliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
+        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
+        Iota = iotaShuffle(origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2273,14 +2297,29 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /*package-private*/
     final
     @ForceInline
+    $abstractvectortype$
+    unsliceTemplate(int origin, Vector<$Boxtype$> w, int part) {
+        $abstractvectortype$ that = ($abstractvectortype$) w;
+        that.check(this);
+        Objects.checkIndex(origin, length());
+        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
+        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                                  (broadcast(($type$)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return (($abstractvectortype$)w).blend(this.rearrange(Iota), BlendMask);
+    }
+
+    /*package-private*/
+    final
+    @ForceInline
     <M extends VectorMask<$Boxtype$>>
     $abstractvectortype$
     unsliceTemplate(Class<M> maskType, int origin, Vector<$Boxtype$> w, int part, M m) {
         $abstractvectortype$ that = ($abstractvectortype$) w;
         that.check(this);
-        $abstractvectortype$ slice = that.slice(origin, that);
+        $abstractvectortype$ slice = that.sliceTemplate(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
-        return slice.unslice(origin, w, part);
+        return slice.unsliceTemplate(origin, w, part);
     }
 
     /**
@@ -2296,6 +2335,19 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @Override
     public abstract
     $abstractvectortype$ unslice(int origin);
+
+    /*package-private*/
+    final
+    @ForceInline
+    $abstractvectortype$
+    unsliceTemplate(int origin) {
+        Objects.checkIndex(origin, length());
+        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
+        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE,
+                                                                  (broadcast(($type$)(origin))));
+        Iota = iotaShuffle(-origin, 1, true);
+        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
+    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -387,41 +387,19 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ slice(int origin, Vector<$Boxtype$> v) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            $shuffletype$ Iota = iotaShuffle();
-            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return (($vectortype$)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
-        }
+        return ($vectortype$) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
     public $vectortype$ slice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            $shuffletype$ Iota = iotaShuffle();
-            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH - origin))));
-            Iota = iotaShuffle(origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return ($vectortype$) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
     public $vectortype$ unslice(int origin, Vector<$Boxtype$> w, int part) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            $shuffletype$ Iota = iotaShuffle();
-            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                               (broadcast(($type$)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return (($vectortype$)w).blend(this.rearrange(Iota), BlendMask);
-        }
+        return ($vectortype$) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
@@ -436,14 +414,7 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ unslice(int origin) {
-        if ((origin < 0) || (origin >= VLENGTH)) {
-            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-        } else {
-            $shuffletype$ Iota = iotaShuffle();
-            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast(($type$)(origin))));
-            Iota = iotaShuffle(-origin, 1, true);
-            return ZERO.blend(this.rearrange(Iota), BlendMask);
-        }
+        return ($vectortype$) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,26 +387,41 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ slice(int origin, Vector<$Boxtype$> v) {
-        return ($vectortype$) super.sliceTemplate(origin, v);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            $shuffletype$ Iota = iotaShuffle();
+            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return (($vectortype$)v).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public $vectortype$ slice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         $shuffletype$ Iota = iotaShuffle();
-         VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH-origin))));
-         Iota = iotaShuffle(origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            $shuffletype$ Iota = iotaShuffle();
+            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH - origin))));
+            Iota = iotaShuffle(origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
     @ForceInline
     public $vectortype$ unslice(int origin, Vector<$Boxtype$> w, int part) {
-        return ($vectortype$) super.unsliceTemplate(origin, w, part);  // specialize
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            $shuffletype$ Iota = iotaShuffle();
+            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                               (broadcast(($type$)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return (($vectortype$)w).blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override
@@ -421,14 +436,14 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ unslice(int origin) {
-       if ((origin < 0) || (origin >= VLENGTH)) {
-         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
-       } else {
-         $shuffletype$ Iota = iotaShuffle();
-         VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast(($type$)(origin))));
-         Iota = iotaShuffle(-origin, 1, true);
-         return ZERO.blend(this.rearrange(Iota), BlendMask);
-       }
+        if ((origin < 0) || (origin >= VLENGTH)) {
+            throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+        } else {
+            $shuffletype$ Iota = iotaShuffle();
+            VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast(($type$)(origin))));
+            Iota = iotaShuffle(-origin, 1, true);
+            return ZERO.blend(this.rearrange(Iota), BlendMask);
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request optimizes Vector API slice and unslice operations.
All the slice and unslice variants that take more than one argument are implemented in terms of already intrinsic methods on similar lines as slice(origin) and unslice(origin).
Also, the slice and unslice intrinsics for 256-bit byte/short vectors implemented for x86 platforms supporting AVX2 using a sequence of instructions.

For TestSlice.java attached to JBS (https://bugs.openjdk.java.net/browse/JDK-8259278):
Before:
Benchmark                                                       (size) Mode  Cnt    Score    Error   Units
TestSlice.vectorSliceOrigin                               1024  thrpt    5    17.665 ±  0.980  ops/ms
TestSlice.vectorSliceOriginVector                     1024  thrpt    5  604.179 ±  5.795  ops/ms
TestSlice.vectorSliceUnsliceOrigin                    1024  thrpt    5      9.286 ±  0.088  ops/ms
TestSlice.vectorSliceUnsliceOriginVector          1024  thrpt    5  435.678 ± 30.171 ops/ms
TestSlice.vectorSliceUnsliceOriginVectorPart    1024  thrpt    5  440.492 ± 24.592 ops/ms

After:
Benchmark                                                        (size)   Mode  Cnt     Score    Error   Units
TestSlice.vectorSliceOrigin                                1024  thrpt    5  1319.044 ± 67.862  ops/ms
TestSlice.vectorSliceOriginVector                      1024  thrpt    5    969.514 ± 33.411  ops/ms
TestSlice.vectorSliceUnsliceOrigin                     1024  thrpt    5    687.804 ± 31.511  ops/ms
TestSlice.vectorSliceUnsliceOriginVector           1024  thrpt    5    560.807 ± 20.600  ops/ms
TestSlice.vectorSliceUnsliceOriginVectorPart     1024  thrpt    5    560.202 ±  4.012  ops/ms

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259278](https://bugs.openjdk.java.net/browse/JDK-8259278): Optimize Vector API slice and unslice operations


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1950/head:pull/1950`
`$ git checkout pull/1950`
