### PR TITLE
JDK-8258187 IllegalMonitorStateException in ArrayBlockingQueue

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RejectedExecutionException;
 import jdk.internal.misc.Unsafe;
 
 /**
@@ -1197,13 +1198,18 @@ public abstract class AbstractQueuedLongSynchronizer
             ConditionNode node = new ConditionNode();
             long savedState = enableWait(node);
             LockSupport.setCurrentBlocker(this); // for back-compatibility
-            boolean interrupted = false;
+            boolean interrupted = false, rejected = false;
             while (!canReacquire(node)) {
                 if (Thread.interrupted())
                     interrupted = true;
                 else if ((node.status & COND) != 0) {
                     try {
-                        ForkJoinPool.managedBlock(node);
+                        if (rejected)
+                            node.block();
+                        else
+                            ForkJoinPool.managedBlock(node);
+                    } catch (RejectedExecutionException ex) {
+                        rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
                     }
@@ -1236,14 +1242,19 @@ public abstract class AbstractQueuedLongSynchronizer
             ConditionNode node = new ConditionNode();
             long savedState = enableWait(node);
             LockSupport.setCurrentBlocker(this); // for back-compatibility
-            boolean interrupted = false, cancelled = false;
+            boolean interrupted = false, cancelled = false, rejected = false;
             while (!canReacquire(node)) {
                 if (interrupted |= Thread.interrupted()) {
                     if (cancelled = (node.getAndUnsetStatus(COND) & COND) != 0)
                         break;              // else interrupted after signal
                 } else if ((node.status & COND) != 0) {
                     try {
-                        ForkJoinPool.managedBlock(node);
+                        if (rejected)
+                            node.block();
+                        else
+                            ForkJoinPool.managedBlock(node);
+                    } catch (RejectedExecutionException ex) {
+                        rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
                     }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RejectedExecutionException;
 import jdk.internal.misc.Unsafe;
 
 /**
@@ -1565,13 +1566,18 @@ public abstract class AbstractQueuedSynchronizer
             ConditionNode node = new ConditionNode();
             int savedState = enableWait(node);
             LockSupport.setCurrentBlocker(this); // for back-compatibility
-            boolean interrupted = false;
+            boolean interrupted = false, rejected = false;
             while (!canReacquire(node)) {
                 if (Thread.interrupted())
                     interrupted = true;
                 else if ((node.status & COND) != 0) {
                     try {
-                        ForkJoinPool.managedBlock(node);
+                        if (rejected)
+                            node.block();
+                        else
+                            ForkJoinPool.managedBlock(node);
+                    } catch (RejectedExecutionException ex) {
+                        rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
                     }
@@ -1604,14 +1610,19 @@ public abstract class AbstractQueuedSynchronizer
             ConditionNode node = new ConditionNode();
             int savedState = enableWait(node);
             LockSupport.setCurrentBlocker(this); // for back-compatibility
-            boolean interrupted = false, cancelled = false;
+            boolean interrupted = false, cancelled = false, rejected = false;
             while (!canReacquire(node)) {
                 if (interrupted |= Thread.interrupted()) {
                     if (cancelled = (node.getAndUnsetStatus(COND) & COND) != 0)
                         break;              // else interrupted after signal
                 } else if ((node.status & COND) != 0) {
                     try {
-                        ForkJoinPool.managedBlock(node);
+                        if (rejected)
+                            node.block();
+                        else
+                            ForkJoinPool.managedBlock(node);
+                    } catch (RejectedExecutionException ex) {
+                        rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
                     }


### PR DESCRIPTION
/cc core-libs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258187](https://bugs.openjdk.java.net/browse/JDK-8258187): IllegalMonitorStateException in ArrayBlockingQueue


### Reviewers
 * [Doug Lea](https://openjdk.java.net/census#dl) (@DougLea - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2015/head:pull/2015`
`$ git checkout pull/2015`
