### PR TITLE
8254973: CompletableFuture.ThreadPerTaskExecutor does not throw NPE in #execute

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -43,6 +43,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.Objects;
 
 /**
  * A {@link Future} that may be explicitly completed (setting its
@@ -438,7 +439,10 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
 
     /** Fallback if ForkJoinPool.commonPool() cannot support parallelism */
     static final class ThreadPerTaskExecutor implements Executor {
-        public void execute(Runnable r) { new Thread(r).start(); }
+        public void execute(Runnable r) {
+            Objects.requireNonNull(r);
+            new Thread(r).start();
+        }
     }
 
     /**


### PR DESCRIPTION
/cc core-libs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254973](https://bugs.openjdk.java.net/browse/JDK-8254973): CompletableFuture.ThreadPerTaskExecutor does not throw NPE in #execute


### Reviewers
 * [Doug Lea](https://openjdk.java.net/census#dl) (@DougLea - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2018/head:pull/2018`
`$ git checkout pull/2018`
