### PR TITLE
8259374: Make ThreadInVMfromNative have ResetNoHandleMark

### DIFF
--- a/src/hotspot/share/ci/ciUtilities.inline.hpp
+++ b/src/hotspot/share/ci/ciUtilities.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
 #define VM_ENTRY_MARK                       \
   CompilerThread* thread=CompilerThread::current(); \
   ThreadInVMfromNative __tiv(thread);       \
-  ResetNoHandleMark rnhm;                   \
   HandleMarkCleaner __hm(thread);           \
   Thread* THREAD = thread;                  \
   debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1803,7 +1803,6 @@ bool CompileBroker::init_compiler_runtime() {
 
     // Switch back to VM state to do compiler initialization
     ThreadInVMfromNative tv(thread);
-    ResetNoHandleMark rnhm;
 
     // Perform per-thread and global initializations
     comp->initialize();

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,7 +374,6 @@ size_t JfrCheckpointManager::write_threads(Thread* thread) {
   assert(thread != NULL, "invariant");
   // can safepoint here
   ThreadInVMfromNative transition(thread->as_Java_thread());
-  ResetNoHandleMark rnhm;
   ResourceMark rm(thread);
   HandleMark hm(thread);
   JfrCheckpointWriter writer(true, thread, THREADS);
@@ -402,7 +401,6 @@ void JfrCheckpointManager::clear_type_set() {
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(t));
   // can safepoint here
   ThreadInVMfromNative transition(t);
-  ResetNoHandleMark rnhm;
   MutexLocker cld_lock(ClassLoaderDataGraph_lock);
   MutexLocker module_lock(Module_lock);
   JfrTypeSet::clear();
@@ -414,7 +412,6 @@ void JfrCheckpointManager::write_type_set() {
     DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(thread));
     // can safepoint here
     ThreadInVMfromNative transition(thread);
-    ResetNoHandleMark rnhm;
     MutexLocker cld_lock(thread, ClassLoaderDataGraph_lock);
     MutexLocker module_lock(thread, Module_lock);
     if (LeakProfiler::is_running()) {
@@ -454,7 +451,6 @@ size_t JfrCheckpointManager::flush_type_set() {
     if (thread->is_Java_thread()) {
       // can safepoint here
       ThreadInVMfromNative transition(thread->as_Java_thread());
-      ResetNoHandleMark rnhm;
       elements = ::flush_type_set(thread);
     } else {
       elements = ::flush_type_set(thread);

--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,6 @@ static void notify() {
   JavaThread* const thread = JavaThread::current();
   // can safepoint here
   ThreadInVMfromNative transition(thread);
-  ResetNoHandleMark rnhm;
   JfrJavaSupport::notify_all(get_chunk_monitor(thread), thread);
 }
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,6 @@ Handle JavaArgumentUnboxer::next_arg(BasicType expectedType) {
 // Bring the JVMCI compiler thread into the VM state.
 #define JVMCI_VM_ENTRY_MARK                   \
   ThreadInVMfromNative __tiv(thread);         \
-  ResetNoHandleMark rnhm;                     \
   HandleMarkCleaner __hm(thread);             \
   Thread* THREAD = thread;                    \
   debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,6 +288,9 @@ class NoHandleMark: public StackObj {
 };
 
 
+// ResetNoHandleMark is called in a context where there is an enclosing
+// NoHandleMark.  Thread in _thread_in_native must not create handles so
+// this is used when transitioning via ThreadInVMfromNative.
 class ResetNoHandleMark: public StackObj {
   int _no_handle_mark_nesting;
  public:

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -289,7 +289,7 @@ class NoHandleMark: public StackObj {
 
 
 // ResetNoHandleMark is called in a context where there is an enclosing
-// NoHandleMark.  Thread in _thread_in_native must not create handles so
+// NoHandleMark. A thread in _thread_in_native must not create handles so
 // this is used when transitioning via ThreadInVMfromNative.
 class ResetNoHandleMark: public StackObj {
   int _no_handle_mark_nesting;

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -192,6 +192,7 @@ class ThreadInVMfromUnknown {
 
 
 class ThreadInVMfromNative : public ThreadStateTransition {
+  ResetNoHandleMark __rnhm;
  public:
   ThreadInVMfromNative(JavaThread* thread) : ThreadStateTransition(thread) {
     trans_from_native(_thread_in_vm);


### PR DESCRIPTION
Please review this straightforward change to add a ResetNoHandleMark in the ThreadInVMfromNative transition class so that callers don't have to do this.  Tested with tier1-3.
This was broken out of a larger change for JDK-8258032 Reconsider LEAF entry restrictions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259374](https://bugs.openjdk.java.net/browse/JDK-8259374): Make ThreadInVMfromNative have ResetNoHandleMark


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to d8114d8d2d3043605d16d0648a7076786b6ef6c9
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1983/head:pull/1983`
`$ git checkout pull/1983`
