### PR TITLE
JDK-8030048: (fs) Support UserDefinedFileAttributeView/extended attributes on OS X / HFS+

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
@@ -101,8 +101,7 @@ class BsdFileStore
 
     @Override
     public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
-        // support DosFileAttributeView and UserDefinedAttributeView if extended
-        // attributes enabled
+        // support UserDefinedAttributeView if extended attributes enabled
         if (type == UserDefinedFileAttributeView.class) {
             // lookup fstypes.properties
             FeatureStatus status = checkIfFeaturePresent("user_xattr");

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
@@ -77,4 +77,57 @@ class BsdFileStore
 
         throw new IOException("Mount point not found in fstab");
     }
+
+    // returns true if extended attributes enabled on file system where given
+    // file resides, returns false if disabled or unable to determine.
+    private boolean isExtendedAttributesEnabled(UnixPath path) {
+        int fd = -1;
+        try {
+            fd = path.openForAttributeAccess(false);
+
+            // fgetxattr returns size if called with size==0
+            byte[] name = Util.toBytes("user.java");
+            BsdNativeDispatcher.fgetxattr(fd, name, 0L, 0);
+            return true;
+        } catch (UnixException e) {
+            // attribute does not exist
+            if (e.errno() == UnixConstants.ENOATTR)
+                return true;
+        } finally {
+            UnixNativeDispatcher.close(fd);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+        // support DosFileAttributeView and UserDefinedAttributeView if extended
+        // attributes enabled
+        if (type == UserDefinedFileAttributeView.class) {
+            // lookup fstypes.properties
+            FeatureStatus status = checkIfFeaturePresent("user_xattr");
+            if (status == FeatureStatus.PRESENT)
+                return true;
+            if (status == FeatureStatus.NOT_PRESENT)
+                return false;
+
+            // typical macOS file system types that are known to support xattr
+            if (entry().fstype().equals("apfs")
+                || entry().fstype().equals("hfs")) {
+                return true;
+            }
+
+            // probe file system capabilities
+            UnixPath dir = new UnixPath(file().getFileSystem(), entry().dir());
+            return isExtendedAttributesEnabled(dir);
+        }
+        return super.supportsFileAttributeView(type);
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(String name) {
+        if (name.equals("user"))
+            return supportsFileAttributeView(UserDefinedFileAttributeView.class);
+        return super.supportsFileAttributeView(name);
+    }
 }

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
@@ -56,6 +56,8 @@ class BsdFileSystem extends UnixFileSystem {
         private static Set<String> supportedFileAttributeViews() {
             Set<String> result = new HashSet<String>();
             result.addAll(standardFileAttributeViews());
+            // additional BSD-specific views
+            result.add("user");
             return Collections.unmodifiableSet(result);
         }
     }

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystemProvider.java
@@ -25,6 +25,8 @@
 
 package sun.nio.fs;
 
+import java.nio.file.*;
+import java.nio.file.attribute.*;
 import java.io.IOException;
 
 /**
@@ -44,5 +46,30 @@ class BsdFileSystemProvider extends UnixFileSystemProvider {
     @Override
     BsdFileStore getFileStore(UnixPath path) throws IOException {
         return new BsdFileStore(path);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V extends FileAttributeView> V getFileAttributeView(Path obj,
+                                                                Class<V> type,
+                                                                LinkOption... options)
+    {
+        if (type == UserDefinedFileAttributeView.class) {
+            return (V) new BsdUserDefinedFileAttributeView(UnixPath.toUnixPath(obj),
+                    Util.followLinks(options));
+        }
+        return super.getFileAttributeView(obj, type, options);
+    }
+
+    @Override
+    public DynamicFileAttributeView getFileAttributeView(Path obj,
+                                                         String name,
+                                                         LinkOption... options)
+    {
+        if (name.equals("user")) {
+            return new BsdUserDefinedFileAttributeView(UnixPath.toUnixPath(obj),
+                    Util.followLinks(options));
+        }
+        return super.getFileAttributeView(obj, name, options);
     }
 }

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -65,6 +65,68 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
     }
     static native byte[] getmntonname0(long pathAddress) throws UnixException;
 
+    /**
+     * ssize_t fgetxattr(int fd, const char *name, void *value, size_t size, u_int32_t position, int options);
+     */
+    static int fgetxattr(int fd, byte[] name, long valueAddress, int valueLen) throws UnixException
+    {
+        NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
+        try {
+            // position: According to man2 fgetxattr, position is reserved and should be 0
+            // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
+            return fgetxattr0(fd, buffer.address(), valueAddress, valueLen, 0L, 0);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static native int fgetxattr0(int fd, long nameAddress, long valueAddress, int valueLen,
+                                         long position, int options) throws UnixException;
+
+    /**
+     * int fsetxattr(int fd, const char *name, void *value, size_t size, u_int32_t position, int options);
+     */
+    static void fsetxattr(int fd, byte[] name, long valueAddress, int valueLen) throws UnixException
+    {
+        NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
+        try {
+            // position: According to man2 fgetxattr, position is reserved and should be 0
+            // options: XATTR_NOFOLLOW not applicable, XATTR_CREATE/XATTR_REPLACE will not be set,
+            //   matching behaviour of LinuxNativeDispatcher (therefore no atomic check-and-set support atm)
+            fsetxattr0(fd, buffer.address(), valueAddress, valueLen, 0L, 0);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static native void fsetxattr0(int fd, long nameAddress, long valueAddress, int valueLen,
+                                          long position, int options) throws UnixException;
+
+    /**
+     * int fremovexattr(int fd, const char *name, int options);
+     */
+    static void fremovexattr(int fd, byte[] name) throws UnixException {
+        NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
+        try {
+            // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
+            fremovexattr0(fd, buffer.address(), 0);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static native void fremovexattr0(int fd, long nameAddress, int options) throws UnixException;
+
+    /**
+     * ssize_t flistxattr(int fd, char *namebuf, size_t size, int options);
+     */
+    static int flistxattr(int fd, long nameBufAddress, int size) throws UnixException {
+        // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
+        return flistxattr0(fd, nameBufAddress, size, 0);
+    }
+
+    private static native int flistxattr0(int fd, long nameBufAddress, int size, int options) throws UnixException;
+
     // initialize field IDs
     private static native void initIDs();
 

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -66,9 +66,11 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
     static native byte[] getmntonname0(long pathAddress) throws UnixException;
 
     /**
-     * ssize_t fgetxattr(int fd, const char *name, void *value, size_t size, u_int32_t position, int options);
+     * ssize_t fgetxattr(int fd, const char *name, void *value, size_t size,
+     *  u_int32_t position, int options);
      */
-    static int fgetxattr(int fd, byte[] name, long valueAddress, int valueLen) throws UnixException
+    static int fgetxattr(int fd, byte[] name, long valueAddress,
+                         int valueLen) throws UnixException
     {
         NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
         try {
@@ -78,13 +80,15 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
         }
     }
 
-    private static native int fgetxattr0(int fd, long nameAddress, long valueAddress, int valueLen,
-                                         long position, int options) throws UnixException;
+    private static native int fgetxattr0(int fd, long nameAddress,
+        long valueAddress, int valueLen, long position, int options) throws UnixException;
 
     /**
-     * int fsetxattr(int fd, const char *name, void *value, size_t size, u_int32_t position, int options);
+     * int fsetxattr(int fd, const char *name, void *value, size_t size,
+     *  u_int32_t position, int options);
      */
-    static void fsetxattr(int fd, byte[] name, long valueAddress, int valueLen) throws UnixException
+    static void fsetxattr(int fd, byte[] name, long valueAddress,
+                          int valueLen) throws UnixException
     {
         NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
         try {
@@ -94,8 +98,8 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
         }
     }
 
-    private static native void fsetxattr0(int fd, long nameAddress, long valueAddress, int valueLen,
-                                          long position, int options) throws UnixException;
+    private static native void fsetxattr0(int fd, long nameAddress,
+        long valueAddress, int valueLen, long position, int options) throws UnixException;
 
     /**
      * int fremovexattr(int fd, const char *name, int options);
@@ -109,7 +113,8 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
         }
     }
 
-    private static native void fremovexattr0(int fd, long nameAddress, int options) throws UnixException;
+    private static native void fremovexattr0(int fd, long nameAddress, int options)
+        throws UnixException;
 
     /**
      * ssize_t flistxattr(int fd, char *namebuf, size_t size, int options);
@@ -118,7 +123,8 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
         return flistxattr0(fd, nameBufAddress, size, 0);
     }
 
-    private static native int flistxattr0(int fd, long nameBufAddress, int size, int options) throws UnixException;
+    private static native int flistxattr0(int fd, long nameBufAddress, int size,
+        int options) throws UnixException;
 
     // initialize field IDs
     private static native void initIDs();

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -72,8 +72,6 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
     {
         NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
         try {
-            // position: According to man2 fgetxattr, position is reserved and should be 0
-            // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
             return fgetxattr0(fd, buffer.address(), valueAddress, valueLen, 0L, 0);
         } finally {
             buffer.release();
@@ -90,9 +88,6 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
     {
         NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
         try {
-            // position: According to man2 fgetxattr, position is reserved and should be 0
-            // options: XATTR_NOFOLLOW not applicable, XATTR_CREATE/XATTR_REPLACE will not be set,
-            //   matching behaviour of LinuxNativeDispatcher (therefore no atomic check-and-set support atm)
             fsetxattr0(fd, buffer.address(), valueAddress, valueLen, 0L, 0);
         } finally {
             buffer.release();
@@ -108,7 +103,6 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
     static void fremovexattr(int fd, byte[] name) throws UnixException {
         NativeBuffer buffer = NativeBuffers.asNativeBuffer(name);
         try {
-            // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
             fremovexattr0(fd, buffer.address(), 0);
         } finally {
             buffer.release();
@@ -121,7 +115,6 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
      * ssize_t flistxattr(int fd, char *namebuf, size_t size, int options);
      */
     static int flistxattr(int fd, long nameBufAddress, int size) throws UnixException {
-        // options: XATTR_NOFOLLOW not applicable, XATTR_SHOWCOMPRESSION irrelevant to user-defined attributes
         return flistxattr0(fd, nameBufAddress, size, 0);
     }
 

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdUserDefinedFileAttributeView.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdUserDefinedFileAttributeView.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.fs;
+
+import java.nio.file.*;
+import java.nio.ByteBuffer;
+import java.io.IOException;
+import java.util.*;
+import jdk.internal.misc.Unsafe;
+
+import static sun.nio.fs.UnixConstants.*;
+import static sun.nio.fs.BsdNativeDispatcher.*;
+
+/**
+ * BSD implementation of UserDefinedFileAttributeView using extended attributes.
+ */
+
+class BsdUserDefinedFileAttributeView
+    extends AbstractUserDefinedFileAttributeView
+{
+    private static final Unsafe unsafe = Unsafe.getUnsafe();
+
+    // namespace for extended user attributes
+    private static final String USER_NAMESPACE = "user.";
+
+    // maximum bytes in extended attribute name (includes namespace),
+    // see XATTR_MAXNAMELEN in https://github.com/apple/darwin-xnu/blob/master/bsd/sys/xattr.h
+    private static final int XATTR_NAME_MAX = 127;
+
+    private byte[] nameAsBytes(UnixPath file, String name) throws IOException {
+        if (name == null)
+            throw new NullPointerException("'name' is null");
+        name = USER_NAMESPACE + name;
+        byte[] bytes = Util.toBytes(name);
+        if (bytes.length > XATTR_NAME_MAX) {
+            throw new FileSystemException(file.getPathForExceptionMessage(),
+                null, "'" + name + "' is too big");
+        }
+        return bytes;
+    }
+
+    // Parses buffer as array of NULL-terminated C strings.
+    private List<String> asList(long address, int size) {
+        List<String> list = new ArrayList<>();
+        int start = 0;
+        int pos = 0;
+        while (pos < size) {
+            if (unsafe.getByte(address + pos) == 0) {
+                int len = pos - start;
+                byte[] value = new byte[len];
+                unsafe.copyMemory(null, address+start, value,
+                    Unsafe.ARRAY_BYTE_BASE_OFFSET, len);
+                String s = Util.toString(value);
+                if (s.startsWith(USER_NAMESPACE)) {
+                    s = s.substring(USER_NAMESPACE.length());
+                    list.add(s);
+                }
+                start = pos + 1;
+            }
+            pos++;
+        }
+        return list;
+    }
+
+    private final UnixPath file;
+    private final boolean followLinks;
+
+    BsdUserDefinedFileAttributeView(UnixPath file, boolean followLinks) {
+        this.file = file;
+        this.followLinks = followLinks;
+    }
+
+    @Override
+    public List<String> list() throws IOException  {
+        if (System.getSecurityManager() != null)
+            checkAccess(file.getPathForPermissionCheck(), true, false);
+
+        int fd = -1;
+        try {
+            fd = file.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(file);
+        }
+        NativeBuffer buffer = null;
+        try {
+            int size = 1024;
+            buffer = NativeBuffers.getNativeBuffer(size);
+            for (;;) {
+                try {
+                    int n = flistxattr(fd, buffer.address(), size);
+                    List<String> list = asList(buffer.address(), n);
+                    return Collections.unmodifiableList(list);
+                } catch (UnixException x) {
+                    // allocate larger buffer if required
+                    if (x.errno() == ERANGE && size < 32*1024) {
+                        buffer.release();
+                        size *= 2;
+                        buffer = null;
+                        buffer = NativeBuffers.getNativeBuffer(size);
+                        continue;
+                    }
+                    throw new FileSystemException(file.getPathForExceptionMessage(),
+                        null, "Unable to get list of extended attributes: " +
+                        x.getMessage());
+                }
+            }
+        } finally {
+            if (buffer != null)
+                buffer.release();
+            close(fd);
+        }
+    }
+
+    @Override
+    public int size(String name) throws IOException  {
+        if (System.getSecurityManager() != null)
+            checkAccess(file.getPathForPermissionCheck(), true, false);
+
+        int fd = -1;
+        try {
+            fd = file.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(file);
+        }
+        try {
+            // fgetxattr returns size if called with size==0
+            return fgetxattr(fd, nameAsBytes(file,name), 0L, 0);
+        } catch (UnixException x) {
+            throw new FileSystemException(file.getPathForExceptionMessage(),
+                null, "Unable to get size of extended attribute '" + name +
+                "': " + x.getMessage());
+        } finally {
+            close(fd);
+        }
+    }
+
+    @Override
+    public int read(String name, ByteBuffer dst) throws IOException {
+        if (System.getSecurityManager() != null)
+            checkAccess(file.getPathForPermissionCheck(), true, false);
+
+        if (dst.isReadOnly())
+            throw new IllegalArgumentException("Read-only buffer");
+        int pos = dst.position();
+        int lim = dst.limit();
+        assert (pos <= lim);
+        int rem = (pos <= lim ? lim - pos : 0);
+
+        NativeBuffer nb;
+        long address;
+        if (dst instanceof sun.nio.ch.DirectBuffer) {
+            nb = null;
+            address = ((sun.nio.ch.DirectBuffer)dst).address() + pos;
+        } else {
+            // substitute with native buffer
+            nb = NativeBuffers.getNativeBuffer(rem);
+            address = nb.address();
+        }
+
+        int fd = -1;
+        try {
+            fd = file.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(file);
+        }
+        try {
+            try {
+                int n = fgetxattr(fd, nameAsBytes(file,name), address, rem);
+
+                // if remaining is zero then fgetxattr returns the size
+                if (rem == 0) {
+                    if (n > 0)
+                        throw new UnixException(ERANGE);
+                    return 0;
+                }
+
+                // copy from buffer into backing array if necessary
+                if (nb != null) {
+                    int off = dst.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                    unsafe.copyMemory(null, address, dst.array(), off, n);
+                }
+                dst.position(pos + n);
+                return n;
+            } catch (UnixException x) {
+                String msg = (x.errno() == ERANGE) ?
+                    "Insufficient space in buffer" : x.getMessage();
+                throw new FileSystemException(file.getPathForExceptionMessage(),
+                    null, "Error reading extended attribute '" + name + "': " + msg);
+            } finally {
+                close(fd);
+            }
+        } finally {
+            if (nb != null)
+                nb.release();
+        }
+    }
+
+    @Override
+    public int write(String name, ByteBuffer src) throws IOException {
+        if (System.getSecurityManager() != null)
+            checkAccess(file.getPathForPermissionCheck(), false, true);
+
+        int pos = src.position();
+        int lim = src.limit();
+        assert (pos <= lim);
+        int rem = (pos <= lim ? lim - pos : 0);
+
+        NativeBuffer nb;
+        long address;
+        if (src instanceof sun.nio.ch.DirectBuffer) {
+            nb = null;
+            address = ((sun.nio.ch.DirectBuffer)src).address() + pos;
+        } else {
+            // substitute with native buffer
+            nb = NativeBuffers.getNativeBuffer(rem);
+            address = nb.address();
+
+            if (src.hasArray()) {
+                // copy from backing array into buffer
+                int off = src.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                unsafe.copyMemory(src.array(), off, null, address, rem);
+            } else {
+                // backing array not accessible so transfer via temporary array
+                byte[] tmp = new byte[rem];
+                src.get(tmp);
+                src.position(pos);  // reset position as write may fail
+                unsafe.copyMemory(tmp, Unsafe.ARRAY_BYTE_BASE_OFFSET, null,
+                    address, rem);
+            }
+        }
+
+        int fd = -1;
+        try {
+            fd = file.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(file);
+        }
+        try {
+            try {
+                fsetxattr(fd, nameAsBytes(file,name), address, rem);
+                src.position(pos + rem);
+                return rem;
+            } catch (UnixException x) {
+                throw new FileSystemException(file.getPathForExceptionMessage(),
+                    null, "Error writing extended attribute '" + name + "': " +
+                    x.getMessage());
+            } finally {
+                close(fd);
+            }
+        } finally {
+            if (nb != null)
+                nb.release();
+        }
+    }
+
+    @Override
+    public void delete(String name) throws IOException {
+        if (System.getSecurityManager() != null)
+            checkAccess(file.getPathForPermissionCheck(), false, true);
+
+        int fd = -1;
+        try {
+            fd = file.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(file);
+        }
+        try {
+            fremovexattr(fd, nameAsBytes(file,name));
+        } catch (UnixException x) {
+            throw new FileSystemException(file.getPathForExceptionMessage(),
+                null, "Unable to delete extended attribute '" + name + "': " + x.getMessage());
+        } finally {
+            close(fd);
+        }
+    }
+
+    /**
+     * Used by copyTo/moveTo to copy extended attributes from source to target.
+     *
+     * @param   ofd
+     *          file descriptor for source file
+     * @param   nfd
+     *          file descriptor for target file
+     */
+    static void copyExtendedAttributes(int ofd, int nfd) {
+        NativeBuffer buffer = null;
+        try {
+
+            // call flistxattr to get list of extended attributes.
+            int size = 1024;
+            buffer = NativeBuffers.getNativeBuffer(size);
+            for (;;) {
+                try {
+                    size = flistxattr(ofd, buffer.address(), size);
+                    break;
+                } catch (UnixException x) {
+                    // allocate larger buffer if required
+                    if (x.errno() == ERANGE && size < 32*1024) {
+                        buffer.release();
+                        size *= 2;
+                        buffer = null;
+                        buffer = NativeBuffers.getNativeBuffer(size);
+                        continue;
+                    }
+
+                    // unable to get list of attributes
+                    return;
+                }
+            }
+
+            // parse buffer as array of NULL-terminated C strings.
+            long address = buffer.address();
+            int start = 0;
+            int pos = 0;
+            while (pos < size) {
+                if (unsafe.getByte(address + pos) == 0) {
+                    // extract attribute name and copy attribute to target.
+                    // FIXME: We can avoid needless copying by using address+pos
+                    // as the address of the name.
+                    int len = pos - start;
+                    byte[] name = new byte[len];
+                    unsafe.copyMemory(null, address+start, name,
+                        Unsafe.ARRAY_BYTE_BASE_OFFSET, len);
+                    try {
+                        copyExtendedAttribute(ofd, name, nfd);
+                    } catch (UnixException ignore) {
+                        // ignore
+                    }
+                    start = pos + 1;
+                }
+                pos++;
+            }
+
+        } finally {
+            if (buffer != null)
+                buffer.release();
+        }
+    }
+
+    private static void copyExtendedAttribute(int ofd, byte[] name, int nfd)
+        throws UnixException
+    {
+        int size = fgetxattr(ofd, name, 0L, 0);
+        NativeBuffer buffer = NativeBuffers.getNativeBuffer(size);
+        try {
+            long address = buffer.address();
+            size = fgetxattr(ofd, name, address, size);
+            fsetxattr(nfd, name, address, size);
+        } finally {
+            buffer.release();
+        }
+    }
+}

--- a/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
+++ b/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
@@ -30,6 +30,7 @@
 
 #include <sys/param.h>
 #include <sys/mount.h>
+#include <sys/xattr.h>
 #ifdef ST_RDONLY
 #define statfs statvfs
 #define getfsstat getvfsstat
@@ -223,4 +224,53 @@ Java_sun_nio_fs_BsdNativeDispatcher_getmntonname0(JNIEnv *env, jclass this,
     }
 
     return mntonname;
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_fgetxattr0(JNIEnv* env, jclass clazz,
+    jint fd, jlong nameAddress, jlong valueAddress, jint valueLen, jlong position, jint options)
+{
+    const char* name = jlong_to_ptr(nameAddress);
+    void* value = jlong_to_ptr(valueAddress);
+
+    ssize_t res = fgetxattr(fd, name, value, valueLen, (u_int32_t)position, options);
+    if (res == (ssize_t)-1)
+        throwUnixException(env, errno);
+    return (jint)res;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_fsetxattr0(JNIEnv* env, jclass clazz,
+    jint fd, jlong nameAddress, jlong valueAddress, jint valueLen, jlong position, jint options)
+{
+    const char* name = jlong_to_ptr(nameAddress);
+    void* value = jlong_to_ptr(valueAddress);
+
+    int res = fsetxattr(fd, name, value, valueLen, (u_int32_t)position, options);
+    if (res == -1)
+        throwUnixException(env, errno);
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_fremovexattr0(JNIEnv* env, jclass clazz,
+    jint fd, jlong nameAddress, jint options)
+{
+    const char* name = jlong_to_ptr(nameAddress);
+
+    int res = fremovexattr(fd, name, options);
+    if (res == -1)
+        throwUnixException(env, errno);
+}
+
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_flistxattr(JNIEnv* env, jclass clazz,
+    jint fd, jlong nameBufAddress, jint size, jint options)
+{
+    char* nameBuf = jlong_to_ptr(nameBufAddress);
+
+    ssize_t res = flistxattr(fd, nameBuf, (size_t)size, options);
+
+    if (res == (ssize_t)-1)
+        throwUnixException(env, errno);
+    return (jint)res;
 }

--- a/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
+++ b/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
@@ -263,7 +263,7 @@ Java_sun_nio_fs_BsdNativeDispatcher_fremovexattr0(JNIEnv* env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_fs_BsdNativeDispatcher_flistxattr(JNIEnv* env, jclass clazz,
+Java_sun_nio_fs_BsdNativeDispatcher_flistxattr0(JNIEnv* env, jclass clazz,
     jint fd, jlong nameBufAddress, jint size, jint options)
 {
     char* nameBuf = jlong_to_ptr(nameBufAddress);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
@@ -117,6 +117,11 @@ class UnixConstants {
     static final int PREFIX_ENODATA = ENODATA;
 #endif
 
+#ifdef ENOATTR
+    // BSD uses ENOATTR instead of ENODATA during xattr calls
+    static final int PREFIX_ENOATTR = ENOATTR;
+#endif
+
     static final int PREFIX_ERANGE = ERANGE;
     static final int PREFIX_EMFILE = EMFILE;
 


### PR DESCRIPTION
This adds support for UserDefinedFileAttributeView on macOS 10.4 and newer.

While the main audience for this will probably be macOS users, the relevant changes take place in (mostly existing) classes carrying BSD in their names as none of this is really macOS-specific.

Code is mostly copied from the Linux implementation except for three differences:
1. max length for attribute names is 127 bytes
2. we know for sure that APFS and HFS+ support extended attributes, therefore we [simply return `true`](https://github.com/skymatic/jdk/blob/7a3619df12853bd3a44e4f49c98f35e15bceb652/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java#L114-L118) from `supportsFileAttributeView(UserDefinedFileAttributeView.class)` for these two FS types, while for all other types support is determined experimentally in [`isExtendedAttributesEnabled(...)`](https://github.com/skymatic/jdk/blob/7a3619df12853bd3a44e4f49c98f35e15bceb652/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java#L83-L100)
3. For the aforementioned check the new `UnixConstants.ENOATTR` is added, which [seems to be macOS and BSD-specific](https://mail-index.netbsd.org/tech-kern/2012/04/30/msg013090.html).

As discussed in the mailing list, for ease of tracking changes it is not a goal of this patch to modernize the existing Linux implementation, nor to deduplicate anything.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8030048](https://bugs.openjdk.java.net/browse/JDK-8030048): (fs) Support UserDefinedFileAttributeView/extended attributes on OS X / HFS+


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2017/head:pull/2017`
`$ git checkout pull/2017`
