### PR TITLE
8259359: javac does not attribute unexpected super constructor invocation qualifier, and may crash

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2404,6 +2404,7 @@ public class Attr extends JCTree.Visitor {
                 } else if (tree.meth.hasTag(SELECT)) {
                     log.error(tree.meth.pos(),
                               Errors.IllegalQualNotIcls(site.tsym));
+                    attribExpr(((JCFieldAccess) tree.meth).selected, localEnv, site);
                 }
 
                 // if we're calling a java.lang.Enum constructor,
@@ -2429,6 +2430,8 @@ public class Attr extends JCTree.Visitor {
                 Type mpt = newMethodTemplate(resultInfo.pt, argtypes, typeargtypes);
                 checkId(tree.meth, site, sym, localEnv,
                         new ResultInfo(kind, mpt));
+            } else if (site.hasTag(ERROR) && tree.meth.hasTag(SELECT)) {
+                attribExpr(((JCFieldAccess) tree.meth).selected, localEnv, site);
             }
             // Otherwise, `site' is an error type and we do nothing
             result = tree.type = syms.voidType;

--- a/test/langtools/tools/javac/recovery/T8259359.java
+++ b/test/langtools/tools/javac/recovery/T8259359.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8259359
+ * @summary javac does not attribute unexpected super constructor invocation qualifier, and may crash
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8259359
+ */
+
+import java.util.List;
+import java.util.Arrays;
+
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+import toolbox.Task;
+
+public class T8259359 extends TestRunner {
+    ToolBox tb;
+
+    public T8259359() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new T8259359().runTests();
+    }
+
+    @Test
+    public void testSuperConstructorCallInErrorClass() throws Exception {
+        String code = """
+                public class SuperConstructorCallInErrorClass extends Undefined1 {
+                     public SuperConstructorCallInErrorClass(int i) {
+                         new Undefined2() { public void test(int i) { Undefined3 u; } }.super();
+                     }
+                }""";
+        List<String> output = new JavacTask(tb)
+                .sources(code)
+                .options("-XDshould-stop.at=FLOW", "-XDdev", "-XDrawDiagnostics")
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        List<String> expected = Arrays.asList(
+                "SuperConstructorCallInErrorClass.java:1:55: compiler.err.cant.resolve: kindname.class, Undefined1, , ",
+                "SuperConstructorCallInErrorClass.java:3:14: compiler.err.cant.resolve.location: kindname.class, " +
+                        "Undefined2, , , (compiler.misc.location: kindname.class, SuperConstructorCallInErrorClass, null)",
+                "SuperConstructorCallInErrorClass.java:3:55: compiler.err.cant.resolve: kindname.class, Undefined3, , ",
+                "3 errors");
+        tb.checkEqual(expected, output);
+    }
+
+    @Test
+    public void testSuperConstructorCallInNormalClass() throws Exception {
+        String code = """
+                public class SuperConstructorCallInNormalClass {
+                     public SuperConstructorCallInNormalClass(int i) {
+                         new Undefined2() { public void test(int i) { Undefined3 u; } }.super();
+                     }
+                }""";
+        List<String> output = new JavacTask(tb)
+                .sources(code)
+                .options("-XDshould-stop.at=FLOW", "-XDdev", "-XDrawDiagnostics")
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        List<String> expected = Arrays.asList(
+                "SuperConstructorCallInNormalClass.java:3:72: compiler.err.illegal.qual.not.icls: java.lang.Object",
+                "SuperConstructorCallInNormalClass.java:3:14: compiler.err.cant.resolve.location: kindname.class, " +
+                    "Undefined2, , , (compiler.misc.location: kindname.class, SuperConstructorCallInNormalClass, null)",
+                "SuperConstructorCallInNormalClass.java:3:55: compiler.err.cant.resolve: kindname.class, Undefined3, , ",
+                "3 errors");
+        tb.checkEqual(expected, output);
+    }
+}


### PR DESCRIPTION
Hi all,

Currently, javac doesn't attribute unexpected super constructor invocation qualifier. Please see the following code.

```
public class SuperConstructorCallInErrorClass extends Undefined1 {
     public SuperConstructorCallInErrorClass(int i) {
         new Undefined2() { public void test(int i) { Undefined3 u; } }.super();  //<-------------------
     }
}
```

The code `new Undefined2() { public void test(int i) { Undefined3 u; } }` isn't attributed by javac.
If we use options like `-XDshould-stop.at=FLOW -XDdev`, the compiler would crash.

This patch fixes it and adds the corresponding test cases.

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259359](https://bugs.openjdk.java.net/browse/JDK-8259359): javac does not attribute unexpected super constructor invocation qualifier, and may crash


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2021/head:pull/2021`
`$ git checkout pull/2021`
