### PR TITLE
8225045: javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java fails on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -752,7 +752,6 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
-javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/UIDefaults/6302464/bug6302464.java 8199079 macosx-all

--- a/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
@@ -63,7 +63,6 @@ public class JInternalFrameIconTest {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(100);
         UIManager.LookAndFeelInfo[] lookAndFeelArray
                 = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo lookAndFeelItem : lookAndFeelArray) {

--- a/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
@@ -30,6 +30,7 @@
  * @build Util
  * @run main JInternalFrameIconTest
  */
+import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -37,6 +38,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JDesktopPane;
@@ -61,7 +63,7 @@ public class JInternalFrameIconTest {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.delay(2000);
+        robot.setAutoDelay(100);
         UIManager.LookAndFeelInfo[] lookAndFeelArray
                 = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo lookAndFeelItem : lookAndFeelArray) {
@@ -76,21 +78,28 @@ public class JInternalFrameIconTest {
     private static void executeCase(String lookAndFeelString) throws Exception {
         if (tryLookAndFeel(lookAndFeelString)) {
             createImageIconUI(lookAndFeelString);
+            robot.waitForIdle();
             robot.delay(1000);
             getImageIconBufferedImage();
+            robot.waitForIdle();
             robot.delay(1000);
             cleanUp();
             robot.waitForIdle();
+            robot.delay(1000);
 
             createIconUI(lookAndFeelString);
+            robot.waitForIdle();
             robot.delay(1000);
             getIconBufferedImage();
+            robot.waitForIdle();
             robot.delay(1000);
             cleanUp();
             robot.waitForIdle();
+            robot.delay(1000);
 
             testIfSame(lookAndFeelString);
             robot.waitForIdle();
+            robot.delay(1000);
         }
 
     }
@@ -208,6 +217,8 @@ public class JInternalFrameIconTest {
     private static void testIfSame(final String lookAndFeelString)
             throws Exception {
         if (!bufferedImagesEqual(imageIconImage, iconImage)) {
+            ImageIO.write(imageIconImage, "png", new File("imageicon-fail.png"));
+            ImageIO.write(iconImage, "png", new File("iconImage-fail.png"));
             String error ="[" + lookAndFeelString
                     + "] : ERROR: icon and imageIcon not same.";
             errorString += error;


### PR DESCRIPTION
This test was failing on mach5 nightly on ubuntu systems long time back. Modified the test to add some delays and call robot.waitForIdle() to make it more stable and the resultant test passes on all mach5 systems including linux consisting of ubuntu 19.10, 18.04,20.10,20.04 so we can remove the test from problemlist.
mach5 job running for several iterations is posted in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225045](https://bugs.openjdk.java.net/browse/JDK-8225045): javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java fails on linux-x64


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2003/head:pull/2003`
`$ git checkout pull/2003`
