### PR TITLE
8259493: [test] Use HexFormat instead of adhoc hex utilities in network code and locale SoftKeys

### DIFF
--- a/test/jdk/java/net/Authenticator/B6870935.java
+++ b/test/jdk/java/net/Authenticator/B6870935.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,11 +186,6 @@ public class B6870935 {
             return finalHash;
         }
 
-        private final static char charArray[] = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-        };
-
         private String encode(String src, char[] passwd, MessageDigest md) {
             md.update(src.getBytes());
             if (passwd != null) {
@@ -201,15 +196,7 @@ public class B6870935 {
                 Arrays.fill(passwdBytes, (byte)0x00);
             }
             byte[] digest = md.digest();
-
-            StringBuffer res = new StringBuffer(digest.length * 2);
-            for (int i = 0; i < digest.length; i++) {
-                int hashchar = ((digest[i] >>> 4) & 0xf);
-                res.append(charArray[hashchar]);
-                hashchar = (digest[i] & 0xf);
-                res.append(charArray[hashchar]);
-            }
-            return res.toString();
+            return HexFormat.of().formatHex(digest);
         }
     }
 

--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -582,11 +583,6 @@ public class HTTPTestServer extends HTTPTest {
 
         // Code stolen from DigestAuthentication:
 
-        private static final char charArray[] = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-        };
-
         private static String encode(String src, char[] passwd, MessageDigest md) {
             try {
                 md.update(src.getBytes("ISO-8859-1"));
@@ -601,15 +597,7 @@ public class HTTPTestServer extends HTTPTest {
                 Arrays.fill(passwdBytes, (byte)0x00);
             }
             byte[] digest = md.digest();
-
-            StringBuilder res = new StringBuilder(digest.length * 2);
-            for (int i = 0; i < digest.length; i++) {
-                int hashchar = ((digest[i] >>> 4) & 0xf);
-                res.append(charArray[hashchar]);
-                hashchar = (digest[i] & 0xf);
-                res.append(charArray[hashchar]);
-            }
-            return res.toString();
+            return HexFormat.of().formatHex(digest);
         }
 
         public static String computeDigest(boolean isRequest,

--- a/test/jdk/java/net/httpclient/DigestEchoServer.java
+++ b/test/jdk/java/net/httpclient/DigestEchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -821,11 +822,6 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
 
         // Code stolen from DigestAuthentication:
 
-        private static final char charArray[] = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-        };
-
         private static String encode(String src, char[] passwd, MessageDigest md) {
             try {
                 md.update(src.getBytes("ISO-8859-1"));
@@ -840,15 +836,7 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
                 Arrays.fill(passwdBytes, (byte)0x00);
             }
             byte[] digest = md.digest();
-
-            StringBuilder res = new StringBuilder(digest.length * 2);
-            for (int i = 0; i < digest.length; i++) {
-                int hashchar = ((digest[i] >>> 4) & 0xf);
-                res.append(charArray[hashchar]);
-                hashchar = (digest[i] & 0xf);
-                res.append(charArray[hashchar]);
-            }
-            return res.toString();
+            return HexFormat.of().formatHex(digest);
         }
 
         public static String computeDigest(boolean isRequest,

--- a/test/jdk/java/util/Locale/SoftKeys.java
+++ b/test/jdk/java/util/Locale/SoftKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import java.util.*;
 
 public class SoftKeys {
 
-    private static final char[] CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-
     public static void main(String[] args) {
         try {
             // With 4 characters in "language", we'll fill up a 16M heap quickly,
@@ -44,7 +42,7 @@ public class SoftKeys {
             // been cleared.
             for (int i = 0; i < 2; i++) {
                 for (int j = 0; j < 512*1024; j++) {
-                    new Locale(langForInt(j), "", "");
+                    new Locale(HexFormat.of().toHexDigits((short)j), "", "");
                 }
             }
         } catch (OutOfMemoryError e) {
@@ -56,15 +54,6 @@ public class SoftKeys {
             // Do a System.gc() to not throw an OOME again in the jtreg wrapper.
             System.gc();
         }
-    }
-
-    private static String langForInt(int val) {
-        StringBuilder buf = new StringBuilder(4);
-        buf.append(CHARS[(val >> 12) & 0xF]);
-        buf.append(CHARS[(val >>  8) & 0xF]);
-        buf.append(CHARS[(val >>  4) & 0xF]);
-        buf.append(CHARS[(val >>  0) & 0xF]);
-        return buf.toString();
     }
 }
 

--- a/test/jdk/sun/net/www/protocol/http/DigestTest.java
+++ b/test/jdk/sun/net/www/protocol/http/DigestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,11 +172,6 @@ class DigestServer extends Thread {
         return finalHash;
     }
 
-    private final static char charArray[] = {
-        '0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-    };
-
     private String encode(String src, char[] passwd, MessageDigest md) {
         md.update(src.getBytes());
         if (passwd != null) {
@@ -187,15 +182,7 @@ class DigestServer extends Thread {
             Arrays.fill(passwdBytes, (byte)0x00);
         }
         byte[] digest = md.digest();
-
-        StringBuffer res = new StringBuffer(digest.length * 2);
-        for (int i = 0; i < digest.length; i++) {
-            int hashchar = ((digest[i] >>> 4) & 0xf);
-            res.append(charArray[hashchar]);
-            hashchar = (digest[i] & 0xf);
-            res.append(charArray[hashchar]);
-        }
-        return res.toString();
+        return HexFormat.of().formatHex(digest);
     }
 
 }


### PR DESCRIPTION
Cleanup of tests test/jdk/java/net and test/jdk/sun/net that format hexadecimal strings to use java.util.HexFormat methods.
Also in tests test/jdk/java/util/Locale/SoftKeys.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259493](https://bugs.openjdk.java.net/browse/JDK-8259493): [test] Use HexFormat instead of adhoc hex utilities in network code and locale SoftKeys


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2009/head:pull/2009`
`$ git checkout pull/2009`
