### PR TITLE
8259368: Zero: UseCompressedClassPointers does not depend on UseCompressedOops

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2009, 2015, Red Hat, Inc.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2009, 2021, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -36,6 +36,6 @@
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;
 
-#define COMPRESSED_CLASS_POINTERS_DEPENDS_ON_COMPRESSED_OOPS true
+#define COMPRESSED_CLASS_POINTERS_DEPENDS_ON_COMPRESSED_OOPS false
 
 #endif // CPU_ZERO_GLOBALDEFINITIONS_ZERO_HPP


### PR DESCRIPTION
JDK-8241825 decoupled `UseCompressedClassPointers` and `UseCompressedOops`, and introduced `COMPRESSED_CLASS_POINTERS_DEPENDS_ON_COMPRESSED_OOPS` that platforms can set to say if their generated code is ready for this decoupling.

Zero defaults to `true` for that flag, meaning the flags are still coupled. But there is not actual coupling: Zero delegates all this work to VM code, which handles everything correctly. This makes at least one test fail with Zero:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=runtime/CompressedOops/CompressedClassPointers.java
java.lang.RuntimeException: 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr
...
```

Additional testing:
 - [x] Linux x86_64 Zero `runtime/CompressedOops/` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259368](https://bugs.openjdk.java.net/browse/JDK-8259368): Zero: UseCompressedClassPointers does not depend on UseCompressedOops


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to 5e9771799559296284894e06fce1e7e5e5950012
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to 5e9771799559296284894e06fce1e7e5e5950012


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1973/head:pull/1973`
`$ git checkout pull/1973`
