### PR TITLE
8259519: The java.awt.datatransfer.DataFlavor#ioInputStreamClass field is redundant

### DIFF
--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,6 @@ import sun.reflect.misc.ReflectUtil;
 public class DataFlavor implements Externalizable, Cloneable {
 
     private static final long serialVersionUID = 8367026044764648243L;
-    private static final Class<InputStream> ioInputStreamClass = InputStream.class;
 
     /**
      * Tries to load a class from: the bootstrap loader, the system loader, the
@@ -1139,7 +1138,7 @@ public class DataFlavor implements Externalizable, Cloneable {
      * @return the default representation class
      */
     public final Class<?> getDefaultRepresentationClass() {
-        return ioInputStreamClass;
+        return java.io.InputStream.class;
     }
 
     /**
@@ -1158,7 +1157,7 @@ public class DataFlavor implements Externalizable, Cloneable {
      *         {@code java.io.InputStream}
      */
     public boolean isRepresentationClassInputStream() {
-        return ioInputStreamClass.isAssignableFrom(representationClass);
+        return java.io.InputStream.class.isAssignableFrom(representationClass);
     }
 
     /**

--- a/test/jdk/java/awt/datatransfer/DataFlavor/DefaultRepresentation.java
+++ b/test/jdk/java/awt/datatransfer/DataFlavor/DefaultRepresentation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.datatransfer.DataFlavor;
+import java.io.InputStream;
+
+/**
+ * @test
+ * @bug 8259519
+ * @summary InputStream should be used as a default data flavor representation
+ */
+public final class DefaultRepresentation extends InputStream {
+
+    public static void main(String[] args) {
+        DataFlavor df = new DataFlavor(DefaultRepresentation.class, "stream");
+        if (df.getDefaultRepresentationClass() != InputStream.class) {
+            // default representation class is not specified!
+            // this check just defends against accidental changes
+            throw new RuntimeException("InputStream class is expected");
+        }
+        if (!df.isRepresentationClassInputStream()) {
+            throw new RuntimeException("true is expected");
+        }
+    }
+
+    @Override
+    public int read() {
+        return 0;
+    }
+}


### PR DESCRIPTION
A long time ago in the pre-1.0 era, this field was initialized via reflection since the "InputStream" class was optional. This was changed since then and a separate field to refer the "InputStream.class" is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259519](https://bugs.openjdk.java.net/browse/JDK-8259519): The java.awt.datatransfer.DataFlavor#ioInputStreamClass field is redundant


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2016/head:pull/2016`
`$ git checkout pull/2016`
