### PR TITLE
8259291: Cleanup unnecessary local variables

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -265,8 +265,7 @@ final class Finished {
                         "Invalid PRF output, format must be RAW. " +
                         "Format received: " + prfKey.getFormat());
                 }
-                byte[] finished = prfKey.getEncoded();
-                return finished;
+                return prfKey.getEncoded();
             } catch (GeneralSecurityException e) {
                 throw new RuntimeException("PRF failed", e);
             }
@@ -317,8 +316,7 @@ final class Finished {
                         "Invalid PRF output, format must be RAW. " +
                         "Format received: " + prfKey.getFormat());
                 }
-                byte[] finished = prfKey.getEncoded();
-                return finished;
+                return prfKey.getEncoded();
             } catch (GeneralSecurityException e) {
                 throw new RuntimeException("PRF failed", e);
             }

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,8 +474,7 @@ abstract class OutputRecord
         }
 
         byte[] sequenceNumber = encCipher.authenticator.sequenceNumber();
-        int position = headerSize;
-        int contentLen = count - position;
+        int contentLen = count - headerSize;
 
         // ensure the capacity
         int requiredPacketSize =
@@ -495,7 +494,7 @@ abstract class OutputRecord
             pv = ProtocolVersion.TLS12;
         }
 
-        ByteBuffer destination = ByteBuffer.wrap(buf, position, contentLen);
+        ByteBuffer destination = ByteBuffer.wrap(buf, headerSize, contentLen);
         count = headerSize + encCipher.encrypt(contentType, destination);
 
         // Fill out the header, write it and the message.

--- a/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -674,8 +674,7 @@ enum SSLExtension implements SSLStringizer {
         String extData;
         if (stringizer == null) {
             HexDumpEncoder hexEncoder = new HexDumpEncoder();
-            String encoded = hexEncoder.encode(byteBuffer.duplicate());
-            extData = encoded;
+            extData = hexEncoder.encode(byteBuffer.duplicate());
         } else {
             extData = stringizer.toString(handshakeContext, byteBuffer);
         }

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,7 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
             }
 
             // use the buf of ByteArrayOutputStream
-            int position = headerSize + writeCipher.getExplicitNonceSize();
-            count = position;
+            count = headerSize + writeCipher.getExplicitNonceSize();
 
             write(level);
             write(description);
@@ -221,8 +220,7 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
             }
 
             // use the buf of ByteArrayOutputStream
-            int position = headerSize + writeCipher.getExplicitNonceSize();
-            count = position;
+            count = headerSize + writeCipher.getExplicitNonceSize();
 
             write((byte)1);         // byte 1: change_cipher_spec(
 

--- a/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.text.MessageFormat;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import javax.net.ssl.SSLProtocolException;


### PR DESCRIPTION
In the SunJSSE provider implementation, there are a few local variables that is not necessary. For example: 

    byte[] finished = prfKey.getEncoded(); 
    return finished; 

could be simplified as: 

     return prfKey.getEncoded();

Code clean up, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259291](https://bugs.openjdk.java.net/browse/JDK-8259291): Cleanup unnecessary local variables


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1955/head:pull/1955`
`$ git checkout pull/1955`
