### PR TITLE
8237578: JDK-8214339 (SSLSocketImpl wraps SocketException) appears to not be fully fixed

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1696,7 +1696,12 @@ public final class SSLSocketImpl
         }
 
         if (cause instanceof SocketException) {
-            conContext.teardownTransport(cause, alert, false);
+            try {
+                conContext.fatal(alert, cause);
+            } catch (Exception e) {
+                // Just delivering the fatal alert, re-throw the socket exception instead.
+            }
+
             throw (SocketException)cause;
         }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -447,6 +447,8 @@ public final class SSLSocketImpl
                     throw conContext.fatal(Alert.HANDSHAKE_FAILURE,
                             "Couldn't kickstart handshaking", iioe);
                 }
+            } catch (SocketException se) {
+                handleException(se);
             } catch (IOException ioe) {
                 throw conContext.fatal(Alert.HANDSHAKE_FAILURE,
                     "Couldn't kickstart handshaking", ioe);
@@ -1411,6 +1413,9 @@ public final class SSLSocketImpl
             } catch (InterruptedIOException iioe) {
                 // don't change exception in case of timeouts or interrupts
                 throw iioe;
+            } catch (SocketException se) {
+                // don't change exception in case of SocketException
+                throw se;
             } catch (IOException ioe) {
                 throw new SSLException("readHandshakeRecord", ioe);
             }
@@ -1476,6 +1481,9 @@ public final class SSLSocketImpl
             } catch (InterruptedIOException iioe) {
                 // don't change exception in case of timeouts or interrupts
                 throw iioe;
+            } catch (SocketException se) {
+                // don't change exception in case of SocketException
+                throw se;
             } catch (IOException ioe) {
                 if (!(ioe instanceof SSLException)) {
                     throw new SSLException("readApplicationRecord", ioe);
@@ -1685,6 +1693,11 @@ public final class SSLSocketImpl
                 // RuntimeException
                 alert = Alert.INTERNAL_ERROR;
             }
+        }
+
+        if (cause instanceof SocketException) {
+            conContext.teardownTransport(cause, alert, false);
+            throw (SocketException)cause;
         }
 
         throw conContext.fatal(alert, cause);

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -28,6 +28,7 @@ package sun.security.ssl;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.SocketException;
 import java.nio.ByteBuffer;
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
@@ -140,6 +141,9 @@ interface SSLTransport {
         } catch (InterruptedIOException iioe) {
             // don't close the Socket in case of timeouts or interrupts.
             throw iioe;
+        } catch (SocketException se) {
+            // don't change exception in case of SocketException
+            throw se;
         } catch (IOException ioe) {
             throw context.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
         }

