### PR TITLE
8259373: c1 and jvmci runtime code use ResetNoHandleMark incorrectly

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -640,7 +640,7 @@ address Runtime1::exception_handler_for_pc(JavaThread* thread) {
   oop exception = thread->exception_oop();
   address pc = thread->exception_pc();
   // Still in Java mode
-  DEBUG_ONLY(ResetNoHandleMark rnhm);
+  DEBUG_ONLY(NoHandleMark nhm);
   nmethod* nm = NULL;
   address continuation = NULL;
   {
@@ -1307,7 +1307,6 @@ int Runtime1::move_klass_patching(JavaThread* thread) {
   debug_only(NoHandleMark nhm;)
   {
     // Enter VM mode
-
     ResetNoHandleMark rnhm;
     patch_code(thread, load_klass_patching_id);
   }
@@ -1326,7 +1325,6 @@ int Runtime1::move_mirror_patching(JavaThread* thread) {
   debug_only(NoHandleMark nhm;)
   {
     // Enter VM mode
-
     ResetNoHandleMark rnhm;
     patch_code(thread, load_mirror_patching_id);
   }
@@ -1345,7 +1343,6 @@ int Runtime1::move_appendix_patching(JavaThread* thread) {
   debug_only(NoHandleMark nhm;)
   {
     // Enter VM mode
-
     ResetNoHandleMark rnhm;
     patch_code(thread, load_appendix_patching_id);
   }
@@ -1365,14 +1362,14 @@ int Runtime1::move_appendix_patching(JavaThread* thread) {
 // assembly code in the cpu directories.
 //
 int Runtime1::access_field_patching(JavaThread* thread) {
-//
-// NOTE: we are still in Java
-//
-  Thread* THREAD = thread;
-  debug_only(NoHandleMark nhm;)
+  //
+  // NOTE: we are still in Java
+  //
+  // Handles created in this function will be deleted by the
+  // HandleMarkCleaner in the transition to the VM.
+  NoHandleMark nhm;
   {
     // Enter VM mode
-
     ResetNoHandleMark rnhm;
     patch_code(thread, access_field_patching_id);
   }

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -703,8 +703,6 @@ address CompiledMethod::continuation_for_implicit_exception(address pc, bool for
 #ifdef ASSERT
   if (cont_offset == 0) {
     Thread* thread = Thread::current();
-    ResetNoHandleMark rnm; // Might be called from LEAF/QUICK ENTRY
-    HandleMark hm(thread);
     ResourceMark rm(thread);
     CodeBlob* cb = CodeCache::find_blob(pc);
     assert(cb != NULL && cb == this, "");

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -368,7 +368,7 @@ address JVMCIRuntime::exception_handler_for_pc(JavaThread* thread) {
   oop exception = thread->exception_oop();
   address pc = thread->exception_pc();
   // Still in Java mode
-  DEBUG_ONLY(ResetNoHandleMark rnhm);
+  DEBUG_ONLY(NoHandleMark nhm);
   CompiledMethod* cm = NULL;
   address continuation = NULL;
   {


### PR DESCRIPTION
Please review this trivial change to the compiler runtime code.  See CR for details.  Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259373](https://bugs.openjdk.java.net/browse/JDK-8259373): c1 and jvmci runtime code use ResetNoHandleMark incorrectly


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1982/head:pull/1982`
`$ git checkout pull/1982`
