### PR TITLE
8259392: Zero error reporting is broken after JDK-8255711

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -608,23 +608,23 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
       // prepare fault pc address for error reporting.
       if (S390_ONLY(sig == SIGILL || sig == SIGFPE) NOT_S390(false)) {
         pc = (address)info->si_addr;
+      } else if (ZERO_ONLY(true) NOT_ZERO(false)) {
+        // Non-arch-specific Zero code does not really know the pc.
+        // This can be alleviated by making arch-specific os::Posix::ucontext_get_pc
+        // available for Zero for known architectures. But for generic Zero
+        // code, it would still remain unknown.
+        pc = NULL;
       } else {
         pc = os::Posix::ucontext_get_pc(uc);
       }
     }
-#if defined(ZERO) && !defined(PRODUCT)
-    char buf[64];
-    VMError::report_and_die(t, sig, pc, info, ucVoid,
-          "\n#"
-          "\n#    /--------------------\\"
-          "\n#    |      %-7s       |"
-          "\n#    \\---\\ /--------------/"
-          "\n#        /"
-          "\n#    [-]        |\\_/|    "
-          "\n#    (+)=C      |o o|__  "
-          "\n#    | |        =-*-=__\\ "
-          "\n#    OOO        c_c_(___)",
-          get_signal_name(sig, buf, sizeof(buf)));
+#ifdef ZERO
+    // For Zero, we ignore the crash context, because:
+    //  a) The crash would be in C++ interpreter code, so context is not really relevant;
+    //  b) Generic Zero code would not be able to parse it, so when generic error
+    //     reporting code asks e.g. about frames on stack, Zero would experience
+    //     a secondary ShouldNotCallThis() crash.
+    VMError::report_and_die(t, sig, pc, info, NULL);
 #else
     VMError::report_and_die(t, sig, pc, info, ucVoid);
 #endif

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -618,16 +618,12 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
         pc = os::Posix::ucontext_get_pc(uc);
       }
     }
-#ifdef ZERO
     // For Zero, we ignore the crash context, because:
     //  a) The crash would be in C++ interpreter code, so context is not really relevant;
     //  b) Generic Zero code would not be able to parse it, so when generic error
     //     reporting code asks e.g. about frames on stack, Zero would experience
     //     a secondary ShouldNotCallThis() crash.
-    VMError::report_and_die(t, sig, pc, info, NULL);
-#else
-    VMError::report_and_die(t, sig, pc, info, ucVoid);
-#endif
+    VMError::report_and_die(t, sig, pc, info, NOT_ZERO(ucVoid) ZERO_ONLY(NULL));
     // VMError should not return.
     ShouldNotReachHere();
   }


### PR DESCRIPTION
This manifests on the following `tier1` tests with Linux x86_64 Zero:

runtime/ErrorHandling/ErrorFileRedirectTest.java
runtime/ErrorHandling/SecondaryErrorTest.java
runtime/memory/ReadFromNoaccessArea.java
runtime/Unsafe/InternalErrorTest.java
runtime/Safepoint/TestAbortVMOnSafepointTimeout.java

```
00:17:25 #  Internal Error (/home/shade/trunks/jdk/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp:94), pid=739632, tid=739633
00:17:25 #  Error: ShouldNotCall()
```

```
address os::Posix::ucontext_get_pc(const ucontext_t* uc) {
  ShouldNotCallThis(); <---- crash here
  return NULL; // silence compile warnings
}
```

I believe the generification in JDK-8255711 applies to Zero awkwardly. 

Zero is awkward in the sense it is too generic for its own good. It does not have any access to crash context decoders, and that is why `ucontext_*` parsers are `ShouldNotCallThis()`-ed. Before JDK-8255711, Zero error reporting code was specially crafted to avoid this, apparently.

There are at least two problems:
 1. `ucontext_get_pc` in unimplemented, so we can special-case those for Zero. Instead of returning a bogus value from Zero implementation, I decided to just special-case at its critical use in error reporting.
 2. generic `VMError::report_and_die` circles back at Zero's unimplemented `os::fetch_frame_from_context`. Before JDK-8255711, Zero did `fatal()` that avoided this trouble. The patch ignores the context to match that behavior.

While the regression starts at JDK 16, it affects the path when VM is already crashing, so should not affect product quality per se. Therefore, I would prefer to get it to JDK 17 for some testing, and then maybe consider it for 16.0.{1,2}.

Also, this changeset kills the cat.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259392](https://bugs.openjdk.java.net/browse/JDK-8259392): Zero error reporting is broken after JDK-8255711


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1980/head:pull/1980`
`$ git checkout pull/1980`
