### PR TITLE
8258143: Update --release 16 symbol information for JDK 16 build 30 or later

### DIFF
--- a/make/data/symbols/java.desktop-G.sym.txt
+++ b/make/data/symbols/java.desktop-G.sym.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -768,6 +768,9 @@ method name <init> descriptor ()V flags 4
 class name javax/swing/JList$AccessibleJList$AccessibleJListChild
 -method name getAccessibleAction descriptor ()Ljavax/accessibility/AccessibleAction;
 method name getAccessibleAction descriptor ()Ljavax/accessibility/AccessibleAction; flags 1
+
+class name javax/swing/JPasswordField
+method name setText descriptor (Ljava/lang/String;)V flags 1 runtimeAnnotations @Ljava/beans/BeanProperty;(bound=Zfalse,description="the\u005C;u0020;text\u005C;u0020;of\u005C;u0020;this\u005C;u0020;component")
 
 class name javax/swing/JSlider$AccessibleJSlider
 header extends javax/swing/JComponent$AccessibleJComponent implements javax/accessibility/AccessibleValue,javax/swing/event/ChangeListener nestHost javax/swing/JSlider flags 21


### PR DESCRIPTION
Updating to the symbol files for JDK 16 b30; change generated with the script 

make/scripts/generate-symbol-data.sh

The change to the java.desktop module looks to be for JDK-8258373.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258143](https://bugs.openjdk.java.net/browse/JDK-8258143): Update --release 16 symbol information for JDK 16 build 30 or later


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1954/head:pull/1954`
`$ git checkout pull/1954`
