### PR TITLE
8258243: C2: assert failed ("Bad derived pointer") with -XX:+VerifyRegisterAllocator

### DIFF
--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -2406,9 +2406,9 @@ void PhaseChaitin::verify_base_ptrs(ResourceArea* a) const {
                     worklist.push(check->in(m));
                   }
                 } else if (check->is_Con()) {
-                  if (is_derived) {
-                    // Derived is NULL+offset
-                    assert(!is_derived || check->bottom_type()->is_ptr()->ptr() == TypePtr::Null, "Bad derived pointer");
+                  if (is_derived && check->bottom_type()->is_ptr()->_offset != 0) {
+                    // Derived is NULL+non-zero offset, base must be NULL.
+                    assert(check->bottom_type()->is_ptr()->ptr() == TypePtr::Null, "Bad derived pointer");
                   } else {
                     assert(check->bottom_type()->is_ptr()->_offset == 0, "Bad base pointer");
                     // Base either ConP(NULL) or loadConP

--- a/test/hotspot/jtreg/compiler/regalloc/TestVerifyRegisterAllocator.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestVerifyRegisterAllocator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8258243
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @summary Sanity check the -XX:+VerifyRegisterAllocator flag in a hello world program.
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+VerifyRegisterAllocator
+ *                   compiler.regalloc.TestVerifyRegisterAllocator
+ */
+package compiler.regalloc;
+
+public class TestVerifyRegisterAllocator {
+    public static void main(String[] strArr) {
+        System.out.println("Hello world!");
+    }
+}
+


### PR DESCRIPTION
The base pointer verification code in the register allocator checks that a base for a derived constant node is always `NULL`. However, this is not the case if the offset is zero (returns on L1744):
https://github.com/openjdk/jdk/blob/b549cbd39250c5b22c6e863172d18cf247022894/src/hotspot/share/opto/chaitin.cpp#L1740-L1754

This case is added to the verification code which fixes the reported failing testcases.

I additionally added a hello world test to sanity check the `-XX:+VerifyRegisterAllocator` flag.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258243](https://bugs.openjdk.java.net/browse/JDK-8258243): C2: assert failed ("Bad derived pointer") with -XX:+VerifyRegisterAllocator


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2005/head:pull/2005`
`$ git checkout pull/2005`
