### PR TITLE
8259451: Zero: skip serviceability/sa tests, set vm.hasSA to false

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -226,6 +226,9 @@ public class Platform {
      * on this platform.
      */
     public static boolean hasSA() {
+        if (isZero()) {
+            return false; // SA is not enabled.
+        }
         if (isAix()) {
             return false; // SA not implemented.
         } else if (isLinux()) {


### PR DESCRIPTION
Zero does not build SA (see make/autoconf/jdk-options.m4), yet the serviceability/sa tests do not know about this, because vm.hasSA is still "true" for Zero. This makes Serviceability test fail for no good reason. The tests should be skipped for Zero.

Additional testing:
 - [x] Linux x86_64 Zero `serviceability/sa` tests (now skipped)
 - [x] Linux x86_64 Server `serviceability/sa` tests (still run)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259451](https://bugs.openjdk.java.net/browse/JDK-8259451): Zero: skip serviceability/sa tests, set vm.hasSA to false


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1999/head:pull/1999`
`$ git checkout pull/1999`
