### PR TITLE
8258217: PriorityBlockingQueue constructor spec and behavior mismatch

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
@@ -226,7 +226,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
     /**
      * Creates a {@code PriorityBlockingQueue} containing the elements
      * in the specified collection.  If the specified collection is a
-     * {@link SortedSet} or a {@link PriorityQueue}, this
+     * {@link SortedSet} or a {@link PriorityBlockingQueue}, this
      * priority queue will be ordered according to the same ordering.
      * Otherwise, this priority queue will be ordered according to the
      * {@linkplain Comparable natural ordering} of its elements.


### PR DESCRIPTION
/cc core-libs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258217](https://bugs.openjdk.java.net/browse/JDK-8258217): PriorityBlockingQueue constructor spec and behavior mismatch


### Reviewers
 * [Doug Lea](https://openjdk.java.net/census#dl) (@DougLea - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2014/head:pull/2014`
`$ git checkout pull/2014`
