### PR TITLE
8259232: Bad JNI lookup during printing

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -58,7 +58,7 @@ static jmethodID sjm_printerJob = NULL;
 
 #define GET_CPRINTERDIALOG_METHOD_RETURN(ret) \
    GET_CPRINTERDIALOG_CLASS_RETURN(ret); \
-   GET_METHOD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
+   GET_FIELD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
 
 static NSPrintInfo* createDefaultNSPrintInfo();
 

--- a/test/jdk/java/awt/print/bug8023392/bug8023392.java
+++ b/test/jdk/java/awt/print/bug8023392/bug8023392.java
@@ -23,7 +23,7 @@
 
 /*
   test
-  @bug 8023392
+  @bug 8023392 8259232
   @summary Swing text components printed with spaces between chars
   @author Anton Nashatyrev
   @run applet/manual=yesno bug8023392.html


### PR DESCRIPTION
Didn't hit this because all the print testing I conducted used the swing print + page dialog but the logging made it easy to find the source of the problem.
I've also done an audit of GET_METHOD_* usages for this pattern - I had previously done it for DECLARE_METHOD* which is the bulk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259232](https://bugs.openjdk.java.net/browse/JDK-8259232): Bad JNI lookup during printing


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1952/head:pull/1952`
`$ git checkout pull/1952`
