### PR TITLE
8259216: javadoc omits method receiver for any nested type annotation

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -85,7 +85,7 @@ import javax.lang.model.util.ElementKindVisitor14;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleAnnotationValueVisitor14;
 import javax.lang.model.util.SimpleElementVisitor14;
-import javax.lang.model.util.SimpleTypeVisitor9;
+import javax.lang.model.util.SimpleTypeVisitor14;
 import javax.lang.model.util.TypeKindVisitor9;
 import javax.lang.model.util.Types;
 import javax.tools.FileObject;
@@ -628,7 +628,7 @@ public class Utils {
     }
 
     public boolean isPrimitive(TypeMirror t) {
-        return new SimpleTypeVisitor9<Boolean, Void>() {
+        return new SimpleTypeVisitor14<Boolean, Void>() {
 
             @Override
             public Boolean visitNoType(NoType t, Void p) {
@@ -733,7 +733,7 @@ public class Utils {
     }
 
     public String getTypeSignature(TypeMirror t, boolean qualifiedName, boolean noTypeParameters) {
-        return new SimpleTypeVisitor9<StringBuilder, Void>() {
+        return new SimpleTypeVisitor14<StringBuilder, Void>() {
             final StringBuilder sb = new StringBuilder();
 
             @Override
@@ -1211,7 +1211,7 @@ public class Utils {
      *         or null if it is a primitive type.
      */
     public TypeElement asTypeElement(TypeMirror t) {
-        return new SimpleTypeVisitor9<TypeElement, Void>() {
+        return new SimpleTypeVisitor14<TypeElement, Void>() {
 
             @Override
             public TypeElement visitDeclared(DeclaredType t, Void p) {
@@ -1267,7 +1267,7 @@ public class Utils {
      * @return the type's dimension information as a string.
      */
     public String getDimension(TypeMirror t) {
-        return new SimpleTypeVisitor9<String, Void>() {
+        return new SimpleTypeVisitor14<String, Void>() {
             StringBuilder dimension = new StringBuilder();
             @Override
             public String visitArray(ArrayType t, Void p) {
@@ -1379,7 +1379,7 @@ public class Utils {
     private final Map<String, String> kindNameMap = new HashMap<>();
 
     public String getTypeName(TypeMirror t, boolean fullyQualified) {
-        return new SimpleTypeVisitor9<String, Void>() {
+        return new SimpleTypeVisitor14<String, Void>() {
 
             @Override
             public String visitArray(ArrayType t, Void p) {
@@ -1764,7 +1764,7 @@ public class Utils {
      * @return the fully qualified name of Reference type or the primitive name
      */
     public String getQualifiedTypeName(TypeMirror t) {
-        return new SimpleTypeVisitor9<String, Void>() {
+        return new SimpleTypeVisitor14<String, Void>() {
             @Override
             public String visitDeclared(DeclaredType t, Void p) {
                 return getFullyQualifiedName(t.asElement());

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      8005091 8009686 8025633 8026567 6469562 8071982 8071984 8162363 8175200 8186332 8182765
- *           8187288 8241969
+ *           8187288 8241969 8259216
  * @summary  Make sure that type annotations are displayed correctly
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -371,7 +371,7 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">withException</span>&#8203;<span class="parameters">(<a href\
-                    ="RcvrA.html" title="annotation in typeannos">@RcvrA</a>&nbsp;DefaultUnmodified&\
+                    ="RcvrA.html" title="annotation in typeannos">@RcvrA</a> DefaultUnmodified&\
                     nbsp;this)</span>
                                 throws <span class="exceptions">java.lang.Exception</span></div>""",
 
@@ -379,14 +379,14 @@ public class TestTypeAnnotations extends JavadocTester {
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&\
                     nbsp;<span class="element-name">nonVoid</span>&#8203;<span class="parameters">(<a href="\
                     RcvrA.html" title="annotation in typeannos">@RcvrA</a> <a href="RcvrB.html" titl\
-                    e="annotation in typeannos">@RcvrB</a>("m")&nbsp;DefaultUnmodified&nbsp;this)</s\
+                    e="annotation in typeannos">@RcvrB</a>("m") DefaultUnmodified&nbsp;this)</s\
                     pan></div>""",
 
                 """
                     <div class="member-signature"><span class="type-parameters">&lt;T extends java.l\
                     ang.Runnable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span cl\
                     ass="element-name">accept</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation in typeannos">@RcvrA</a>&nbsp;DefaultUnmodified&nbsp;thi\
+                    html" title="annotation in typeannos">@RcvrA</a> DefaultUnmodified&nbsp;thi\
                     s,
                      T&nbsp;r)</span>
                                                         throws <span class="exceptions">java.lang.Exception</span></div>""");
@@ -396,14 +396,14 @@ public class TestTypeAnnotations extends JavadocTester {
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">nonVoid\
                     </span>&#8203;<span class="parameters">(<a href="RcvrA.html" title="annotation i\
-                    n typeannos">@RcvrA</a>&nbsp;PublicModified&nbsp;this)</span></div>""",
+                    n typeannos">@RcvrA</a> PublicModified&nbsp;this)</span></div>""",
 
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="type-parameters">&lt;T extends java.lang.Runnable&gt;</span>&nbsp;<s\
                     pan class="return-type">void</span>&nbsp;<span class="element-name">accept</span>&#8203;\
                     <span class="parameters">(<a href="RcvrA.html" title="annotation in typea\
-                    nnos">@RcvrA</a>&nbsp;PublicModified&nbsp;this,
+                    nnos">@RcvrA</a> PublicModified&nbsp;this,
                      T&nbsp;r)</span>
                                                                      throws <span class="exceptions">java.lang.Exception</span></div>""");
 
@@ -412,7 +412,7 @@ public class TestTypeAnnotations extends JavadocTester {
                     <div class="member-signature"><span class="type-parameters">&lt;T extends java.l\
                     ang.Runnable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span cl\
                     ass="element-name">accept</span>&#8203;<span class="parameters">(<a href="RcvrB.\
-                    html" title="annotation in typeannos">@RcvrB</a>("m")&nbsp;WithValue&nbsp;this,
+                    html" title="annotation in typeannos">@RcvrB</a>("m") WithValue&nbsp;this,
                      T&nbsp;r)</span>
                                                         throws <span class="exceptions">java.lang.Exception</span></div>""");
 
@@ -427,15 +427,28 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">field</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation in typeannos">@RcvrA</a>&nbsp;WithBody&nbsp;this)</span>\
+                    html" title="annotation in typeannos">@RcvrA</a> WithBody&nbsp;this)</span>\
                     </div>""");
 
         checkOutput("typeannos/Generic2.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
+                    lass="element-name">test1</span>()</div>""",
+                """
+                    <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">test2</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation in typeannos">@RcvrA</a>&nbsp;Generic2&lt;X&gt;&nbsp;thi\
-                    s)</span></div>""");
+                    html" title="annotation in typeannos">@RcvrA</a> Generic2&lt;X&gt;&nbsp;thi\
+                    s)</span></div>""",
+                """
+                    <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
+                    lass="element-name">test3</span>&#8203;<span class="parameters">(Generic2&lt;<a \
+                    href="RcvrA.html" title="annotation in typeannos">@RcvrA</a> X&gt;&nbsp;this)</s\
+                    pan></div>""",
+                """
+                   <div class="member-signature"><span class="return-type">void</span>&nbsp;<span cl\
+                   ass="element-name">test4</span>&#8203;<span class="parameters">(<a href="RcvrA.ht\
+                   ml" title="annotation in typeannos">@RcvrA</a> Generic2&lt;<a href="RcvrA.html" t\
+                   itle="annotation in typeannos">@RcvrA</a> X&gt;&nbsp;this)</span></div>""");
 
 
         // Test for repeated type annotations (RepeatedAnnotations.java).
@@ -535,7 +548,8 @@ public class TestTypeAnnotations extends JavadocTester {
                     nnotation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annot\
                     ation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotatio\
                     n in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation in\
-                     typeannos">@RepTypeUseB</a>&nbsp;RepeatingOnConstructor&nbsp;this,
+                     typeannos">@RepTypeUseB</a> <a href="RepeatingOnConstructor.html" title="class \
+                    in typeannos">RepeatingOnConstructor</a>&nbsp;RepeatingOnConstructor.this,
                      <a href="RepParameterA.html" title="annotation in typeannos">@RepParameterA</a> \
                     <a href="RepParameterA.html" title="annotation in typeannos">@RepParameterA</a> \
                     <a href="RepParameterB.html" title="annotation in typeannos">@RepParameterB</a> \
@@ -743,7 +757,7 @@ public class TestTypeAnnotations extends JavadocTester {
                     RepTypeUseA</a> <a href="RepTypeUseA.html" title="annotation in typeannos">@RepT\
                     ypeUseA</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeU\
                     seB</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeUseB<\
-                    /a>&nbsp;RepeatingOnMethod&nbsp;this,
+                    /a> RepeatingOnMethod&nbsp;this,
                      <a href="RepParameterA.html" title="annotation in typeannos">@RepParameterA</a> \
                     <a href="RepParameterA.html" title="annotation in typeannos">@RepParameterA</a> \
                     <a href="RepParameterB.html" title="annotation in typeannos">@RepParameterB</a> \
@@ -781,7 +795,7 @@ public class TestTypeAnnotations extends JavadocTester {
                     on in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annotation i\
                     n typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotation in ty\
                     peannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation in typean\
-                    nos">@RepTypeUseB</a>&nbsp;RepeatingOnTypeParametersBoundsTypeArgumentsOnMethod&\
+                    nos">@RepTypeUseB</a> RepeatingOnTypeParametersBoundsTypeArgumentsOnMethod&\
                     lt;<a href="RepTypeUseA.html" title="annotation in typeannos">@RepTypeUseA</a> <\
                     a href="RepTypeUseA.html" title="annotation in typeannos">@RepTypeUseA</a> <a hr\
                     ef="RepTypeUseB.html" title="annotation in typeannos">@RepTypeUseB</a> <a href="\


### PR DESCRIPTION
Fixes the bug where receiver type is omitted in generated Javadoc when the immediate receiver type is not annotated (but some other type within is).

In addition, fixed the bug where receiver type for constructor is not properly qualified (without a clickable link), i.e. `OuterClass.this` vs `this`.

Testing can is done with these two Java Files:
`Ape.java`
```java
public class Ape<T> {
	public void m0(@Cute("m0") Ape<T>this) {}
	public void m1(@Cute("m1 outer")Ape<@Cute("m1 inner") T>this) {}
	public void m2(Ape<@Cute("m2") T>this) {}
	public void m3(Ape<T> this) {}
	public class Bee<Q, R> {
		public Bee(Ape<@Cute("parent ape's T") T> Ape.this) {}
                public Bee(@Cute("top level") Ape<T> Ape.this, Void varArg) {}
		public void f0(Ape<T>.Bee<Q, R> this) {}
		public void f1(Ape<T>.Bee<@Cute("Bee Q f1") Q, R> this) {}
		public void f2(Ape<T>.@Cute("Bee f2") Bee<Q, R> this) {}
		public void f3(Ape<@Cute("Ape T f3") T>.Bee<Q, R> this, Ape<@Cute("A regular param's ape T") Throwable>.Bee<Integer, Long> anotherParam) {}
	}
}
```

`Cute.java`
```java
import java.lang.annotation.Documented;
import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;
import java.lang.annotation.Target;

@Documented
@Target(ElementType.TYPE_USE)
@Retention(RetentionPolicy.RUNTIME)
public @interface Cute {
	String value() default "";
}

```

Before the fix (tested in oracle jdk 15.0.1):
 - javadoc misses receiver for `Ape#m2()` `Bee#<init>()` `Bee#f1()` `Bee#f3(Bee)` in the method details section 
 - javadoc's receiver for `Bee#<init>(Void)` is unqualified; such unqualified receiver fails in `javac`
After the fix:
 - The 4 methods now have receivers in method details.
   - `Ape#m3` `Bee#f0` still don't have receivers documented as their receivers are not annotated
   - `Bee#f3(Bee)`'s receiver is not annotated due to a distinct bug
 - javadoc's receiver for `Bee#<init>(Void)` is now qualified as `Bee.this` (without a link on `Bee`)

(Note: receiver parameters are never included in the method summary section; they only present in method details sections)

Non goal:
 - Won't fix the bug that a nested type's parent's type parameters are not documented, such as in `Ape.Bee#f3` in this example

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259216](https://bugs.openjdk.java.net/browse/JDK-8259216): javadoc omits method receiver for any nested type annotation


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1997/head:pull/1997`
`$ git checkout pull/1997`
