### PR TITLE
8233555: [TESTBUG] JRadioButton tests failing on MacoS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -764,9 +764,6 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JTree/6263446/bug6263446.java 8213125 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
-javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
-javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all
-javax/swing/JRadioButton/8033699/bug8033699.java 8233555 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 


### PR DESCRIPTION
These radiobutton tests were failing on macos in nightly testing. However recent run of these test are working fine on local mac10.14.6, 10.15.7 systems as well as mach5 macos systems, so we can deproblemlist these tests. Mach5 job link is in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233555](https://bugs.openjdk.java.net/browse/JDK-8233555): [TESTBUG] JRadioButton tests failing on MacoS


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1957/head:pull/1957`
`$ git checkout pull/1957`
