### PR TITLE
8259350:  Add some internal debugging APIs to the debug agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,5 +74,11 @@ jvmtiError eventFilter_setSourceNameMatchFilter(HandlerNode *node,
 
 jboolean eventFilter_predictFiltering(HandlerNode *node, jclass clazz, char *classname);
 jboolean isBreakpointSet(jclass clazz, jmethodID method, jlocation location);
+
+/***** debugging *****/
+
+#ifdef DEBUG
+void eventFilter_dumpHandlerFilters(HandlerNode *node);
+#endif
 
 #endif /* _EVENT_FILTER_H */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1752,8 +1752,8 @@ eventHandler_dumpHandlers(EventIndex ei, jboolean dumpPermanent)
 void
 eventHandler_dumpHandler(HandlerNode *node)
 {
-  tty_message("Handler for %s(%d)\n", eventIndex2EventName(node->ei), node->ei);
-  eventFilter_dumpHandlerFilters(node);
+    tty_message("Handler for %s(%d)\n", eventIndex2EventName(node->ei), node->ei);
+    eventFilter_dumpHandlerFilters(node);
 }
 
 #endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1713,3 +1713,47 @@ eventHandler_installExternal(HandlerNode *node)
                           standardHandlers_defaultHandler(node->ei),
                           JNI_TRUE);
 }
+
+/***** debugging *****/
+
+#ifdef DEBUG
+
+void
+eventHandler_dumpAllHandlers(jboolean dumpPermanent)
+{
+    int ei;
+    for (ei = EI_min; ei <= EI_max; ++ei) {
+        eventHandler_dumpHandlers(ei, dumpPermanent);
+    }
+}
+
+void
+eventHandler_dumpHandlers(EventIndex ei, jboolean dumpPermanent)
+{
+  HandlerNode *nextNode;
+  nextNode = getHandlerChain(ei)->first;
+  if (nextNode != NULL) {
+      tty_message("\nHandlers for %s(%d)", eventIndex2EventName(ei), ei);
+      while (nextNode != NULL) {
+          HandlerNode *node = nextNode;
+          nextNode = NEXT(node);
+
+          if (node->permanent && !dumpPermanent) {
+              continue; // ignore permanent handlers
+          }
+
+          tty_message("node(%p) handlerID(%d) suspendPolicy(%d) permanent(%d)",
+                      node, node->handlerID, node->suspendPolicy, node->permanent);
+          eventFilter_dumpHandlerFilters(node);
+      }
+  }
+}
+
+void
+eventHandler_dumpHandler(HandlerNode *node)
+{
+  tty_message("Handler for %s(%d)\n", eventIndex2EventName(node->ei), node->ei);
+  eventFilter_dumpHandlerFilters(node);
+}
+
+#endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,5 +78,13 @@ void eventHandler_unlock(void);
 
 
 jclass getMethodClass(jvmtiEnv *jvmti_env, jmethodID method);
+
+/***** debugging *****/
+
+#ifdef DEBUG
+void eventHandler_dumpAllHandlers(jboolean dumpPermanent);
+void eventHandler_dumpHandlers(EventIndex ei, jboolean dumpPermanent);
+void eventHandler_dumpHandler(HandlerNode *node);
+#endif
 
 #endif /* _EVENTHANDLER_H */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2526,32 +2526,32 @@ threadControl_getFrameGeneration(jthread thread)
 void
 threadControl_dumpAllThreads()
 {
-  tty_message("Dumping runningThreads:\n");
-  dumpThreadList(&runningThreads);
-  tty_message("Dumping otherThreads:\n");
-  dumpThreadList(&otherThreads);
+    tty_message("Dumping runningThreads:\n");
+    dumpThreadList(&runningThreads);
+    tty_message("Dumping otherThreads:\n");
+    dumpThreadList(&otherThreads);
 }
 
 static void
 dumpThreadList(ThreadList *list)
 {
-  ThreadNode *node;
-  for (node = list->first; node != NULL; node = node->next) {
-    if (!node->isDebugThread) {
-      dumpThread(node);
+    ThreadNode *node;
+    for (node = list->first; node != NULL; node = node->next) {
+        if (!node->isDebugThread) {
+            dumpThread(node);
+        }
     }
-  }
 }
 
 static void
 dumpThread(ThreadNode *node) {
-  tty_message("  Thread: node = %p, jthread = %p", node, node->thread);
+    tty_message("  Thread: node = %p, jthread = %p", node, node->thread);
 #ifdef DEBUG_THREADNAME
-  tty_message("\tname: %s", node->name);
+    tty_message("\tname: %s", node->name);
 #endif
-  // More fields can be printed here when needed. The amount of output is intentionlly
-  // kept small so it doesn't generate too much output.
-  tty_message("\tsuspendCount: %d", node->suspendCount);
+    // More fields can be printed here when needed. The amount of output is intentionlly
+    // kept small so it doesn't generate too much output.
+    tty_message("\tsuspendCount: %d", node->suspendCount);
 }
 
 #endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,6 +139,11 @@ typedef struct {
 } DeferredEventModeList;
 
 static DeferredEventModeList deferredEventModes;
+
+#ifdef DEBUG
+static void dumpThreadList(ThreadList *list);
+static void dumpThread(ThreadNode *node);
+#endif
 
 static jint
 getStackDepth(jthread thread)
