### PR TITLE
JDK-8258484: AIX build fails in Harfbuzz with XLC 16.01.0000.0006

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -474,6 +474,11 @@ else
     #
 
   LIBHARFBUZZ_OPTIMIZATION := HIGH
+  # Early re-canonizing has to be disabled to workaround an internal compiler error
+  # in libharfbuzz
+  ifeq ($(call isTargetOs, aix), true)
+    LIBHARFBUZZ_CFLAGS += -qdebug=necan
+  endif
 
   LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -474,8 +474,8 @@ else
     #
 
   LIBHARFBUZZ_OPTIMIZATION := HIGH
-  # Early re-canonizing has to be disabled to workaround an internal compiler error
-  # in libharfbuzz
+  # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
+  # when building libharfbuzz
   ifeq ($(call isTargetOs, aix), true)
     LIBHARFBUZZ_CFLAGS += -qdebug=necan
   endif


### PR DESCRIPTION
Hello,  for a while the AIX build fails with the following error in the harfbuzz build 
    1500-004: (U) INTERNAL COMPILER ERROR while compiling OT::MarkBasePosFormat1::collect_variation_indices(hb_collect_variation_indices_context_t *) const.
Compilation ended. Contact your Service Representative and provide the following information: GRARNN: gr29643 is used before it is defined.

This xlc 16 version is used for compiling 
bash-4.4$ xlc -qversion
IBM XL C/C++ for AIX, V16.1.0 (5725-C72, 5765-J12)
Version: 16.01.0000.0006

Solution by IBM compiler support is to use  "-qdebug=necan", this  effectively turns off an optimisation called "Early Re-canonizing" on the harfbuzz lib.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258484](https://bugs.openjdk.java.net/browse/JDK-8258484): AIX build fails in Harfbuzz with XLC 16.01.0000.0006


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1972/head:pull/1972`
`$ git checkout pull/1972`
