### PR TITLE
8259274: Increase timeout duration in sun/nio/ch/TestMaxCachedBufferSize.java

### DIFF
--- a/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
+++ b/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,11 +44,11 @@ import jdk.test.lib.RandomFactory;
  * @modules java.management
  * @library /test/lib
  * @build TestMaxCachedBufferSize
- * @run main/othervm TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=0 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=2000 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=100000 TestMaxCachedBufferSize
- * @run main/othervm -Djdk.nio.maxCachedBufferSize=10000000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=0 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=2000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=100000 TestMaxCachedBufferSize
+ * @run main/othervm/timeout=150 -Djdk.nio.maxCachedBufferSize=10000000 TestMaxCachedBufferSize
  * @summary Test the implementation of the jdk.nio.maxCachedBufferSize property
  * (use -Dseed=X to set PRNG seed)
  * @key randomness


### PR DESCRIPTION
The change for JDK-8255913 integrated on 2020-11-05 reduced by half the number of iterations in `TestMaxCachedBufferSize`. As reported in JDK-8212812 on 2021-01-05, the test still failed due to a timeout after an elapsed time of 502738ms including timeout handling. The current timeout is 480000ms which represents the default timeout of 120s multiplied by the timeout factor of 4.

The present change proposes to increase the timeout by 25% to 150s. This should hopefully dispense with the ongoing test timeouts. As these timeouts have been observed primarily if not exclusively on decade-old MacPro5_1 machines, the timeout should not appreciably increase the overall CI test execution time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259274](https://bugs.openjdk.java.net/browse/JDK-8259274): Increase timeout duration in sun/nio/ch/TestMaxCachedBufferSize.java


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1969/head:pull/1969`
`$ git checkout pull/1969`
