### PR TITLE
8259385: Cleanup unused assignment

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
@@ -1103,7 +1103,7 @@ final class CertStatusExtension {
         public byte[] produce(ConnectionContext context,
                 HandshakeMessage message) throws IOException {
             ServerHandshakeContext shc = (ServerHandshakeContext)context;
-            byte[] producedData = null;
+            byte[] producedData;
 
             // Stapling needs to be active and have valid data to proceed
             if (shc.stapleParams == null) {

--- a/src/java.base/share/classes/sun/security/ssl/CertificateStatus.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ final class CertificateStatus {
     static final class CertificateStatusMessage extends HandshakeMessage {
 
         final CertStatusRequestType statusType;
-        int encodedResponsesLen = 0;
-        int messageLength = -1;
+        final int encodedResponsesLen;
+        final int messageLength;
         final List<byte[]> encodedResponses = new ArrayList<>();
 
         CertificateStatusMessage(HandshakeContext handshakeContext) {
@@ -114,6 +114,7 @@ final class CertificateStatus {
             // Walk the certificate list and add the correct encoded responses
             // to the encoded responses list
             statusType = stapleParams.statReqType;
+            int encodedLen = 0;
             if (statusType == CertStatusRequestType.OCSP) {
                 // Just worry about the first cert in the chain
                 byte[] resp = stapleParams.responseMap.get(certChain[0]);
@@ -124,7 +125,7 @@ final class CertificateStatus {
                     resp = new byte[0];
                 }
                 encodedResponses.add(resp);
-                encodedResponsesLen += resp.length + 3;
+                encodedLen += resp.length + 3;
             } else if (statusType == CertStatusRequestType.OCSP_MULTI) {
                 for (X509Certificate cert : certChain) {
                     byte[] resp = stapleParams.responseMap.get(cert);
@@ -132,14 +133,15 @@ final class CertificateStatus {
                         resp = new byte[0];
                     }
                     encodedResponses.add(resp);
-                    encodedResponsesLen += resp.length + 3;
+                    encodedLen += resp.length + 3;
                 }
             } else {
                 throw new IllegalArgumentException(
                         "Unsupported StatusResponseType: " + statusType);
             }
 
-            messageLength = messageLength();
+            encodedResponsesLen = encodedLen;
+            messageLength = messageLength(statusType, encodedResponsesLen);
         }
 
         CertificateStatusMessage(HandshakeContext handshakeContext,
@@ -182,7 +184,18 @@ final class CertificateStatus {
                         Alert.HANDSHAKE_FAILURE,
                         "Unsupported StatusResponseType: " + statusType);
             }
-            messageLength = messageLength();
+            messageLength = messageLength(statusType, encodedResponsesLen);
+        }
+
+        private static int messageLength(
+                CertStatusRequestType statusType, int encodedResponsesLen) {
+            if (statusType == CertStatusRequestType.OCSP) {
+                return 1 + encodedResponsesLen;
+            } else if (statusType == CertStatusRequestType.OCSP_MULTI) {
+                return 4 + encodedResponsesLen;
+            }
+
+            return -1;
         }
 
         @Override
@@ -192,17 +205,6 @@ final class CertificateStatus {
 
         @Override
         public int messageLength() {
-            int len = 1;
-
-            if (messageLength == -1) {
-                if (statusType == CertStatusRequestType.OCSP) {
-                    len += encodedResponsesLen;
-                } else if (statusType == CertStatusRequestType.OCSP_MULTI) {
-                    len += 3 + encodedResponsesLen;
-                }
-                messageLength = len;
-            }
-
             return messageLength;
         }
 
@@ -214,11 +216,7 @@ final class CertificateStatus {
             } else if (statusType == CertStatusRequestType.OCSP_MULTI) {
                 s.putInt24(encodedResponsesLen);
                 for (byte[] respBytes : encodedResponses) {
-                    if (respBytes != null) {
-                        s.putBytes24(respBytes);
-                    } else {
-                        s.putBytes24(null);
-                    }
+                    s.putBytes24(respBytes);
                 }
             } else {
                 // It is highly unlikely that we will fall into this section

--- a/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ final class CertificateVerify {
 
             // This happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-            byte[] temproary = null;
+            byte[] temproary;
             String algorithm = x509Possession.popPrivateKey.getAlgorithm();
             try {
                 Signature signer =
@@ -194,7 +194,7 @@ final class CertificateVerify {
          */
         private static Signature getSignature(String algorithm,
                 Key key) throws GeneralSecurityException {
-            Signature signer = null;
+            Signature signer;
             switch (algorithm) {
                 case "RSA":
                     signer = Signature.getInstance(JsseJce.SIGNATURE_RAWRSA);
@@ -330,7 +330,7 @@ final class CertificateVerify {
 
             // This happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-            byte[] temproary = null;
+            byte[] temproary;
             String algorithm = x509Possession.popPrivateKey.getAlgorithm();
             try {
                 Signature signer =
@@ -448,7 +448,7 @@ final class CertificateVerify {
          */
         private static Signature getSignature(String algorithm,
                 Key key) throws GeneralSecurityException {
-            Signature signer = null;
+            Signature signer;
             switch (algorithm) {
                 case "RSA":
                     signer = Signature.getInstance(JsseJce.SIGNATURE_RAWRSA);
@@ -605,7 +605,7 @@ final class CertificateVerify {
             }
 
             this.signatureScheme = schemeAndSigner.getKey();
-            byte[] temproary = null;
+            byte[] temproary;
             try {
                 Signature signer = schemeAndSigner.getValue();
                 signer.update(chc.handshakeHash.archived());
@@ -930,7 +930,7 @@ final class CertificateVerify {
                         serverSignHead.length, hashValue.length);
             }
 
-            byte[] temproary = null;
+            byte[] temproary;
             try {
                 Signature signer = schemeAndSigner.getValue();
                 signer.update(contentCovered);

--- a/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
@@ -74,7 +74,7 @@ final class CertificateVerify {
 
             // This happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-            byte[] temproary;
+            byte[] temporary;
             String algorithm = x509Possession.popPrivateKey.getAlgorithm();
             try {
                 Signature signer =
@@ -82,7 +82,7 @@ final class CertificateVerify {
                 byte[] hashes = chc.handshakeHash.digest(algorithm,
                         chc.handshakeSession.getMasterSecret());
                 signer.update(hashes);
-                temproary = signer.sign();
+                temporary = signer.sign();
             } catch (NoSuchAlgorithmException nsae) {
                 throw chc.conContext.fatal(Alert.INTERNAL_ERROR,
                         "Unsupported signature algorithm (" + algorithm +
@@ -92,7 +92,7 @@ final class CertificateVerify {
                         "Cannot produce CertificateVerify signature", gse);
             }
 
-            this.signature = temproary;
+            this.signature = temporary;
         }
 
         S30CertificateVerifyMessage(HandshakeContext context,
@@ -330,14 +330,14 @@ final class CertificateVerify {
 
             // This happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-            byte[] temproary;
+            byte[] temporary;
             String algorithm = x509Possession.popPrivateKey.getAlgorithm();
             try {
                 Signature signer =
                         getSignature(algorithm, x509Possession.popPrivateKey);
                 byte[] hashes = chc.handshakeHash.digest(algorithm);
                 signer.update(hashes);
-                temproary = signer.sign();
+                temporary = signer.sign();
             } catch (NoSuchAlgorithmException nsae) {
                 throw chc.conContext.fatal(Alert.INTERNAL_ERROR,
                         "Unsupported signature algorithm (" + algorithm +
@@ -347,7 +347,7 @@ final class CertificateVerify {
                     "Cannot produce CertificateVerify signature", gse);
             }
 
-            this.signature = temproary;
+            this.signature = temporary;
         }
 
         T10CertificateVerifyMessage(HandshakeContext context,
@@ -605,17 +605,17 @@ final class CertificateVerify {
             }
 
             this.signatureScheme = schemeAndSigner.getKey();
-            byte[] temproary;
+            byte[] temporary;
             try {
                 Signature signer = schemeAndSigner.getValue();
                 signer.update(chc.handshakeHash.archived());
-                temproary = signer.sign();
+                temporary = signer.sign();
             } catch (SignatureException ikse) {
                 throw chc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Cannot produce CertificateVerify signature", ikse);
             }
 
-            this.signature = temproary;
+            this.signature = temporary;
         }
 
         T12CertificateVerifyMessage(HandshakeContext handshakeContext,
@@ -930,17 +930,17 @@ final class CertificateVerify {
                         serverSignHead.length, hashValue.length);
             }
 
-            byte[] temproary;
+            byte[] temporary;
             try {
                 Signature signer = schemeAndSigner.getValue();
                 signer.update(contentCovered);
-                temproary = signer.sign();
+                temporary = signer.sign();
             } catch (SignatureException ikse) {
                 throw context.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Cannot produce CertificateVerify signature", ikse);
             }
 
-            this.signature = temproary;
+            this.signature = temporary;
         }
 
         T13CertificateVerifyMessage(HandshakeContext context,

--- a/src/java.base/share/classes/sun/security/ssl/DHServerKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/DHServerKeyExchange.java
@@ -123,7 +123,7 @@ final class DHServerKeyExchange {
             } else {
                 useExplicitSigAlgorithm =
                         shc.negotiatedProtocol.useTLS12PlusSpec();
-                Signature signer = null;
+                Signature signer;
                 if (useExplicitSigAlgorithm) {
                     Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                             SignatureScheme.getSignerOfPreferableAlgorithm(
@@ -155,7 +155,7 @@ final class DHServerKeyExchange {
                     }
                 }
 
-                byte[] signature = null;
+                byte[] signature;
                 try {
                     updateSignature(signer, shc.clientHelloRandom.randomBytes,
                             shc.serverHelloRandom.randomBytes);
@@ -415,7 +415,7 @@ final class DHServerKeyExchange {
 
         private static Signature getSignature(String keyAlgorithm,
                 Key key) throws NoSuchAlgorithmException, InvalidKeyException {
-            Signature signer = null;
+            Signature signer;
             switch (keyAlgorithm) {
                 case "DSA":
                     signer = Signature.getInstance(JsseJce.SIGNATURE_DSA);

--- a/src/java.base/share/classes/sun/security/ssl/DTLSInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSInputRecord.java
@@ -1118,7 +1118,7 @@ final class DTLSInputRecord extends InputRecord implements DTLSRecord {
             bufferedFragments.remove(rFrag);    // popup the fragment
 
             ByteBuffer fragment = ByteBuffer.wrap(rFrag.fragment);
-            ByteBuffer plaintextFragment = null;
+            ByteBuffer plaintextFragment;
             try {
                 Plaintext plaintext = readCipher.decrypt(
                         rFrag.contentType, fragment, rFrag.recordEnS);

--- a/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
@@ -367,7 +367,6 @@ final class ECDHClientKeyExchange {
 
             SSLCredentials sslCredentials = null;
             NamedGroup ng = null;
-            PublicKey publicKey = null;
 
             // Find a good EC/XEC credential to use, determine the
             // NamedGroup to use for creating Possessions/Credentials/Keys.
@@ -375,7 +374,6 @@ final class ECDHClientKeyExchange {
                 if (cd instanceof NamedGroupCredentials) {
                     NamedGroupCredentials creds = (NamedGroupCredentials)cd;
                     ng = creds.getNamedGroup();
-                    publicKey = creds.getPublicKey();
                     sslCredentials = cd;
                     break;
                 }

--- a/src/java.base/share/classes/sun/security/ssl/ECDHServerKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHServerKeyExchange.java
@@ -133,7 +133,7 @@ final class ECDHServerKeyExchange {
             } else {
                 useExplicitSigAlgorithm =
                         shc.negotiatedProtocol.useTLS12PlusSpec();
-                Signature signer = null;
+                Signature signer;
                 if (useExplicitSigAlgorithm) {
                     Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                             SignatureScheme.getSignerOfPreferableAlgorithm(
@@ -165,7 +165,7 @@ final class ECDHServerKeyExchange {
                     }
                 }
 
-                byte[] signature = null;
+                byte[] signature;
                 try {
                     updateSignature(signer, shc.clientHelloRandom.randomBytes,
                             shc.serverHelloRandom.randomBytes,
@@ -419,7 +419,7 @@ final class ECDHServerKeyExchange {
 
         private static Signature getSignature(String keyAlgorithm,
                 Key key) throws NoSuchAlgorithmException, InvalidKeyException {
-            Signature signer = null;
+            Signature signer;
             switch (keyAlgorithm) {
                 case "EC":
                     signer = Signature.getInstance(JsseJce.SIGNATURE_ECDSA);

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -79,7 +79,7 @@ final class Finished {
             VerifyDataScheme vds =
                     VerifyDataScheme.valueOf(context.negotiatedProtocol);
 
-            byte[] vd = null;
+            byte[] vd;
             try {
                 vd = vds.createVerifyData(context, false);
             } catch (IOException ioe) {

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -486,7 +486,7 @@ abstract class OutputRecord
         }
 
         // use the right TLSCiphertext.opaque_type and legacy_record_version
-        ProtocolVersion pv = protocolVersion;
+        ProtocolVersion pv;
         if (!encCipher.isNullCipher()) {
             pv = ProtocolVersion.TLS12;
             contentType = ContentType.APPLICATION_DATA.id;

--- a/src/java.base/share/classes/sun/security/ssl/RSAKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/RSAKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ final class RSAKeyExchange {
                 byte[] encrypted) throws GeneralSecurityException {
 
             byte[] encoded = null;
-            boolean needFailover = false;
+            boolean needFailover;
             Cipher cipher = Cipher.getInstance(JsseJce.CIPHER_RSA_PKCS1);
             try {
                 // Try UNWRAP_MODE mode firstly.

--- a/src/java.base/share/classes/sun/security/ssl/RSAServerKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/RSAServerKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ final class RSAServerKeyExchange {
             RSAPublicKeySpec spec = JsseJce.getRSAPublicKeySpec(publicKey);
             this.modulus = Utilities.toByteArray(spec.getModulus());
             this.exponent = Utilities.toByteArray(spec.getPublicExponent());
-            byte[] signature = null;
+            byte[] signature;
             try {
                 Signature signer = RSASignature.getInstance();
                 signer.initSign(x509Possession.popPrivateKey,

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2200,7 +2200,7 @@ enum SSLCipher {
 
                 // DON'T decrypt the nonce_explicit for AEAD mode. The buffer
                 // position has moved out of the nonce_explicit range.
-                int len = bb.remaining();
+                int len;
                 int pos = bb.position();
                 ByteBuffer dup = bb.duplicate();
                 try {
@@ -2320,7 +2320,6 @@ enum SSLCipher {
                 cipher.updateAAD(aad);
 
                 // DON'T encrypt the nonce for AEAD mode.
-                int len = bb.remaining();
                 int pos = bb.position();
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
@@ -2339,6 +2338,7 @@ enum SSLCipher {
                     bb.limit(pos + outputSize);
                 }
 
+                int len;
                 try {
                     len = cipher.doFinal(dup, bb);
                 } catch (IllegalBlockSizeException |
@@ -2470,7 +2470,7 @@ enum SSLCipher {
                                         contentType, bb.remaining(), sn);
                 cipher.updateAAD(aad);
 
-                int len = bb.remaining();
+                int len;
                 int pos = bb.position();
                 ByteBuffer dup = bb.duplicate();
                 try {
@@ -2602,7 +2602,6 @@ enum SSLCipher {
                                         contentType, outputSize, sn);
                 cipher.updateAAD(aad);
 
-                int len = bb.remaining();
                 int pos = bb.position();
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
@@ -2620,6 +2619,7 @@ enum SSLCipher {
                     bb.limit(pos + outputSize);
                 }
 
+                int len;
                 try {
                     len = cipher.doFinal(dup, bb);
                 } catch (IllegalBlockSizeException |

--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1023,9 +1023,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                     passwd = defaultKeyStorePassword.toCharArray();
                 }
 
-                /**
-                 * Try to initialize key store.
-                 */
+                // Try to initialize key store.
                 if ((defaultKeyStoreType.length()) != 0) {
                     if (SSLLogger.isOn && SSLLogger.isOn("ssl,defaultctx")) {
                         SSLLogger.finest("init keystore");
@@ -1304,7 +1302,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         private static final List<CipherSuite> clientDefaultCipherSuites;
         private static final List<CipherSuite> serverDefaultCipherSuites;
 
-        private static IllegalArgumentException reservedException = null;
+        private static IllegalArgumentException reservedException;
 
         // Don't want a java.lang.LinkageError for illegal system property.
         //

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,7 @@ final class SSLEngineInputRecord extends InputRecord implements SSLRecord {
 
         int pos = packet.position();
         byte byteZero = packet.get(pos);
-
-        int len = 0;
+        int len;
 
         /*
          * If we have already verified previous packets, we can

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -307,9 +307,6 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      */
 
     SSLSessionImpl(HandshakeContext hc, ByteBuffer buf) throws IOException {
-        int i = 0;
-        byte[] b;
-
         boundValues = new ConcurrentHashMap<>();
         this.protocolVersion =
                 ProtocolVersion.valueOf(Short.toUnsignedInt(buf.getShort()));
@@ -323,7 +320,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
 
         // Local Supported signature algorithms
         ArrayList<SignatureScheme> list = new ArrayList<>();
-        i = Byte.toUnsignedInt(buf.get());
+        int i = Byte.toUnsignedInt(buf.get());
         while (i-- > 0) {
             list.add(SignatureScheme.valueOf(
                     Short.toUnsignedInt(buf.getShort())));
@@ -340,6 +337,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         this.peerSupportedSignAlgs = Collections.unmodifiableCollection(list);
 
         // PSK
+        byte[] b;
         i = Short.toUnsignedInt(buf.getShort());
         if (i > 0) {
             b = new byte[i];

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -74,7 +74,7 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         }
 
         byte byteZero = header[0];
-        int len = 0;
+        int len;
 
         /*
          * If we have already verified previous packets, we can

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ interface SSLTransport {
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
         ByteBuffer[] dsts, int dstsOffset, int dstsLength) throws IOException {
 
-        Plaintext[] plaintexts = null;
+        Plaintext[] plaintexts;
         try {
             plaintexts =
                     context.inputRecord.decode(srcs, srcsOffset, srcsLength);

--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,7 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
                 "null or zero-length authentication type");
         }
 
-        Validator v = null;
+        Validator v;
         if (checkClientTrusted) {
             v = clientValidator;
             if (v == null) {
@@ -197,7 +197,7 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
             boolean checkClientTrusted) throws CertificateException {
         Validator v = checkTrustedInit(chain, authType, checkClientTrusted);
 
-        X509Certificate[] trustedChain = null;
+        X509Certificate[] trustedChain;
         if ((socket != null) && socket.isConnected() &&
                                         (socket instanceof SSLSocket)) {
 
@@ -254,7 +254,7 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
             boolean checkClientTrusted) throws CertificateException {
         Validator v = checkTrustedInit(chain, authType, checkClientTrusted);
 
-        X509Certificate[] trustedChain = null;
+        X509Certificate[] trustedChain;
         if (engine != null) {
             SSLSession session = engine.getHandshakeSession();
             if (session == null) {


### PR DESCRIPTION
In the SunJSSE provider implementation, there are a few cases that the assigned value is never used.  For example:
```
  int i = 0;
  i = Byte.toUnsignedInt(buf.get());
```
could be simplified as
`    int i = Byte.toUnsignedInt(buf.get());`

Code cleanup, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259385](https://bugs.openjdk.java.net/browse/JDK-8259385): Cleanup unused assignment


### Reviewers
 * [Attila Szegedi](https://openjdk.java.net/census#attila) (@szegedi - **Reviewer**) ⚠️ Review applies to 9a31381bcac34391013c51452fc89492480dbbc0


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1984/head:pull/1984`
`$ git checkout pull/1984`
