### PR TITLE
8259287: AbstractCompiler marks const in wrong position for is_c1/is_c2/is_jvmci

### DIFF
--- a/src/hotspot/share/compiler/abstractCompiler.hpp
+++ b/src/hotspot/share/compiler/abstractCompiler.hpp
@@ -149,10 +149,10 @@ class AbstractCompiler : public CHeapObj<mtCompiler> {
   }
 
   // Compiler type queries.
-  const bool is_c1()                             { return _type == compiler_c1; }
-  const bool is_c2()                             { return _type == compiler_c2; }
-  const bool is_jvmci()                          { return _type == compiler_jvmci; }
-  const CompilerType type()                      { return _type; }
+  bool is_c1() const                     { return _type == compiler_c1; }
+  bool is_c2() const                     { return _type == compiler_c2; }
+  bool is_jvmci() const                  { return _type == compiler_jvmci; }
+  CompilerType type() const              { return _type; }
 
   // Customization
   virtual void initialize () = 0;


### PR DESCRIPTION
I think the intention is to have constant member functions.
/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259287](https://bugs.openjdk.java.net/browse/JDK-8259287): AbstractCompiler marks const in wrong position for is_c1/is_c2/is_jvmci


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1953/head:pull/1953`
`$ git checkout pull/1953`
