### PR TITLE
JDK-8259238: Clean up Log.java and remove usage of non-final static variables.

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -100,12 +100,12 @@ public class Arguments {
     private String buildRoot = null;
     private String mainJarPath = null;
 
-    private static boolean runtimeInstaller = false;
+    private boolean runtimeInstaller = false;
 
     private List<AddLauncherArguments> addLaunchers = null;
 
-    private static Map<String, CLIOptions> argIds = new HashMap<>();
-    private static Map<String, CLIOptions> argShortIds = new HashMap<>();
+    private static final Map<String, CLIOptions> argIds = new HashMap<>();
+    private static final Map<String, CLIOptions> argShortIds = new HashMap<>();
 
     static {
         // init maps for parsing arguments
@@ -117,7 +117,12 @@ public class Arguments {
         });
     }
 
+    private static final InheritableThreadLocal<Arguments> instance =
+            new InheritableThreadLocal<Arguments>();
+
     public Arguments(String[] args) {
+        instance.set(this);
+
         argList = new ArrayList<String>(args.length);
         for (String arg : args) {
             argList.add(arg);
@@ -392,16 +397,8 @@ public class Arguments {
             this.category = category;
         }
 
-        static void setContext(Arguments context) {
-            argContext = context;
-        }
-
         public static Arguments context() {
-            if (argContext != null) {
-                return argContext;
-            } else {
-                throw new RuntimeException("Argument context is not set.");
-            }
+            return instance.get();
         }
 
         public String getId() {
@@ -462,10 +459,6 @@ public class Arguments {
 
     public boolean processArguments() {
         try {
-
-            // init context of arguments
-            CLIOptions.setContext(this);
-
             // parse cmd line
             String arg;
             CLIOptions option;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
@@ -75,16 +75,12 @@ public class Log {
         public void info(String msg) {
             if (out != null) {
                 out.println(msg);
-            } else {
-                System.out.println(msg);
             }
         }
 
         public void fatalError(String msg) {
             if (err != null) {
                 err.println(msg);
-            } else {
-                System.err.println(msg);
             }
         }
 
@@ -92,8 +88,6 @@ public class Log {
             msg = addTimestamp(msg);
             if (err != null) {
                 err.println(msg);
-            } else {
-                System.err.println(msg);
             }
         }
 
@@ -101,9 +95,6 @@ public class Log {
             if (out != null && verbose) {
                 out.print(addTimestamp(""));
                 t.printStackTrace(out);
-            } else if (verbose) {
-                System.out.print(addTimestamp(""));
-                t.printStackTrace(System.out);
             }
         }
 
@@ -111,8 +102,6 @@ public class Log {
             msg = addTimestamp(msg);
             if (out != null && verbose) {
                 out.println(msg);
-            } else if (verbose) {
-                System.out.println(msg);
             }
         }
 
@@ -142,62 +131,50 @@ public class Log {
         }
     }
 
-    private static Logger delegate = null;
+    private static final InheritableThreadLocal<Logger> instance =
+            new InheritableThreadLocal<Logger>() {
+                @Override protected Logger initialValue() {
+                    return new Logger();
+                }
+            };
 
-    public static void setLogger(Logger logger) {
-        delegate = (logger != null) ? logger : new Logger();
+    public static void setPrintWriter (PrintWriter out, PrintWriter err) {
+        instance.get().setPrintWriter(out, err);
     }
 
     public static void flush() {
-        if (delegate != null) {
-            delegate.flush();
-        }
+        instance.get().flush();
     }
 
     public static void info(String msg) {
-        if (delegate != null) {
-           delegate.info(msg);
-        }
+        instance.get().info(msg);
     }
 
     public static void fatalError(String msg) {
-        if (delegate != null) {
-            delegate.fatalError(msg);
-        }
+        instance.get().fatalError(msg);
     }
 
     public static void error(String msg) {
-        if (delegate != null) {
-            delegate.error(msg);
-        }
+        instance.get().error(msg);
     }
 
     public static void setVerbose() {
-        if (delegate != null) {
-            delegate.setVerbose();
-        }
+        instance.get().setVerbose();
     }
 
     public static boolean isVerbose() {
-        return (delegate != null) ? delegate.isVerbose() : false;
+        return instance.get().isVerbose();
     }
 
     public static void verbose(String msg) {
-        if (delegate != null) {
-           delegate.verbose(msg);
-        }
+       instance.get().verbose(msg);
     }
 
     public static void verbose(Throwable t) {
-        if (delegate != null) {
-           delegate.verbose(t);
-        }
+       instance.get().verbose(t);
     }
 
     public static void verbose(List<String> strings, List<String> out, int ret) {
-        if (delegate != null) {
-           delegate.verbose(strings, out, ret);
-        }
+       instance.get().verbose(strings, out, ret);
     }
-
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
@@ -46,10 +46,10 @@ public class Main {
      * @param args command line arguments
      */
     public static void main(String... args) throws Exception {
-        // Create logger with default system.out and system.err
-        Log.setLogger(null);
 
-        int status = new jdk.jpackage.main.Main().execute(args);
+        PrintWriter out = new PrintWriter(System.out);
+        PrintWriter err = new PrintWriter(System.err);
+        int status = new jdk.jpackage.main.Main().execute(out, err, args);
         System.exit(status);
     }
 
@@ -62,15 +62,8 @@ public class Main {
      * @return an exit code. 0 means success, non-zero means an error occurred.
      */
     public int execute(PrintWriter out, PrintWriter err, String... args) {
-        // Create logger with provided streams
-        Log.Logger logger = new Log.Logger();
-        logger.setPrintWriter(out, err);
-        Log.setLogger(logger);
+        Log.setPrintWriter(out, err);
 
-        return execute(args);
-    }
-
-    private int execute(String... args) {
         try {
             String[] newArgs;
             try {


### PR DESCRIPTION
JDK-8259238: Clean up Log.java and remove usage of non-final static variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259238](https://bugs.openjdk.java.net/browse/JDK-8259238): Clean up Log.java and remove usage of non-final static variables.


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1977/head:pull/1977`
`$ git checkout pull/1977`