@@ -2513,3 +2518,40 @@ threadControl_getFrameGeneration(jthread thread)
 
     return frameGeneration;
 }
+
+/***** debugging *****/
+
+#ifdef DEBUG
+
+void
+threadControl_dumpAllThreads()
+{
+  tty_message("Dumping runningThreads:\n");
+  dumpThreadList(&runningThreads);
+  tty_message("Dumping otherThreads:\n");
+  dumpThreadList(&otherThreads);
+}
+
+static void
+dumpThreadList(ThreadList *list)
+{
+  ThreadNode *node;
+  for (node = list->first; node != NULL; node = node->next) {
+    if (!node->isDebugThread) {
+      dumpThread(node);
+    }
+  }
+}
+
+static void
+dumpThread(ThreadNode *node) {
+  tty_message("  Thread: node = %p, jthread = %p", node, node->thread);
+#ifdef DEBUG_THREADNAME
+  tty_message("\tname: %s", node->name);
+#endif
+  // More fields can be printed here when needed. The amount of output is intentionlly
+  // kept small so it doesn't generate too much output.
+  tty_message("\tsuspendCount: %d", node->suspendCount);
+}
+
+#endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,5 +74,11 @@ void threadControl_saveCLEInfo(JNIEnv *env, jthread thread, EventIndex ei,
                                jclass clazz, jmethodID method,
                                jlocation location);
 jlong threadControl_getFrameGeneration(jthread thread);
+
+/***** debugging *****/
+
+#ifdef DEBUG
+void threadControl_dumpAllThreads();
+#endif
 
 #endif

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1981,6 +1981,60 @@ eventIndex2jvmti(EventIndex i)
     }
     return index2jvmti[i-EI_min];
 }
+
+#ifdef DEBUG
+
+char*
+eventIndex2EventName(EventIndex ei)
+{
+    switch ( ei ) {
+        case EI_SINGLE_STEP:
+            return "EI_SINGLE_STEP";
+        case EI_BREAKPOINT:
+            return "EI_BREAKPOINT";
+        case EI_FRAME_POP:
+            return "EI_FRAME_POP";
+        case EI_EXCEPTION:
+            return "EI_EXCEPTION";
+        case EI_THREAD_START:
+            return "EI_THREAD_START";
+        case EI_THREAD_END:
+            return "EI_THREAD_END";
+        case EI_CLASS_PREPARE:
+            return "EI_CLASS_PREPARE";
+        case EI_GC_FINISH:
+            return "EI_GC_FINISH";
+        case EI_CLASS_LOAD:
+            return "EI_CLASS_LOAD";
+        case EI_FIELD_ACCESS:
+            return "EI_FIELD_ACCESS";
+        case EI_FIELD_MODIFICATION:
+            return "EI_FIELD_MODIFICATION";
+        case EI_EXCEPTION_CATCH:
+            return "EI_EXCEPTION_CATCH";
+        case EI_METHOD_ENTRY:
+            return "EI_METHOD_ENTRY";
+        case EI_METHOD_EXIT:
+            return "EI_METHOD_EXIT";
+        case EI_MONITOR_CONTENDED_ENTER:
+            return "EI_MONITOR_CONTENDED_ENTER";
+        case EI_MONITOR_CONTENDED_ENTERED:
+            return "EI_MONITOR_CONTENDED_ENTERED";
+        case EI_MONITOR_WAIT:
+            return "EI_MONITOR_WAIT";
+        case EI_MONITOR_WAITED:
+            return "EI_MONITOR_WAITED";
+        case EI_VM_INIT:
+            return "EI_VM_INIT";
+        case EI_VM_DEATH:
+            return "EI_VM_DEATH";
+        default:
+            JDI_ASSERT(JNI_FALSE);
+            return "Bad EI";
+    }
+}
+
+#endif
 
 EventIndex
 jdwp2EventIndex(jdwpEvent eventType)

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -379,6 +379,9 @@ void *jvmtiAllocate(jint numBytes);
 void jvmtiDeallocate(void *buffer);
 
 void             eventIndexInit(void);
+#ifdef DEBUG
+char*            eventIndex2EventName(EventIndex ei);
+#endif
 jdwpEvent        eventIndex2jdwp(EventIndex i);
 jvmtiEvent       eventIndex2jvmti(EventIndex i);
 EventIndex       jdwp2EventIndex(jdwpEvent eventType);


### PR DESCRIPTION
This PR adds some APIs that are useful when debugging the debug agent. They can be called from gdb or from other parts of the debug agent. They mostly do things like dumping internal data structures that are tedious to dump or iterate over in gdb. I developed them while working on loom and found them useful.

Note that `dumpThreadList()` and `dumpThread()` are not exported from threadControl.c because the argument types are only visible within threadControl.c.

I debated whether to bracket all these APIs with `#ifdef DEBUG`. In the end I decided to in order to make it clear they are only meant for debugging purposes. If you temporarily need them with a product build, you can always modify the code to include them. I could be persuaded `#ifdef DEBUG` though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259350](https://bugs.openjdk.java.net/browse/JDK-8259350): Add some internal debugging APIs to the debug agent


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1970/head:pull/1970`
`$ git checkout pull/1970`