--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -80,7 +80,6 @@ final class TransportContext implements ConnectionContext {
     boolean                         needHandshakeFinishedStatus = false;
     boolean                         hasDelegatedFinished = false;
 
-
     // negotiated security parameters
     SSLSessionImpl                  conSession;
     ProtocolVersion                 protocolVersion;
@@ -369,6 +368,16 @@ final class TransportContext implements ConnectionContext {
             closeReason = alert.createSSLException(diagnostic, cause);
         }
 
+        teardownTransport(closeReason, alert, recvFatalAlert);
+
+        if (closeReason instanceof SSLException) {
+            throw (SSLException)closeReason;
+        } else {
+            throw (RuntimeException)closeReason;
+        }
+    }
+
+    void teardownTransport(Exception closeReason, Alert alert, boolean recvFatalAlert) {
         // close inbound
         try {
             inputRecord.close();
@@ -435,12 +444,6 @@ final class TransportContext implements ConnectionContext {
             closeReason.addSuppressed(ioe);
         } finally {
             isBroken = true;
-        }
-
-        if (closeReason instanceof SSLException) {
-            throw (SSLException)closeReason;
-        } else {
-            throw (RuntimeException)closeReason;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -80,6 +80,7 @@ final class TransportContext implements ConnectionContext {
     boolean                         needHandshakeFinishedStatus = false;
     boolean                         hasDelegatedFinished = false;
 
+
     // negotiated security parameters
     SSLSessionImpl                  conSession;
     ProtocolVersion                 protocolVersion;
@@ -368,16 +369,6 @@ final class TransportContext implements ConnectionContext {
             closeReason = alert.createSSLException(diagnostic, cause);
         }
 
-        teardownTransport(closeReason, alert, recvFatalAlert);
-
-        if (closeReason instanceof SSLException) {
-            throw (SSLException)closeReason;
-        } else {
-            throw (RuntimeException)closeReason;
-        }
-    }
-
-    void teardownTransport(Exception closeReason, Alert alert, boolean recvFatalAlert) {
         // close inbound
         try {
             inputRecord.close();
@@ -444,6 +435,12 @@ final class TransportContext implements ConnectionContext {
             closeReason.addSuppressed(ioe);
         } finally {
             isBroken = true;
+        }
+
+        if (closeReason instanceof SSLException) {
+            throw (SSLException)closeReason;
+        } else {
+            throw (RuntimeException)closeReason;
         }
     }
 

--- a/test/jdk/sun/security/ssl/SSLContextImpl/TrustTrustedCert.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/TrustTrustedCert.java
@@ -131,9 +131,9 @@ public class TrustTrustedCert extends SSLSocketTemplate {
             sslIS.read();
             sslOS.write('A');
             sslOS.flush();
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             if (!expectFail) {
-                throw ssle;
+                throw se;
             }   // Otherwise, ignore.
         }
     }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2017, 2020, Amazon and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8214339
+ * @summary When a SocketException is thrown by the underlying layer, It
+ *      should be thrown as is and not be transformed to an SSLException.
+ * @run main/othervm SSLSocketShouldThrowSocketException
+ */
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.security.*;
+import javax.net.ssl.*;
+
+public class SSLSocketShouldThrowSocketException {
+
+    /*
+     * =============================================================
+     * Set the various variables needed for the tests, then
+     * specify what tests to run on each side.
+     */
+
+    /*
+     * Should we run the client or server in a separate thread?
+     * Both sides can throw exceptions, but do you have a preference
+     * as to which side should be the main thread.
+     */
+    static boolean separateServerThread = true;
+
+    /*
+     * Where do we find the keystores?
+     */
+    static String pathToStores = "../../../../javax/net/ssl/etc";
+    static String keyStoreFile = "keystore";
+    static String trustStoreFile = "truststore";
+    static String passwd = "passphrase";
+
+    /*
+     * Is the server ready to serve?
+     */
+    volatile static boolean serverReady = false;
+
+    /*
+     * Was the client responsible for closing the socket
+     */
+    volatile static boolean clientClosed = false;
+
+    /*
+     * Turn on SSL debugging?
+     */
+    static boolean debug = false;
+
+    /*
+     * If the client or server is doing some kind of object creation
+     * that the other side depends on, and that thread prematurely
+     * exits, you may experience a hang.  The test harness will
+     * terminate all hung threads after its timeout has expired,
+     * currently 3 minutes by default, but you might try to be
+     * smart about it....
+     */
+
+    /*
+     * Define the server side of the test.
+     *
+     * The server accepts 2 requests, The first request does not send
+     * back a handshake message. The second request sends back a
+     * handshake message.
+     *
+     * If the server prematurely exits, serverReady will be set to true
+     * to avoid infinite hangs.
+     */
+    void doServerSide() throws Exception {
+        SSLServerSocketFactory sslssf =
+            (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
+        SSLServerSocket sslServerSocket =
+            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+
+        serverPort = sslServerSocket.getLocalPort();
+
+        /*
+         * Signal Client, we're ready for his connect.
+         */
+        serverReady = true;
+
+        System.err.println("Server accepting: " + System.nanoTime());
+        SSLSocket sslSocket = (SSLSocket) sslServerSocket.accept();
+        System.err.println("Server accepted: " + System.nanoTime());
+
+        System.err.println("Server accepting: " + System.nanoTime());
+        sslSocket = (SSLSocket) sslServerSocket.accept();
+        sslSocket.startHandshake();
+        System.err.println("Server accepted: " + System.nanoTime());
+
+        while (!clientClosed) {
+            Thread.sleep(500);
+        }
+    }
+
+    Socket initilizeClientSocket() throws Exception {
+        /*
+         * Wait for server to get started.
+         */
+        System.out.println("waiting on server");
+        while (!serverReady) {
+            Thread.sleep(50);
+        }
+        Thread.sleep(500);
+        System.out.println("server ready");
+
+        Socket baseSocket = new Socket("localhost", serverPort);
+        baseSocket.setSoTimeout(1000);
+        return baseSocket;
+    }
+
+    SSLSocket initilizeSSLSocket(Socket baseSocket) throws Exception {
+        SSLSocketFactory sslsf =
+            (SSLSocketFactory) SSLSocketFactory.getDefault();
+        SSLSocket sslSocket = (SSLSocket)
+            sslsf.createSocket(baseSocket, "localhost", serverPort, false);
+        return sslSocket;
+    }
+
+    /*
+     * The client should throw a SocketException without wrapping it
+     * during the handshake process.
+     */
+    void doClientSideHandshakeClose() throws Exception {
+
+        Socket baseSocket = initilizeClientSocket();
+        SSLSocket sslSocket = initilizeSSLSocket(baseSocket);
+
+        Thread aborter = new Thread() {
+            @Override
+            public void run() {
+
+                try {
+                    Thread.sleep(10);
+                    System.err.println("Closing the client socket : " + System.nanoTime());
+                    baseSocket.close();
+                } catch (Exception ieo) {
+                    ieo.printStackTrace();
+                }
+            }
+        };
+
+        aborter.start();
+
+        try {
+            // handshaking
+            System.err.println("Client starting handshake: " + System.nanoTime());
+            sslSocket.startHandshake();
+            throw new Exception("Start handshake did not throw an exception");
+        } catch (SocketException se) {
+            System.err.println("Caught Expected SocketException");
+        }
+
+        aborter.join();
+
+    }
+
+    volatile static boolean handshakeCompleted = false;
+
+    /*
+     * The client should throw SocketException without wrapping it
+     * while waiting to read data from the socket.
+     */
+    void doClientSideDataClose() throws Exception {
+
+        Socket baseSocket = initilizeClientSocket();
+        SSLSocket sslSocket = initilizeSSLSocket(baseSocket);
+
+        handshakeCompleted = false;
+
+        Thread aborter = new Thread() {
+            @Override
+            public void run() {
+
+                try {
+                    while (!handshakeCompleted) {
+                        Thread.sleep(10);
+                    }
+                    System.err.println("Closing the client socket : " + System.nanoTime());
+                    baseSocket.close();
+                } catch (Exception ieo) {
+                    ieo.printStackTrace();
+                }
+            }
+        };
+
+        aborter.start();
+
+        try {
+            // handshaking
+            System.err.println("Client starting handshake: " + System.nanoTime());
+            sslSocket.startHandshake();
+            handshakeCompleted = true;
+            System.err.println("Reading data from server");
+            BufferedReader is = new BufferedReader(
+                    new InputStreamReader(sslSocket.getInputStream()));
+            String data = is.readLine();
+            throw new Exception("Start handshake did not throw an exception");
+        } catch (SocketException se) {
+            System.err.println("Caught Expected SocketException");
+        }
+
+        aborter.join();
+
+    }
+
+    /*
+     * =============================================================
+     * The remainder is just support stuff
+     */
+
+    // use any free port by default
+    volatile int serverPort = 0;
+
+    volatile Exception serverException = null;
+
+    volatile byte[] serverDigest = null;
+
+    public static void main(String[] args) throws Exception {
+        String keyFilename =
+            System.getProperty("test.src", "./") + "/" + pathToStores +
+                "/" + keyStoreFile;
+        String trustFilename =
+            System.getProperty("test.src", "./") + "/" + pathToStores +
+                "/" + trustStoreFile;
+
+        System.setProperty("javax.net.ssl.keyStore", keyFilename);
+        System.setProperty("javax.net.ssl.keyStorePassword", passwd);
+        System.setProperty("javax.net.ssl.trustStore", trustFilename);
+        System.setProperty("javax.net.ssl.trustStorePassword", passwd);
+
+        if (debug)
+            System.setProperty("javax.net.debug", "all");
+
+        /*
+         * Start the tests.
+         */
+        new SSLSocketShouldThrowSocketException();
+    }
+
+    Thread serverThread = null;
+
+    /*
+     * Primary constructor, used to drive remainder of the test.
+     *
+     * Fork off the server side.
+     */
+    SSLSocketShouldThrowSocketException() throws Exception {
+        startServer();
+        startClient();
+
+        clientClosed = true;
+        System.err.println("Client closed: " + System.nanoTime());
+
+        /*
+         * Wait for other side to close down.
+         */
+        serverThread.join();
+
+        /*
+         * When we get here, the test is pretty much over.
+         *
+         * If the main thread excepted, that propagates back
+         * immediately.  If the other thread threw an exception, we
+         * should report back.
+         */
+        if (serverException != null) {
+            System.out.print("Server Exception:");
+            throw serverException;
+        }
+    }
+
+    void startServer() throws Exception {
+        serverThread = new Thread() {
+            public void run() {
+                try {
+                     doServerSide();
+                } catch (Exception e) {
+                    /*
+                     * Our server thread just died.
+                     *
+                     * Release the client, if not active already...
+                     */
+                    System.err.println("Server died...");
+                    System.err.println(e);
+                    serverReady = true;
+                    serverException = e;
+                }
+            }
+        };
+        serverThread.start();
+    }
+
+    void startClient() throws Exception {
+        doClientSideHandshakeClose();
+        doClientSideDataClose();
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java
@@ -31,18 +31,18 @@
  * @bug 8214339
  * @summary SSLSocketImpl erroneously wraps SocketException
  * @library /javax/net/ssl/templates
- * @run main/othervm SSLExceptionForIOIssue
+ * @run main/othervm SocketExceptionForSocketIssues
  */
 
 import javax.net.ssl.*;
 import java.io.*;
 import java.net.*;
 
-public class SSLExceptionForIOIssue implements SSLContextTemplate {
+public class SocketExceptionForSocketIssues implements SSLContextTemplate {
 
     public static void main(String[] args) throws Exception {
         System.err.println("===================================");
-        new SSLExceptionForIOIssue().test();
+        new SocketExceptionForSocketIssues().test();
     }
 
     private void test() throws Exception {
@@ -79,9 +79,9 @@ public class SSLExceptionForIOIssue implements SSLContextTemplate {
             os.flush();
         } catch (SSLProtocolException | SSLHandshakeException sslhe) {
             throw sslhe;
-        } catch (SSLException ssle) {
+        } catch (SocketException se) {
             // the expected exception, ignore it
-            System.err.println("server exception: " + ssle);
+            System.err.println("server exception: " + se);
         } finally {
             if (listenSocket != null) {
                 listenSocket.close();


### PR DESCRIPTION
This PR aims to revert some more cases where SocketExceptions are improperly being wrapped as SSLException. Some work for this was done in [JDK-8235263](https://bugs.openjdk.java.net/browse/JDK-8235263), but that change did not cover all the cases.

As it was mentioned in JDK-8235263, some applications rely on receiving SocketException to decide if the connection should be retried. An example of this would be Apache HTTP client. This PR should ideally fix https://issues.apache.org/jira/browse/HTTPCLIENT-2032

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8237578](https://bugs.openjdk.java.net/browse/JDK-8237578): JDK-8214339 (SSLSocketImpl wraps SocketException) appears to not be fully fixed


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1968/head:pull/1968`
`$ git checkout pull/1968`
