### PR TITLE
8255339: CodeBuffer::_last_insn is only used on AArch64

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -404,7 +404,7 @@ class CodeBuffer: public StackObj {
   OopRecorder  _default_oop_recorder;  // override with initialize_oop_recorder
   Arena*       _overflow_arena;
 
-  address      _last_insn;      // used to merge consecutive memory barriers, loads or stores.
+  AARCH64_ONLY(address _last_insn;)    // used to merge consecutive memory barriers, loads or stores.
 
 #if INCLUDE_AOT
   bool         _immutable_PIC;
@@ -425,7 +425,7 @@ class CodeBuffer: public StackObj {
     _blob            = NULL;
     _oop_recorder    = NULL;
     _overflow_arena  = NULL;
-    _last_insn       = NULL;
+    AARCH64_ONLY(_last_insn = NULL;)
 #if INCLUDE_AOT
     _immutable_PIC   = false;
 #endif
@@ -632,9 +632,11 @@ class CodeBuffer: public StackObj {
 
   OopRecorder* oop_recorder() const { return _oop_recorder; }
 
+#ifdef AARCH64
   address last_insn() const { return _last_insn; }
   void set_last_insn(address a) { _last_insn = a; }
   void clear_last_insn() { set_last_insn(NULL); }
+#endif
 
 #ifndef PRODUCT
   CodeStrings& strings() { return _code_strings; }


### PR DESCRIPTION
CodeBuffer::_last_insn was used to merge consecutive memory barriers and
adjacent load/store on AArch64.

This patch marks it as AArch64 only so that 8 bytes could be dropped
from CodeBuffer on other architectures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255339](https://bugs.openjdk.java.net/browse/JDK-8255339): CodeBuffer::_last_insn is only used on AARCH64


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1971/head:pull/1971`
`$ git checkout pull/1971`
