### PR TITLE
Use switch expressions and multiple labels switch case statements in jdk.javadoc

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
@@ -393,12 +393,13 @@ public class Contents {
         while (m.find(start)) {
             c.add(text.substring(start, m.start()));
 
-            Object o = null;
-            switch (m.group(1).charAt(0)) {
-                case '0': o = o0; break;
-                case '1': o = o1; break;
-                case '2': o = o2; break;
-            }
+            Object o = switch (m.group(1).charAt(0)) {
+                case '0' -> o0;
+                case '1' -> o1;
+                case '2' -> o2;
+
+                default -> null;
+            };
 
             if (o == null) {
                 c.add("{" + m.group(1) + "}");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -52,6 +52,9 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
 import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
 
+import static jdk.javadoc.internal.doclets.toolkit.util.DeprecatedAPIListBuilder.DeprElementKind.RECORD_CLASS;
+import static jdk.javadoc.internal.doclets.toolkit.util.DeprecatedAPIListBuilder.DeprElementKind.RECORD_CLASS;
+
 /**
  * Generate File to list all the deprecated classes and class members with the
  * appropriate links.
@@ -66,151 +69,83 @@ import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
 public class DeprecatedListWriter extends SubWriterHolderWriter {
 
     private String getAnchorName(DeprElementKind kind) {
-        switch (kind) {
-            case REMOVAL:
-                return "forRemoval";
-            case MODULE:
-                return "module";
-            case PACKAGE:
-                return "package";
-            case INTERFACE:
-                return "interface";
-            case CLASS:
-                return "class";
-            case ENUM:
-                return "enum.class";
-            case EXCEPTION:
-                return "exception";
-            case ERROR:
-                return "error";
-            case ANNOTATION_TYPE:
-                return "annotation.interface";
-            case FIELD:
-                return "field";
-            case METHOD:
-                return "method";
-            case CONSTRUCTOR:
-                return "constructor";
-            case ENUM_CONSTANT:
-                return "enum.constant";
-            case ANNOTATION_TYPE_MEMBER:
-                return "annotation.interface.member";
-            case RECORD_CLASS:
-                return "record.class";
-            default:
-                throw new AssertionError("unknown kind: " + kind);
-        }
+        return switch (kind) {
+            case REMOVAL                -> "forRemoval";
+            case MODULE                 -> "module";
+            case PACKAGE                -> "package";
+            case INTERFACE              -> "interface";
+            case CLASS                  -> "class";
+            case ENUM                   -> "enum.class";
+            case EXCEPTION              -> "exception";
+            case ERROR                  -> "error";
+            case ANNOTATION_TYPE        -> "annotation.interface";
+            case FIELD                  -> "field";
+            case METHOD                 -> "method";
+            case CONSTRUCTOR            -> "constructor";
+            case ENUM_CONSTANT          -> "enum.constant";
+            case ANNOTATION_TYPE_MEMBER -> "annotation.interface.member";
+            case RECORD_CLASS           -> "record.class";
+        };
     }
 
     private String getHeadingKey(DeprElementKind kind) {
-        switch (kind) {
-            case REMOVAL:
-                return "doclet.For_Removal";
-            case MODULE:
-                return "doclet.Modules";
-            case PACKAGE:
-                return "doclet.Packages";
-            case INTERFACE:
-                return "doclet.Interfaces";
-            case CLASS:
-                return "doclet.Classes";
-            case ENUM:
-                return "doclet.Enums";
-            case EXCEPTION:
-                return "doclet.Exceptions";
-            case ERROR:
-                return "doclet.Errors";
-            case ANNOTATION_TYPE:
-                return "doclet.Annotation_Types";
-            case RECORD_CLASS:
-                return "doclet.RecordClasses";
-            case FIELD:
-                return "doclet.Fields";
-            case METHOD:
-                return "doclet.Methods";
-            case CONSTRUCTOR:
-                return "doclet.Constructors";
-            case ENUM_CONSTANT:
-                return "doclet.Enum_Constants";
-            case ANNOTATION_TYPE_MEMBER:
-                return "doclet.Annotation_Type_Members";
-            default:
-                throw new AssertionError("unknown kind: " + kind);
-        }
+        return switch (kind) {
+            case REMOVAL                -> "doclet.For_Removal";
+            case MODULE                 -> "doclet.Modules";
+            case PACKAGE                -> "doclet.Packages";
+            case INTERFACE              -> "doclet.Interfaces";
+            case CLASS                  -> "doclet.Classes";
+            case ENUM                   -> "doclet.Enums";
+            case EXCEPTION              -> "doclet.Exceptions";
+            case ERROR                  -> "doclet.Errors";
+            case ANNOTATION_TYPE        -> "doclet.Annotation_Types";
+            case RECORD_CLASS           -> "doclet.RecordClasses";
+            case FIELD                  -> "doclet.Fields";
+            case METHOD                 -> "doclet.Methods";
+            case CONSTRUCTOR            -> "doclet.Constructors";
+            case ENUM_CONSTANT          -> "doclet.Enum_Constants";
+            case ANNOTATION_TYPE_MEMBER -> "doclet.Annotation_Type_Members";
+        };
     }
 
     private String getSummaryKey(DeprElementKind kind) {
-        switch (kind) {
-            case REMOVAL:
-                return "doclet.for_removal";
-            case MODULE:
-                return "doclet.modules";
-            case PACKAGE:
-                return "doclet.packages";
-            case INTERFACE:
-                return "doclet.interfaces";
-            case CLASS:
-                return "doclet.classes";
-            case ENUM:
-                return "doclet.enums";
-            case EXCEPTION:
-                return "doclet.exceptions";
-            case ERROR:
-                return "doclet.errors";
-            case ANNOTATION_TYPE:
-                return "doclet.annotation_types";
-            case RECORD_CLASS:
-                return "doclet.record_classes";
-            case FIELD:
-                return "doclet.fields";
-            case METHOD:
-                return "doclet.methods";
-            case CONSTRUCTOR:
-                return "doclet.constructors";
-            case ENUM_CONSTANT:
-                return "doclet.enum_constants";
-            case ANNOTATION_TYPE_MEMBER:
-                return "doclet.annotation_type_members";
-            default:
-                throw new AssertionError("unknown kind: " + kind);
-        }
+        return switch (kind) {
+            case REMOVAL                -> "doclet.for_removal";
+            case MODULE                 -> "doclet.modules";
+            case PACKAGE                -> "doclet.packages";
+            case INTERFACE              -> "doclet.interfaces";
+            case CLASS                  -> "doclet.classes";
+            case ENUM                   -> "doclet.enums";
+            case EXCEPTION              -> "doclet.exceptions";
+            case ERROR                  -> "doclet.errors";
+            case ANNOTATION_TYPE        -> "doclet.annotation_types";
+            case RECORD_CLASS           -> "doclet.record_classes";
+            case FIELD                  -> "doclet.fields";
+            case METHOD                 -> "doclet.methods";
+            case CONSTRUCTOR            -> "doclet.constructors";
+            case ENUM_CONSTANT          -> "doclet.enum_constants";
+            case ANNOTATION_TYPE_MEMBER -> "doclet.annotation_type_members";
+        };
     }
 
     private String getHeaderKey(DeprElementKind kind) {
-        switch (kind) {
-            case REMOVAL:
-                return "doclet.Element";
-            case MODULE:
-                return "doclet.Module";
-            case PACKAGE:
-                return "doclet.Package";
-            case INTERFACE:
-                return "doclet.Interface";
-            case CLASS:
-                return "doclet.Class";
-            case ENUM:
-                return "doclet.Enum";
-            case EXCEPTION:
-                return "doclet.Exceptions";
-            case ERROR:
-                return "doclet.Errors";
-            case ANNOTATION_TYPE:
-                return "doclet.AnnotationType";
-            case RECORD_CLASS:
-                return "doclet.RecordClass";
-            case FIELD:
-                return "doclet.Field";
-            case METHOD:
-                return "doclet.Method";
-            case CONSTRUCTOR:
-                return "doclet.Constructor";
-            case ENUM_CONSTANT:
-                return "doclet.Enum_Constant";
-            case ANNOTATION_TYPE_MEMBER:
-                return "doclet.Annotation_Type_Member";
-            default:
-                throw new AssertionError("unknown kind: " + kind);
-        }
+        return switch (kind) {
+            case REMOVAL                -> "doclet.Element";
+            case MODULE                 -> "doclet.Module";
+            case PACKAGE                -> "doclet.Package";
+            case INTERFACE              -> "doclet.Interface";
+            case CLASS                  -> "doclet.Class";
+            case ENUM                   -> "doclet.Enum";
+            case EXCEPTION              -> "doclet.Exceptions";
+            case ERROR                  -> "doclet.Errors";
+            case ANNOTATION_TYPE        -> "doclet.AnnotationType";
+            case RECORD_CLASS           -> "doclet.RecordClass";
+            case FIELD                  -> "doclet.Field";
+            case METHOD                 -> "doclet.Method";
+            case CONSTRUCTOR            -> "doclet.Constructor";
+            case ENUM_CONSTANT          -> "doclet.Enum_Constant";
+            case ANNOTATION_TYPE_MEMBER -> "doclet.Annotation_Type_Member";
+        };
     }
 
     private EnumMap<DeprElementKind, AbstractMemberWriter> writerMap;
@@ -228,35 +163,16 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
         writerMap = new EnumMap<>(DeprElementKind.class);
         for (DeprElementKind kind : DeprElementKind.values()) {
             switch (kind) {
-                case REMOVAL:
-                case MODULE:
-                case PACKAGE:
-                case INTERFACE:
-                case CLASS:
-                case ENUM:
-                case EXCEPTION:
-                case ERROR:
-                case ANNOTATION_TYPE:
-                case RECORD_CLASS:
-                    writerMap.put(kind, classW);
-                    break;
-                case FIELD:
-                    writerMap.put(kind, new FieldWriterImpl(this));
-                    break;
-                case METHOD:
-                    writerMap.put(kind, new MethodWriterImpl(this));
-                    break;
-                case CONSTRUCTOR:
-                    writerMap.put(kind, new ConstructorWriterImpl(this));
-                    break;
-                case ENUM_CONSTANT:
-                    writerMap.put(kind, new EnumConstantWriterImpl(this));
-                    break;
-                case ANNOTATION_TYPE_MEMBER:
-                    writerMap.put(kind, new AnnotationTypeOptionalMemberWriterImpl(this, null));
-                    break;
-                default:
-                   throw new AssertionError("unknown kind: " + kind);
+                case REMOVAL, MODULE, PACKAGE, INTERFACE, CLASS, ENUM, EXCEPTION, ERROR,
+                        ANNOTATION_TYPE, RECORD_CLASS
+                                            -> writerMap.put(kind, classW);
+                case FIELD                  -> writerMap.put(kind, new FieldWriterImpl(this));
+                case METHOD                 -> writerMap.put(kind, new MethodWriterImpl(this));
+                case CONSTRUCTOR            -> writerMap.put(kind, new ConstructorWriterImpl(this));
+                case ENUM_CONSTANT          -> writerMap.put(kind, new EnumConstantWriterImpl(this));
+                case ANNOTATION_TYPE_MEMBER -> writerMap.put(kind, new AnnotationTypeOptionalMemberWriterImpl(this, null));
+
+                default -> throw new AssertionError("unknown kind: " + kind);
             }
         }
     }
@@ -405,30 +321,15 @@ public class DeprecatedListWriter extends SubWriterHolderWriter {
     }
 
     protected Content getDeprecatedLink(Element e) {
-        AbstractMemberWriter writer;
-        switch (e.getKind()) {
-            case INTERFACE:
-            case CLASS:
-            case ENUM:
-            case ANNOTATION_TYPE:
-            case RECORD:
-                writer = new NestedClassWriterImpl(this);
-                break;
-            case FIELD:
-                writer = new FieldWriterImpl(this);
-                break;
-            case METHOD:
-                writer = new MethodWriterImpl(this);
-                break;
-            case CONSTRUCTOR:
-                writer = new ConstructorWriterImpl(this);
-                break;
-            case ENUM_CONSTANT:
-                writer = new EnumConstantWriterImpl(this);
-                break;
-            default:
-                writer = new AnnotationTypeOptionalMemberWriterImpl(this, null);
-        }
+        AbstractMemberWriter writer = switch (e.getKind()) {
+            case INTERFACE, CLASS, ENUM, ANNOTATION_TYPE, RECORD    -> new NestedClassWriterImpl(this);
+            case FIELD                                              -> new FieldWriterImpl(this);
+            case METHOD                                             -> new MethodWriterImpl(this);
+            case CONSTRUCTOR                                        -> new ConstructorWriterImpl(this);
+            case ENUM_CONSTANT                                      -> new EnumConstantWriterImpl(this);
+
+            default -> new AnnotationTypeOptionalMemberWriterImpl(this, null);
+        };
         return writer.getDeprecatedLink(e);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1399,18 +1399,12 @@ public class HtmlDocletWriter {
                         return false;
                     }
                     sb.append("=");
-                    String quote;
-                    switch (node.getValueKind()) {
-                        case DOUBLE:
-                            quote = "\"";
-                            break;
-                        case SINGLE:
-                            quote = "'";
-                            break;
-                        default:
-                            quote = "";
-                            break;
-                    }
+                    String quote = switch (node.getValueKind()) {
+                        case DOUBLE -> "\"";
+                        case SINGLE -> "'";
+
+                        default     -> "";
+                    };
                     sb.append(quote);
                     result.add(sb);
                     Content docRootContent = new ContentBuilder();
@@ -2011,8 +2005,7 @@ public class HtmlDocletWriter {
         for (Element e: chain) {
             CharSequence name;
             switch (e.getKind()) {
-                case MODULE:
-                case PACKAGE:
+                case MODULE, PACKAGE:
                     name = ((QualifiedNameable) e).getQualifiedName();
                     if (name.length() == 0) {
                         name = "<unnamed>";

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -209,21 +209,14 @@ public class IndexWriter extends HtmlDocletWriter {
                 dt.add(" - ").add(contents.package_).add(" " + label);
                 break;
 
-            case CLASS:
-            case ENUM:
-            case RECORD:
-            case ANNOTATION_TYPE:
-            case INTERFACE:
+            case CLASS, ENUM, RECORD, ANNOTATION_TYPE, INTERFACE:
                 dt = HtmlTree.DT(getLink(new LinkInfoImpl(configuration,
                         LinkInfoImpl.Kind.INDEX, (TypeElement) element).strong(true)));
                 dt.add(" - ");
                 addClassInfo((TypeElement) element, dt);
                 break;
 
-            case CONSTRUCTOR:
-            case METHOD:
-            case FIELD:
-            case ENUM_CONSTANT:
+            case CONSTRUCTOR, METHOD, FIELD, ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
                 dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.memberNameLink,
                         getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element, new StringContent(label))));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -188,9 +188,7 @@ public class LinkFactoryImpl extends LinkFactory {
             // TODO: use the context for now, and special case for Receiver_Types,
             // which takes the default case.
             switch (((LinkInfoImpl)linkInfo).context) {
-                case MEMBER_TYPE_PARAMS:
-                case EXECUTABLE_MEMBER_PARAM:
-                case CLASS_SIGNATURE:
+                case MEMBER_TYPE_PARAMS, EXECUTABLE_MEMBER_PARAM, CLASS_SIGNATURE:
                     Element element = utils.typeUtils.asElement(linkInfo.type);
                     annotations = element.getAnnotationMirrors();
                     break;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -350,12 +350,8 @@ public class LinkInfoImpl extends LinkInfo {
     public final void setContext(Kind c) {
         //NOTE:  Put context specific link code here.
         switch (c) {
-            case PACKAGE_FRAME:
-            case IMPLEMENTED_CLASSES:
-            case SUBCLASSES:
-            case EXECUTABLE_ELEMENT_COPY:
-            case PROPERTY_COPY:
-            case CLASS_USE_HEADER:
+            case PACKAGE_FRAME, IMPLEMENTED_CLASSES, SUBCLASSES,
+                    EXECUTABLE_ELEMENT_COPY, PROPERTY_COPY, CLASS_USE_HEADER:
                 includeTypeInClassLinkLabel = false;
                 break;
 
@@ -364,24 +360,17 @@ public class LinkInfoImpl extends LinkInfo {
                 excludeTypeBounds = true;
                 break;
 
-            case IMPLEMENTED_INTERFACES:
-            case SUPER_INTERFACES:
-            case SUBINTERFACES:
-            case CLASS_TREE_PARENT:
-            case TREE:
-            case CLASS_SIGNATURE_PARENT_NAME:
-            case PERMITTED_SUBCLASSES:
+            case IMPLEMENTED_INTERFACES, SUPER_INTERFACES, SUBINTERFACES,
+                    CLASS_TREE_PARENT, TREE, CLASS_SIGNATURE_PARENT_NAME,
+                    PERMITTED_SUBCLASSES:
                 excludeTypeParameterLinks = true;
                 excludeTypeBounds = true;
                 includeTypeInClassLinkLabel = false;
                 includeTypeAsSepLink = true;
                 break;
 
-            case PACKAGE:
-            case CLASS_USE:
-            case CLASS_HEADER:
-            case CLASS_SIGNATURE:
-            case RECEIVER_TYPE:
+            case PACKAGE, CLASS_USE, CLASS_HEADER, CLASS_SIGNATURE,
+                    RECEIVER_TYPE:
                 excludeTypeParameterLinks = true;
                 includeTypeAsSepLink = true;
                 includeTypeInClassLinkLabel = false;
@@ -392,10 +381,8 @@ public class LinkInfoImpl extends LinkInfo {
                 includeTypeInClassLinkLabel = false;
                 break;
 
-            case RETURN_TYPE:
-            case SUMMARY_RETURN_TYPE:
-            case EXECUTABLE_MEMBER_PARAM:
-            case THROWS_TYPE:
+            case RETURN_TYPE, SUMMARY_RETURN_TYPE,
+                    EXECUTABLE_MEMBER_PARAM, THROWS_TYPE:
                 excludeTypeBounds = true;
                 break;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -183,13 +183,11 @@ public class TagletWriterImpl extends TagletWriter {
 
     @Override
     public Content getParamHeader(ParamTaglet.ParamKind kind) {
-        Content header;
-        switch (kind) {
-            case PARAMETER:         header = contents.parameters ; break;
-            case TYPE_PARAMETER:    header = contents.typeParameters ; break;
-            case RECORD_COMPONENT:  header = contents.recordComponents ; break;
-            default: throw new IllegalArgumentException(kind.toString());
-        }
+        Content header = switch (kind) {
+            case PARAMETER          -> contents.parameters;
+            case TYPE_PARAMETER     -> contents.typeParameters;
+            case RECORD_COMPONENT   -> contents.recordComponents;
+        };
         return HtmlTree.DT(header);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/WriterFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/WriterFactoryImpl.java
@@ -126,29 +126,19 @@ public class WriterFactoryImpl implements WriterFactory {
     @Override
     public MemberSummaryWriter getMemberSummaryWriter(ClassWriter classWriter,
             VisibleMemberTable.Kind memberType) {
-        switch (memberType) {
-            case CONSTRUCTORS:
-                return getConstructorWriter(classWriter);
-            case ENUM_CONSTANTS:
-                return getEnumConstantWriter(classWriter);
-            case ANNOTATION_TYPE_MEMBER_OPTIONAL:
-                return (AnnotationTypeOptionalMemberWriterImpl)
-                        getAnnotationTypeOptionalMemberWriter(classWriter);
-            case ANNOTATION_TYPE_MEMBER_REQUIRED:
-                return (AnnotationTypeRequiredMemberWriterImpl)
-                        getAnnotationTypeRequiredMemberWriter(classWriter);
-            case FIELDS:
-                return getFieldWriter(classWriter);
-            case PROPERTIES:
-                return getPropertyWriter(classWriter);
-            case INNER_CLASSES:
-                return new NestedClassWriterImpl((SubWriterHolderWriter)
+        return switch (memberType) {
+            case CONSTRUCTORS                    -> getConstructorWriter(classWriter);
+            case ENUM_CONSTANTS                  -> getEnumConstantWriter(classWriter);
+            case ANNOTATION_TYPE_MEMBER_OPTIONAL -> (AnnotationTypeOptionalMemberWriterImpl)
+                    getAnnotationTypeOptionalMemberWriter(classWriter);
+            case ANNOTATION_TYPE_MEMBER_REQUIRED -> (AnnotationTypeRequiredMemberWriterImpl)
+                    getAnnotationTypeRequiredMemberWriter(classWriter);
+            case FIELDS                          -> getFieldWriter(classWriter);
+            case PROPERTIES                      -> getPropertyWriter(classWriter);
+            case INNER_CLASSES                   -> new NestedClassWriterImpl((SubWriterHolderWriter)
                     classWriter, classWriter.getTypeElement());
-            case METHODS:
-                return getMethodWriter(classWriter);
-            default:
-                return null;
-        }
+            case METHODS                         -> getMethodWriter(classWriter);
+        };
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
@@ -104,10 +104,11 @@ public class Entity extends Content {
         for (int i = start ; i < s.length(); i++) {
             char ch = s.charAt(i);
             switch (ch) {
-                case '<': sb.append(Entity.LESS_THAN.text);     break;
-                case '>': sb.append(Entity.GREATER_THAN.text);  break;
-                case '&': sb.append(Entity.AMPERSAND.text);     break;
-                default:  sb.append(ch);                        break;
+                case '<' -> sb.append(Entity.LESS_THAN.text);
+                case '>' -> sb.append(Entity.GREATER_THAN.text);
+                case '&' -> sb.append(Entity.AMPERSAND.text);
+
+                default  -> sb.append(ch);
             }
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -494,12 +494,10 @@ public class HtmlTree extends Content {
     }
 
     private static TagName checkHeading(TagName headingTag) {
-        switch (headingTag) {
-            case H1: case H2: case H3: case H4: case H5: case H6:
-                return headingTag;
-            default:
-                throw new IllegalArgumentException(headingTag.toString());
-        }
+        return switch (headingTag) {
+            case H1, H2, H3, H4, H5, H6 -> headingTag;
+            default -> throw new IllegalArgumentException(headingTag.toString());
+        };
     }
 
     /**
@@ -895,28 +893,19 @@ public class HtmlTree extends Content {
      */
     @Override
     public boolean isValid() {
-        switch (tagName) {
-            case A:
-                return (hasAttr(HtmlAttr.ID) || (hasAttr(HtmlAttr.HREF) && hasContent()));
-            case BR:
-                return (!hasContent() && (!hasAttrs() || hasAttr(HtmlAttr.CLEAR)));
-            case HR:
-            case INPUT:
-                return (!hasContent());
-            case IMG:
-                return (hasAttr(HtmlAttr.SRC) && hasAttr(HtmlAttr.ALT) && !hasContent());
-            case LINK:
-                return (hasAttr(HtmlAttr.HREF) && !hasContent());
-            case META:
-                return (hasAttr(HtmlAttr.CONTENT) && !hasContent());
-            case SCRIPT:
-                return ((hasAttr(HtmlAttr.TYPE) && hasAttr(HtmlAttr.SRC) && !hasContent()) ||
-                        (hasAttr(HtmlAttr.TYPE) && hasContent()));
-            case SPAN:
-                return (hasAttr(HtmlAttr.ID) || hasContent());
-            default :
-                return hasContent();
-        }
+        return switch (tagName) {
+            case A          -> (hasAttr(HtmlAttr.ID) || (hasAttr(HtmlAttr.HREF) && hasContent()));
+            case BR         -> (!hasContent() && (!hasAttrs() || hasAttr(HtmlAttr.CLEAR)));
+            case HR, INPUT  -> (!hasContent());
+            case IMG        -> (hasAttr(HtmlAttr.SRC) && hasAttr(HtmlAttr.ALT) && !hasContent());
+            case LINK       -> (hasAttr(HtmlAttr.HREF) && !hasContent());
+            case META       -> (hasAttr(HtmlAttr.CONTENT) && !hasContent());
+            case SCRIPT     -> ((hasAttr(HtmlAttr.TYPE) && hasAttr(HtmlAttr.SRC) && !hasContent()) ||
+                    (hasAttr(HtmlAttr.TYPE) && hasContent()));
+            case SPAN       -> (hasAttr(HtmlAttr.ID) || hasContent());
+
+            default         -> hasContent();
+        };
     }
 
     /**
@@ -927,13 +916,10 @@ public class HtmlTree extends Content {
      * @see <a href="https://www.w3.org/TR/html51/dom.html#kinds-of-content-phrasing-content">Phrasing Content</a>
      */
     public boolean isInline() {
-        switch (tagName) {
-            case A: case BUTTON: case BR: case CODE: case EM: case I: case IMG:
-            case LABEL: case SMALL: case SPAN: case STRONG: case SUB:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tagName) {
+            case A, BUTTON, BR, CODE, EM, I, IMG, LABEL, SMALL, SPAN, STRONG, SUB -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -944,12 +930,10 @@ public class HtmlTree extends Content {
      * @see <a href="https://www.w3.org/TR/html51/syntax.html#void-elements">Void Elements</a>
      */
     public boolean isVoid() {
-        switch (tagName) {
-            case BR: case HR: case IMG: case INPUT: case LINK: case META:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tagName) {
+            case BR, HR, IMG, INPUT, LINK, META -> true;
+            default -> false;
+        };
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
@@ -119,15 +119,11 @@ public abstract class AbstractDoclet implements Doclet {
             }
 
         } catch (DocFileIOException e) {
-            switch (e.mode) {
-                case READ:
-                    messages.error("doclet.exception.read.file",
-                            e.fileName.getPath(), e.getCause());
-                    break;
-                case WRITE:
-                    messages.error("doclet.exception.write.file",
-                            e.fileName.getPath(), e.getCause());
-            }
+            var errorTag = switch (e.mode) {
+                case READ -> "doclet.exception.read.file";
+                case WRITE -> "doclet.exception.write.file";
+            };
+            messages.error(errorTag, e.fileName.getPath(), e.getCause());
             dumpStack(options.dumpOnError(), e);
 
         } catch (ResourceIOException e) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
@@ -119,26 +119,15 @@ public class ClassBuilder extends AbstractBuilder {
       * @throws DocletException if there is a problem while building the documentation
       */
      protected void buildClassDoc() throws DocletException {
-        String key;
-         switch (typeElement.getKind()) {
-             case INTERFACE:
-                 key = "doclet.Interface";
-                 break;
-             case ENUM:
-                 key = "doclet.Enum";
-                 break;
-             case RECORD:
-                 key = "doclet.RecordClass";
-                 break;
-             case ANNOTATION_TYPE:
-                 key = "doclet.AnnotationType";
-                 break;
-             case CLASS:
-                 key = "doclet.Class";
-                 break;
-             default:
-                 throw new IllegalStateException(typeElement.getKind() + " " + typeElement);
-         }
+        String key = switch (typeElement.getKind()) {
+            case INTERFACE       -> "doclet.Interface";
+            case ENUM            -> "doclet.Enum";
+            case RECORD          -> "doclet.RecordClass";
+            case ANNOTATION_TYPE -> "doclet.AnnotationType";
+            case CLASS           -> "doclet.Class";
+
+            default -> throw new IllegalStateException(typeElement.getKind() + " " + typeElement);
+        };
         Content contentTree = writer.getHeader(resources.getText(key) + " "
                 + utils.getSimpleName(typeElement));
         Content classContentTree = writer.getClassContentHeader();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -252,24 +252,20 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                         ? name.toString()
                         : "<" + name + ">";
                 if (!rankMap.containsKey(name)) {
-                    String key;
-                    switch (kind) {
-                        case PARAMETER:       key = "doclet.Parameters_warn" ; break;
-                        case TYPE_PARAMETER:  key = "doclet.TypeParameters_warn" ; break;
-                        case RECORD_COMPONENT: key = "doclet.RecordComponents_warn" ; break;
-                        default: throw new IllegalArgumentException(kind.toString());
-                }
+                    String key = switch (kind) {
+                        case PARAMETER          -> "doclet.Parameters_warn";
+                        case TYPE_PARAMETER     -> "doclet.TypeParameters_warn";
+                        case RECORD_COMPONENT   -> "doclet.RecordComponents_warn";
+                    };
                     messages.warning(ch.getDocTreePath(dt), key, paramName);
                 }
                 String rank = rankMap.get(name);
                 if (rank != null && alreadyDocumented.contains(rank)) {
-                    String key;
-                    switch (kind) {
-                        case PARAMETER:       key = "doclet.Parameters_dup_warn" ; break;
-                        case TYPE_PARAMETER:  key = "doclet.TypeParameters_dup_warn" ; break;
-                        case RECORD_COMPONENT: key = "doclet.RecordComponents_dup_warn" ; break;
-                        default: throw new IllegalArgumentException(kind.toString());
-                }
+                    String key = switch (kind) {
+                        case PARAMETER          -> "doclet.Parameters_dup_warn";
+                        case TYPE_PARAMETER     -> "doclet.TypeParameters_dup_warn";
+                        case RECORD_COMPONENT   -> "doclet.RecordComponents_dup_warn";
+                    };
                     messages.warning(ch.getDocTreePath(dt), key, paramName);
                 }
                 result.add(processParamTag(e, kind, writer, dt,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -114,27 +114,15 @@ public class CommentHelper {
     }
 
     public String getTagName(DocTree dtree) {
-        switch (dtree.getKind()) {
-            case AUTHOR:
-            case DEPRECATED:
-            case PARAM:
-            case PROVIDES:
-            case RETURN:
-            case SEE:
-            case SERIAL_DATA:
-            case SERIAL_FIELD:
-            case THROWS:
-            case UNKNOWN_BLOCK_TAG:
-            case USES:
-            case VERSION:
-                return ((BlockTagTree) dtree).getTagName();
-            case UNKNOWN_INLINE_TAG:
-                return ((InlineTagTree) dtree).getTagName();
-            case ERRONEOUS:
-                return "erroneous";
-            default:
-                return dtree.getKind().tagName;
-        }
+        return switch (dtree.getKind()) {
+            case AUTHOR, DEPRECATED, PARAM, PROVIDES, RETURN, SEE,
+                    SERIAL_DATA, SERIAL_FIELD, THROWS, UNKNOWN_BLOCK_TAG,
+                    USES, VERSION   -> ((BlockTagTree) dtree).getTagName();
+            case UNKNOWN_INLINE_TAG -> ((InlineTagTree) dtree).getTagName();
+            case ERRONEOUS          -> "erroneous";
+
+            default -> dtree.getKind().tagName;
+        };
     }
 
     public boolean isTypeParameter(DocTree dtree) {
@@ -231,18 +219,12 @@ public class CommentHelper {
                 }
 
                 sb.append("=");
-                String quote;
-                switch (node.getValueKind()) {
-                    case DOUBLE:
-                        quote = "\"";
-                        break;
-                    case SINGLE:
-                        quote = "'";
-                        break;
-                    default:
-                        quote = "";
-                        break;
-                }
+                String quote = switch (node.getValueKind()) {
+                    case DOUBLE -> "\"";
+                    case SINGLE -> "'";
+
+                    default     -> "";
+                };
                 sb.append(quote);
                 node.getValue().forEach(dt -> dt.accept(this, null));
                 sb.append(quote);
@@ -517,14 +499,12 @@ public class CommentHelper {
     }
 
     public IdentifierTree getName(DocTree dtree) {
-        switch (dtree.getKind()) {
-            case PARAM:
-                return ((ParamTree)dtree).getName();
-            case SERIAL_FIELD:
-                return ((SerialFieldTree)dtree).getName();
-            default:
-                return null;
-            }
+        return switch (dtree.getKind()) {
+            case PARAM        -> ((ParamTree) dtree).getName();
+            case SERIAL_FIELD -> ((SerialFieldTree) dtree).getName();
+
+            default -> null;
+        };
     }
 
     public List<? extends DocTree> getTags(DocTree dtree) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -649,33 +649,25 @@ public class Utils {
 
     public boolean isExecutableElement(Element e) {
         ElementKind kind = e.getKind();
-        switch (kind) {
-            case CONSTRUCTOR: case METHOD: case INSTANCE_INIT:
-                return true;
-            default:
-                return false;
-        }
+        return switch (kind) {
+            case CONSTRUCTOR, METHOD, INSTANCE_INIT -> true;
+            default -> false;
+        };
     }
 
     public boolean isVariableElement(Element e) {
         ElementKind kind = e.getKind();
-        switch(kind) {
-              case ENUM_CONSTANT: case EXCEPTION_PARAMETER: case FIELD:
-              case LOCAL_VARIABLE: case PARAMETER:
-              case RESOURCE_VARIABLE:
-                  return true;
-              default:
-                  return false;
-        }
+        return switch (kind) {
+            case ENUM_CONSTANT, EXCEPTION_PARAMETER, FIELD, LOCAL_VARIABLE, PARAMETER, RESOURCE_VARIABLE -> true;
+            default -> false;
+        };
     }
 
     public boolean isTypeElement(Element e) {
-        switch (e.getKind()) {
-            case CLASS: case ENUM: case INTERFACE: case ANNOTATION_TYPE: case RECORD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (e.getKind()) {
+            case CLASS, ENUM, INTERFACE, ANNOTATION_TYPE, RECORD -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -1438,7 +1430,7 @@ public class Utils {
         for (int i = 0; i < textLength; i++) {
             char ch = text.charAt(i);
             switch (ch) {
-                case '\n': case '\r':
+                case '\n', '\r':
                     lineLength = 0;
                     break;
                 case '\t':

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -441,7 +441,7 @@ public class VisibleMemberTable {
                 if (list.isEmpty())
                     return false;
                 return elementUtils.hides(list.get(0), inheritedMember);
-            case METHODS: case CONSTRUCTORS: // Handled elsewhere.
+            case METHODS, CONSTRUCTORS: // Handled elsewhere.
                 throw new IllegalArgumentException("incorrect kind");
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -199,32 +199,22 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         switch (p.getLeaf().getKind()) {
             // the following are for declarations that have their own top-level page,
             // and so the doc comment comes after the <h1> page title.
-            case MODULE:
-            case PACKAGE:
-            case CLASS:
-            case INTERFACE:
-            case ENUM:
-            case ANNOTATION_TYPE:
-            case RECORD:
+            case MODULE, PACKAGE, CLASS, INTERFACE, ENUM, ANNOTATION_TYPE, RECORD ->
                 implicitHeadingRank = 1;
-                break;
 
             // this is for html files
             // ... if it is a legacy package.html, the doc comment comes after the <h1> page title
             // ... otherwise, (e.g. overview file and doc-files/*.html files) no additional headings are inserted
-            case COMPILATION_UNIT:
+            case COMPILATION_UNIT ->
                 implicitHeadingRank = fo.isNameCompatible("package", JavaFileObject.Kind.HTML) ? 1 : 0;
-                break;
 
             // the following are for member declarations, which appear in the page
             // for the enclosing type, and so appear after the <h2> "Members"
             // aggregate heading and the specific <h3> "Member signature" heading.
-            case METHOD:
-            case VARIABLE:
+            case METHOD, VARIABLE ->
                 implicitHeadingRank = 3;
-                break;
 
-            default:
+            default ->
                 Assert.error("unexpected tree kind: " + p.getLeaf().getKind() + " " + fo);
         }
 
@@ -232,14 +222,12 @@ public class Checker extends DocTreePathScanner<Void, Void> {
 
         if (!isOverridingMethod) {
             switch (env.currElement.getKind()) {
-                case METHOD:
-                case CONSTRUCTOR: {
+                case METHOD, CONSTRUCTOR: {
                     ExecutableElement ee = (ExecutableElement) env.currElement;
                     checkParamsDocumented(ee.getTypeParameters());
                     checkParamsDocumented(ee.getParameters());
                     switch (ee.getReturnType().getKind()) {
-                        case VOID:
-                        case NONE:
+                        case VOID, NONE:
                             break;
                         default:
                             if (!foundReturn
@@ -355,7 +343,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
             // tag specific checks
             switch (t) {
                 // check for out of sequence headings, such as <h1>...</h1>  <h3>...</h3>
-                case H1: case H2: case H3: case H4: case H5: case H6:
+                case H1, H2, H3, H4, H5, H6:
                     checkHeading(tree, t);
                     break;
             }
@@ -436,8 +424,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                     }
                     break;
 
-                    case LINK:
-                    case LINK_PLAIN: {
+                    case LINK, LINK_PLAIN: {
                         String name = top.tree.getKind().tagName;
                         env.messages.error(HTML, tree, "dc.tag.not.allowed.inline.tag",
                                 treeName, name);
@@ -451,8 +438,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                     return;
                 break;
 
-            case LIST_ITEM:
-            case TABLE_ITEM:
+            case LIST_ITEM, TABLE_ITEM:
                 if (top != null) {
                     // reset this flag so subsequent bad inline content gets reported
                     top.flags.remove(Flag.REPORTED_BAD_INLINE);
@@ -499,15 +485,15 @@ public class Checker extends DocTreePathScanner<Void, Void> {
     private int getHeadingRank(HtmlTag tag) {
         if (tag == null)
             return implicitHeadingRank;
-        switch (tag) {
-            case H1: return 1;
-            case H2: return 2;
-            case H3: return 3;
-            case H4: return 4;
-            case H5: return 5;
-            case H6: return 6;
-            default: throw new IllegalArgumentException();
-        }
+        return switch (tag) {
+            case H1 -> 1;
+            case H2 -> 2;
+            case H3 -> 3;
+            case H4 -> 4;
+            case H5 -> 5;
+            case H6 -> 6;
+            default -> throw new IllegalArgumentException();
+        };
     }
 
     @Override @DefinedBy(Api.COMPILER_TREE)
@@ -991,12 +977,10 @@ public class Checker extends DocTreePathScanner<Void, Void> {
     }
 
     private boolean isThrowable(TypeMirror tm) {
-        switch (tm.getKind()) {
-            case DECLARED:
-            case TYPEVAR:
-                return env.types.isAssignable(tm, env.java_lang_Throwable);
-        }
-        return false;
+        return switch (tm.getKind()) {
+            case DECLARED, TYPEVAR -> env.types.isAssignable(tm, env.java_lang_Throwable);
+            default -> false;
+        };
     }
 
     private void checkThrowsDeclared(ReferenceTree tree, TypeMirror t, List<? extends TypeMirror> list) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -152,12 +152,10 @@ public enum HtmlTag {
             EnumSet.of(Flag.ACCEPTS_BLOCK, Flag.ACCEPTS_INLINE)) {
         @Override
         public boolean accepts(HtmlTag t) {
-            switch (t) {
-                case HEADER: case FOOTER: case MAIN:
-                    return false;
-                default:
-                    return (t.blockType == BlockType.BLOCK) || (t.blockType == BlockType.INLINE);
-            }
+            return switch (t) {
+                case HEADER, FOOTER, MAIN -> false;
+                default -> (t.blockType == BlockType.BLOCK) || (t.blockType == BlockType.INLINE);
+            };
         }
     },
 
@@ -189,12 +187,10 @@ public enum HtmlTag {
             EnumSet.of(Flag.ACCEPTS_BLOCK, Flag.ACCEPTS_INLINE)) {
         @Override
         public boolean accepts(HtmlTag t) {
-            switch (t) {
-                case HEADER: case FOOTER: case MAIN:
-                    return false;
-                default:
-                    return (t.blockType == BlockType.BLOCK) || (t.blockType == BlockType.INLINE);
-            }
+            return switch (t) {
+                case HEADER, FOOTER, MAIN -> false;
+                default -> (t.blockType == BlockType.BLOCK) || (t.blockType == BlockType.INLINE);
+            };
         }
     },
 
@@ -265,12 +261,10 @@ public enum HtmlTag {
             attrs(AttrKind.HTML4, WIDTH)) {
         @Override
         public boolean accepts(HtmlTag t) {
-            switch (t) {
-                case IMG: case BIG: case SMALL: case SUB: case SUP:
-                    return false;
-                default:
-                    return (t.blockType == BlockType.INLINE);
-            }
+            return switch (t) {
+                case IMG, BIG, SMALL, SUB, SUP -> false;
+                default -> (t.blockType == BlockType.INLINE);
+            };
         }
     },
 
@@ -316,15 +310,10 @@ public enum HtmlTag {
                     Attr.FRAME, RULES, WIDTH, ALIGN, BGCOLOR)) {
         @Override
         public boolean accepts(HtmlTag t) {
-            switch (t) {
-                case CAPTION:
-                case COLGROUP:
-                case THEAD: case TBODY: case TFOOT:
-                case TR: // HTML 3.2
-                    return true;
-                default:
-                    return false;
-            }
+            return switch (t) {
+                case CAPTION, COLGROUP, THEAD, TBODY, TFOOT, TR -> true; // TR: HTML 3.2
+                default -> false;
+            };
         }
     },
 
@@ -605,19 +594,15 @@ public enum HtmlTag {
         } else if (flags.contains(Flag.ACCEPTS_INLINE)) {
             return (t.blockType == BlockType.INLINE);
         } else
-            switch (blockType) {
-                case BLOCK:
-                case INLINE:
-                    return (t.blockType == BlockType.INLINE);
-                case OTHER:
-                    // OTHER tags are invalid in doc comments, and will be
-                    // reported separately, so silently accept/ignore any content
-                    return true;
-                default:
-                    // any combination which could otherwise arrive here
-                    // ought to have been handled in an overriding method
-                    throw new AssertionError(this + ":" + t);
-            }
+            return switch (blockType) {
+                case BLOCK, INLINE -> t.blockType == BlockType.INLINE;
+                // OTHER tags are invalid in doc comments, and will be
+                // reported separately, so silently accept/ignore any content
+                case OTHER -> true;
+                // any combination which could otherwise arrive here
+                // ought to have been handled in an overriding method
+                default -> throw new AssertionError(this + ":" + t);
+            };
     }
 
     public boolean acceptsText() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -239,12 +239,11 @@ public class ElementsTable {
      * @return the module documentation level mode
      */
     public ModuleMode getModuleMode() {
-        switch(accessFilter.getAccessValue(ElementKind.MODULE)) {
-            case PACKAGE: case PRIVATE:
-                return DocletEnvironment.ModuleMode.ALL;
-            default:
-                return DocletEnvironment.ModuleMode.API;
-        }
+        return switch (accessFilter.getAccessValue(ElementKind.MODULE)) {
+            case PACKAGE, PRIVATE -> DocletEnvironment.ModuleMode.ALL;
+
+            default -> DocletEnvironment.ModuleMode.API;
+        };
     }
 
     private Set<Element> specifiedElements = null;
@@ -1064,14 +1063,12 @@ public class ElementsTable {
                 }
                 Element enclosing = e.getEnclosingElement();
                 if (enclosing != null) {
-                    switch(enclosing.getKind()) {
-                        case PACKAGE:
-                            return specifiedPackageElements.contains((PackageElement)enclosing);
-                        case CLASS: case INTERFACE: case ENUM: case ANNOTATION_TYPE:
-                            return visit((TypeElement) enclosing);
-                        default:
-                            throw new AssertionError("unknown element: " + enclosing);
-                    }
+                    return switch (enclosing.getKind()) {
+                        case PACKAGE -> specifiedPackageElements.contains((PackageElement) enclosing);
+                        case CLASS, INTERFACE, ENUM, ANNOTATION_TYPE -> visit((TypeElement) enclosing);
+
+                        default -> throw new AssertionError("unknown element: " + enclosing);
+                    };
                 }
             }
             return false;
@@ -1084,8 +1081,7 @@ public class ElementsTable {
                 return true;
             if (visit(e.getEnclosingElement()) && isSelected(e)) {
                 switch(e.getKind()) {
-                    case ANNOTATION_TYPE: case CLASS: case ENUM: case INTERFACE:
-                    case MODULE: case OTHER: case PACKAGE:
+                    case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE, MODULE, OTHER, PACKAGE:
                         throw new AssertionError("invalid element for this operation: " + e);
                     default:
                         // the only allowed kinds in the cache are "members"
@@ -1212,40 +1208,27 @@ public class ElementsTable {
 
             AccessKind accessValue = null;
             for (ElementKind kind : ALLOWED_KINDS) {
-                switch (kind) {
-                    case METHOD:
-                        accessValue  = options.showMembersAccess();
-                        break;
-                    case CLASS:
-                        accessValue  = options.showTypesAccess();
-                        break;
-                    case PACKAGE:
-                        accessValue  = options.showPackagesAccess();
-                        break;
-                    case MODULE:
-                        accessValue  = options.showModuleContents();
-                        break;
-                    default:
-                        throw new AssertionError("unknown element: " + kind);
+                accessValue = switch (kind) {
+                    case METHOD     -> options.showMembersAccess();
+                    case CLASS      -> options.showTypesAccess();
+                    case PACKAGE    -> options.showPackagesAccess();
+                    case MODULE     -> options.showModuleContents();
 
-                }
+                    default -> throw new AssertionError("unknown element: " + kind);
+                };
                 accessMap.put(kind, accessValue);
                 filterMap.put(kind, getFilterSet(accessValue));
             }
         }
 
         static EnumSet<AccessKind> getFilterSet(AccessKind accessValue) {
-            switch (accessValue) {
-                case PUBLIC:
-                    return EnumSet.of(AccessKind.PUBLIC);
-                case PROTECTED:
-                default:
-                    return EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
-                case PACKAGE:
-                    return EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
-                case PRIVATE:
-                    return EnumSet.allOf(AccessKind.class);
-            }
+            return switch (accessValue) {
+                case PUBLIC  -> EnumSet.of(AccessKind.PUBLIC);
+                case PACKAGE -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
+                case PRIVATE -> EnumSet.allOf(AccessKind.class);
+
+                default -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
+            };
         }
 
         public AccessKind getAccessValue(ElementKind kind) {
@@ -1277,18 +1260,15 @@ public class ElementsTable {
 
         // convert a requested element kind to an allowed access kind
         private ElementKind getAllowedKind(ElementKind kind) {
-            switch (kind) {
-                case CLASS: case METHOD: case MODULE: case PACKAGE:
-                    return kind;
-                case RECORD: case ANNOTATION_TYPE: case ENUM: case INTERFACE:
-                    return ElementKind.CLASS;
-                case CONSTRUCTOR: case ENUM_CONSTANT: case EXCEPTION_PARAMETER:
-                case FIELD: case INSTANCE_INIT: case LOCAL_VARIABLE: case PARAMETER:
-                case RESOURCE_VARIABLE: case STATIC_INIT: case TYPE_PARAMETER:
-                    return ElementKind.METHOD;
-                default:
-                    throw new AssertionError("unsupported kind: " + kind);
-            }
+            return switch (kind) {
+                case CLASS, METHOD, MODULE, PACKAGE                    -> kind;
+                case RECORD, ANNOTATION_TYPE, ENUM, INTERFACE          -> ElementKind.CLASS;
+                case CONSTRUCTOR, ENUM_CONSTANT, EXCEPTION_PARAMETER,
+                        FIELD, INSTANCE_INIT, LOCAL_VARIABLE, PARAMETER,
+                        RESOURCE_VARIABLE, STATIC_INIT, TYPE_PARAMETER -> ElementKind.METHOD;
+
+                default -> throw new AssertionError("unsupported kind: " + kind);
+            };
         }
     } // end ModifierFilter
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Messager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Messager.java
@@ -84,50 +84,29 @@ public class Messager extends Log implements Reporter {
     @Override
     public void print(Kind kind, String msg) {
         switch (kind) {
-            case ERROR:
-                printError(msg);
-                return;
-            case WARNING:
-            case MANDATORY_WARNING:
-                printWarning(msg);
-                return;
-            default:
-                printNotice(msg);
-                return;
+            case ERROR                      -> printError(msg);
+            case WARNING, MANDATORY_WARNING -> printWarning(msg);
+            default                         -> printNotice(msg);
         }
     }
 
     @Override
     public void print(Kind kind, DocTreePath path, String msg) {
         switch (kind) {
-            case ERROR:
-                printError(path, msg);
-                return;
-            case WARNING:
-            case MANDATORY_WARNING:
-                printWarning(path, msg);
-                return;
-            default:
-                printWarning(path, msg);
-                return;
+            case ERROR                      -> printError(path, msg);
+            case WARNING, MANDATORY_WARNING -> printWarning(path, msg);
+            default                         -> printWarning(path, msg);
         }
     }
 
     @Override
     public void print(Kind kind, Element e, String msg) {
-                switch (kind) {
-            case ERROR:
-                printError(e, msg);
-                return;
-            case WARNING:
-            case MANDATORY_WARNING:
-                printWarning(e, msg);
-                return;
-            case NOTE:
-                printNotice(e, msg);
-                return;
-            default:
-                throw new IllegalArgumentException(String.format("unexpected option %s", kind));
+        switch (kind) {
+            case ERROR                      -> printError(e, msg);
+            case WARNING, MANDATORY_WARNING -> printWarning(e, msg);
+            case NOTE                       -> printNotice(e, msg);
+
+            default -> throw new IllegalArgumentException(String.format("unexpected option %s", kind));
         }
     }
 
@@ -385,8 +364,7 @@ public class Messager extends Log implements Reporter {
 
     private void report(DiagnosticType type, String pos, String msg) {
         switch (type) {
-            case ERROR:
-            case WARNING:
+            case ERROR, WARNING:
                 Object prefix = (pos == null) ? programName : pos;
                 report(javadocDiags.create(type, null, null, "msg", prefix, msg));
                 break;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -890,40 +890,28 @@ public class ToolOptions {
 
     private void setExpandRequires(String arg) throws OptionException {
         switch (arg) {
-            case "transitive":
-                expandRequires = AccessKind.PUBLIC;
-                break;
-            case "all":
-                expandRequires = AccessKind.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "transitive" -> expandRequires = AccessKind.PUBLIC;
+            case "all"        -> expandRequires = AccessKind.PRIVATE;
+
+            default -> throw illegalOptionValue(arg);
         }
     }
 
     private void setShowModuleContents(String arg) throws OptionException {
         switch (arg) {
-            case "api":
-                showModuleContents = AccessKind.PUBLIC;
-                break;
-            case "all":
-                showModuleContents = AccessKind.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "api" -> showModuleContents = AccessKind.PUBLIC;
+            case "all" -> showModuleContents = AccessKind.PRIVATE;
+
+            default -> throw illegalOptionValue(arg);
         }
     }
 
     private void setShowPackageAccess(String arg) throws OptionException {
         switch (arg) {
-            case "exported":
-                showPackagesAccess = AccessKind.PUBLIC;
-                break;
-            case "all":
-                showPackagesAccess = AccessKind.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "exported" -> showPackagesAccess = AccessKind.PUBLIC;
+            case "all"      -> showPackagesAccess = AccessKind.PRIVATE;
+
+            default -> throw illegalOptionValue(arg);
         }
     }
 
@@ -958,18 +946,14 @@ public class ToolOptions {
         String value = (colon > 0)
                 ? arg.substring(colon + 1)
                 : arg;
-        switch (value) {
-            case "public":
-                return AccessKind.PUBLIC;
-            case "protected":
-                return AccessKind.PROTECTED;
-            case "package":
-                return AccessKind.PACKAGE;
-            case "private":
-                return AccessKind.PRIVATE;
-            default:
-                throw illegalOptionValue(value);
-        }
+        return switch (value) {
+            case "public"    -> AccessKind.PUBLIC;
+            case "protected" -> AccessKind.PROTECTED;
+            case "package"   -> AccessKind.PACKAGE;
+            case "private"   -> AccessKind.PRIVATE;
+
+            default -> throw illegalOptionValue(value);
+        };
     }
 
     /*
@@ -986,20 +970,12 @@ public class ToolOptions {
     private void setAccess(AccessKind accessValue) {
         for (ElementKind kind : ElementsTable.ModifierFilter.ALLOWED_KINDS) {
             switch (kind) {
-                case METHOD:
-                    showMembersAccess = accessValue;
-                    break;
-                case CLASS:
-                    showTypesAccess = accessValue;
-                    break;
-                case PACKAGE:
-                    showPackagesAccess = accessValue;
-                    break;
-                case MODULE:
-                    showModuleContents = accessValue;
-                    break;
-                default:
-                    throw new AssertionError("unknown element kind:" + kind);
+                case METHOD  -> showMembersAccess = accessValue;
+                case CLASS   -> showTypesAccess = accessValue;
+                case PACKAGE -> showPackagesAccess = accessValue;
+                case MODULE  -> showModuleContents = accessValue;
+
+                default -> throw new AssertionError("unknown element kind:" + kind);
             }
         }
     }


### PR DESCRIPTION
Hi!
I propose to use switch expressions and multiple case label switch statements in the jdk.javadoc module with the intent to improve the readability of the code and make it more concise.
Thanks.
Regards,
Kartik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2023/head:pull/2023`
`$ git checkout pull/2023`
