### PR TITLE
8259517: Incorrect test path in test cases

### DIFF
--- a/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
@@ -152,7 +152,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB);
@@ -172,7 +172,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB, 0, appBB.length);

--- a/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB);
@@ -172,7 +172,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB, 0, appBB.length);

--- a/test/jdk/javax/net/ssl/SSLEngine/Basics.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/Basics.java
@@ -177,7 +177,7 @@ public class Basics {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //if (ssle.unwrap(smallBB, smallBB).getStatus() !=

--- a/test/jdk/javax/net/ssl/SSLEngine/Basics.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/Basics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class Basics {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //if (ssle.unwrap(smallBB, smallBB).getStatus() !=

--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,8 @@ import java.util.concurrent.TimeUnit;
  * Template to help speed your client/server tests.
  *
  * Two examples that use this template:
- *    test/sun/security/ssl/ServerHandshaker/AnonCipherWithWantClientAuth.java
- *    test/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
+ * test/jdk/sun/security/ssl/ServerHandshaker/AnonCipherWithWantClientAuth.java
+ * test/jdk/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
  */
 public class SSLSocketTemplate {
 


### PR DESCRIPTION
There are a few test paths mentioned in test cases, for example: 
`        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check 
`
The test path is no longer good as test directories were re-orged in the past.

Code cleanup, test update, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259517](https://bugs.openjdk.java.net/browse/JDK-8259517): Incorrect test path in test cases


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to c3ff7f50e3c62656cd7930833d55d54817f8a6a6


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2011/head:pull/2011`
`$ git checkout pull/2011`
