### PR TITLE
8259375: JvmtiExport::jni_Get/SetField_probe calls do not need ResetNoHandleMark

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -1941,8 +1941,6 @@ JNI_ENTRY_NO_PRESERVE(Return, jni_Get##Result##Field(JNIEnv *env, jobject obj, j
   Klass* k = o->klass(); \
   int offset = jfieldIDWorkaround::from_instance_jfieldID(k, fieldID);  \
   /* Keep JVMTI addition small and only check enabled flag here.       */ \
-  /* jni_GetField_probe_nh() assumes that is not okay to create handles */ \
-  /* and creates a ResetNoHandleMark.                                   */ \
   if (JvmtiExport::should_post_field_access()) { \
     o = JvmtiExport::jni_GetField_probe_nh(thread, obj, o, k, fieldID, false); \
   } \
@@ -2008,8 +2006,6 @@ JNI_ENTRY_NO_PRESERVE(void, jni_SetObjectField(JNIEnv *env, jobject obj, jfieldI
   Klass* k = o->klass();
   int offset = jfieldIDWorkaround::from_instance_jfieldID(k, fieldID);
   // Keep JVMTI addition small and only check enabled flag here.
-  // jni_SetField_probe_nh() assumes that is not okay to create handles
-  // and creates a ResetNoHandleMark.
   if (JvmtiExport::should_post_field_modification()) {
     jvalue field_value;
     field_value.l = value;
@@ -2032,8 +2028,6 @@ JNI_ENTRY_NO_PRESERVE(void, jni_Set##Result##Field(JNIEnv *env, jobject obj, jfi
   Klass* k = o->klass(); \
   int offset = jfieldIDWorkaround::from_instance_jfieldID(k, fieldID);  \
   /* Keep JVMTI addition small and only check enabled flag here.       */ \
-  /* jni_SetField_probe_nh() assumes that is not okay to create handles */ \
-  /* and creates a ResetNoHandleMark.                                   */ \
   if (JvmtiExport::should_post_field_modification()) { \
     jvalue field_value; \
     field_value.unionType = value; \

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1886,11 +1886,7 @@ oop JvmtiExport::jni_GetField_probe(JavaThread *thread, jobject jobj, oop obj,
 oop JvmtiExport::jni_GetField_probe_nh(JavaThread *thread, jobject jobj, oop obj,
                                        Klass* klass, jfieldID fieldID, bool is_static) {
   if (*((int *)get_field_access_count_addr()) > 0 && thread->has_last_Java_frame()) {
-    // At least one field access watch is set so we have more work
-    // to do. This wrapper is used by "quick" entry points that don't
-    // allow us to create handles in post_field_access_by_jni(). We
-    // override that with a ResetNoHandleMark.
-    ResetNoHandleMark rnhm;
+    // At least one field access watch is set so we have more work to do.
     post_field_access_by_jni(thread, obj, klass, fieldID, is_static);
     // event posting can block so refetch oop if we were passed a jobj
     if (jobj != NULL) return JNIHandles::resolve_non_null(jobj);
@@ -1981,11 +1977,7 @@ oop JvmtiExport::jni_SetField_probe_nh(JavaThread *thread, jobject jobj, oop obj
                                        Klass* klass, jfieldID fieldID, bool is_static,
                                        char sig_type, jvalue *value) {
   if (*((int *)get_field_modification_count_addr()) > 0 && thread->has_last_Java_frame()) {
-    // At least one field modification watch is set so we have more work
-    // to do. This wrapper is used by "quick" entry points that don't
-    // allow us to create handles in post_field_modification_by_jni(). We
-    // override that with a ResetNoHandleMark.
-    ResetNoHandleMark rnhm;
+    // At least one field modification watch is set so we have more work to do.
     post_field_modification_by_jni(thread, obj, klass, fieldID, is_static, sig_type, value);
     // event posting can block so refetch oop if we were passed a jobj
     if (jobj != NULL) return JNIHandles::resolve_non_null(jobj);


### PR DESCRIPTION
This is a trivial change to remove the comments and the ResetNoHandleMark from jvmti functions.  They're called by JNI_ENTRY so they don't have a NoHandleMark that needs to be reset.  It may not have always been the case.
Tested with the other patch for https://bugs.openjdk.java.net/browse/JDK-8258032 and retesting with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259375](https://bugs.openjdk.java.net/browse/JDK-8259375): JvmtiExport::jni_Get/SetField_probe calls do not need ResetNoHandleMark


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1975/head:pull/1975`
`$ git checkout pull/1975`
