### PR TITLE
8259446: runtime/jni/checked/TestCheckedReleaseArrayElements.java fails with stderr not empty

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
@@ -44,10 +44,11 @@ public class TestCheckedReleaseArrayElements {
         if (args == null || args.length == 0) {
             test();
         } else {
-            OutputAnalyzer output =
-                ProcessTools.executeTestJvm("-Xcheck:jni",
-                                            "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                                            "TestCheckedReleaseArrayElements");
+            ProcessBuilder pb =
+                ProcessTools.createJavaProcessBuilder("-Xcheck:jni",
+                                                      "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                                      "TestCheckedReleaseArrayElements");
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);
             output.stderrShouldBeEmpty();
             output.stdoutShouldNotBeEmpty();

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
@@ -44,6 +44,8 @@ public class TestCheckedReleaseArrayElements {
         if (args == null || args.length == 0) {
             test();
         } else {
+            // Uses executeProcess() instead of executeTestJvm() to avoid passing options
+            // that might generate output on stderr (which should be empty for this test).
             ProcessBuilder pb =
                 ProcessTools.createJavaProcessBuilder("-Xcheck:jni",
                                                       "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,


### PR DESCRIPTION
The test checks stderr is empty.
The test is run in our tier3 CI testing.
Tier3 (and some other tiers) has a configuration that includes the -showversion flag which outputs the version string to stderr.

=> ergo the test fails because stderr is not empty!

Fix: exec the secondary VM without including the jtreg test VM arguments.

I think this is really a bug in our test job definitions and we've been very lucky to not encounter problems with using `-showversion`, but as a quick fix this suffices, and we don't expect any other JVM flags to have any impact here.

Tested by running jtreg with/without -showversion being passed to JVM under test.
Tier3 test run in progress too.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259446](https://bugs.openjdk.java.net/browse/JDK-8259446): runtime/jni/checked/TestCheckedReleaseArrayElements.java fails with stderr not empty


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2001/head:pull/2001`
`$ git checkout pull/2001`
