### PR TITLE
8253910: UseCompressedClassPointers depends on UseCompressedOops in vmError.cpp

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -341,7 +341,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                 buf, jdk_debug_level, runtime_version);
 
    // This is the long version with some default settings added
-   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s, %s, %s)",
+   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s%s, %s, %s)",
                  VM_Version::vm_name(),
                 (*vendor_version != '\0') ? " " : "", vendor_version,
                  jdk_debug_level,
@@ -355,6 +355,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                  "", "",
 #endif
                  UseCompressedOops ? ", compressed oops" : "",
+                 UseCompressedClassPointers ? ", compressed class ptrs" : "",
                  GCConfig::hs_err_name(),
                  VM_Version::vm_platform_string()
                );
@@ -920,11 +921,15 @@ void VMError::report(outputStream* st, bool _verbose) {
 
      if (_verbose && UseCompressedOops) {
        CompressedOops::print_mode(st);
-       if (UseCompressedClassPointers) {
-         CDS_ONLY(MetaspaceShared::print_on(st);)
-         Metaspace::print_compressed_class_space(st);
-         CompressedKlassPointers::print_mode(st);
-       }
+       st->cr();
+     }
+
+  STEP("printing compressed klass pointers mode")
+
+     if (_verbose && UseCompressedClassPointers) {
+       CDS_ONLY(MetaspaceShared::print_on(st);)
+       Metaspace::print_compressed_class_space(st);
+       CompressedKlassPointers::print_mode(st);
        st->cr();
      }
 #endif
@@ -1131,11 +1136,14 @@ void VMError::print_vm_info(outputStream* st) {
   // STEP("printing compressed oops mode")
   if (UseCompressedOops) {
     CompressedOops::print_mode(st);
-    if (UseCompressedClassPointers) {
-      CDS_ONLY(MetaspaceShared::print_on(st);)
-      Metaspace::print_compressed_class_space(st);
-      CompressedKlassPointers::print_mode(st);
-    }
+    st->cr();
+  }
+
+  // STEP("printing compressed class ptrs mode")
+  if (UseCompressedClassPointers) {
+    CDS_ONLY(MetaspaceShared::print_on(st);)
+    Metaspace::print_compressed_class_space(st);
+    CompressedKlassPointers::print_mode(st);
     st->cr();
   }
 #endif


### PR DESCRIPTION
As noted in the bug report, there are places in `vmError.cpp`, where information on compressed classes is only printed if compressed oops are enabled. After JDK-8241825 both features should be independent. In addition to 2 reported places, we also need to print the setting in JVM modeline.

Sample outputs:

```
Command Line: Crash
...
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc.shade.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
...
VM Mutex/Monitor currently owned by a thread: None

Heap address: 0x0000000082000000, size: 30688 MB, Compressed Oops mode: Zero based, Oop shift amount: 3

CDS archive(s) mapped at: [0x0000000800000000-0x0000000800c5c000-0x0000000800c5c000), size 12959744, SharedBaseAddress: 0x0000000800000000, ArchiveRelocationMode: 0.
Compressed class space mapped at: 0x0000000801000000-0x0000000841000000, reserved size: 1073741824
Narrow klass base: 0x0000000800000000, Narrow klass shift: 3, Narrow klass range: 0x100000000

GC Precious Log:
```

```
Command Line: -XX:-UseCompressedOops Crash
...
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc.shade.jdk, mixed mode, sharing, tiered, compressed class ptrs, g1 gc, linux-amd64)
...
VM Mutex/Monitor currently owned by a thread: None

CDS archive(s) mapped at: [0x0000000800000000-0x0000000800c2f000-0x0000000800c2f000), size 12775424, SharedBaseAddress: 0x0000000800000000, ArchiveRelocationMode: 0.
Compressed class space mapped at: 0x0000000801000000-0x0000000841000000, reserved size: 1073741824
Narrow klass base: 0x0000000800000000, Narrow klass shift: 3, Narrow klass range: 0x100000000

GC Precious Log:
...
```

```
Command Line: -XX:-UseCompressedOops -XX:-UseCompressedClassPointers Crash
...
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc.shade.jdk, mixed mode, tiered, g1 gc, linux-amd64)
...
VM Mutex/Monitor currently owned by a thread: None

GC Precious Log:
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253910](https://bugs.openjdk.java.net/browse/JDK-8253910): UseCompressedClassPointers depends on UseCompressedOops in vmError.cpp


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1974/head:pull/1974`
`$ git checkout pull/1974`
