### PR TITLE
8259403: Zero: crash with NULL MethodHandle receiver

### DIFF
--- a/src/hotspot/cpu/zero/methodHandles_zero.hpp
+++ b/src/hotspot/cpu/zero/methodHandles_zero.hpp
@@ -32,7 +32,10 @@ enum /* platform_dependent_constants */ {
 private:
   static oop popFromStack(TRAPS);
   static void invoke_target(Method* method, TRAPS);
+  static void setup_frame_anchor(JavaThread* thread);
+  static void teardown_frame_anchor(JavaThread* thread);
   static void throw_AME(Klass* rcvr, Method* interface_method, TRAPS);
+  static void throw_NPE(TRAPS);
   static int method_handle_entry_invokeBasic(Method* method, intptr_t UNUSED, TRAPS);
   static int method_handle_entry_linkToStaticOrSpecial(Method* method, intptr_t UNUSED, TRAPS);
   static int method_handle_entry_linkToVirtual(Method* method, intptr_t UNUSED, TRAPS);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -632,6 +632,10 @@ JRT_ENTRY(void, InterpreterRuntime::throw_IncompatibleClassChangeErrorVerbose(Ja
   THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), buf);
 JRT_END
 
+JRT_ENTRY(void, InterpreterRuntime::throw_NullPointerException(JavaThread* thread))
+  THROW(vmSymbols::java_lang_NullPointerException());
+JRT_END
+
 //------------------------------------------------------------------------------------------------------------------------
 // Fields
 //

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -82,6 +82,8 @@ class InterpreterRuntime: AllStatic {
   static void    throw_delayed_StackOverflowError(JavaThread* thread);
   static void    throw_ArrayIndexOutOfBoundsException(JavaThread* thread, arrayOopDesc* a, jint index);
   static void    throw_ClassCastException(JavaThread* thread, oopDesc* obj);
+  static void    throw_NullPointerException(JavaThread* thread);
+
   static void    create_exception(JavaThread* thread, char* name, char* message);
   static void    create_klass_exception(JavaThread* thread, char* name, oopDesc* obj);
   static address exception_handler_for_exception(JavaThread* thread, oopDesc* exception);


### PR DESCRIPTION
Happens reliably:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=compiler/jsr292/NullConstantReceiver.java
# A fatal error has been detected by the Java Runtime Environment:
# SIGSEGV (0xb) at pc=0x0000000000000000, pid=4059994, tid=4060008
```

Zero's MH handling code does not check if receiver is NULL before accessing its klass.

Additional testing:
 - [x] Linux x86_64 Zero `compiler/jsr292/NullConstantReceiver.java`
 - [x] Linux x86_64 Zero `tier1` (no new failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259403](https://bugs.openjdk.java.net/browse/JDK-8259403): Zero: crash with NULL MethodHandle receiver


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1987/head:pull/1987`
`$ git checkout pull/1987`
