### PR TITLE
8259288: Debug build failure with clang-10 due to -Wimplicit-int-float-conversion

### DIFF
--- a/src/hotspot/share/runtime/threadHeapSampler.cpp
+++ b/src/hotspot/share/runtime/threadHeapSampler.cpp
@@ -394,7 +394,7 @@ void ThreadHeapSampler::pick_next_geometric_sample() {
   double log_val = (fast_log2(q) - 26);
   double result =
       (0.0 < log_val ? 0.0 : log_val) * (-log(2.0) * (get_sampling_interval())) + 1;
-  assert(result > 0 && result < (double) SIZE_MAX, "Result is not in an acceptable range.");
+  assert(result > 0 && result < static_cast<double>(SIZE_MAX), "Result is not in an acceptable range.");
   size_t interval = static_cast<size_t>(result);
   _bytes_until_sample = interval;
 }

--- a/src/hotspot/share/runtime/threadHeapSampler.cpp
+++ b/src/hotspot/share/runtime/threadHeapSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -394,7 +394,7 @@ void ThreadHeapSampler::pick_next_geometric_sample() {
   double log_val = (fast_log2(q) - 26);
   double result =
       (0.0 < log_val ? 0.0 : log_val) * (-log(2.0) * (get_sampling_interval())) + 1;
-  assert(result > 0 && result < SIZE_MAX, "Result is not in an acceptable range.");
+  assert(result > 0 && result < (double) SIZE_MAX, "Result is not in an acceptable range.");
   size_t interval = static_cast<size_t>(result);
   _bytes_until_sample = interval;
 }


### PR DESCRIPTION
Making the conversion explicit would fix it.

Flag '-Wimplicit-int-float-conversion' is first introduced in clang-10.
Therefore clang-8 and clang-9 are not affected. The flag with similar
functionality in gcc is '-Wfloat-conversion', but it is not enabled by
'-Wall' or '-Wextra'. That's why this warning does not appear when
building with gcc.


Note that we have tested with this patch, debug build succeeded with clang-10 on Linux X86-64/AArch64 machines.
Note that '--with-extra-cxxflags=-Wno-deprecated-copy' should be added when configuration. It's another issue (See JDK-8258010)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259288](https://bugs.openjdk.java.net/browse/JDK-8259288): Debug build failure with clang-10 due to -Wimplicit-int-float-conversion


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/1956/head:pull/1956` \
`$ git checkout pull/1956`

Update a local copy of the PR: \
`$ git checkout pull/1956` \
`$ git pull https://git.openjdk.java.net/jdk pull/1956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1956`

View PR using the GUI difftool: \
`$ git pr show -t 1956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/1956.diff">https://git.openjdk.java.net/jdk/pull/1956.diff</a>

</details>
