### PR TITLE
8259522: Apply java.io.Serial annotations in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/editors/ColorEditor.java
+++ b/src/java.desktop/share/classes/com/sun/beans/editors/ColorEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,24 @@
 
 package com.sun.beans.editors;
 
-import java.awt.*;
-import java.beans.*;
+import java.awt.Canvas;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Event;
+import java.awt.Panel;
+import java.awt.TextField;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.beans.PropertyEditor;
+import java.io.Serial;
 
 public class ColorEditor extends Panel implements PropertyEditor {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 1781257185164716054L;
 
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
+++ b/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,25 @@
 
 package com.sun.beans.editors;
 
-import java.awt.*;
-import java.beans.*;
+import java.awt.Choice;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Event;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.Toolkit;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.Serial;
 
 public class FontEditor extends Panel implements java.beans.PropertyEditor {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 6732704486002715933L;
 
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/com/sun/beans/finder/SignatureException.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/SignatureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.beans.finder;
 
+import java.io.Serial;
+
 final class SignatureException extends RuntimeException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 4536098341586118473L;
 
     SignatureException(Throwable cause) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleCMYKColorSpace.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleCMYKColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.imageio.plugins.common;
 
 import java.awt.color.ColorSpace;
+import java.io.Serial;
 
 /**
  * Singleton class representing a simple, mathematically defined CMYK
  * color space.
  */
 public final class SimpleCMYKColorSpace extends ColorSpace {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 5387117338644522424L;
 
     private static ColorSpace theInstance = null;

--- a/src/java.desktop/share/classes/com/sun/media/sound/InvalidDataException.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/InvalidDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.media.sound;
 
 import java.io.IOException;
+import java.io.Serial;
 
 /**
  * This exception is used when a file contains illegal or unexpected data.
@@ -34,6 +35,10 @@ import java.io.IOException;
  */
 public class InvalidDataException extends IOException {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public InvalidDataException() {

--- a/src/java.desktop/share/classes/com/sun/media/sound/InvalidFormatException.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/InvalidFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package com.sun.media.sound;
 
+import java.io.Serial;
+
 /**
  * This exception is used when a reader is used to read file of a format
  * it doesn't unterstand or support.
@@ -33,6 +35,10 @@ package com.sun.media.sound;
  */
 public class InvalidFormatException extends InvalidDataException {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public InvalidFormatException() {

--- a/src/java.desktop/share/classes/com/sun/media/sound/RIFFInvalidDataException.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/RIFFInvalidDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package com.sun.media.sound;
 
+import java.io.Serial;
+
 /**
  * This exception is used when a RIFF file contains illegal or unexpected data.
  *
@@ -32,6 +34,10 @@ package com.sun.media.sound;
  */
 public final class RIFFInvalidDataException extends InvalidDataException {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public RIFFInvalidDataException() {

--- a/src/java.desktop/share/classes/com/sun/media/sound/RIFFInvalidFormatException.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/RIFFInvalidFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package com.sun.media.sound;
 
+import java.io.Serial;
+
 /**
  * This exception is used when a reader is used to read RIFF file of a format it
  * doesn't unterstand or support.
@@ -33,6 +35,10 @@ package com.sun.media.sound;
  */
 public final class RIFFInvalidFormatException extends InvalidFormatException {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public RIFFInvalidFormatException() {

--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.awt.Panel;
 import java.awt.event.ComponentEvent;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
@@ -94,6 +95,7 @@ public class Applet extends Panel {
     /**
      * Use serialVersionUID from JDK 1.0 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5836846270535785031L;
 
     /**
@@ -579,6 +581,7 @@ public class Applet extends Panel {
         /**
          * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 8127374778187708896L;
 
         /**

--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -111,6 +111,7 @@ public class Applet extends Panel {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException {
         if (GraphicsEnvironment.isHeadless()) {

--- a/src/java.desktop/share/classes/java/awt/AWTError.java
+++ b/src/java.desktop/share/classes/java/awt/AWTError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 1997, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 /**
  * Thrown when a serious Abstract Window Toolkit error has occurred.
  *
@@ -32,9 +34,10 @@ package java.awt;
  */
 public class AWTError extends Error {
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -1819846354050686206L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/AWTEvent.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.awt.event.TextEvent;
 import java.awt.event.WindowEvent;
 import java.awt.peer.ComponentPeer;
 import java.awt.peer.LightweightPeer;
+import java.io.Serial;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.util.EventObject;
@@ -252,9 +253,10 @@ public abstract class AWTEvent extends EventObject {
      */
     public static final int RESERVED_ID_MAX = 1999;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1825314779160409405L;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/AWTException.java
+++ b/src/java.desktop/share/classes/java/awt/AWTException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.io.Serial;
 
 /**
  * Signals that an Abstract Window Toolkit exception has occurred.
@@ -32,9 +34,10 @@ package java.awt;
  */
 public class AWTException extends Exception {
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -1900414231151323879L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
+++ b/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
@@ -731,6 +731,7 @@ public class AWTKeyStroke implements Serializable {
      * @return a cached instance which is equal to this instance
      * @throws java.io.ObjectStreamException if a serialization problem occurs
      */
+    @Serial
     protected Object readResolve() throws java.io.ObjectStreamException {
         synchronized (AWTKeyStroke.class) {
 

--- a/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
+++ b/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt;
 
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -64,7 +65,12 @@ import sun.swing.SwingAccessor;
  * @since 1.4
  */
 public class AWTKeyStroke implements Serializable {
-    static final long serialVersionUID = -6430539691155161871L;
+
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = -6430539691155161871L;
 
     private static Map<String, Integer> modifierKeywords;
     /**

--- a/src/java.desktop/share/classes/java/awt/AWTPermission.java
+++ b/src/java.desktop/share/classes/java/awt/AWTPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt;
 
+import java.io.Serial;
 import java.security.BasicPermission;
 
 /**
@@ -172,7 +173,10 @@ import java.security.BasicPermission;
  */
 public final class AWTPermission extends BasicPermission {
 
-    /** use serialVersionUID from the Java 2 platform for interoperability */
+    /**
+     * Use serialVersionUID from JDK 1.2 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 8890392402588814465L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/BorderLayout.java
+++ b/src/java.desktop/share/classes/java/awt/BorderLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 package java.awt;
 
-import java.util.Hashtable;
+import java.io.Serial;
 
 /**
  * A border layout lays out a container, arranging and resizing
@@ -338,9 +338,10 @@ public class BorderLayout implements LayoutManager2,
      */
     public static final String LINE_END = AFTER_LINE_ENDS;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -8658291919501921765L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -462,6 +462,7 @@ public class Button extends Component implements Accessible {
      * @see java.awt.Component#actionListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.beans.BeanProperty;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.Accessible;
@@ -115,9 +116,10 @@ public class Button extends Component implements Accessible {
     private static final String base = "button";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8774683716313001058L;
 
 
@@ -540,9 +542,10 @@ public class Button extends Component implements Accessible {
     protected class AccessibleAWTButton extends AccessibleAWTComponent
         implements AccessibleAction, AccessibleValue
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -5932203980244017102L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -490,6 +490,7 @@ public class Button extends Component implements Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Canvas.java
+++ b/src/java.desktop/share/classes/java/awt/Canvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.image.BufferStrategy;
 import java.awt.peer.CanvasPeer;
-import javax.accessibility.*;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * A {@code Canvas} component represents a blank rectangular
@@ -46,9 +51,10 @@ public class Canvas extends Component implements Accessible {
     private static final String base = "canvas";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -2284879212465893870L;
 
     /**
@@ -238,6 +244,10 @@ public class Canvas extends Component implements Accessible {
      */
     protected class AccessibleAWTCanvas extends AccessibleAWTComponent
     {
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
+         */
+        @Serial
         private static final long serialVersionUID = -6325592262103146699L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -123,6 +123,7 @@ public class CardLayout implements LayoutManager2,
      * @serialField vector      Vector the pairs of components and their names
      * @serialField currentCard int the index of Component currently displayed
      */
+    @Serial
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("tab", Hashtable.class),
         new ObjectStreamField("hgap", Integer.TYPE),

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -574,6 +574,7 @@ public class CardLayout implements LayoutManager2,
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -57,7 +58,10 @@ import java.util.Vector;
 
 public class CardLayout implements LayoutManager2,
                                    Serializable {
-
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -4328196481005934313L;
 
     /*
@@ -71,7 +75,12 @@ public class CardLayout implements LayoutManager2,
      * A pair of component and string that represents its name.
      */
     class Card implements Serializable {
-        static final long serialVersionUID = 6640330810709497518L;
+
+        /**
+         * Use serialVersionUID from JDK 1.4 for interoperability.
+         */
+        @Serial
+        private static final long serialVersionUID = 6640330810709497518L;
         public String name;
         public Component comp;
         public Card(String cardName, Component cardComponent) {

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -609,6 +609,7 @@ public class CardLayout implements LayoutManager2,
      * @param  s the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
         throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Checkbox.java
+++ b/src/java.desktop/share/classes/java/awt/Checkbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.peer.CheckboxPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.Accessible;
@@ -123,9 +124,10 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
     private static final String base = "checkbox";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7270714317450821763L;
 
     /**
@@ -718,9 +720,10 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
     protected class AccessibleAWTCheckbox extends AccessibleAWTComponent
         implements ItemListener, AccessibleAction, AccessibleValue
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7881579233144754107L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Checkbox.java
+++ b/src/java.desktop/share/classes/java/awt/Checkbox.java
@@ -666,6 +666,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Checkbox.java
+++ b/src/java.desktop/share/classes/java/awt/Checkbox.java
@@ -638,6 +638,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * @see java.awt.Component#itemListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/CheckboxGroup.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
+
+import java.io.Serial;
 
 /**
  * The {@code CheckboxGroup} class is used to group together
@@ -63,9 +66,10 @@ public class CheckboxGroup implements java.io.Serializable {
      */
     Checkbox selectedCheckbox = null;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 3729780091441768983L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.peer.CheckboxMenuItemPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.Accessible;
@@ -100,9 +101,10 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
     private static final String base = "chkmenuitem";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 6190621106981774043L;
 
     /**
@@ -536,9 +538,10 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
     protected class AccessibleAWTCheckboxMenuItem extends AccessibleAWTMenuItem
         implements AccessibleAction, AccessibleValue
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -1122642964303476L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -455,6 +455,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
      * @see java.awt.Component#itemListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -480,6 +480,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
      * @see #addActionListener(ActionListener)
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Choice.java
+++ b/src/java.desktop/share/classes/java/awt/Choice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.peer.ChoicePeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 import java.util.Vector;
 
@@ -102,9 +103,10 @@ public class Choice extends Component implements ItemSelectable, Accessible {
     private static final String base = "choice";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4075310674757313071L;
 
     static {
@@ -766,9 +768,10 @@ public class Choice extends Component implements ItemSelectable, Accessible {
     protected class AccessibleAWTChoice extends AccessibleAWTComponent
         implements AccessibleAction
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7175603582428509322L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Choice.java
+++ b/src/java.desktop/share/classes/java/awt/Choice.java
@@ -714,6 +714,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Choice.java
+++ b/src/java.desktop/share/classes/java/awt/Choice.java
@@ -686,6 +686,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * @see java.awt.Component#itemListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Color.java
+++ b/src/java.desktop/share/classes/java/awt/Color.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,12 @@
 
 package java.awt;
 
-import java.beans.ConstructorProperties;
-import java.awt.image.ColorModel;
+import java.awt.color.ColorSpace;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
-import java.awt.color.ColorSpace;
+import java.awt.image.ColorModel;
+import java.beans.ConstructorProperties;
+import java.io.Serial;
 
 /**
  * The {@code Color} class is used to encapsulate colors in the default
@@ -253,9 +254,10 @@ public class Color implements Paint, java.io.Serializable {
      */
     private ColorSpace cs = null;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 118526816881161077L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -8987,6 +8987,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @throws IOException if an I/O error occurs
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.Serializable;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -671,9 +672,10 @@ public abstract class Component implements ImageObserver, MenuContainer,
      */
     public static final float RIGHT_ALIGNMENT = 1.0f;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -7644114512714619750L;
 
     /**
@@ -9310,6 +9312,10 @@ public abstract class Component implements ImageObserver, MenuContainer,
     protected abstract class AccessibleAWTComponent extends AccessibleContext
         implements Serializable, AccessibleComponent {
 
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
+         */
+        @Serial
         private static final long serialVersionUID = 642321655757800191L;
 
         /**
@@ -9346,6 +9352,11 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * @since 1.3
          */
         protected class AccessibleAWTComponentHandler implements ComponentListener, Serializable {
+
+            /**
+             * Use serialVersionUID from JDK 1.3 for interoperability.
+             */
+            @Serial
             private static final long serialVersionUID = -1009684107426231869L;
 
             /**
@@ -9383,6 +9394,11 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * @since 1.3
          */
         protected class AccessibleAWTFocusHandler implements FocusListener, Serializable {
+
+            /**
+             * Use serialVersionUID from JDK 1.3 for interoperability.
+             */
+            @Serial
             private static final long serialVersionUID = 3150908257351582233L;
 
             /**

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -8947,6 +8947,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @see #mouseWheelListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
+++ b/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@
 
 package java.awt;
 
+import java.io.Serial;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -90,9 +91,10 @@ import java.util.ResourceBundle;
   */
 public final class ComponentOrientation implements java.io.Serializable
 {
-    /*
-     * serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4113291392143563828L;
 
     // Internal constants used in the implementation

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -242,6 +242,7 @@ public class Container extends Component {
      * @serialField focusTraversalPolicyProvider    boolean
      *       Stores the value of focusTraversalPolicyProvider property.
      */
+    @Serial
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("ncomponents", Integer.TYPE),
         new ObjectStreamField("component", Component[].class),

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -3685,6 +3685,7 @@ public class Container extends Component {
      * @see Container#containerListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         ObjectOutputStream.PutField f = s.putFields();
         f.put("ncomponents", component.size());

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.security.AccessController;
@@ -181,8 +182,9 @@ public class Container extends Component {
     transient Color preserveBackgroundColor = null;
 
     /**
-     * JDK 1.1 serialVersionUID
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4613797578919906343L;
 
     /**
@@ -3807,8 +3809,9 @@ public class Container extends Component {
     protected class AccessibleAWTContainer extends AccessibleAWTComponent {
 
         /**
-         * JDK1.3 serialVersionUID
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 5081320404842566097L;
 
         /**
@@ -3871,6 +3874,11 @@ public class Container extends Component {
          */
         protected class AccessibleContainerHandler
             implements ContainerListener, Serializable {
+
+            /**
+             * Use serialVersionUID from JDK 1.3 for interoperability.
+             */
+            @Serial
             private static final long serialVersionUID = -480855353991814677L;
 
             /**
@@ -4427,9 +4435,10 @@ public class Container extends Component {
  */
 class LightweightDispatcher implements java.io.Serializable, AWTEventListener {
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5184291520170872969L;
     /*
      * Our own mouse event for when we're dragged over from another hw

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -3727,6 +3727,7 @@ public class Container extends Component {
      * @see #addContainerListener
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,9 +75,10 @@ public class ContainerOrderFocusTraversalPolicy extends FocusTraversalPolicy
      */
     private final int BACKWARD_TRAVERSAL = 1;
 
-    /*
-     * JDK 1.4 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 486933713763926351L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Cursor.java
+++ b/src/java.desktop/share/classes/java/awt/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.beans.ConstructorProperties;
 import java.io.InputStream;
+import java.io.Serial;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
@@ -173,9 +175,10 @@ public class Cursor implements java.io.Serializable {
     private static final String DOT_HOTSPOT_SUFFIX = ".HotSpot";
     private static final String DOT_NAME_SUFFIX = ".Name";
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8028237497568985504L;
 
     private static final PlatformLogger log = PlatformLogger.getLogger("java.awt.Cursor");

--- a/src/java.desktop/share/classes/java/awt/DefaultFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/DefaultFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.peer.ComponentPeer;
-
+import java.io.Serial;
 
 /**
  * A FocusTraversalPolicy that determines traversal order based on the order
@@ -70,9 +71,10 @@ import java.awt.peer.ComponentPeer;
 public class DefaultFocusTraversalPolicy
     extends ContainerOrderFocusTraversalPolicy
 {
-    /*
-     * serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8876966522510157497L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
+++ b/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.event.FocusEvent;
@@ -29,6 +30,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.awt.peer.ComponentPeer;
 import java.awt.peer.LightweightPeer;
+import java.io.Serial;
 import java.lang.ref.WeakReference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -227,9 +229,10 @@ public class DefaultKeyboardFocusManager extends KeyboardFocusManager {
     private static class DefaultKeyboardFocusManagerSentEvent
         extends SentEvent
     {
-        /*
-         * serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -2924743257508701758L;
 
         public DefaultKeyboardFocusManagerSentEvent(AWTEvent nested,

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.event.WindowEvent;
 import java.awt.peer.DialogPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -316,9 +317,10 @@ public class Dialog extends Window {
     private static final String base = "dialog";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5920926903803293709L;
 
     /**
@@ -1668,9 +1670,10 @@ public class Dialog extends Window {
      */
     protected class AccessibleAWTDialog extends AccessibleAWTWindow
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 4837230331833941201L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -1604,6 +1604,7 @@ public class Dialog extends Window {
      * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
      *         returns {@code true}
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Dimension.java
+++ b/src/java.desktop/share/classes/java/awt/Dimension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt;
 
 import java.awt.geom.Dimension2D;
 import java.beans.Transient;
+import java.io.Serial;
 
 /**
  * The {@code Dimension} class encapsulates the width and
@@ -73,9 +74,10 @@ public class Dimension extends Dimension2D implements java.io.Serializable {
      */
     public int height;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 4723952579491349524L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Event.java
+++ b/src/java.desktop/share/classes/java/awt/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.event.KeyEvent;
+import java.io.Serial;
 
 /**
  * <b>NOTE:</b> The {@code Event} class is obsolete and is
@@ -592,9 +594,10 @@ public class Event implements java.io.Serializable {
      */
     private boolean consumed = false;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5488922509400504703L;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 
 import sun.awt.AWTAccessor;
 
@@ -133,9 +134,10 @@ public class FileDialog extends Dialog {
     private static final String base = "filedlg";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 5035145889651310422L;
 
 

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -607,6 +607,7 @@ public class FileDialog extends Dialog {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/FlowLayout.java
+++ b/src/java.desktop/share/classes/java/awt/FlowLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 
 /**
  * A flow layout arranges components in a directional flow, much
@@ -191,9 +192,10 @@ public class FlowLayout implements LayoutManager, java.io.Serializable {
      */
     private boolean alignOnBaseline;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -7262534875583282631L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/FlowLayout.java
+++ b/src/java.desktop/share/classes/java/awt/FlowLayout.java
@@ -671,6 +671,7 @@ public class FlowLayout implements LayoutManager, java.io.Serializable {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream stream)
          throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -1918,6 +1918,7 @@ public class Font implements java.io.Serializable
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(java.io.ObjectInputStream)
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.lang.ref.SoftReference;
 import java.nio.file.Files;
 import java.security.AccessController;
@@ -469,9 +470,10 @@ public class Font implements java.io.Serializable
      */
     private static final AffineTransform identityTx = new AffineTransform();
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4206021311591459213L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -1945,6 +1945,7 @@ public class Font implements java.io.Serializable
      * @serial
      * @see #writeObject(java.io.ObjectOutputStream)
      */
+    @Serial
     private void readObject(java.io.ObjectInputStream s)
       throws java.lang.ClassNotFoundException,
              java.io.IOException

--- a/src/java.desktop/share/classes/java/awt/FontFormatException.java
+++ b/src/java.desktop/share/classes/java/awt/FontFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 /**
  * Thrown by method createFont in the {@code Font} class to indicate
  * that the specified font is bad.
@@ -35,9 +37,11 @@ package java.awt;
  */
 public
 class FontFormatException extends Exception {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4481290147811361272L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/FontMetrics.java
+++ b/src/java.desktop/share/classes/java/awt/FontMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package java.awt;
 
-import java.awt.Graphics2D;
 import java.awt.font.FontRenderContext;
 import java.awt.font.LineMetrics;
 import java.awt.geom.Rectangle2D;
+import java.io.Serial;
 import java.text.CharacterIterator;
 
 /**
@@ -119,9 +119,10 @@ public abstract class FontMetrics implements java.io.Serializable {
      */
     protected Font font;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1681126225205050147L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -1226,6 +1226,7 @@ public class Frame extends Window implements MenuContainer {
      * @see #setIconImage(Image)
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -1189,6 +1189,7 @@ public class Frame extends Window implements MenuContainer {
      * @see #setIconImage(Image)
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.peer.FramePeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Vector;
@@ -364,9 +365,10 @@ public class Frame extends Window implements MenuContainer {
     private static final String base = "frame";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 2673458971256075116L;
 
     static {
@@ -1296,9 +1298,10 @@ public class Frame extends Window implements MenuContainer {
      */
     protected class AccessibleAWTFrame extends AccessibleAWTWindow
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -6172960752956030250L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/GraphicsConfigTemplate.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsConfigTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,8 @@
 
 package java.awt;
 
-import java.io.*;
+import java.io.Serial;
+import java.io.Serializable;
 
 /**
  * The {@code GraphicsConfigTemplate} class is used to obtain a valid
@@ -42,9 +43,11 @@ import java.io.*;
  * @since       1.2
  */
 public abstract class GraphicsConfigTemplate implements Serializable {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8061369279557787079L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/GridBagConstraints.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
+
+import java.io.Serial;
 
 /**
  * The {@code GridBagConstraints} class specifies constraints
@@ -565,9 +568,10 @@ public class GridBagConstraints implements Cloneable, java.io.Serializable {
     // Where the baseline lands relative to the center of the component.
     transient int centerOffset;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1000070633030801713L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.util.Hashtable;
+import java.io.Serial;
 import java.util.Arrays;
+import java.util.Hashtable;
 
 /**
  * The {@code GridBagLayout} class is a flexible layout
@@ -2230,6 +2232,9 @@ java.io.Serializable {
         }
     }
 
-    // Added for serial backwards compatibility (4348425)
-    static final long serialVersionUID = 8838754796412211005L;
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 8838754796412211005L;
 }

--- a/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 /**
  * The {@code GridBagLayoutInfo} is an utility class for
  * {@code GridBagLayout} layout manager.
@@ -36,9 +38,10 @@ package java.awt;
  */
 public class GridBagLayoutInfo implements java.io.Serializable {
 
-    /*
-     * serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4899416460737170217L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/GridLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.awt;
+
+import java.io.Serial;
 
 /**
  * The {@code GridLayout} class is a layout manager that
@@ -87,9 +89,11 @@ package java.awt;
  * @since   1.0
  */
 public class GridLayout implements LayoutManager, java.io.Serializable {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -7411804673224730901L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/HeadlessException.java
+++ b/src/java.desktop/share/classes/java/awt/HeadlessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 /**
  * Thrown when code that is dependent on a keyboard, display, or mouse
  * is called in an environment that does not support a keyboard, display,
@@ -38,9 +40,11 @@ package java.awt;
  * @see GraphicsEnvironment#isHeadless
  */
 public class HeadlessException extends UnsupportedOperationException {
-    /*
-     * JDK 1.4 serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 167183644944358563L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/IllegalComponentStateException.java
+++ b/src/java.desktop/share/classes/java/awt/IllegalComponentStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 1997, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 /**
  * Signals that an AWT component is not in an appropriate state for
  * the requested operation.
@@ -32,9 +34,11 @@ package java.awt;
  * @author      Jonni Kanerva
  */
 public class IllegalComponentStateException extends IllegalStateException {
-    /*
-     * JDK 1.1 serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -1889339587208144238L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Insets.java
+++ b/src/java.desktop/share/classes/java/awt/Insets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.awt;
+
+import java.io.Serial;
 
 /**
  * An {@code Insets} object is a representation of the borders
@@ -79,9 +81,10 @@ public class Insets implements Cloneable, java.io.Serializable {
      */
     public int right;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2272572637695466749L;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/Label.java
+++ b/src/java.desktop/share/classes/java/awt/Label.java
@@ -170,6 +170,7 @@ public class Label extends Component implements Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException {
         GraphicsEnvironment.checkHeadless();

--- a/src/java.desktop/share/classes/java/awt/Label.java
+++ b/src/java.desktop/share/classes/java/awt/Label.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt;
 import java.awt.peer.LabelPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
@@ -104,9 +105,10 @@ public class Label extends Component implements Accessible {
     private static final String base = "label";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 3094126758329070636L;
 
     /**
@@ -325,9 +327,10 @@ public class Label extends Component implements Accessible {
      */
     protected class AccessibleAWTLabel extends AccessibleAWTComponent
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -3568967560160480438L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1253,6 +1253,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * @see java.awt.Component#actionListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1289,6 +1289,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.awt.peer.ListPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 import java.util.Locale;
 import java.util.Vector;
@@ -180,9 +181,10 @@ public class List extends Component implements ItemSelectable, Accessible {
     private static final String base = "list";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -3304312411574666869L;
 
     /**
@@ -1339,9 +1341,10 @@ public class List extends Component implements ItemSelectable, Accessible {
     protected class AccessibleAWTList extends AccessibleAWTComponent
         implements AccessibleSelection, ItemListener, ActionListener
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7924617370136012829L;
 
         /**
@@ -1538,9 +1541,10 @@ public class List extends Component implements ItemSelectable, Accessible {
         protected class AccessibleAWTListChild extends AccessibleAWTComponent
             implements Accessible
         {
-            /*
-             * JDK 1.3 serialVersionUID
+            /**
+             * Use serialVersionUID from JDK 1.3 for interoperability.
              */
+            @Serial
             private static final long serialVersionUID = 4412022926028300317L;
 
         // [[[FIXME]]] need to finish implementing this!!!

--- a/src/java.desktop/share/classes/java/awt/MediaTracker.java
+++ b/src/java.desktop/share/classes/java/awt/MediaTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt;
 
 import java.awt.image.ImageObserver;
+import java.io.Serial;
 
 import sun.awt.image.MultiResolutionToolkitImage;
 
@@ -187,9 +188,10 @@ public class MediaTracker implements java.io.Serializable {
     @SuppressWarnings("serial") // Not statically typed as Serializable
     MediaEntry head;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -483174189758638095L;
 
     /**
@@ -934,9 +936,10 @@ java.io.Serializable {
     int width;
     int height;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4739377000350280650L;
 
     ImageMediaEntry(MediaTracker mt, Image img, int c, int w, int h) {

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -533,6 +533,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.peer.MenuPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Vector;
@@ -114,9 +115,10 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
     private static final String base = "menu";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -8809584163345499784L;
 
     /**
@@ -622,9 +624,10 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      */
     protected class AccessibleAWTMenu extends AccessibleAWTMenuItem
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 5228160894980069094L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -553,6 +553,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws IOException, ClassNotFoundException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -434,6 +434,7 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(java.io.ObjectInputStream)
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -454,6 +454,7 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(java.io.ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.peer.MenuBarPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Vector;
@@ -118,9 +119,10 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
     private static final String base = "menubar";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -4930327919388951260L;
 
     /**
@@ -509,9 +511,10 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
      */
     protected class AccessibleAWTMenuBar extends AccessibleAWTMenuComponent
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -8577604491830083815L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -449,6 +449,7 @@ public abstract class MenuComponent implements java.io.Serializable {
      * @serial
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.event.ActionEvent;
 import java.awt.peer.MenuComponentPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 
@@ -133,9 +134,10 @@ public abstract class MenuComponent implements java.io.Serializable {
     static final String actionListenerK = Component.actionListenerK;
     static final String itemListenerK = Component.itemListenerK;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4536902356223894379L;
 
     static {
@@ -507,9 +509,10 @@ public abstract class MenuComponent implements java.io.Serializable {
         implements java.io.Serializable, AccessibleComponent,
                    AccessibleSelection
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -4269533416223798698L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.peer.MenuItemPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.Accessible;
@@ -175,9 +176,10 @@ public class MenuItem extends MenuComponent implements Accessible {
     private static final String base = "menuitem";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -21757335363267194L;
 
     /**
@@ -821,9 +823,10 @@ public class MenuItem extends MenuComponent implements Accessible {
     protected class AccessibleAWTMenuItem extends AccessibleAWTMenuComponent
         implements AccessibleAction, AccessibleValue
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -217847831945965825L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -765,6 +765,7 @@ public class MenuItem extends MenuComponent implements Accessible {
      * @see #addActionListener(ActionListener)
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -739,6 +739,7 @@ public class MenuItem extends MenuComponent implements Accessible {
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/MenuShortcut.java
+++ b/src/java.desktop/share/classes/java/awt/MenuShortcut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.io.Serial;
 
 /**
  * The {@code MenuShortcut} class represents a keyboard accelerator
@@ -87,9 +89,10 @@ public class MenuShortcut implements java.io.Serializable
      */
     boolean usesShift;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 143448358473180225L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Panel.java
+++ b/src/java.desktop/share/classes/java/awt/Panel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import javax.accessibility.*;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * {@code Panel} is the simplest container class. A panel
@@ -42,9 +47,10 @@ public class Panel extends Container implements Accessible {
     private static final String base = "panel";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -2728009084054400034L;
 
     /**
@@ -117,6 +123,10 @@ public class Panel extends Container implements Accessible {
      */
     protected class AccessibleAWTPanel extends AccessibleAWTContainer {
 
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
+         */
+        @Serial
         private static final long serialVersionUID = -6409552226660031050L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Point.java
+++ b/src/java.desktop/share/classes/java/awt/Point.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt;
 
 import java.awt.geom.Point2D;
 import java.beans.Transient;
+import java.io.Serial;
 
 /**
  * A point representing a location in {@code (x,y)} coordinate space,
@@ -58,9 +59,10 @@ public class Point extends Point2D implements java.io.Serializable {
      */
     public int y;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5276940640259749850L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import sun.awt.geom.Crossings;
+import java.io.Serial;
 import java.util.Arrays;
+
+import sun.awt.geom.Crossings;
 
 /**
  * The {@code Polygon} class encapsulates a description of a
@@ -109,9 +112,10 @@ public class Polygon implements Shape, java.io.Serializable {
      */
     protected Rectangle bounds;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6460061437900069969L;
 
     /*

--- a/src/java.desktop/share/classes/java/awt/PopupMenu.java
+++ b/src/java.desktop/share/classes/java/awt/PopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt;
 
 import java.awt.peer.PopupMenuPeer;
+import java.io.Serial;
 
 import javax.accessibility.AccessibleContext;
 import javax.accessibility.AccessibleRole;
@@ -60,9 +61,10 @@ public class PopupMenu extends Menu {
             });
     }
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4620452533522760060L;
 
     /**
@@ -223,9 +225,10 @@ public class PopupMenu extends Menu {
      */
     protected class AccessibleAWTPopupMenu extends AccessibleAWTMenu
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -4282044795947239955L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Rectangle.java
+++ b/src/java.desktop/share/classes/java/awt/Rectangle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt;
 
 import java.awt.geom.Rectangle2D;
 import java.beans.Transient;
+import java.io.Serial;
 
 /**
  * A {@code Rectangle} specifies an area in a coordinate space that is
@@ -158,9 +159,10 @@ public class Rectangle extends Rectangle2D
      */
     public int height;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = -4345857070255674764L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -704,6 +704,7 @@ public class ScrollPane extends Container implements Accessible {
      *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -685,6 +685,7 @@ public class ScrollPane extends Container implements Accessible {
      * @param  s the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         // 4352819: We only need this degenerate writeObject to make
         // it safe for future versions of this class to write optional

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.beans.Transient;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
@@ -178,9 +179,10 @@ public class ScrollPane extends Container implements Accessible {
      */
     private boolean wheelScrollingEnabled = defaultWheelScroll;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7956609840827222915L;
 
     /**
@@ -738,6 +740,10 @@ public class ScrollPane extends Container implements Accessible {
      */
     class PeerFixer implements AdjustmentListener, java.io.Serializable
     {
+        /**
+         * Use serialVersionUID from JDK 1.1.1 for interoperability.
+         */
+        @Serial
         private static final long serialVersionUID = 1043664721353696630L;
 
         PeerFixer(ScrollPane scroller) {
@@ -803,9 +809,10 @@ public class ScrollPane extends Container implements Accessible {
      */
     protected class AccessibleAWTScrollPane extends AccessibleAWTContainer
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6100703663886637L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.peer.ScrollPanePeer;
+import java.io.Serial;
 import java.io.Serializable;
 
 import sun.awt.AWTAccessor;
@@ -172,8 +173,9 @@ public class ScrollPaneAdjustable implements Adjustable, Serializable {
     }
 
     /**
-     * JDK 1.1 serialVersionUID.
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3359745691033257079L;
 
 

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -1219,6 +1219,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.peer.ScrollbarPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.Accessible;
@@ -280,9 +281,10 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
     private static final String base = "scrollbar";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8451667562882310543L;
 
     /**
@@ -1267,9 +1269,10 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
     protected class AccessibleAWTScrollBar extends AccessibleAWTComponent
         implements AccessibleValue
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -344337268523697807L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -1193,6 +1193,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * @see java.awt.Component#adjustmentListenerK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/SentEvent.java
+++ b/src/java.desktop/share/classes/java/awt/SentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt;
 
+import java.io.Serial;
+
 import sun.awt.AppContext;
 import sun.awt.SunToolkit;
 
@@ -37,9 +39,11 @@ import sun.awt.SunToolkit;
  * @author David Mendenhall
  */
 class SentEvent extends AWTEvent implements ActiveEvent {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -383615247028828931L;
 
     static final int ID =

--- a/src/java.desktop/share/classes/java/awt/SequencedEvent.java
+++ b/src/java.desktop/share/classes/java/awt/SequencedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,11 @@
 
 package java.awt;
 
+import java.io.Serial;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Iterator;
 import java.util.LinkedList;
+
 import sun.awt.AWTAccessor;
 import sun.awt.AppContext;
 import sun.awt.SunToolkit;
@@ -45,9 +46,11 @@ import sun.awt.SunToolkit;
  * @author David Mendenhall
  */
 class SequencedEvent extends AWTEvent implements ActiveEvent {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 547742659238625067L;
 
     private static final int ID =

--- a/src/java.desktop/share/classes/java/awt/SystemColor.java
+++ b/src/java.desktop/share/classes/java/awt/SystemColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt;
 
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.lang.annotation.Native;
 
 import sun.awt.AWTAccessor;
@@ -421,9 +422,10 @@ public final class SystemColor extends Color implements java.io.Serializable {
      */
     public static final SystemColor infoText = new SystemColor((byte)INFO_TEXT);
 
-    /*
-     * JDK 1.1 serialVersionUID.
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4503142729533789064L;
 
     /*

--- a/src/java.desktop/share/classes/java/awt/SystemColor.java
+++ b/src/java.desktop/share/classes/java/awt/SystemColor.java
@@ -516,6 +516,7 @@ public final class SystemColor extends Color implements java.io.Serializable {
      * @return one of the {@code SystemColor} static object
      *         fields that refers to the same system color.
      */
+    @Serial
     private Object readResolve() {
         // The instances of SystemColor are tightly controlled and
         // only the canonical instances appearing above as static

--- a/src/java.desktop/share/classes/java/awt/SystemColor.java
+++ b/src/java.desktop/share/classes/java/awt/SystemColor.java
@@ -541,6 +541,7 @@ public final class SystemColor extends Color implements java.io.Serializable {
      * @throws ObjectStreamException if a new object replacing this object could
      *         not be created
      */
+    @Serial
     private Object writeReplace() throws ObjectStreamException
     {
         // we put an array index in the SystemColor.value while serialize

--- a/src/java.desktop/share/classes/java/awt/TextArea.java
+++ b/src/java.desktop/share/classes/java/awt/TextArea.java
@@ -661,6 +661,7 @@ public class TextArea extends TextComponent {
      *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/TextArea.java
+++ b/src/java.desktop/share/classes/java/awt/TextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt;
 import java.awt.peer.TextAreaPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -126,9 +127,10 @@ public class TextArea extends TextComponent {
      */
     private static Set<AWTKeyStroke> forwardTraversalKeys, backwardTraversalKeys;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 3692302836626095722L;
 
     /**
@@ -719,9 +721,10 @@ public class TextArea extends TextComponent {
      */
     protected class AccessibleAWTTextArea extends AccessibleAWTTextComponent
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 3472827823632144419L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -817,6 +817,7 @@ public class TextComponent extends Component implements Accessible {
      * @see #addTextListener
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -781,6 +781,7 @@ public class TextComponent extends Component implements Accessible {
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#textListenerK
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.peer.TextComponentPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.text.BreakIterator;
 import java.util.EventListener;
 
@@ -123,9 +124,10 @@ public class TextComponent extends Component implements Accessible {
      */
     protected transient TextListener textListener;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2214773872412987419L;
 
     /**
@@ -871,9 +873,10 @@ public class TextComponent extends Component implements Accessible {
     protected class AccessibleAWTTextComponent extends AccessibleAWTComponent
         implements AccessibleText, TextListener
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 3631432373506317811L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -712,6 +712,7 @@ public class TextField extends TextComponent {
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#actionListenerK
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.peer.TextFieldPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
 
 import javax.accessibility.AccessibleContext;
@@ -130,9 +131,10 @@ public class TextField extends TextComponent {
     private static final String base = "textfield";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2966288784432217853L;
 
     /**
@@ -792,9 +794,10 @@ public class TextField extends TextComponent {
      */
     protected class AccessibleAWTTextField extends AccessibleAWTTextComponent
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6219164359235943158L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -738,6 +738,7 @@ public class TextField extends TextComponent {
      * @see #addActionListener(ActionListener)
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -2961,6 +2961,7 @@ public class Window extends Container implements Accessible {
      * @see Component#ownedWindowK
      * @see #readObject(ObjectInputStream)
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         synchronized (this) {
             // Update old focusMgr fields so that our object stream can be read

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -3108,6 +3108,7 @@ public class Window extends Container implements Accessible {
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OptionalDataException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -387,9 +388,10 @@ public class Window extends Container implements Accessible {
     private static final String base = "win";
     private static int nameCounter = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4497834738069338734L;
 
     private static final PlatformLogger log = PlatformLogger.getLogger("java.awt.Window");
@@ -3165,9 +3167,10 @@ public class Window extends Container implements Accessible {
      */
     protected class AccessibleAWTWindow extends AccessibleAWTContainer
     {
-        /*
-         * JDK 1.3 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.3 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 4215068635060671780L;
 
         /**
@@ -4126,8 +4129,9 @@ class FocusManager implements java.io.Serializable {
     Container focusRoot;
     Component focusOwner;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
-    static final long serialVersionUID = 2491878825643557906L;
+    @Serial
+    private static final long serialVersionUID = 2491878825643557906L;
 }

--- a/src/java.desktop/share/classes/java/awt/color/CMMException.java
+++ b/src/java.desktop/share/classes/java/awt/color/CMMException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@
 
 package java.awt.color;
 
+import java.io.Serial;
+
 /**
  * This exception is thrown if the native CMM returns an error.
  */
@@ -43,6 +45,7 @@ public class CMMException extends RuntimeException {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5775558044142994965L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 
 package java.awt.color;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.annotation.Native;
 
@@ -97,6 +98,7 @@ public abstract class ColorSpace implements Serializable {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -409452704308689724L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@
 package java.awt.color;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import sun.java2d.cmm.CMSManager;
 import sun.java2d.cmm.ColorTransform;
@@ -82,6 +83,7 @@ public class ICC_ColorSpace extends ColorSpace {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 3455889114070431483L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -157,6 +157,7 @@ public class ICC_ColorSpace extends ColorSpace {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(java.io.ObjectInputStream s)
         throws ClassNotFoundException, java.io.IOException {
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -2007,6 +2007,7 @@ public class ICC_Profile implements Serializable {
      *         serialization spec
      * @since 1.3
      */
+    @Serial
     protected Object readResolve() throws ObjectStreamException {
         return resolvedDeserializedProfile;
     }

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1898,6 +1898,7 @@ public class ICC_Profile implements Serializable {
      *         only the color space name, but the profile data as well so that
      *         older versions could still deserialize the object.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s)
       throws IOException
     {

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1964,6 +1964,7 @@ public class ICC_Profile implements Serializable {
      * @see #getInstance(int)
      * @see #getInstance(byte[])
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -89,6 +90,7 @@ public class ICC_Profile implements Serializable {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3938515861990936766L;
 
     private transient Profile cmmProfile;

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ProfileGray.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ProfileGray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@
 
 package java.awt.color;
 
+import java.io.Serial;
+
 import sun.java2d.cmm.Profile;
 import sun.java2d.cmm.ProfileDeferralInfo;
 
@@ -69,6 +71,7 @@ public class ICC_ProfileGray extends ICC_Profile {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1124721290732002649L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ProfileRGB.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ProfileRGB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@
  **********************************************************************/
 
 package java.awt.color;
+
+import java.io.Serial;
 
 import sun.java2d.cmm.Profile;
 import sun.java2d.cmm.ProfileDeferralInfo;
@@ -83,6 +85,7 @@ public class ICC_ProfileRGB extends ICC_Profile {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8505067385152579334L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ProfileDataException.java
+++ b/src/java.desktop/share/classes/java/awt/color/ProfileDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.color;
 
+import java.io.Serial;
+
 /**
  * This exception is thrown when an error occurs in accessing or processing an
  * {@code ICC_Profile} object.
@@ -34,6 +36,7 @@ public class ProfileDataException extends RuntimeException {
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7286140888240322498L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/AboutEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/AboutEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application is asked to open its about window.
@@ -40,6 +41,7 @@ public final class AboutEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5987180734802756477L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/AppEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/AppEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -41,6 +42,7 @@ public class AppEvent extends EventObject {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5958503993556009432L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/AppForegroundEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/AppForegroundEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application has become the foreground app, and when it is
@@ -42,6 +43,7 @@ public final class AppForegroundEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5513582555740533911L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/AppHiddenEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/AppHiddenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application has been hidden or shown.
@@ -41,6 +42,7 @@ public final class AppHiddenEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2637465279476429224L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/AppReopenedEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/AppReopenedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application is asked to re-open itself.
@@ -40,6 +41,7 @@ public final class AppReopenedEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1503238361530407990L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/FilesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/FilesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.io.File;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,6 +43,7 @@ public class FilesEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5271763715462312871L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/OpenFilesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/OpenFilesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.io.File;
+import java.io.Serial;
 import java.util.List;
 
 /**
@@ -42,6 +43,7 @@ public final class OpenFilesEvent extends FilesEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3982871005867718956L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/OpenURIEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/OpenURIEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 import java.net.URI;
 
 /**
@@ -41,6 +42,7 @@ public final class OpenURIEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 221209100935933476L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/PreferencesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/PreferencesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application is asked to open its preferences window.
@@ -40,6 +41,7 @@ public final class PreferencesEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6398607097086476160L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/PrintFilesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/PrintFilesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.io.File;
+import java.io.Serial;
 import java.util.List;
 
 /**
@@ -42,6 +43,7 @@ public final class PrintFilesEvent extends FilesEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5752560876153618618L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/QuitEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/QuitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the application is asked to quit.
@@ -40,6 +41,7 @@ public final class QuitEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -256100795532403146L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/ScreenSleepEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/ScreenSleepEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the displays attached to the system enter and exit power save
@@ -42,6 +43,7 @@ public final class ScreenSleepEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7521606180376544150L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/SystemSleepEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/SystemSleepEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the system enters and exits power save sleep.
@@ -41,6 +42,7 @@ public final class SystemSleepEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 11372269824930549L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/desktop/UserSessionEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/UserSessionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.desktop;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
+import java.io.Serial;
 
 /**
  * Event sent when the user session has been changed. Some systems may provide a
@@ -42,6 +43,7 @@ public final class UserSessionEvent extends AppEvent {
     /**
      * Use serialVersionUID from JDK 9 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6747138462796569055L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Collections;
 import java.util.EventObject;
 import java.util.Iterator;
@@ -65,6 +66,10 @@ import java.util.List;
 
 public class DragGestureEvent extends EventObject {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 9080172649166731306L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
@@ -329,6 +329,7 @@ public class DragGestureEvent extends EventObject {
      * @throws IOException if an I/O error occurs
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
@@ -304,6 +304,7 @@ public class DragGestureEvent extends EventObject {
      *             {@code null}.
      * @since 1.4
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
@@ -402,6 +402,7 @@ public abstract class DragGestureRecognizer implements Serializable {
      *             {@code null}.
      * @since 1.4
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
@@ -422,6 +422,7 @@ public abstract class DragGestureRecognizer implements Serializable {
      * @throws IOException if an I/O error occurs
      * @since 1.4
      */
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.TooManyListenersException;
@@ -82,6 +83,10 @@ import java.util.TooManyListenersException;
 
 public abstract class DragGestureRecognizer implements Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 8996673345831063337L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.awt.datatransfer.Transferable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.util.EventListener;
@@ -117,6 +118,10 @@ import sun.security.action.GetIntegerAction;
 
 public class DragSource implements Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 6236096958971414066L;
 
     /*

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -863,6 +863,7 @@ public class DragSource implements Serializable {
      * @see java.awt.datatransfer.SystemFlavorMap#getDefaultFlavorMap
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -823,6 +823,7 @@ public class DragSource implements Serializable {
      *      </ul>.
      * @since 1.4
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
@@ -558,6 +558,7 @@ public class DragSourceContext
      *             {@code null}.
      * @since 1.4
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.TooManyListenersException;
 
@@ -92,6 +93,10 @@ import sun.awt.ComponentFactory;
 public class DragSourceContext
     implements DragSourceListener, DragSourceMotionListener, Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -115407898692194719L;
 
     // used by updateCurrentCursor

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
@@ -584,6 +584,7 @@ public class DragSourceContext
      * @throws IOException if an I/O error occurs
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceDragEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceDragEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.dnd;
 
 import java.awt.event.InputEvent;
+import java.io.Serial;
 
 /**
  * The {@code DragSourceDragEvent} is
@@ -71,6 +72,10 @@ import java.awt.event.InputEvent;
 
 public class DragSourceDragEvent extends DragSourceEvent {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 481346297933902471L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceDropEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceDropEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.dnd;
 
+import java.io.Serial;
+
 /**
  * The {@code DragSourceDropEvent} is delivered
  * from the {@code DragSourceContextPeer},
@@ -42,6 +44,10 @@ package java.awt.dnd;
 
 public class DragSourceDropEvent extends DragSourceEvent {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -5571321229470821891L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package java.awt.dnd;
 
 import java.awt.Point;
-
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -59,6 +59,10 @@ import java.util.EventObject;
 
 public class DragSourceEvent extends EventObject {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -763287114604032641L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -586,6 +586,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      *             instance, or {@code null}.
      * @since 1.4
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -610,6 +610,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      * @throws IOException if an I/O error occurs
      * @since 1.4
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import java.awt.peer.LightweightPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.TooManyListenersException;
 
@@ -67,6 +68,10 @@ import sun.awt.AWTAccessor.ComponentAccessor;
 
 public class DropTarget implements DropTargetListener, Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -6283860791671019047L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,13 @@
 package java.awt.dnd;
 
 import java.awt.Component;
-
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-
 import java.awt.dnd.peer.DropTargetContextPeer;
-
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -58,6 +55,10 @@ import sun.awt.AWTAccessor.DropTargetContextAccessor;
 
 public class DropTargetContext implements Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -634158968993743371L;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDragEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDragEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 package java.awt.dnd;
 
 import java.awt.Point;
-
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
-
+import java.io.Serial;
 import java.util.List;
 
 /**
@@ -72,6 +71,10 @@ import java.util.List;
 
 public class DropTargetDragEvent extends DropTargetEvent {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -8422265619058953682L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 package java.awt.dnd;
 
 import java.awt.Point;
-
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
-
+import java.io.Serial;
 import java.util.List;
 
 /**
@@ -71,6 +70,10 @@ import java.util.List;
 
 public class DropTargetDropEvent extends DropTargetEvent {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -1721911170440459322L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,7 @@
 
 package java.awt.dnd;
 
-import java.util.EventObject;
-import java.awt.dnd.DropTargetContext;
+import java.io.Serial;
 
 /**
  * The {@code DropTargetEvent} is the base
@@ -42,6 +41,10 @@ import java.awt.dnd.DropTargetContext;
 
 public class DropTargetEvent extends java.util.EventObject {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 2821229066521922993L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/dnd/InvalidDnDOperationException.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/InvalidDnDOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.dnd;
 
+import java.io.Serial;
+
 /**
  * This exception is thrown by various methods in the java.awt.dnd package.
  * It is usually thrown to indicate that the target in question is unable
@@ -36,6 +38,10 @@ package java.awt.dnd;
 
 public class InvalidDnDOperationException extends IllegalStateException {
 
+    /**
+     * Use serialVersionUID from JDK 1.8 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -6062568741193956678L;
 
     private static String dft_msg = "The operation requested cannot be performed by the DnD system since it is not in the appropriate state";

--- a/src/java.desktop/share/classes/java/awt/dnd/MouseDragGestureRecognizer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/MouseDragGestureRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,10 @@
 package java.awt.dnd;
 
 import java.awt.Component;
-
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.io.Serial;
 
 /**
  * This abstract subclass of {@code DragGestureRecognizer}
@@ -64,6 +64,10 @@ import java.awt.event.MouseMotionListener;
 
 public abstract class MouseDragGestureRecognizer extends DragGestureRecognizer implements MouseListener, MouseMotionListener {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 6220099344182281120L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.event;
 
 import java.awt.AWTEvent;
+import java.io.Serial;
 import java.lang.annotation.Native;
 
 /**
@@ -130,9 +131,10 @@ public class ActionEvent extends AWTEvent {
      */
     int modifiers;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -7671078796273832149L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/AdjustmentEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/AdjustmentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package java.awt.event;
 
-import java.awt.Adjustable;
 import java.awt.AWTEvent;
+import java.awt.Adjustable;
+import java.io.Serial;
 import java.lang.annotation.Native;
-
 
 /**
  * The adjustment event emitted by Adjustable objects like
@@ -141,9 +141,10 @@ public class AdjustmentEvent extends AWTEvent {
     boolean isAdjusting;
 
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+     @Serial
      private static final long serialVersionUID = 5700290645205279921L;
 
 

--- a/src/java.desktop/share/classes/java/awt/event/ComponentEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ComponentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.event;
 import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.Rectangle;
+import java.io.Serial;
 import java.lang.annotation.Native;
 
 /**
@@ -97,9 +98,10 @@ public class ComponentEvent extends AWTEvent {
      */
     @Native public static final int COMPONENT_HIDDEN    = 3 + COMPONENT_FIRST;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8101406823902992965L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/ContainerEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ContainerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package java.awt.event;
 
-import java.awt.Container;
 import java.awt.Component;
+import java.awt.Container;
+import java.io.Serial;
 
 /**
  * A low-level event which indicates that a container's contents
@@ -89,9 +90,10 @@ public class ContainerEvent extends ComponentEvent {
      */
     Component child;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4114942250539772041L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.event;
 
 import java.awt.Component;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AppContext;
@@ -180,9 +181,10 @@ public class FocusEvent extends ComponentEvent {
      */
     transient Component opposite;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 523753786457416396L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
@@ -390,6 +390,7 @@ public class FocusEvent extends ComponentEvent {
      * @see #cause
      * @since 9
      */
+    @Serial
     @SuppressWarnings("serial")
     Object readResolve() throws ObjectStreamException {
         if (cause != null) {

--- a/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.event;
 import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.Container;
+import java.io.Serial;
 
 /**
  * An event which indicates a change to the {@code Component}
@@ -90,9 +91,11 @@ import java.awt.Container;
  * @since       1.3
  */
 public class HierarchyEvent extends AWTEvent {
-    /*
-     * serialVersionUID
+
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5337576970038043990L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/InputEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,11 @@
 
 package java.awt.event;
 
-import java.awt.Event;
 import java.awt.Component;
+import java.awt.Event;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
+import java.io.Serial;
 import java.util.Arrays;
 
 import sun.awt.AWTAccessor;
@@ -522,8 +523,11 @@ public abstract class InputEvent extends ComponentEvent {
         return consumed;
     }
 
-    // state serialization compatibility with JDK 1.1
-    static final long serialVersionUID = -2482525981698309786L;
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = -2482525981698309786L;
 
     /**
      * Returns a String describing the extended modifier keys and

--- a/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
@@ -422,6 +422,7 @@ public class InputMethodEvent extends AWTEvent {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         s.defaultReadObject();
         if (when == 0) {

--- a/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.EventQueue;
 import java.awt.font.TextHitInfo;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.lang.annotation.Native;
 import java.text.AttributedCharacterIterator;
 import java.text.CharacterIterator;
@@ -63,8 +64,9 @@ import sun.awt.SunToolkit;
 public class InputMethodEvent extends AWTEvent {
 
     /**
-     * Serial Version ID.
+     * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4727190874778922661L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,11 @@
 
 package java.awt.event;
 
-import sun.awt.AWTAccessor;
-
-import java.awt.ActiveEvent;
 import java.awt.AWTEvent;
+import java.awt.ActiveEvent;
+import java.io.Serial;
+
+import sun.awt.AWTAccessor;
 
 /**
  * An event which executes the {@code run()} method on a {@code Runnable
@@ -146,9 +147,10 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
      */
     private long when;
 
-    /*
-     * JDK 1.1 serialVersionUID.
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 436056344909459450L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/ItemEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.event;
 
 import java.awt.AWTEvent;
 import java.awt.ItemSelectable;
+import java.io.Serial;
 
 /**
  * A semantic event which indicates that an item was selected or deselected.
@@ -107,9 +108,10 @@ public class ItemEvent extends AWTEvent {
      */
     int stateChange;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -608708132447206933L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 
 import sun.awt.AWTAccessor;
 
@@ -1061,9 +1062,10 @@ public class KeyEvent extends InputEvent {
     private transient long scancode = 0; // for MS Windows only
     private transient long extendedKeyCode = 0;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2352130953028126954L;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -1888,6 +1888,7 @@ public class KeyEvent extends InputEvent {
      * @throws IOException if an I/O error occurs
      * @serial
      */
+    @Serial
     @SuppressWarnings("deprecation")
     private void readObject(ObjectInputStream s)
       throws IOException, ClassNotFoundException {

--- a/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.Point;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
@@ -381,9 +382,10 @@ public class MouseEvent extends InputEvent {
      */
     boolean popupTrigger = false;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -991214153494842848L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
@@ -1196,6 +1196,7 @@ public class MouseEvent extends InputEvent {
      * @throws IOException if an I/O error occurs
      * @serial
      */
+    @Serial
     @SuppressWarnings("deprecation")
     private void readObject(ObjectInputStream s)
       throws IOException, ClassNotFoundException {

--- a/src/java.desktop/share/classes/java/awt/event/MouseWheelEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseWheelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package java.awt.event;
 
 import java.awt.Component;
-
+import java.io.Serial;
 import java.lang.annotation.Native;
 
 /**
@@ -153,10 +153,10 @@ public class MouseWheelEvent extends MouseEvent {
      */
     double preciseWheelRotation;
 
-    /*
-     * serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
-
+    @Serial
     private static final long serialVersionUID = 6459879390515399677L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/PaintEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/PaintEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.event;
 
 import java.awt.Component;
 import java.awt.Rectangle;
+import java.io.Serial;
 
 /**
  * The component-level paint event.
@@ -78,9 +79,10 @@ public class PaintEvent extends ComponentEvent {
      */
     Rectangle updateRect;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1267492026433337593L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/TextEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/TextEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.event;
 
 import java.awt.AWTEvent;
+import java.io.Serial;
 
 /**
  * A semantic event which indicates that an object's text changed.
@@ -68,9 +69,10 @@ public class TextEvent extends AWTEvent {
      */
     public static final int TEXT_VALUE_CHANGED  = TEXT_FIRST;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6269902291250941179L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.event;
 
 import java.awt.Window;
+import java.io.Serial;
 import java.lang.annotation.Native;
 
 import sun.awt.AppContext;
@@ -173,9 +174,10 @@ public class WindowEvent extends ComponentEvent {
      */
     int newState;
 
-    /*
-     * JDK 1.1 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1567959133147912127L;
 
 

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,12 @@ package java.awt.font;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Set;
+
 import jdk.internal.access.SharedSecrets;
 
 /**
@@ -426,6 +428,10 @@ public final class NumericShaper implements java.io.Serializable {
      */
     private static final int BSEARCH_THRESHOLD = 3;
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -8022764705923730308L;
 
     /** Identifies the Latin-1 (European) and extended range, and

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -1968,6 +1968,7 @@ public final class NumericShaper implements java.io.Serializable {
      * @throws IOException if an I/O error occurs while writing to {@code stream}
      * @since 1.7
      */
+    @Serial
     private void writeObject(ObjectOutputStream stream) throws IOException {
         if (shapingRange != null) {
             int index = Range.toRangeIndex(shapingRange);

--- a/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,9 @@ package java.awt.font;
 
 import java.io.InvalidObjectException;
 import java.text.AttributedCharacterIterator.Attribute;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
+
 import jdk.internal.access.SharedSecrets;
 
 /**
@@ -280,11 +281,12 @@ public final class TextAttribute extends Attribute {
         }
     }
 
-    // Serialization compatibility with Java 2 platform v1.2.
-    // 1.2 will throw an InvalidObjectException if ever asked to
-    // deserialize INPUT_METHOD_UNDERLINE.
-    // This shouldn't happen in real life.
-    static final long serialVersionUID = 7744112784117861702L;
+    /**
+     * Use serialVersionUID from JDK 1.2 for interoperability.
+     * 1.2 will throw an InvalidObjectException if ever asked to deserialize
+     * INPUT_METHOD_UNDERLINE. This shouldn't happen in real life.
+     */
+    private static final long serialVersionUID = 7744112784117861702L;
 
     //
     // For use with Font.

--- a/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
@@ -41,6 +41,7 @@
 package java.awt.font;
 
 import java.io.InvalidObjectException;
+import java.io.Serial;
 import java.text.AttributedCharacterIterator.Attribute;
 import java.util.HashMap;
 import java.util.Map;
@@ -267,6 +268,7 @@ public final class TextAttribute extends Attribute {
     /**
      * Resolves instances being deserialized to the predefined constants.
      */
+    @Serial
     protected Object readResolve() throws InvalidObjectException {
         if (this.getClass() != TextAttribute.class) {
             throw new InvalidObjectException(

--- a/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextAttribute.java
@@ -288,6 +288,7 @@ public final class TextAttribute extends Attribute {
      * 1.2 will throw an InvalidObjectException if ever asked to deserialize
      * INPUT_METHOD_UNDERLINE. This shouldn't happen in real life.
      */
+    @Serial
     private static final long serialVersionUID = 7744112784117861702L;
 
     //

--- a/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
@@ -107,6 +107,7 @@ public final class TransformAttribute implements Serializable {
      * @param  s the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
       throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
@@ -126,6 +126,7 @@ public final class TransformAttribute implements Serializable {
      *         not be created
      * @since 1.6
      */
+    @Serial
     private Object readResolve() throws ObjectStreamException {
         if (transform == null || transform.isIdentity()) {
             return IDENTITY;

--- a/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ package java.awt.font;
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -131,8 +132,11 @@ public final class TransformAttribute implements Serializable {
         return this;
     }
 
-    // Added for serial backwards compatibility (4348425)
-    static final long serialVersionUID = 3356247357827709530L;
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 3356247357827709530L;
 
     /**
      * @since 1.6

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.geom;
 import java.awt.Shape;
 import java.beans.ConstructorProperties;
 import java.io.IOException;
+import java.io.Serial;
 
 /**
  * The {@code AffineTransform} class represents a 2D affine transform
@@ -3938,9 +3939,10 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * readObject method as it is in the 6-argument matrix constructor.
      */
 
-    /*
-     * JDK 1.2 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.2 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1330973210523860834L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -3951,6 +3951,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * @param  s the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
         throws java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -3966,6 +3966,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(java.io.ObjectInputStream s)
         throws java.lang.ClassNotFoundException, java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.geom;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -320,9 +321,10 @@ public abstract class Arc2D extends RectangularShape {
                                          (float) w, (float) h);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 9130893014586380278L;
 
         /**
@@ -618,9 +620,10 @@ public abstract class Arc2D extends RectangularShape {
             return new Rectangle2D.Double(x, y, w, h);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 728264085846882001L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -343,6 +343,7 @@ public abstract class Arc2D extends RectangularShape {
          * {@link #OPEN}, {@link #CHORD}, or {@link #PIE}.
          * </ol>
          */
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
             throws java.io.IOException
         {
@@ -642,6 +643,7 @@ public abstract class Arc2D extends RectangularShape {
          * {@link #OPEN}, {@link #CHORD}, or {@link #PIE}.
          * </ol>
          */
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
             throws java.io.IOException
         {

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -370,6 +370,7 @@ public abstract class Arc2D extends RectangularShape {
          * {@link #OPEN}, {@link #CHORD}, or {@link #PIE}.
          * </ol>
          */
+        @Serial
         private void readObject(java.io.ObjectInputStream s)
             throws java.lang.ClassNotFoundException, java.io.IOException
         {
@@ -670,6 +671,7 @@ public abstract class Arc2D extends RectangularShape {
          * {@link #OPEN}, {@link #CHORD}, or {@link #PIE}.
          * </ol>
          */
+        @Serial
         private void readObject(java.io.ObjectInputStream s)
             throws java.lang.ClassNotFoundException, java.io.IOException
         {

--- a/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,12 @@
 
 package java.awt.geom;
 
-import java.awt.Shape;
 import java.awt.Rectangle;
-import java.util.Arrays;
+import java.awt.Shape;
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
+
 import sun.awt.geom.Curve;
 
 import static java.lang.Math.abs;
@@ -326,9 +328,10 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
                                          right - left, bottom - top);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -1272015596714244385L;
     }
 
@@ -572,9 +575,10 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
                                           right - left, bottom - top);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -4202960122839707295L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/Ellipse2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Ellipse2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -179,9 +180,10 @@ public abstract class Ellipse2D extends RectangularShape {
             return new Rectangle2D.Float(x, y, width, height);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -6633761252372475977L;
     }
 
@@ -304,9 +306,10 @@ public abstract class Ellipse2D extends RectangularShape {
             return new Rectangle2D.Double(x, y, width, height);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 5555464816372320683L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/GeneralPath.java
+++ b/src/java.desktop/share/classes/java/awt/geom/GeneralPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.awt.geom;
 
 import java.awt.Shape;
+import java.io.Serial;
 
 /**
  * The {@code GeneralPath} class represents a geometric path
@@ -120,8 +121,9 @@ public final class GeneralPath extends Path2D.Float {
         this.numCoords = numCoords;
     }
 
-    /*
-     * JDK 1.6 serialVersionUID
+    /**
+     * Use serialVersionUID from JDK 1.6 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8327096662768731142L;
 }

--- a/src/java.desktop/share/classes/java/awt/geom/IllegalPathStateException.java
+++ b/src/java.desktop/share/classes/java/awt/geom/IllegalPathStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
+
 /**
  * The {@code IllegalPathStateException} represents an
  * exception that is thrown if an operation is performed on a path
@@ -35,6 +37,11 @@ package java.awt.geom;
  */
 
 public class IllegalPathStateException extends RuntimeException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -5158084205220481094L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/geom/Line2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Line2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package java.awt.geom;
 
-import java.awt.Shape;
 import java.awt.Rectangle;
+import java.awt.Shape;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -204,9 +205,10 @@ public abstract class Line2D implements Shape, Cloneable {
             return new Rectangle2D.Float(x, y, w, h);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6161772511649436349L;
     }
 
@@ -356,9 +358,10 @@ public abstract class Line2D implements Shape, Cloneable {
             return new Rectangle2D.Double(x, y, w, h);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7979627399746467499L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/NoninvertibleTransformException.java
+++ b/src/java.desktop/share/classes/java/awt/geom/NoninvertibleTransformException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
+
 /**
  * The {@code NoninvertibleTransformException} class represents
  * an exception that is thrown if an operation is performed requiring
@@ -33,6 +35,11 @@ package java.awt.geom;
  */
 
 public class NoninvertibleTransformException extends java.lang.Exception {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 6137225240503990466L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.awt.geom;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.io.StreamCorruptedException;
 import java.util.Arrays;
@@ -847,9 +848,10 @@ public abstract class Path2D implements Shape, Cloneable {
             }
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6990832515060788886L;
 
         /**
@@ -1628,9 +1630,10 @@ public abstract class Path2D implements Shape, Cloneable {
             return new Path2D.Double(this);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 1826762518450014216L;
 
         /**

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -1006,6 +1006,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * @throws IOException if an I/O error occurs
          * @since 1.6
          */
+        @Serial
         private void readObject(java.io.ObjectInputStream s)
             throws java.lang.ClassNotFoundException, java.io.IOException
         {
@@ -1788,6 +1789,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * @throws IOException if an I/O error occurs         *
          * @since 1.6
          */
+        @Serial
         private void readObject(java.io.ObjectInputStream s)
             throws java.lang.ClassNotFoundException, java.io.IOException
         {

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -982,6 +982,7 @@ public abstract class Path2D implements Shape, Cloneable {
          *
          * @since 1.6
          */
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
             throws java.io.IOException
         {
@@ -1763,6 +1764,7 @@ public abstract class Path2D implements Shape, Cloneable {
          *
          * @since 1.6
          */
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
             throws java.io.IOException
         {

--- a/src/java.desktop/share/classes/java/awt/geom/Point2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Point2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -132,9 +133,10 @@ public abstract class Point2D implements Cloneable {
             return "Point2D.Float["+x+", "+y+"]";
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -2870572449815403710L;
     }
 
@@ -216,9 +218,10 @@ public abstract class Point2D implements Cloneable {
             return "Point2D.Double["+x+", "+y+"]";
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6150783262733311327L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package java.awt.geom;
 
-import java.awt.Shape;
 import java.awt.Rectangle;
+import java.awt.Shape;
+import java.io.Serial;
 import java.io.Serializable;
-import sun.awt.geom.Curve;
 
 /**
  * The {@code QuadCurve2D} class defines a quadratic parametric curve
@@ -251,9 +251,10 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
                                          right - left, bottom - top);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -8511188402130719609L;
     }
 
@@ -440,9 +441,10 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
                                           right - left, bottom - top);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 4217149928428559721L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/Rectangle2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Rectangle2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -296,9 +297,10 @@ public abstract class Rectangle2D extends RectangularShape {
                 ",h=" + height + "]";
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 3798716824173675777L;
     }
 
@@ -490,9 +492,10 @@ public abstract class Rectangle2D extends RectangularShape {
                 ",h=" + height + "]";
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7771313791441850493L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/RoundRectangle2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/RoundRectangle2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -250,9 +251,10 @@ public abstract class RoundRectangle2D extends RectangularShape {
             return new Rectangle2D.Float(x, y, width, height);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -3423150618393866922L;
     }
 
@@ -433,9 +435,10 @@ public abstract class RoundRectangle2D extends RectangularShape {
             return new Rectangle2D.Double(x, y, width, height);
         }
 
-        /*
-         * JDK 1.6 serialVersionUID
+        /**
+         * Use serialVersionUID from JDK 1.6 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 1048939333485206117L;
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/ImagingOpException.java
+++ b/src/java.desktop/share/classes/java/awt/image/ImagingOpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,19 @@
 package java.awt.image;
 
 
+import java.io.Serial;
+
 /**
  * The {@code ImagingOpException} is thrown if one of the
  * {@link BufferedImageOp} or {@link RasterOp} filter methods cannot
  * process the image.
  */
 public class ImagingOpException extends java.lang.RuntimeException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 8026288481846276658L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/image/ImagingOpException.java
+++ b/src/java.desktop/share/classes/java/awt/image/ImagingOpException.java
@@ -24,8 +24,6 @@
  */
 
 package java.awt.image;
-
-
 import java.io.Serial;
 
 /**

--- a/src/java.desktop/share/classes/java/awt/image/RasterFormatException.java
+++ b/src/java.desktop/share/classes/java/awt/image/RasterFormatException.java
@@ -24,8 +24,6 @@
  */
 
 package java.awt.image;
-
-
 import java.io.Serial;
 
 /**

--- a/src/java.desktop/share/classes/java/awt/image/RasterFormatException.java
+++ b/src/java.desktop/share/classes/java/awt/image/RasterFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,18 @@
 package java.awt.image;
 
 
+import java.io.Serial;
+
 /**
  * The {@code RasterFormatException} is thrown if there is
  * invalid layout information in the {@link Raster}.
  */
 public class RasterFormatException extends java.lang.RuntimeException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 96598996116164315L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
+++ b/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,9 @@
  */
 
 package java.awt.image.renderable;
+
 import java.awt.image.RenderedImage;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Vector;
 
@@ -93,6 +95,11 @@ import java.util.Vector;
  * </pre>
  * */
 public class ParameterBlock implements Cloneable, Serializable {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -7577115551785240750L;
 
     /** A Vector of sources, stored as arbitrary Objects. */

--- a/src/java.desktop/share/classes/java/awt/print/PrinterAbortException.java
+++ b/src/java.desktop/share/classes/java/awt/print/PrinterAbortException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.print;
 
+import java.io.Serial;
+
 /**
  * The {@code PrinterAbortException} class is a subclass of
  * {@link PrinterException} and is used to indicate that a user
@@ -33,6 +35,11 @@ package java.awt.print;
  */
 
 public class PrinterAbortException extends PrinterException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 4725169026278854136L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/print/PrinterException.java
+++ b/src/java.desktop/share/classes/java/awt/print/PrinterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.awt.print;
 
+import java.io.Serial;
+
 /**
  * The {@code PrinterException} class and its subclasses are used
  * to indicate that an exceptional condition has occurred in the print
@@ -32,6 +34,11 @@ package java.awt.print;
  */
 
 public class PrinterException extends Exception {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -3757589981158265819L;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/print/PrinterIOException.java
+++ b/src/java.desktop/share/classes/java/awt/print/PrinterIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,9 @@
  */
 
 package java.awt.print;
+
 import java.io.IOException;
+import java.io.Serial;
 
 /**
  * The {@code PrinterIOException} class is a subclass of
@@ -40,7 +42,12 @@ import java.io.IOException;
  * as well as the aforementioned "legacy method."
  */
 public class PrinterIOException extends PrinterException {
-    static final long serialVersionUID = 5850870712125932846L;
+
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 5850870712125932846L;
 
     /**
      * The IO error that terminated the print job.

--- a/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
+++ b/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.beans;
 
+import java.io.Serial;
+
 /**
  * An "IndexedPropertyChange" event gets delivered whenever a component that
  * conforms to the JavaBeans specification (a "bean") changes a bound
@@ -43,6 +45,10 @@ package java.beans;
  */
 public class IndexedPropertyChangeEvent extends PropertyChangeEvent {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -320227448495806870L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/IntrospectionException.java
+++ b/src/java.desktop/share/classes/java/beans/IntrospectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.beans;
 
+import java.io.Serial;
+
 /**
  * Thrown when an exception happens during Introspection.
  * <p>
@@ -38,6 +40,11 @@ package java.beans;
 
 public
 class IntrospectionException extends Exception {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -3728150539969542619L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeEvent.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.beans;
 
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -47,6 +48,11 @@ import java.util.EventObject;
  * @since 1.1
  */
 public class PropertyChangeEvent extends EventObject {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 7042693688939648123L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -513,6 +513,7 @@ public class PropertyChangeSupport implements Serializable {
      * @serialField propertyChangeSupportSerializedDataVersion int
      *              The version
      */
+    @Serial
     private static final ObjectStreamField[] serialPersistentFields = {
             new ObjectStreamField("children", Hashtable.class),
             new ObjectStreamField("source", Object.class),

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map.Entry;
@@ -519,9 +520,10 @@ public class PropertyChangeSupport implements Serializable {
     };
 
     /**
-     * Serialization version ID, so we're compatible with JDK 1.1
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
-    static final long serialVersionUID = 6401253773779951803L;
+    @Serial
+    private static final long serialVersionUID = 6401253773779951803L;
 
     /**
      * This is a {@link ChangeListenerMap ChangeListenerMap} implementation

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -477,6 +477,7 @@ public class PropertyChangeSupport implements Serializable {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         this.map = new PropertyChangeListenerMap();
 

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -434,6 +434,7 @@ public class PropertyChangeSupport implements Serializable {
      * At serialization time we skip non-serializable listeners and
      * only serialize the serializable listeners.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Hashtable<String, PropertyChangeSupport> children = null;
         PropertyChangeListener[] listeners = null;

--- a/src/java.desktop/share/classes/java/beans/PropertyVetoException.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyVetoException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.beans;
 
+import java.io.Serial;
 
 /**
  * A PropertyVetoException is thrown when a proposed change to a
@@ -34,6 +35,11 @@ package java.beans;
 
 public
 class PropertyVetoException extends Exception {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 129596057694162164L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
@@ -502,6 +502,7 @@ public class VetoableChangeSupport implements Serializable {
      * @serialField vetoableChangeSupportSerializedDataVersion int
      *              The version
      */
+    @Serial
     private static final ObjectStreamField[] serialPersistentFields = {
             new ObjectStreamField("children", Hashtable.class),
             new ObjectStreamField("source", Object.class),

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
@@ -423,6 +423,7 @@ public class VetoableChangeSupport implements Serializable {
      * At serialization time we skip non-serializable listeners and
      * only serialize the serializable listeners.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Hashtable<String, VetoableChangeSupport> children = null;
         VetoableChangeListener[] listeners = null;

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
@@ -466,6 +466,7 @@ public class VetoableChangeSupport implements Serializable {
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         this.map = new VetoableChangeListenerMap();
 

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map.Entry;
@@ -508,9 +509,10 @@ public class VetoableChangeSupport implements Serializable {
     };
 
     /**
-     * Serialization version ID, so we're compatible with JDK 1.1
+     * Use serialVersionUID from JDK 1.1 for interoperability.
      */
-    static final long serialVersionUID = -5090210921595982017L;
+    @Serial
+    private static final long serialVersionUID = -5090210921595982017L;
 
     /**
      * This is a {@link ChangeListenerMap ChangeListenerMap} implementation

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -344,6 +344,7 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         ois.defaultReadObject();
     }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.beans.VetoableChangeSupport;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -55,7 +56,11 @@ import java.io.Serializable;
 
 public class BeanContextChildSupport implements BeanContextChild, BeanContextServicesListener, Serializable {
 
-    static final long serialVersionUID = 6328947014421475877L;
+    /**
+     * Use serialVersionUID from JDK 1.2 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 6328947014421475877L;
 
     /**
      * construct a BeanContextChildSupport where this class has been

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -318,6 +318,7 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
      * @param  oos the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private void writeObject(ObjectOutputStream oos) throws IOException {
 
         /*

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,8 @@
 
 package java.beans.beancontext;
 
+import java.io.Serial;
 import java.util.EventObject;
-
-import java.beans.beancontext.BeanContext;
 
 /**
  * <p>
@@ -48,6 +47,11 @@ import java.beans.beancontext.BeanContext;
  */
 
 public abstract class BeanContextEvent extends EventObject {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 7267998073569045052L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,7 @@
 
 package java.beans.beancontext;
 
-import java.util.EventObject;
-
-import java.beans.beancontext.BeanContext;
-import java.beans.beancontext.BeanContextEvent;
-
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -55,6 +51,11 @@ import java.util.Iterator;
  * @see         java.beans.beancontext.BeanContextMembershipListener
  */
 public class BeanContextMembershipEvent extends BeanContextEvent {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 3499346510334590959L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,7 @@
 
 package java.beans.beancontext;
 
-import java.beans.beancontext.BeanContextChild;
-import java.beans.beancontext.BeanContextEvent;
-
-import java.beans.beancontext.BeanContextServices;
-
+import java.io.Serial;
 import java.util.Iterator;
 
 /**
@@ -40,6 +36,11 @@ import java.util.Iterator;
  */
 
 public class BeanContextServiceAvailableEvent extends BeanContextEvent {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -5333985775656400778L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.beans.beancontext;
 
+import java.io.Serial;
+
 /**
  * <p>
  * This event type is used by the
@@ -33,6 +35,11 @@ package java.beans.beancontext;
  * </p>
  */
 public class BeanContextServiceRevokedEvent extends BeanContextEvent {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -1295543154724961754L;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1231,6 +1231,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private synchronized void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
 
         ois.defaultReadObject();

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package java.beans.beancontext;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +57,11 @@ import java.util.TooManyListenersException;
 
 public class      BeanContextServicesSupport extends BeanContextSupport
        implements BeanContextServices {
+
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -8494482757288719206L;
 
     /**
@@ -153,6 +159,10 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
     protected class BCSSChild extends BeanContextSupport.BCSChild  {
 
+        /**
+         * Use serialVersionUID from JDK 1.7 for interoperability.
+         */
+        @Serial
         private static final long serialVersionUID = -3263851306889194873L;
 
         /*
@@ -588,6 +598,11 @@ public class      BeanContextServicesSupport extends BeanContextSupport
          */
 
         protected static class BCSSServiceProvider implements Serializable {
+
+            /**
+             * Use serialVersionUID from JDK 1.7 for interoperability.
+             */
+            @Serial
             private static final long serialVersionUID = 861278251667444782L;
 
             BCSSServiceProvider(Class<?> sc, BeanContextServiceProvider bcsp) {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1216,6 +1216,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
      * @param  oos the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private synchronized void writeObject(ObjectOutputStream oos) throws IOException {
         oos.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
@@ -64,8 +65,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
                   PropertyChangeListener,
                   VetoableChangeListener {
 
-    // Fix for bug 4282900 to pass JCK regression test
-    static final long serialVersionUID = -4879613978649577204L;
+    /**
+     * Use serialVersionUID from JDK 1.3 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = -4879613978649577204L;
 
     /**
      *
@@ -302,6 +306,10 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
     protected class BCSChild implements Serializable {
 
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -5815286101609939109L;
 
         BCSChild(Object bcc, Object peer) {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1074,6 +1074,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
      *         not be found
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private synchronized void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
 
         synchronized(BeanContext.globalHierarchyLock) {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1002,6 +1002,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
      * @param  oos the {@code ObjectOutputStream} to write
      * @throws IOException if an I/O error occurs
      */
+    @Serial
     private synchronized void writeObject(ObjectOutputStream oos) throws IOException {
         serializing = true;
 

--- a/src/java.desktop/share/classes/javax/imageio/IIOException.java
+++ b/src/java.desktop/share/classes/javax/imageio/IIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javax.imageio;
 
 import java.io.IOException;
+import java.io.Serial;
 
 /**
  * An exception class used for signaling run-time failure of reading
@@ -40,6 +41,11 @@ import java.io.IOException;
  *
  */
 public class IIOException extends IOException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -3216210718638985251L;
 
     /**

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOInvalidTreeException.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOInvalidTreeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
 
 package javax.imageio.metadata;
 
+import java.io.Serial;
+
 import javax.imageio.IIOException;
+
 import org.w3c.dom.Node;
 
 /**
@@ -44,6 +47,11 @@ import org.w3c.dom.Node;
  *
  */
 public class IIOInvalidTreeException extends IIOException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -1314083172544132777L;
 
     /**

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 
 package javax.imageio.metadata;
 
+import java.io.Serial;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.w3c.dom.Attr;
@@ -44,6 +44,11 @@ import org.w3c.dom.UserDataHandler;
  * "exceptional" circumstances.
  */
 class IIODOMException extends DOMException {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -4369510142067447468L;
 
     public IIODOMException(short code, String message) {

--- a/src/java.desktop/share/classes/javax/imageio/spi/DigraphNode.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/DigraphNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.imageio.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -40,6 +41,11 @@ import java.util.Set;
  *
  */
 class DigraphNode<E> implements Cloneable, Serializable {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 5308261378582246841L;
 
     /** The data associated with this node. */

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -565,6 +565,7 @@ public class DocFlavor implements Serializable, Cloneable {
      * @throws IOException if I/O errors occur while writing to the underlying
      *         stream
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
 
         s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.print;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -389,6 +390,7 @@ public class DocFlavor implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4512080796965449721L;
 
     /**
@@ -601,6 +603,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -9065578006593857475L;
 
         /**
@@ -769,6 +772,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -7045842700749194127L;
 
         /**
@@ -950,6 +954,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 2936725788144902062L;
 
         /**
@@ -1121,6 +1126,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -8720590903724405128L;
 
         /**
@@ -1168,6 +1174,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 4414407504887034035L;
 
         /**
@@ -1213,6 +1220,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7100295812579351567L;
 
         /**
@@ -1261,6 +1269,7 @@ public class DocFlavor implements Serializable, Cloneable {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6181337766266637256L;
 
         /**

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -585,6 +585,7 @@ public class DocFlavor implements Serializable, Cloneable {
      *             the {@code String} representing the canonical form of the
      *             mime type
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException {
 

--- a/src/java.desktop/share/classes/javax/print/MimeType.java
+++ b/src/java.desktop/share/classes/javax/print/MimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
@@ -79,6 +80,7 @@ class MimeType implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2785720609362367683L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/PrintException.java
+++ b/src/java.desktop/share/classes/javax/print/PrintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print;
 
+import java.io.Serial;
+
 /**
  * Class {@code PrintException} encapsulates a printing-related error condition
  * that occurred while using a Print Service instance. This base class furnishes
@@ -36,6 +38,7 @@ public class PrintException extends Exception {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5932531546705242471L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -81,6 +82,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -6131802583863447813L;
 
         /**
@@ -164,6 +166,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -6349408326066898956L;
 
         /**
@@ -190,6 +193,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 7799373532614825073L;
 
         /**
@@ -216,6 +220,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -8002245296274522112L;
 
         /**
@@ -242,6 +247,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -7112165137107826819L;
 
         /**
@@ -342,6 +348,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 8365731020128564925L;
 
         /**
@@ -424,6 +431,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 6455869095246629354L;
 
         /**
@@ -448,6 +456,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 5671237023971169027L;
 
         /**
@@ -473,6 +482,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = 2117188707856965749L;
 
         /**
@@ -498,6 +508,7 @@ public final class AttributeSetUtilities {
         /**
          * Use serialVersionUID from JDK 1.4 for interoperability.
          */
+        @Serial
         private static final long serialVersionUID = -2830705374001675073L;
 
         /**

--- a/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -58,6 +59,7 @@ public abstract class DateTimeSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1400819079791208582L;
 
     // Hidden data members.

--- a/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javax.print.attribute;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -111,6 +112,7 @@ public abstract class EnumSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2739521845085831642L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
@@ -189,6 +189,7 @@ public abstract class EnumSyntax implements Serializable, Cloneable {
      *         subclass of {@link ObjectStreamException ObjectStreamException},
      *         which {@code readResolve()} is declared to throw.)
      */
+    @Serial
     protected Object readResolve() throws ObjectStreamException {
 
         EnumSyntax[] theTable = getEnumValueTable();

--- a/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
@@ -71,6 +71,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *             This does not guarantee equality of serialized forms since
      *             the order in which the attributes are written is not defined.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
 
         s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
@@ -89,6 +89,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @throws ClassNotFoundException if the class is not found
      * @throws IOException if an I/O exception has occurred
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException {
 

--- a/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.print.attribute;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 
@@ -42,6 +43,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5311560590283707917L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/HashDocAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashDocAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -41,6 +42,7 @@ public class HashDocAttributeSet extends HashAttributeSet
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1128534486061432528L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/HashPrintJobAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashPrintJobAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -41,6 +42,7 @@ public class HashPrintJobAttributeSet extends HashAttributeSet
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4204473656070350348L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/HashPrintRequestAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashPrintRequestAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -41,6 +42,7 @@ public class HashPrintRequestAttributeSet extends HashAttributeSet
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2364756266107751933L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/HashPrintServiceAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashPrintServiceAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -42,6 +43,7 @@ public class HashPrintServiceAttributeSet extends HashAttributeSet
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6642904616179203070L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -45,6 +46,7 @@ public abstract class IntegerSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 3644574816328081943L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -84,6 +85,7 @@ public abstract class ResolutionSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2706743076526672017L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Vector;
 
@@ -82,6 +83,7 @@ public abstract class SetOfIntegerSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 3666874174847632203L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -83,6 +84,7 @@ public abstract class Size2DSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5584439964938660530L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
 
@@ -43,6 +44,7 @@ public abstract class TextSyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8130648736378144102L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.URI;
 
@@ -40,6 +41,7 @@ public abstract class URISyntax implements Serializable, Cloneable {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -7842661210486401678L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/UnmodifiableSetException.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/UnmodifiableSetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute;
 
+import java.io.Serial;
+
 /**
  * Thrown to indicate that the requested operation cannot be performed because
  * the set is unmodifiable.
@@ -37,6 +39,7 @@ public class UnmodifiableSetException extends RuntimeException {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2255250308571511731L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Chromaticity.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Chromaticity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -74,6 +76,7 @@ public final class Chromaticity extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4660543931355214012L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/ColorSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/ColorSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -63,6 +65,7 @@ public final class ColorSupported extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2700555589688535545L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Compression.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Compression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
 import javax.print.attribute.EnumSyntax;
@@ -49,6 +51,7 @@ public class Compression extends EnumSyntax implements DocAttribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5716748913324997674L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Copies.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Copies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -69,6 +71,7 @@ public final class Copies extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6426631521680023833L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/CopiesSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/CopiesSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.SetOfIntegerSyntax;
@@ -50,6 +52,7 @@ public final class CopiesSupported extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6927711687034846001L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtCompleted.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtCompleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -58,6 +59,7 @@ public final class DateTimeAtCompleted extends DateTimeSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6497399708058490000L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtCreation.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -58,6 +59,7 @@ public final class DateTimeAtCreation   extends DateTimeSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2923732231056647903L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtProcessing.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DateTimeAtProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -58,6 +59,7 @@ public final class DateTimeAtProcessing extends DateTimeSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3710068197278263244L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Destination.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Destination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javax.print.attribute.standard;
 
 import java.io.File;
+import java.io.Serial;
 import java.net.URI;
 
 import javax.print.attribute.Attribute;
@@ -61,6 +62,7 @@ public final class Destination extends URISyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6776739171700415321L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javax.print.attribute.standard;
 
 import java.awt.Window;
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.PrintRequestAttribute;
@@ -59,6 +60,10 @@ public final class DialogOwner implements PrintRequestAttribute {
              DialogOwnerAccessor.setAccessor(accessor);
     }
 
+    /**
+     * Use serialVersionUID from JDK 11 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -1901909867156076547L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DialogTypeSelection.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DialogTypeSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -53,6 +55,7 @@ public final class DialogTypeSelection extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.7 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7518682952133256029L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DocumentName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DocumentName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -51,6 +52,7 @@ public final class DocumentName extends TextSyntax implements DocAttribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7883105848533280430L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Fidelity.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Fidelity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -52,6 +54,7 @@ public final class Fidelity extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6320827847329172308L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Finishings.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Finishings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -131,6 +133,7 @@ public class Finishings extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -627840419548391754L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobHoldUntil.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobHoldUntil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -93,6 +94,7 @@ public final class JobHoldUntil extends DateTimeSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1664471048860415024L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressions.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -79,6 +81,7 @@ public final class JobImpressions extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8225537206784322464L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressionsCompleted.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressionsCompleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -62,6 +64,7 @@ public final class JobImpressionsCompleted extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6722648442432393294L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressionsSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobImpressionsSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.SetOfIntegerSyntax;
@@ -52,6 +54,7 @@ public final class JobImpressionsSupported extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4887354803843173692L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctets.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -129,6 +131,7 @@ public final class JobKOctets   extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8959710146498202869L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctetsProcessed.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctetsProcessed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -73,6 +75,7 @@ public final class JobKOctetsProcessed extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6265238509657881806L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctetsSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobKOctetsSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.SetOfIntegerSyntax;
@@ -52,6 +54,7 @@ public final class JobKOctetsSupported extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2867871140549897443L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheets.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -71,6 +73,7 @@ public class JobMediaSheets extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 408871131531979741L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheetsCompleted.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheetsCompleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -62,6 +64,7 @@ public final class JobMediaSheetsCompleted extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1739595973810840475L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheetsSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobMediaSheetsSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.SetOfIntegerSyntax;
@@ -52,6 +54,7 @@ public final class JobMediaSheetsSupported extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2953685470388672940L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobMessageFromOperator.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobMessageFromOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -58,6 +59,7 @@ public final class JobMessageFromOperator extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4620751846003142047L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -59,6 +60,7 @@ public final class JobName extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4660359192078689545L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobOriginatingUserName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobOriginatingUserName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -55,6 +56,7 @@ public final class JobOriginatingUserName extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8052537926362933477L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobPriority.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -63,6 +65,7 @@ public final class JobPriority extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4599900369040602769L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobPrioritySupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobPrioritySupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -53,6 +55,7 @@ public final class JobPrioritySupported extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2564840378013555894L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobSheets.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobSheets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -56,6 +58,7 @@ public class JobSheets extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4735258056132519759L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobState.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -51,6 +53,7 @@ public class JobState extends EnumSyntax implements PrintJobAttribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 400465010094018920L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReason.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -61,6 +63,7 @@ public class JobStateReason extends EnumSyntax implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8765894420449009168L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReasons.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReasons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -73,6 +74,7 @@ public final class JobStateReasons
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8849088261264331812L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Media.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Media.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -61,6 +63,7 @@ public abstract class Media extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2823970704630722439L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
 
@@ -47,6 +49,7 @@ public class MediaName extends Media implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4653117714524155448L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.DocFlavor;
 import javax.print.PrintService;
@@ -95,6 +97,7 @@ public final class MediaPrintableArea
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1597171464050795793L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.HashMap;
 import java.util.Vector;
 
@@ -55,6 +56,7 @@ public class MediaSize extends Size2DSyntax implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1967958664615414771L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSizeName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSizeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.EnumSyntax;
 
 /**
@@ -46,6 +48,7 @@ public class MediaSizeName extends Media {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2778798329756942747L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaTray.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaTray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
 
@@ -46,6 +48,7 @@ public class MediaTray extends Media implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -982503611095214703L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MultipleDocumentHandling.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MultipleDocumentHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -153,6 +155,7 @@ public class MultipleDocumentHandling extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8098326460746413466L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/NumberOfDocuments.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/NumberOfDocuments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
 import javax.print.attribute.PrintJobAttribute;
@@ -46,6 +48,7 @@ public final class NumberOfDocuments extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7891881310684461097L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/NumberOfInterveningJobs.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/NumberOfInterveningJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
 import javax.print.attribute.PrintJobAttribute;
@@ -46,6 +48,7 @@ public final class NumberOfInterveningJobs extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2568141124844982746L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/NumberUp.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/NumberUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -116,6 +118,7 @@ public final class NumberUp extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3040436486786527811L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/NumberUpSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/NumberUpSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.SetOfIntegerSyntax;
 import javax.print.attribute.SupportedValuesAttribute;
@@ -49,6 +51,7 @@ public final class NumberUpSupported    extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1041573395759141805L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/OrientationRequested.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/OrientationRequested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -67,6 +69,7 @@ public final class OrientationRequested extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4447437289862822276L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/OutputDeviceAssigned.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/OutputDeviceAssigned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -53,6 +54,7 @@ public final class OutputDeviceAssigned extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 5486733778854271081L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PDLOverrideSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PDLOverrideSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
 import javax.print.attribute.PrintServiceAttribute;
@@ -48,6 +50,7 @@ public class PDLOverrideSupported extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -4393264467928463934L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PageRanges.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PageRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -99,6 +101,7 @@ public final class PageRanges   extends SetOfIntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8639895197656148392L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PagesPerMinute.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PagesPerMinute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
 import javax.print.attribute.PrintServiceAttribute;
@@ -48,6 +50,7 @@ public final class PagesPerMinute extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6366403993072862015L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PagesPerMinuteColor.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PagesPerMinuteColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
@@ -60,7 +62,8 @@ public final class PagesPerMinuteColor extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
-    static final long serialVersionUID = 1684993151687470944L;
+    @Serial
+    private static final long serialVersionUID = 1684993151687470944L;
 
     /**
      * Construct a new pages per minute color attribute with the given integer

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -55,6 +57,7 @@ public final class PresentationDirection extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8294728067230931780L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrintQuality.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrintQuality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
 import javax.print.attribute.EnumSyntax;
@@ -49,6 +51,7 @@ public class PrintQuality extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3072341285225858365L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterInfo.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -52,6 +53,7 @@ public final class PrinterInfo extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7765280618777599727L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterIsAcceptingJobs.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterIsAcceptingJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -54,6 +56,7 @@ public final class PrinterIsAcceptingJobs extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5052010680537678061L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterLocation.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -48,6 +49,7 @@ public final class PrinterLocation extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1598610039865566337L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMakeAndModel.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMakeAndModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -47,6 +48,7 @@ public final class PrinterMakeAndModel extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4580461489499351411L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMessageFromOperator.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMessageFromOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -59,7 +60,8 @@ public final class PrinterMessageFromOperator   extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
-    static final long serialVersionUID = -4486871203218629318L;
+    @Serial
+    private static final long serialVersionUID = -4486871203218629318L;
 
     /**
      * Constructs a new printer message from operator attribute with the given

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMoreInfo.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMoreInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.net.URI;
 
 import javax.print.attribute.Attribute;
@@ -58,6 +59,7 @@ public final class PrinterMoreInfo extends URISyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 4555850007675338574L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMoreInfoManufacturer.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterMoreInfoManufacturer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.net.URI;
 
 import javax.print.attribute.Attribute;
@@ -57,6 +58,7 @@ public final class PrinterMoreInfoManufacturer extends URISyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 3323271346485076608L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -51,6 +52,7 @@ public final class PrinterName extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 299740639137803127L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterResolution.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterResolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -71,6 +73,7 @@ public final class PrinterResolution    extends ResolutionSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 13090306561090558L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterState.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -52,6 +54,7 @@ implements PrintServiceAttribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -649578618346507718L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterStateReason.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterStateReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -67,6 +69,7 @@ public class PrinterStateReason extends EnumSyntax implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1623720656201472593L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterStateReasons.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterStateReasons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.AbstractSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -88,6 +89,7 @@ public final class PrinterStateReasons
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -3731791085163619457L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterURI.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PrinterURI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.net.URI;
 
 import javax.print.attribute.Attribute;
@@ -49,6 +50,7 @@ public final class PrinterURI extends URISyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7923912792485606497L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/QueuedJobCount.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/QueuedJobCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.IntegerSyntax;
 import javax.print.attribute.PrintServiceAttribute;
@@ -46,6 +48,7 @@ public final class QueuedJobCount extends IntegerSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7499723077864047742L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/ReferenceUriSchemesSupported.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/ReferenceUriSchemesSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -66,6 +68,7 @@ public class ReferenceUriSchemesSupported
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -8989076942813442805L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/RequestingUserName.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/RequestingUserName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.print.attribute.standard;
 
+import java.io.Serial;
 import java.util.Locale;
 
 import javax.print.attribute.Attribute;
@@ -57,6 +58,7 @@ public final class RequestingUserName   extends TextSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2683049894310331454L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Severity.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Severity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.EnumSyntax;
@@ -63,6 +65,7 @@ public final class Severity extends EnumSyntax implements Attribute {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 8781881462717925380L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/SheetCollate.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/SheetCollate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -145,6 +147,7 @@ public final class SheetCollate extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7080587914259873003L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Sides.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Sides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package javax.print.attribute.standard;
+
+import java.io.Serial;
 
 import javax.print.attribute.Attribute;
 import javax.print.attribute.DocAttribute;
@@ -112,6 +114,7 @@ public final class Sides extends EnumSyntax
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6890309414893262822L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/event/PrintEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.event;
 
+import java.io.Serial;
+
 /**
  * Class {@code PrintEvent} is the super class of all Print Service API events.
  */
@@ -33,6 +35,7 @@ public class PrintEvent extends java.util.EventObject {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2286914924430763847L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/event/PrintJobAttributeEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintJobAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.event;
 
+import java.io.Serial;
+
 import javax.print.DocPrintJob;
 import javax.print.attribute.AttributeSetUtilities;
 import javax.print.attribute.PrintJobAttributeSet;
@@ -39,6 +41,7 @@ public class PrintJobAttributeEvent extends PrintEvent {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -6534469883874742101L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/event/PrintJobEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintJobEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.event;
 
+import java.io.Serial;
+
 import javax.print.DocPrintJob;
 
 /**
@@ -36,6 +38,7 @@ public class PrintJobEvent extends PrintEvent {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1711656903622072997L;
 
     /**

--- a/src/java.desktop/share/classes/javax/print/event/PrintServiceAttributeEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintServiceAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.print.event;
 
+import java.io.Serial;
+
 import javax.print.PrintService;
 import javax.print.attribute.AttributeSetUtilities;
 import javax.print.attribute.PrintServiceAttributeSet;
@@ -39,6 +41,7 @@ public class PrintServiceAttributeEvent extends PrintEvent {
     /**
      * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -7565987018140326600L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/midi/InvalidMidiDataException.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/InvalidMidiDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.sound.midi;
 
+import java.io.Serial;
+
 /**
  * An {@code InvalidMidiDataException} indicates that inappropriate MIDI data
  * was encountered. This often means that the data is invalid in and of itself,
@@ -42,6 +44,7 @@ public class InvalidMidiDataException extends Exception {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 2780771756789932067L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/midi/MidiUnavailableException.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/MidiUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.sound.midi;
 
+import java.io.Serial;
+
 /**
  * A {@code MidiUnavailableException} is thrown when a requested MIDI component
  * cannot be opened or created because it is unavailable. This often occurs when
@@ -42,6 +44,7 @@ public class MidiUnavailableException extends Exception {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 6093809578628944323L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/AudioPermission.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/AudioPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.sound.sampled;
 
+import java.io.Serial;
 import java.security.BasicPermission;
 
 /**
@@ -80,6 +81,7 @@ public class AudioPermission extends BasicPermission {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -5518053473477801126L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/LineEvent.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/LineEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.sound.sampled;
 
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -51,6 +52,7 @@ public class LineEvent extends EventObject {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -1274246333383880410L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/LineUnavailableException.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/LineUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.sound.sampled;
 
+import java.io.Serial;
+
 /**
  * A {@code LineUnavailableException} is an exception indicating that a line
  * cannot be opened because it is unavailable. This situation arises most
@@ -38,6 +40,7 @@ public class LineUnavailableException extends Exception {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -2046718279487432130L;
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/UnsupportedAudioFileException.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/UnsupportedAudioFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package javax.sound.sampled;
 
+import java.io.Serial;
+
 /**
  * An {@code UnsupportedAudioFileException} is an exception indicating that an
  * operation failed because a file did not contain valid data of a recognized
@@ -38,6 +40,7 @@ public class UnsupportedAudioFileException extends Exception {
     /**
      * Use serialVersionUID from JDK 1.3 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -139127412623160368L;
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/AbstractAction.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractAction.java
@@ -365,6 +365,7 @@ public abstract class AbstractAction implements Action, Cloneable, Serializable
         ArrayTable.writeArrayTable(s, arrayTable);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException,
         IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/AbstractAction.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,19 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.*;
-import java.util.Hashtable;
-import java.util.Enumeration;
-import java.io.Serializable;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.security.AccessController;
+
 import javax.swing.event.SwingPropertyChangeSupport;
+
 import sun.security.action.GetPropertyAction;
 
 /**
@@ -355,6 +356,7 @@ public abstract class AbstractAction implements Action, Cloneable, Serializable
         return newAction;
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         // Store the default fields
         s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/swing/ActionMap.java
+++ b/src/java.desktop/share/classes/javax/swing/ActionMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Set;
 
 /**
  * <code>ActionMap</code> provides mappings from
@@ -222,6 +223,7 @@ public class ActionMap implements Serializable {
         return keyMap.keySet().toArray();
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/javax/swing/ActionMap.java
+++ b/src/java.desktop/share/classes/javax/swing/ActionMap.java
@@ -230,6 +230,7 @@ public class ActionMap implements Serializable {
         ArrayTable.writeArrayTable(s, arrayTable);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException,
                                                  IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/ActionPropertyChangeListener.java
+++ b/src/java.desktop/share/classes/javax/swing/ActionPropertyChangeListener.java
@@ -136,6 +136,7 @@ abstract class ActionPropertyChangeListener<T extends JComponent>
         s.writeObject(getTarget());
     }
 
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
                      throws IOException, ClassNotFoundException {

--- a/src/java.desktop/share/classes/javax/swing/ActionPropertyChangeListener.java
+++ b/src/java.desktop/share/classes/javax/swing/ActionPropertyChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.*;
-import java.lang.ref.WeakReference;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 
 /**
  * A package-private PropertyChangeListener which listens for
@@ -125,6 +130,7 @@ abstract class ActionPropertyChangeListener<T extends JComponent>
           return action;
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         s.writeObject(getTarget());

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,21 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.io.*;
-import java.beans.PropertyChangeListener;
-import java.util.Locale;
-import java.util.Vector;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * This class is inserted in between cell renderers and the components that
@@ -207,6 +212,7 @@ public class CellRendererPane extends Container implements Accessible
     }
 
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         removeAll();
         s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +22,43 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.image.*;
-import java.beans.ConstructorProperties;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.IllegalComponentStateException;
+import java.awt.Image;
+import java.awt.MediaTracker;
+import java.awt.Toolkit;
+import java.awt.image.ColorModel;
+import java.awt.image.ImageObserver;
+import java.awt.image.MemoryImageSource;
+import java.awt.image.PixelGrabber;
 import java.beans.BeanProperty;
+import java.beans.ConstructorProperties;
 import java.beans.Transient;
-import java.net.URL;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.net.URL;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
 import java.util.Locale;
-import javax.accessibility.*;
 
-import sun.awt.AppContext;
-import java.security.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleIcon;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+
 import sun.awt.AWTAccessor;
+import sun.awt.AppContext;
 
 /**
  * An implementation of the Icon interface that paints Icons
@@ -524,6 +541,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
     }
 
 
+    @Serial
     private void writeObject(ObjectOutputStream s)
         throws IOException
     {
@@ -732,6 +750,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
             s.defaultReadObject();
         }
 
+        @Serial
         private void writeObject(ObjectOutputStream s)
             throws IOException
         {

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -502,6 +502,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
         return super.toString();
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException
     {
@@ -744,6 +745,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
             return ImageIcon.this.width;
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException
         {

--- a/src/java.desktop/share/classes/javax/swing/InputMap.java
+++ b/src/java.desktop/share/classes/javax/swing/InputMap.java
@@ -236,6 +236,7 @@ public class InputMap implements Serializable {
         ArrayTable.writeArrayTable(s, arrayTable);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s) throws ClassNotFoundException,
                                                  IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/InputMap.java
+++ b/src/java.desktop/share/classes/javax/swing/InputMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Set;
 
 /**
  * {@code InputMap} provides a binding between an input event (currently only
@@ -228,6 +229,7 @@ public class InputMap implements Serializable {
         return keyMap.keySet().toArray(allKeys);
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/javax/swing/JButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
 import java.beans.ConstructorProperties;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.ButtonUI;
 
 /**
  * An implementation of a "push" button.
@@ -231,6 +234,7 @@ public class JButton extends AbstractButton implements Accessible {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JCheckBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBox.java
@@ -272,6 +272,7 @@ public class JCheckBox extends JToggleButton implements Accessible {
      * See JComponent.readObject() for information about serialization
      * in Swing.
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/JCheckBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.ButtonUI;
 
 /**
  * An implementation of a check box -- an item that can be selected or
@@ -252,6 +255,7 @@ public class JCheckBox extends JToggleButton implements Accessible {
       * See readObject and writeObject in JComponent for more
       * information about serialization in Swing.
       */
+     @Serial
      private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * A menu item that can be selected or deselected. If selected, the menu
@@ -233,6 +236,7 @@ public class JCheckBoxMenuItem extends JMenuItem implements SwingConstants,
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,43 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.beans.BeanProperty;
-import java.io.*;
-import java.util.*;
+import java.beans.JavaBean;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Locale;
 
-import javax.swing.colorchooser.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.colorchooser.AbstractColorChooserPanel;
+import javax.swing.colorchooser.ColorChooserComponentFactory;
+import javax.swing.colorchooser.ColorSelectionModel;
+import javax.swing.colorchooser.DefaultColorSelectionModel;
 import javax.swing.plaf.ColorChooserUI;
-import javax.accessibility.*;
 
 import sun.swing.SwingUtilities2;
 
@@ -529,6 +554,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JComboBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +22,56 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.IllegalComponentStateException;
+import java.awt.ItemSelectable;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.Transient;
-import java.util.*;
-
-import java.awt.*;
-import java.awt.event.*;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Vector;
 
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleEditableText;
+import javax.accessibility.AccessibleIcon;
+import javax.accessibility.AccessibleRelationSet;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleTable;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.plaf.ComboBoxUI;
 
 /**
  * A component that combines a button or editable field and a drop-down list.
@@ -1572,6 +1602,7 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -5558,6 +5558,7 @@ public abstract class JComponent extends Container implements Serializable,
      *
      * @param s  the <code>ObjectInputStream</code> from which to read
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,41 +22,83 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-
-import java.beans.*;
+import java.applet.Applet;
+import java.awt.AWTEvent;
+import java.awt.AWTKeyStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FocusTraversalPolicy;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ContainerEvent;
+import java.awt.event.ContainerListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.beans.BeanProperty;
+import java.beans.JavaBean;
+import java.beans.PropertyChangeListener;
+import java.beans.Transient;
+import java.beans.VetoableChangeListener;
+import java.beans.VetoableChangeSupport;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectInputValidation;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Enumeration;
+import java.util.EventListener;
 import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.Enumeration;
 import java.util.Locale;
-import java.util.Vector;
-import java.util.EventListener;
 import java.util.Set;
-
-import java.awt.*;
-import java.awt.event.*;
-
-import java.applet.Applet;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
-import java.io.ObjectInputValidation;
-import java.io.InvalidObjectException;
+import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.swing.border.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import static javax.swing.ClientPropertyKey.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleExtendedComponent;
+import javax.accessibility.AccessibleKeyBinding;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.swing.border.AbstractBorder;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.ComponentUI;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
 import sun.swing.SwingAccessor;
 import sun.swing.SwingUtilities2;
+
+import static javax.swing.ClientPropertyKey.JComponent_ANCESTOR_NOTIFIER;
+import static javax.swing.ClientPropertyKey.JComponent_INPUT_VERIFIER;
+import static javax.swing.ClientPropertyKey.JComponent_TRANSFER_HANDLER;
 
 /**
  * The base class for all Swing components except top-level containers.
@@ -5583,6 +5625,7 @@ public abstract class JComponent extends Container implements Serializable,
      *
      * @param s the <code>ObjectOutputStream</code> in which to write
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,29 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package javax.swing;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
+package javax.swing;
 
 import java.awt.Component;
 import java.awt.Container;
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
-import java.io.IOException;
+import java.beans.JavaBean;
 import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.LinkedHashSet;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.DesktopPaneUI;
 
 /**
  * A container used to create a multiple-document interface or a virtual desktop.
@@ -548,6 +552,7 @@ public class JDesktopPane extends JLayeredPane implements Accessible
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,77 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.beans.JavaBean;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.IllegalComponentStateException;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
 import java.beans.BeanProperty;
-import java.lang.reflect.*;
-import java.net.*;
-import java.util.*;
-import java.io.*;
+import java.beans.JavaBean;
+import java.io.BufferedInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.ObjectOutputStream;
+import java.io.Reader;
+import java.io.Serial;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Vector;
 
-import javax.swing.plaf.*;
-import javax.swing.text.*;
-import javax.swing.event.*;
-import javax.swing.text.html.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleHyperlink;
+import javax.accessibility.AccessibleHypertext;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import javax.swing.plaf.TextUI;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.BoxView;
+import javax.swing.text.Caret;
+import javax.swing.text.ChangedCharSetException;
+import javax.swing.text.CompositeView;
+import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.Document;
+import javax.swing.text.EditorKit;
+import javax.swing.text.Element;
+import javax.swing.text.ElementIterator;
+import javax.swing.text.GlyphView;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledEditorKit;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.WrappedPlainView;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+
 import sun.reflect.misc.ReflectUtil;
 
 /**
@@ -1514,6 +1570,7 @@ public class JEditorPane extends JTextComponent {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -1872,6 +1872,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = in.readFields();

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.Vector;
@@ -1918,6 +1919,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         FileSystemView fsv = null;
 

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,19 +22,43 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputMethodEvent;
 import java.awt.im.InputContext;
 import java.beans.BeanProperty;
 import java.beans.JavaBean;
-import java.io.*;
-import java.text.*;
-import java.util.*;
-import javax.swing.event.*;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.text.AttributedCharacterIterator;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Date;
+
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.plaf.UIResource;
-import javax.swing.text.*;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.DateFormatter;
+import javax.swing.text.DefaultFormatter;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.Document;
+import javax.swing.text.DocumentFilter;
+import javax.swing.text.InternationalFormatter;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.NavigationFilter;
+import javax.swing.text.NumberFormatter;
+import javax.swing.text.TextAction;
 
 /**
  * <code>JFormattedTextField</code> extends <code>JTextField</code> adding
@@ -725,6 +749,7 @@ public class JFormattedTextField extends JTextField {
      *
      * @param s Stream to write to
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,22 +25,37 @@
 
 package javax.swing;
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FocusTraversalPolicy;
+import java.awt.Graphics;
+import java.awt.KeyboardFocusManager;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.beans.BeanProperty;
+import java.beans.JavaBean;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
-import java.beans.*;
-
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleValue;
 import javax.swing.event.InternalFrameEvent;
 import javax.swing.event.InternalFrameListener;
-import javax.swing.plaf.*;
-
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
-import java.io.IOException;
+import javax.swing.plaf.DesktopIconUI;
+import javax.swing.plaf.InternalFrameUI;
 
 import sun.awt.AppContext;
 import sun.swing.SwingUtilities2;
-
 
 /**
  * A lightweight object that provides many of the features of
@@ -1858,6 +1873,7 @@ public class JInternalFrame extends JComponent implements
      * in <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {
@@ -2257,6 +2273,7 @@ public class JInternalFrame extends JComponent implements
         ////////////////
         // Serialization support
         ////////////////
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             if (getUIClassID().equals("DesktopIconUI")) {

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,23 +22,41 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Component;
 import java.awt.Image;
-import java.awt.*;
-import java.text.*;
-import java.awt.geom.*;
-import java.beans.JavaBean;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.Transient;
-
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.text.BreakIterator;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleExtendedComponent;
+import javax.accessibility.AccessibleIcon;
+import javax.accessibility.AccessibleKeyBinding;
+import javax.accessibility.AccessibleRelation;
+import javax.accessibility.AccessibleRelationSet;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleText;
 import javax.swing.plaf.LabelUI;
-import javax.accessibility.*;
-import javax.swing.text.*;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.Position;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.View;
 
 /**
  * A display area for a short text string or an image,
@@ -880,6 +898,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JLayer.java
+++ b/src/java.desktop/share/classes/javax/swing/JLayer.java
@@ -36,6 +36,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -687,6 +688,7 @@ public final class JLayer<V extends Component>
         return 1;
     }
 
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
             throws IOException, ClassNotFoundException {

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,37 +22,65 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-
-import java.util.Vector;
-import java.util.Locale;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import java.beans.JavaBean;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.IllegalComponentStateException;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.Transient;
-
-import javax.swing.event.*;
-import javax.accessibility.*;
-import javax.swing.plaf.*;
-import javax.swing.text.Position;
-
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Vector;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleIcon;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.plaf.ListUI;
+import javax.swing.text.Position;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
 import sun.swing.SwingUtilities2;
 import sun.swing.SwingUtilities2.Section;
-import static sun.swing.SwingUtilities2.Section.*;
+
+import static sun.swing.SwingUtilities2.Section.LEADING;
+import static sun.swing.SwingUtilities2.Section.TRAILING;
 
 /**
  * A component that displays a list of objects and allows the user to select
@@ -2810,6 +2838,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      * See {@code readObject} and {@code writeObject} in {@code JComponent}
      * for more information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Component;
@@ -35,20 +36,29 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeListener;
-
-import java.util.*;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Vector;
 
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+import javax.swing.plaf.MenuItemUI;
+import javax.swing.plaf.PopupMenuUI;
 
 /**
  * An implementation of a menu -- a popup window containing
@@ -1330,6 +1340,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -768,6 +768,7 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
      * See JComponent.readObject() for information about serialization
      * in Swing.
      */
+    @Serial
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException
     {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,31 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.Toolkit;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.Transient;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Vector;
 
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleStateSet;
+import javax.swing.plaf.MenuBarUI;
 
 import sun.awt.SunToolkit;
 
@@ -735,6 +741,7 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
     }
 
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,34 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-
-import java.beans.JavaBean;
+import java.awt.Component;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 
-import javax.swing.plaf.*;
-import javax.swing.event.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.MenuDragMouseEvent;
+import javax.swing.event.MenuDragMouseListener;
+import javax.swing.event.MenuKeyEvent;
+import javax.swing.event.MenuKeyListener;
+import javax.swing.plaf.MenuItemUI;
 
 /**
  * An implementation of an item in a menu. A menu item is essentially a button
@@ -760,6 +772,7 @@ public class JMenuItem extends AbstractButton implements Accessible,MenuElement 
         }
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuItem.java
@@ -763,6 +763,7 @@ public class JMenuItem extends AbstractButton implements Accessible,MenuElement 
      * See JComponent.readObject() for information about serialization
      * in Swing.
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -2397,6 +2397,7 @@ public class JOptionPane extends JComponent implements Accessible
         s.writeObject(values);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.BorderLayout;
@@ -29,33 +30,38 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.KeyboardFocusManager;
 import java.awt.Frame;
-import java.awt.Point;
 import java.awt.HeadlessException;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
 import java.awt.Window;
-import java.beans.JavaBean;
-import java.beans.BeanProperty;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.awt.event.WindowListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+import java.beans.BeanProperty;
+import java.beans.JavaBean;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Vector;
-import javax.swing.plaf.OptionPaneUI;
-import javax.swing.event.InternalFrameEvent;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 import javax.swing.event.InternalFrameAdapter;
-import javax.accessibility.*;
-import static javax.swing.ClientPropertyKey.PopupFactory_FORCE_HEAVYWEIGHT_POPUP;
+import javax.swing.event.InternalFrameEvent;
+import javax.swing.plaf.OptionPaneUI;
+
 import sun.awt.AWTAccessor;
+
+import static javax.swing.ClientPropertyKey.PopupFactory_FORCE_HEAVYWEIGHT_POPUP;
 
 /**
  * <code>JOptionPane</code> makes it easy to pop up a standard dialog box that
@@ -2318,6 +2324,7 @@ public class JOptionPane extends JComponent implements Accessible
     }
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Vector<Object> values = new Vector<Object>();
 

--- a/src/java.desktop/share/classes/javax/swing/JPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/JPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,21 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.beans.JavaBean;
+import java.awt.FlowLayout;
+import java.awt.LayoutManager;
 import java.beans.BeanProperty;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.PanelUI;
 
 /**
  * <code>JPanel</code> is a generic lightweight container.
@@ -169,6 +172,7 @@ public class JPanel extends JComponent implements Accessible
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import javax.swing.text.*;
-import javax.accessibility.*;
-
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Arrays;
+
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleTextSequence;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Segment;
 
 /**
  * <code>JPasswordField</code> is a lightweight component that allows
@@ -331,6 +338,7 @@ public class JPasswordField extends JTextField {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,24 +22,47 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.beans.BeanProperty;
+import java.beans.JavaBean;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
-import java.beans.JavaBean;
-import java.beans.BeanProperty;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-
 import java.util.Vector;
-import javax.accessibility.*;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.MenuKeyEvent;
+import javax.swing.event.MenuKeyListener;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.PopupMenuUI;
 import javax.swing.plaf.basic.BasicComboPopup;
-import javax.swing.event.*;
 
 import sun.awt.SunToolkit;
 
@@ -1304,6 +1327,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
 ////////////
 // Serialization support.
 ////////////
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Vector<Object> values = new Vector<Object>();
 

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -1354,6 +1354,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
     }
 
     // implements javax.swing.MenuElement
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/javax/swing/JProgressBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Graphics;
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-
+import java.beans.JavaBean;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.text.Format;
 import java.text.NumberFormat;
 
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.IOException;
-
-import javax.swing.event.*;
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
 import javax.swing.plaf.ProgressBarUI;
 
 /**
@@ -928,6 +935,7 @@ public class JProgressBar extends JComponent implements SwingConstants, Accessib
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JRadioButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.ButtonUI;
 
 /**
  * An implementation of a radio button -- an item that can be selected or
@@ -218,6 +221,7 @@ public class JRadioButton extends JToggleButton implements Accessible {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * An implementation of a radio button menu item.
@@ -205,6 +209,7 @@ public class JRadioButtonMenuItem extends JMenuItem implements Accessible {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,23 +22,31 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.io.Serializable;
-import java.awt.Component;
 import java.awt.Adjustable;
+import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.AdjustmentListener;
 import java.awt.event.AdjustmentEvent;
-import java.beans.JavaBean;
+import java.awt.event.AdjustmentListener;
 import java.beans.BeanProperty;
-
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.ScrollBarUI;
 
 /**
  * An implementation of a scrollbar. The user positions the knob in the
@@ -784,6 +792,7 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JScrollPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,28 +22,33 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package javax.swing;
 
-import javax.swing.plaf.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
-import javax.accessibility.*;
+package javax.swing;
 
 import java.awt.Component;
 import java.awt.ComponentOrientation;
-import java.awt.Rectangle;
 import java.awt.Insets;
 import java.awt.LayoutManager;
 import java.awt.Point;
-
-import java.io.ObjectOutputStream;
-import java.io.IOException;
-
-import java.beans.JavaBean;
+import java.awt.Rectangle;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.Transient;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRelation;
+import javax.accessibility.AccessibleRole;
+import javax.swing.border.Border;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ScrollPaneUI;
+import javax.swing.plaf.UIResource;
 
 /**
  * Provides a scrollable view of a lightweight component.
@@ -1293,6 +1298,7 @@ public class JScrollPane extends JComponent implements ScrollPaneConstants, Acce
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JSeparator.java
+++ b/src/java.desktop/share/classes/javax/swing/JSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.SeparatorUI;
 
 /**
  * <code>JSeparator</code> provides a general purpose component for
@@ -154,6 +158,7 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,36 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.IOException;
-
-import java.awt.*;
-import java.util.*;
-import java.beans.JavaBean;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Image;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Hashtable;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.SliderUI;
+import javax.swing.plaf.UIResource;
 
 /**
  * A component that lets the user graphically select a value by sliding
@@ -1319,6 +1333,7 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JSpinner.java
+++ b/src/java.desktop/share/classes/javax/swing/JSpinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,23 +25,54 @@
 
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-
-import javax.swing.event.*;
-import javax.swing.plaf.FontUIResource;
-import javax.swing.plaf.UIResource;
-import javax.swing.text.*;
-import javax.swing.plaf.SpinnerUI;
-
-import java.util.*;
-import java.beans.*;
-import java.text.*;
-import java.io.*;
+import java.awt.Component;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.beans.BeanProperty;
+import java.beans.JavaBean;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.text.spi.DateFormatProvider;
 import java.text.spi.NumberFormatProvider;
+import java.util.Date;
+import java.util.Locale;
 
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleEditableText;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.SpinnerUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DateFormatter;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.DocumentFilter;
+import javax.swing.text.NumberFormatter;
+
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.LocaleResources;
 
@@ -560,6 +591,7 @@ public class JSpinner extends JComponent implements Accessible
      *
      * @param s Stream to write to
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,22 @@
 
 package javax.swing;
 
-import java.beans.JavaBean;
+import java.awt.Component;
+import java.awt.Graphics;
 import java.beans.BeanProperty;
 import java.beans.ConstructorProperties;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.awt.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
+import javax.swing.plaf.SplitPaneUI;
 
 /**
  * <code>JSplitPane</code> is used to divide two (and only two)
@@ -1038,6 +1044,7 @@ public class JSplitPane extends JComponent implements Accessible
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1830,6 +1830,7 @@ public class JTabbedPane extends JComponent
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,48 +22,44 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.Component;
 import java.awt.Color;
-import java.awt.Point;
+import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.Rectangle;
 import java.awt.Font;
 import java.awt.FontMetrics;
-import java.awt.Cursor;
-
-import java.awt.event.MouseEvent;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.FocusListener;
-
-import java.beans.JavaBean;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.Transient;
-
-import java.util.Locale;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Locale;
 
-import javax.swing.event.ChangeListener;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleIcon;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
 import javax.swing.event.ChangeEvent;
-
+import javax.swing.event.ChangeListener;
 import javax.swing.plaf.TabbedPaneUI;
 import javax.swing.plaf.UIResource;
 
-import javax.accessibility.AccessibleContext;
-import javax.accessibility.Accessible;
-import javax.accessibility.AccessibleRole;
-import javax.accessibility.AccessibleComponent;
-import javax.accessibility.AccessibleStateSet;
-import javax.accessibility.AccessibleIcon;
-import javax.accessibility.AccessibleSelection;
-import javax.accessibility.AccessibleState;
-
 import sun.swing.SwingUtilities2;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
 
 /**
  * A component that lets the user switch between a group of components by
@@ -1804,6 +1800,7 @@ public class JTabbedPane extends JComponent
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -5916,6 +5916,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         }
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,48 +22,105 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.util.*;
-
 import java.applet.Applet;
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
-import java.beans.JavaBean;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.IllegalComponentStateException;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterAbortException;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
 import java.io.InvalidObjectException;
-
-import javax.accessibility.*;
-
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.swing.table.*;
-import javax.swing.border.*;
-
-import java.text.NumberFormat;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.text.DateFormat;
 import java.text.MessageFormat;
-import java.util.List;
+import java.text.NumberFormat;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.EventObject;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.Vector;
 
-import javax.print.attribute.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleExtendedTable;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleTable;
+import javax.accessibility.AccessibleTableModelChange;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
 import javax.print.PrintService;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import javax.swing.event.CellEditorListener;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.event.RowSorterEvent;
+import javax.swing.event.RowSorterListener;
+import javax.swing.event.TableColumnModelEvent;
+import javax.swing.event.TableColumnModelListener;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+import javax.swing.plaf.TableUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableColumnModel;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
 import sun.reflect.misc.ReflectUtil;
-
+import sun.swing.PrintingStatus;
 import sun.swing.SwingUtilities2;
 import sun.swing.SwingUtilities2.Section;
-import static sun.swing.SwingUtilities2.Section.*;
-import sun.swing.PrintingStatus;
+
+import static sun.swing.SwingUtilities2.Section.LEADING;
+import static sun.swing.SwingUtilities2.Section.MIDDLE;
+import static sun.swing.SwingUtilities2.Section.TRAILING;
 
 /**
  * The <code>JTable</code> is used to display and edit regular two-dimensional tables
@@ -5847,6 +5904,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,30 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.beans.JavaBean;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.TextComponent;
 import java.beans.BeanProperty;
-import javax.swing.text.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.PlainDocument;
 
 /**
  * A <code>JTextArea</code> is a multi-line area that displays plain text.
@@ -732,6 +746,7 @@ public class JTextArea extends JTextComponent {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,38 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.AWTEvent;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import javax.swing.text.*;
-import javax.swing.event.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
+
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.PlainDocument;
+import javax.swing.text.TextAction;
 
 /**
  * <code>JTextField</code> is a lightweight component that allows the editing
@@ -863,6 +880,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTextPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.beans.JavaBean;
+import java.awt.Component;
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 
-import javax.swing.text.*;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Caret;
+import javax.swing.text.Document;
+import javax.swing.text.EditorKit;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.StyledEditorKit;
 
 /**
  * A text component that can be marked up with attributes that are
@@ -436,6 +449,7 @@ public class JTextPane extends JEditorPane {
      *
      * @param s the output stream
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JToggleButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JToggleButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,19 +22,29 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.beans.BeanProperty;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.ObjectOutputStream;
+import java.beans.JavaBean;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Iterator;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.swing.plaf.ButtonUI;
 
 /**
  * An implementation of a two-state button.
@@ -413,6 +423,7 @@ public class JToggleButton extends AbstractButton implements Accessible {
      * See readObject() and writeObject() in JComponent for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JToolBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Component;
@@ -31,17 +32,22 @@ import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.LayoutManager;
 import java.awt.LayoutManager2;
-import java.beans.JavaBean;
 import java.beans.BeanProperty;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.swing.plaf.ToolBarUI;
+import javax.swing.plaf.UIResource;
 
 /**
  * <code>JToolBar</code> provides a component that is useful for
@@ -687,6 +693,7 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JToolTip.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolTip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
  * questions.
  */
 
-
 package javax.swing;
 
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
 import java.beans.BeanProperty;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.Objects;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.plaf.ToolTipUI;
 
 /**
  * Used to display a "Tip" for a Component. Typically components provide api
@@ -193,6 +193,7 @@ public class JToolTip extends JComponent implements Accessible {
      * in <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if (getUIClassID().equals(uiClassID)) {

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,28 +22,81 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.JavaBean;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.IllegalComponentStateException;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
 import java.beans.ConstructorProperties;
+import java.beans.JavaBean;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.*;
-import java.util.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.swing.tree.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.Set;
+import java.util.Stack;
+import java.util.Vector;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.event.TreeWillExpandListener;
+import javax.swing.plaf.TreeUI;
 import javax.swing.text.Position;
-import javax.accessibility.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.DefaultTreeSelectionModel;
+import javax.swing.tree.ExpandVetoException;
+import javax.swing.tree.RowMapper;
+import javax.swing.tree.TreeCellEditor;
+import javax.swing.tree.TreeCellRenderer;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
 import sun.swing.SwingUtilities2;
 import sun.swing.SwingUtilities2.Section;
-import static sun.swing.SwingUtilities2.Section.*;
+
+import static sun.swing.SwingUtilities2.Section.LEADING;
+import static sun.swing.SwingUtilities2.Section.TRAILING;
 
 /**
  * A control that displays a set of hierarchical data as an outline.
@@ -3071,6 +3124,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
     }
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Vector<Object> values = new Vector<Object>();
 

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3167,6 +3167,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
         }
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/javax/swing/KeyStroke.java
+++ b/src/java.desktop/share/classes/javax/swing/KeyStroke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.AWTKeyStroke;
 import java.awt.event.KeyEvent;
+import java.io.Serial;
+
 import sun.swing.SwingAccessor;
 
 /**
@@ -67,8 +70,9 @@ import sun.swing.SwingAccessor;
 public class KeyStroke extends AWTKeyStroke {
 
     /**
-     * Serial Version ID.
+     * Use serialVersionUID from JDK 1.4 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = -9060180771037902530L;
 
     static {

--- a/src/java.desktop/share/classes/javax/swing/LayoutFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutFocusTraversalPolicy.java
@@ -286,6 +286,7 @@ public class LayoutFocusTraversalPolicy extends SortingFocusTraversalPolicy
         out.writeObject(getComparator());
         out.writeBoolean(getImplicitDownCycleTraversal());
     }
+    @Serial
     @SuppressWarnings("unchecked") // Cast to (Comparator<? super Component>)
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException

--- a/src/java.desktop/share/classes/javax/swing/LayoutFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Comparator;
-import java.io.*;
 import java.util.Enumeration;
-import sun.awt.SunToolkit;
 
+import sun.awt.SunToolkit;
 
 /**
  * A SortingFocusTraversalPolicy which sorts Components based on their size,
@@ -276,6 +281,7 @@ public class LayoutFocusTraversalPolicy extends SortingFocusTraversalPolicy
         return fitnessTestPolicy.accept(aComponent);
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.writeObject(getComparator());
         out.writeBoolean(getImplicitDownCycleTraversal());

--- a/src/java.desktop/share/classes/javax/swing/LegacyGlueFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/LegacyGlueFocusTraversalPolicy.java
@@ -197,6 +197,7 @@ final class LegacyGlueFocusTraversalPolicy extends FocusTraversalPolicy
             out.writeObject(null);
         }
     }
+    @Serial
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/LegacyGlueFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/LegacyGlueFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,21 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing;
 
-import java.awt.FocusTraversalPolicy;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.FocusTraversalPolicy;
 import java.awt.Window;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.io.*;
-
 
 /**
  * A FocusTraversalPolicy which provides support for legacy applications which
@@ -176,6 +181,7 @@ final class LegacyGlueFocusTraversalPolicy extends FocusTraversalPolicy
 
         return true;
     }
+    @Serial
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
 

--- a/src/java.desktop/share/classes/javax/swing/Timer.java
+++ b/src/java.desktop/share/classes/javax/swing/Timer.java
@@ -623,6 +623,7 @@ public class Timer implements Serializable
         return lock;
     }
 
+    @Serial
     private void readObject(ObjectInputStream in)
         throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/javax/swing/Timer.java
+++ b/src/java.desktop/share/classes/javax/swing/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,24 @@
  * questions.
  */
 
-
-
 package javax.swing;
 
-
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
-import java.io.*;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.EventListener;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import javax.swing.event.EventListenerList;
-
-
 
 /**
  * Fires one or more {@code ActionEvent}s at specified
@@ -654,6 +653,7 @@ public class Timer implements Serializable
      * We have to use readResolve because we can not initialize final
      * fields for deserialized object otherwise
      */
+    @Serial
     private Object readResolve() {
         Timer timer = new Timer(getDelay(), null);
         timer.listenerList = listenerList;

--- a/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
+++ b/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
@@ -292,6 +292,7 @@ public class EventListenerList implements Serializable {
         s.writeObject(null);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         listenerList = NULL_ARRAY;

--- a/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
+++ b/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.event;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.util.EventListener;
+
 import sun.reflect.misc.ReflectUtil;
 
 /**
@@ -268,6 +274,7 @@ public class EventListenerList implements Serializable {
     }
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Object[] lList = listenerList;
         s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/swing/event/SwingPropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/javax/swing/event/SwingPropertyChangeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package javax.swing.event;
 
-import java.beans.PropertyChangeSupport;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeSupport;
+import java.io.Serial;
 
 import javax.swing.SwingUtilities;
 
@@ -111,8 +112,11 @@ public final class SwingPropertyChangeSupport extends PropertyChangeSupport {
         return notifyOnEDT;
     }
 
-    // Serialization version ID
-    static final long serialVersionUID = 7162625831330845068L;
+    /**
+     * Use serialVersionUID from JDK 1.2 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 7162625831330845068L;
 
     /**
      * whether to notify listeners on EDT

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,24 +22,51 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.plaf.synth;
 
-import java.awt.*;
-import java.beans.*;
-import java.io.*;
-import java.lang.ref.*;
-import java.net.*;
-import java.security.*;
-import java.text.*;
-import java.util.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.NotSerializableException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
-import sun.awt.*;
-import sun.security.action.*;
-import sun.swing.*;
-import sun.swing.plaf.synth.*;
+import javax.swing.JComponent;
+import javax.swing.JMenu;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.InsetsUIResource;
+import javax.swing.plaf.basic.BasicLookAndFeel;
+
+import sun.awt.AppContext;
+import sun.awt.SunToolkit;
+import sun.swing.DefaultLookup;
+import sun.swing.SwingAccessor;
+import sun.swing.SwingUtilities2;
+import sun.swing.plaf.synth.SynthFileChooserUI;
 
 /**
  * SynthLookAndFeel provides the basis for creating a customized look and
@@ -914,6 +941,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
         }
     }
 
+    @Serial
     private void writeObject(java.io.ObjectOutputStream out)
             throws IOException {
         throw new NotSerializableException(this.getClass().getName());

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,28 +22,52 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.table;
 
-import sun.swing.table.DefaultTableCellHeaderRenderer;
-
-import java.util.*;
-import java.awt.*;
-import java.awt.event.*;
-
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.accessibility.*;
-
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
 import java.beans.BeanProperty;
 import java.beans.PropertyChangeListener;
 import java.beans.Transient;
-
-import java.io.ObjectOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.util.Locale;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.accessibility.AccessibleValue;
+import javax.swing.JComponent;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.TableColumnModelEvent;
+import javax.swing.event.TableColumnModelListener;
+import javax.swing.plaf.TableHeaderUI;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
+import sun.swing.table.DefaultTableCellHeaderRenderer;
 
 /**
  * This is the object which manages the header of the <code>JTable</code>.
@@ -724,6 +748,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
      * <code>JComponent</code> for more
      * information about serialization in Swing.
      */
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         if ((ui != null) && (getUIClassID().equals(uiClassID))) {

--- a/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
@@ -1458,6 +1458,7 @@ public abstract class AbstractDocument implements Document, Serializable {
 
     // --- serialization ---------------------------------------------
 
+    @Serial
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
@@ -2243,6 +2244,7 @@ public abstract class AbstractDocument implements Document, Serializable {
             StyleContext.writeAttributeSet(s, attributes);
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException
         {
@@ -2664,6 +2666,7 @@ public abstract class AbstractDocument implements Document, Serializable {
             s.writeInt(p1.getOffset());
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException
         {

--- a/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,39 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text;
 
-import java.util.*;
-import java.io.*;
 import java.awt.font.TextAttribute;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectInputValidation;
+import java.io.ObjectOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Serial;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.text.Bidi;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.Hashtable;
+import java.util.Vector;
 
 import javax.swing.UIManager;
-import javax.swing.undo.*;
-import javax.swing.event.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.UndoableEditEvent;
+import javax.swing.event.UndoableEditListener;
 import javax.swing.tree.TreeNode;
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.CompoundEdit;
+import javax.swing.undo.UndoableEdit;
 
 import sun.font.BidiUtils;
 import sun.swing.SwingUtilities2;
@@ -2215,6 +2237,7 @@ public abstract class AbstractDocument implements Document, Serializable {
 
         // --- serialization ---------------------------------------------
 
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             StyleContext.writeAttributeSet(s, attributes);
@@ -2634,6 +2657,7 @@ public abstract class AbstractDocument implements Document, Serializable {
 
         // --- serialization ---------------------------------------------
 
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             s.writeInt(p0.getOffset());

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1552,6 +1552,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
 
     // --- serialization ---------------------------------------------
 
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,19 +22,49 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.datatransfer.*;
-import java.beans.*;
+import java.awt.Graphics;
+import java.awt.HeadlessException;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.EventListener;
+
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.JPasswordField;
+import javax.swing.JRootPane;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.TransferHandler;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.TextUI;
+
 import sun.swing.SwingUtilities2;
 
 /**
@@ -1564,6 +1594,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
         }
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         s.writeBoolean((dotBias == Position.Bias.Backward));

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
@@ -27,6 +27,7 @@ package javax.swing.text;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.font.TextAttribute;
+import java.io.Serial;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Enumeration;
@@ -1082,6 +1083,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
         }
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException {
         listeningStyles = new Vector<>();

--- a/src/java.desktop/share/classes/javax/swing/text/GapContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapContent.java
@@ -24,6 +24,7 @@
  */
 package javax.swing.text;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Vector;
 import java.io.IOException;
@@ -698,6 +699,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
 
     // --- serialization -------------------------------------
 
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/text/InternationalFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/InternationalFormatter.java
@@ -941,6 +941,7 @@ public class InternationalFormatter extends DefaultFormatter {
      * Subclassed to update the internal representation of the mask after
      * the default read operation has completed.
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -3807,6 +3807,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
 
     // --- serialization ---------------------------------------------
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -656,6 +656,7 @@ public class MaskFormatter extends DefaultFormatter {
      * Subclassed to update the internal representation of the mask after
      * the default read operation has completed.
      */
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
@@ -342,6 +342,7 @@ public class SimpleAttributeSet implements MutableAttributeSet, Serializable, Cl
         StyleContext.writeAttributeSet(s, this);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
@@ -336,6 +336,7 @@ public class SimpleAttributeSet implements MutableAttributeSet, Serializable, Cl
         return s;
     }
 
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
         s.defaultWriteObject();
         StyleContext.writeAttributeSet(s, this);

--- a/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text;
 
-import java.util.Hashtable;
-import java.util.Enumeration;
-import java.util.Collections;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
-import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.LinkedHashMap;
 
 /**
@@ -51,6 +51,10 @@ import java.util.LinkedHashMap;
 @SuppressWarnings("serial") // Same-version serialization only
 public class SimpleAttributeSet implements MutableAttributeSet, Serializable, Cloneable
 {
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -6631553454711782652L;
 
     /**
@@ -348,7 +352,12 @@ public class SimpleAttributeSet implements MutableAttributeSet, Serializable, Cl
      * An AttributeSet that is always empty.
      */
     static class EmptyAttributeSet implements AttributeSet, Serializable {
-        static final long serialVersionUID = -8714803568785904228L;
+
+        /**
+         * Use serialVersionUID from JDK 1.7 for interoperability.
+         */
+        @Serial
+        private static final long serialVersionUID = -8714803568785904228L;
 
         public int getAttributeCount() {
             return 0;

--- a/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,35 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text;
 
-import java.awt.*;
-import java.util.*;
-import java.io.*;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Toolkit;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Vector;
+import java.util.WeakHashMap;
 
 import javax.swing.SwingUtilities;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
-import javax.swing.event.ChangeEvent;
-import java.lang.ref.WeakReference;
-import java.util.WeakHashMap;
 
 import sun.font.FontUtilities;
 
@@ -719,6 +736,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
         return key.getClass().getName() + "." + key.toString();
     }
 
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
         throws IOException
     {
@@ -1608,6 +1626,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
 
         // --- serialization ---------------------------------------------
 
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             writeAttributeSet(s, attributes);

--- a/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
@@ -746,6 +746,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
         s.defaultWriteObject();
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
     {
@@ -1632,6 +1633,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
             writeAttributeSet(s, attributes);
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException
         {

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text.html;
 
 import java.awt.Color;
@@ -31,6 +32,7 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -2438,6 +2440,7 @@ public class CSS implements Serializable {
             return null;
         }
 
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
                      throws IOException {
             s.defaultWriteObject();
@@ -3548,6 +3551,7 @@ public class CSS implements Serializable {
     // Serialization support
     //
 
+    @Serial
     private void writeObject(java.io.ObjectOutputStream s)
         throws IOException
     {

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2452,6 +2452,7 @@ public class CSS implements Serializable {
             }
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
                 throws ClassNotFoundException, IOException {
             s.defaultReadObject();
@@ -3582,6 +3583,7 @@ public class CSS implements Serializable {
         }
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException
     {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text.html;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Hashtable;
+
 import javax.swing.text.AttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
@@ -618,6 +623,7 @@ public class HTML {
             return false;
         }
 
+        @Serial
         private void writeObject(java.io.ObjectOutputStream s)
                      throws IOException {
             s.defaultWriteObject();

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -633,6 +633,7 @@ public class HTML {
             s.writeObject(name);
         }
 
+        @Serial
         private void readObject(ObjectInputStream s)
             throws ClassNotFoundException, IOException {
             s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/ParserDelegator.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/ParserDelegator.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.DataInputStream;
 import java.io.ObjectInputStream;
 import java.io.Reader;
+import java.io.Serial;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -132,6 +133,7 @@ public class ParserDelegator extends HTMLEditorKit.Parser implements Serializabl
                 });
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,17 @@ package javax.swing.tree;
    // ISSUE: this class depends on nothing in AWT -- move to java.util?
 
 import java.beans.Transient;
-import java.io.*;
-import java.util.*;
-
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.EmptyStackException;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.Stack;
+import java.util.Vector;
 
 /**
  * A <code>DefaultMutableTreeNode</code> is a general-purpose node in a tree data
@@ -89,6 +97,10 @@ import java.util.*;
 public class DefaultMutableTreeNode implements Cloneable,
        MutableTreeNode, Serializable
 {
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -4298474751201349152L;
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -1292,6 +1292,7 @@ public class DefaultMutableTreeNode implements Cloneable,
 
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Object[]             tValues;
 

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -1308,6 +1308,7 @@ public class DefaultMutableTreeNode implements Cloneable,
         s.writeObject(tValues);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
 

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -698,6 +698,7 @@ public class DefaultTreeModel implements Serializable, TreeModel {
         s.writeObject(values);
     }
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,19 @@
 
 package javax.swing.tree;
 
-import java.util.*;
 import java.beans.ConstructorProperties;
-import java.io.*;
-import javax.swing.event.*;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.EventListener;
+import java.util.Vector;
+
+import javax.swing.event.EventListenerList;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
 
 /**
  * A simple tree data model that uses TreeNodes.
@@ -676,6 +685,7 @@ public class DefaultTreeModel implements Serializable, TreeModel {
     }
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Vector<Object> values = new Vector<Object>();
 

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,12 @@
 package javax.swing.tree;
 
 import java.beans.PropertyChangeListener;
-import java.io.*;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Enumeration;
@@ -34,8 +39,12 @@ import java.util.EventListener;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
-import javax.swing.event.*;
+
 import javax.swing.DefaultListSelectionModel;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.SwingPropertyChangeSupport;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
 
 /**
  * Default implementation of TreeSelectionModel.  Listeners are notified
@@ -1203,6 +1212,7 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
     }
 
     // Serialization support.
+    @Serial
     private void writeObject(ObjectOutputStream s) throws IOException {
         Object[]             tValues;
 

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
@@ -1229,6 +1229,7 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
     }
 
 
+    @Serial
     private void readObject(ObjectInputStream s)
         throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField f = s.readFields();

--- a/src/java.desktop/share/classes/sun/awt/CausedFocusEvent.java
+++ b/src/java.desktop/share/classes/sun/awt/CausedFocusEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,10 @@
 
 package sun.awt;
 
-import java.awt.event.FocusEvent;
 import java.awt.Component;
+import java.awt.event.FocusEvent;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -36,6 +37,11 @@ import java.security.PrivilegedAction;
  * This class exists for deserialization compatibility only.
  */
 class CausedFocusEvent extends FocusEvent {
+
+    /**
+     * Use serialVersionUID from JDK 9 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -3647309088427840738L;
 
     private enum Cause {

--- a/src/java.desktop/share/classes/sun/awt/CausedFocusEvent.java
+++ b/src/java.desktop/share/classes/sun/awt/CausedFocusEvent.java
@@ -72,6 +72,7 @@ class CausedFocusEvent extends FocusEvent {
         throw new IllegalStateException();
     }
 
+    @Serial
     Object readResolve() throws ObjectStreamException {
         FocusEvent.Cause newCause;
         switch (cause) {

--- a/src/java.desktop/share/classes/sun/awt/EmbeddedFrame.java
+++ b/src/java.desktop/share/classes/sun/awt/EmbeddedFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,28 @@
 
 package sun.awt;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.peer.*;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeEvent;
-import java.util.Set;
-import java.awt.AWTKeyStroke;
 import java.applet.Applet;
+import java.awt.AWTKeyStroke;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Image;
+import java.awt.KeyEventDispatcher;
+import java.awt.KeyboardFocusManager;
+import java.awt.MenuBar;
+import java.awt.MenuComponent;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.KeyEvent;
+import java.awt.peer.ComponentPeer;
+import java.awt.peer.FramePeer;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.Serial;
+import java.util.Set;
 
 /**
  * A generic container used for embedding Java components, usually applets.
@@ -58,7 +72,11 @@ public abstract class EmbeddedFrame extends Frame
     private boolean supportsXEmbed = false;
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private KeyboardFocusManager appletKFM;
-    // JDK 1.1 compatibility
+
+    /**
+     * Use serialVersionUID from JDK 1.1 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 2967042741780317130L;
 
     /*

--- a/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
+++ b/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,14 +36,16 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.InputMethodEvent;
 import java.awt.event.InputMethodListener;
-import java.awt.event.WindowEvent;
 import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextHitInfo;
 import java.awt.font.TextLayout;
 import java.awt.geom.Rectangle2D;
 import java.awt.im.InputMethodRequests;
+import java.io.Serial;
 import java.text.AttributedCharacterIterator;
+
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.border.LineBorder;
@@ -313,7 +315,9 @@ public final class CompositionArea extends JPanel implements InputMethodListener
           compositionWindow.pack();
     }
 
-    // Proclaim serial compatibility with 1.7.0
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -1057247068746557444L;
-
 }

--- a/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package sun.awt.im;
+
+import java.io.Serial;
 
 import javax.swing.JFrame;
 import javax.swing.JRootPane;
@@ -69,6 +71,9 @@ public class InputMethodJFrame
         }
     }
 
-    // Proclaim serial compatibility with 1.7.0
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -4705856747771842549L;
 }

--- a/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
+++ b/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.awt.im;
 
 import java.awt.Frame;
+import java.io.Serial;
 
 /**
  * Implements a simple input method window that provides the minimal
@@ -62,6 +63,9 @@ public class SimpleInputMethodWindow
         }
     }
 
-    // Proclaim serial compatibility with 1.7.0
+    /**
+     * Use serialVersionUID from JDK 1.7 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = 5093376647036461555L;
 }

--- a/src/java.desktop/share/classes/sun/awt/shell/DefaultShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/DefaultShellFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,7 @@
 package sun.awt.shell;
 
 import java.io.File;
-import java.security.AccessController;
-import javax.swing.Icon;
-import sun.security.action.GetPropertyAction;
+import java.io.Serial;
 
 /**
  * @author Michael Martak
@@ -52,6 +50,7 @@ class DefaultShellFolder extends ShellFolder {
      *
      * @return a java.io.File replacement object.
      */
+    @Serial
     protected Object writeReplace() throws java.io.ObjectStreamException {
         return new File(getPath());
     }

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,23 @@
 
 package sun.awt.shell;
 
-import javax.swing.*;
 import java.awt.Image;
 import java.awt.Toolkit;
-import java.io.*;
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
-import java.text.Format;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Vector;
 import java.util.concurrent.Callable;
+
+import javax.swing.SwingConstants;
 
 /**
  * @author Michael Martak
@@ -75,6 +80,7 @@ public abstract class ShellFolder extends File {
      * @return a java.io.File replacement object, or null
      *         if no suitable replacement can be found.
      */
+    @Serial
     protected abstract Object writeReplace() throws java.io.ObjectStreamException;
 
     /**

--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -376,6 +376,7 @@ public final class FontDesignMetrics extends FontMetrics {
         }
     }
 
+    @Serial
     private void readObject(ObjectInputStream in) throws IOException,
                                                   ClassNotFoundException {
 

--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.util.concurrent.ConcurrentHashMap;
@@ -103,7 +104,11 @@ import sun.java2d.DisposerRecord;
 
 public final class FontDesignMetrics extends FontMetrics {
 
-    static final long serialVersionUID = 4480069578560887773L;
+    /**
+     * Use serialVersionUID from JDK 1.3 for interoperability.
+     */
+    @Serial
+    private static final long serialVersionUID = 4480069578560887773L;
 
     private static final float UNKNOWN_WIDTH = -1;
     private static final int CURRENT_VERSION = 1;

--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -401,6 +401,7 @@ public final class FontDesignMetrics extends FontMetrics {
         initAdvCache();
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream out) throws IOException {
 
         cache = new int[256];

--- a/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,15 @@
  * questions.
  */
 
-
 package sun.print;
+
+import java.io.Serial;
+import java.util.ArrayList;
 
 import javax.print.attribute.EnumSyntax;
 import javax.print.attribute.standard.Media;
 import javax.print.attribute.standard.MediaSize;
 import javax.print.attribute.standard.MediaSizeName;
-import java.util.ArrayList;
 
 class CustomMediaSizeName extends MediaSizeName {
     private static ArrayList<String> customStringTable = new ArrayList<>();
@@ -86,8 +87,9 @@ class CustomMediaSizeName extends MediaSizeName {
     }
 
     /**
-     * Version ID for serialized form.
+     * Use serialVersionUID from JDK 1.5 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 7412807582228043717L;
 
     /**

--- a/src/java.desktop/share/classes/sun/print/CustomMediaTray.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaTray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,12 @@
 
 package sun.print;
 
-import javax.print.attribute.EnumSyntax;
-import javax.print.attribute.standard.MediaTray;
-import javax.print.attribute.standard.Media;
+import java.io.Serial;
 import java.util.ArrayList;
+
+import javax.print.attribute.EnumSyntax;
+import javax.print.attribute.standard.Media;
+import javax.print.attribute.standard.MediaTray;
 
 public class CustomMediaTray extends MediaTray {
     private static ArrayList<String> customStringTable = new ArrayList<>();
@@ -53,8 +55,9 @@ public class CustomMediaTray extends MediaTray {
     }
 
     /**
-     * Version ID for serialized form.
+     * Use serialVersionUID from JDK 1.5 for interoperability.
      */
+    @Serial
     private static final long serialVersionUID = 1019451298193987013L;
 
 

--- a/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
+++ b/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,17 @@
 package sun.print;
 
 import java.awt.print.PrinterJob;
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.PrintRequestAttribute;
 
 public class PrinterJobWrapper implements PrintRequestAttribute {
 
+    /**
+     * Use serialVersionUID from JDK 1.8 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -8792124426995707237L;
 
     private PrinterJob job;

--- a/src/java.desktop/share/classes/sun/print/SunAlternateMedia.java
+++ b/src/java.desktop/share/classes/sun/print/SunAlternateMedia.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package sun.print;
 
+import java.io.Serial;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.PrintRequestAttribute;
 import javax.print.attribute.standard.Media;
@@ -36,6 +38,10 @@ import javax.print.attribute.standard.Media;
  */
 public class SunAlternateMedia implements PrintRequestAttribute {
 
+    /**
+     * Use serialVersionUID from JDK 1.5 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -8878868345472850201L;
 
     private Media media;

--- a/src/java.desktop/share/classes/sun/swing/PrintColorUIResource.java
+++ b/src/java.desktop/share/classes/sun/swing/PrintColorUIResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 package sun.swing;
 
 import java.awt.Color;
+import java.io.Serial;
+
 import javax.swing.plaf.ColorUIResource;
 
 /**
@@ -86,6 +88,7 @@ public class PrintColorUIResource extends ColorUIResource {
      * back a {@code PrintColorUIResource}. This is acceptable since we
      * don't have a requirement for that in Swing.
      */
+    @Serial
     private Object writeReplace() {
         return new ColorUIResource(this);
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XMouseDragGestureRecognizer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XMouseDragGestureRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,15 @@
 
 package sun.awt.X11;
 
-import java.awt.Toolkit;
 import java.awt.Component;
-
 import java.awt.Point;
 import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
 import java.awt.dnd.DragSource;
 import java.awt.dnd.MouseDragGestureRecognizer;
-import java.awt.dnd.DragGestureListener;
-
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
+import java.io.Serial;
 
 import sun.awt.dnd.SunDragSourceContextPeer;
 
@@ -54,6 +52,10 @@ import sun.awt.dnd.SunDragSourceContextPeer;
 
 class XMouseDragGestureRecognizer extends MouseDragGestureRecognizer {
 
+    /**
+     * Use serialVersionUID from JDK 1.5 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -841711780352520383L;
 
     /*

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,16 @@ import java.awt.image.ImageObserver;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
 import javax.swing.SwingConstants;
 
 // NOTE: This class supersedes Win32ShellFolder, which was removed from
@@ -368,6 +376,7 @@ final class Win32ShellFolder2 extends ShellFolder {
      * is a not a normal directory, then returns the first non-removable
      * drive (normally "C:\").
      */
+    @Serial
     protected Object writeReplace() throws java.io.ObjectStreamException {
         return invoke(new Callable<File>() {
             public File call() {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WMouseDragGestureRecognizer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WMouseDragGestureRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.dnd.DragSource;
 import java.awt.dnd.MouseDragGestureRecognizer;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
+import java.io.Serial;
 
 import sun.awt.dnd.SunDragSourceContextPeer;
 
@@ -51,6 +52,10 @@ import sun.awt.dnd.SunDragSourceContextPeer;
 
 final class WMouseDragGestureRecognizer extends MouseDragGestureRecognizer {
 
+    /**
+     * Use serialVersionUID from JDK 1.4 for interoperability.
+     */
+    @Serial
     private static final long serialVersionUID = -3527844310018033570L;
 
     /*


### PR DESCRIPTION
Please review the application of @java.io.Serial annotation (JDK-8202385) to types in the desktop module to enable stricter compile-time checking of serialization-related declarations.

This annotation can be applied to these methods in the module:

    private void writeObject(java.io.ObjectOutputStream stream) throws IOException
    private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException
    private void readObjectNoData() throws ObjectStreamException
    ANY-ACCESS-MODIFIER Object writeReplace() throws ObjectStreamException
    ANY-ACCESS-MODIFIER Object readResolve() throws ObjectStreamException
    private static final ObjectStreamField[] serialPersistentFields
    private static final long serialVersionUID

Notes:
  - I have tried to update the comments for serialVersionUID as accurately as possible, but mostly based on the source code history and bugs in JBS where that field was added
  - Some of the readObject/writeObject methods in the javax.swing package does not have a spec, because this package and some others are excluded from the serialization specification.

A similar fix was implemented for java.base module as well:
http://mail.openjdk.java.net/pipermail/core-libs-dev/2019-August/062046.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259522](https://bugs.openjdk.java.net/browse/JDK-8259522): Apply java.io.Serial annotations in java.desktop


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to 2e50a258d4a340f806d193369a6f45104a49f1b2
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2020/head:pull/2020`
`$ git checkout pull/2020`
