### PR TITLE
8259475: Fix bad merge in compilerOracle

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -410,19 +410,6 @@ bool CompilerOracle::should_break_at(const methodHandle& method) {
   return check_predicate(CompileCommand::Break, method);
 }
 
-bool CompilerOracle::should_blackhole(const methodHandle& method) {
-  if (!check_predicate(CompileCommand::Blackhole, method)) {
-    return false;
-  }
-  guarantee(UnlockDiagnosticVMOptions, "Checked during initial parsing");
-  if (method->result_type() != T_VOID) {
-    warning("Blackhole compile option only works for methods with void type: %s",
-            method->name_and_sig_as_C_string());
-    return false;
-  }
-  return true;
-}
-
 static enum CompileCommand match_option_name(const char* line, int* bytes_read, char* errorbuf, int bufsize) {
   assert(ARRAY_SIZE(option_names) == static_cast<int>(CompileCommand::Count), "option_names size mismatch");
 

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -51,7 +51,6 @@ class methodHandle;
   option(Print, "print", Bool) \
   option(Inline,  "inline", Bool) \
   option(DontInline,  "dontinline", Bool) \
-  option(Blackhole,  "blackhole", Bool) \
   option(CompileOnly, "compileonly", Bool)\
   option(Exclude, "exclude", Bool) \
   option(Break, "break", Bool) \
@@ -141,9 +140,6 @@ class CompilerOracle : AllStatic {
 
   // Tells whether to break when compiling method
   static bool should_break_at(const methodHandle& method);
-
-  // Tells whether to blackhole when compiling method
-  static bool should_blackhole(const methodHandle& method);
 
   // Tells whether there are any methods to print for print_method_statistics()
   static bool should_print_methods();


### PR DESCRIPTION
When reapplying JDK-8252505 to jdk/jdk, I stumbled upon the bad merge.

This was the original changeset:
  https://github.com/openjdk/jdk16/commit/ad456787

This was the merge:
 https://github.com/openjdk/jdk/commit/555641ede5e234c936fca98436ef6aeace2351fc

Note that not all blocks were removed from compilerOracle.

Attention @JesperIRL.

Additional testing:
  - [x] Patch from JDK-8252505 applies now
  - [x] No refrerences to "blackhole" or "Blackhole" in `src/hotspot` now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259475](https://bugs.openjdk.java.net/browse/JDK-8259475): Fix bad merge in compilerOracle


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2002/head:pull/2002`
`$ git checkout pull/2002`
