### PR TITLE
8259559: COMPARE_BUILD can't compare patch files

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -200,7 +200,7 @@ ifeq ($(HAS_SPEC),)
 	            COMPARE_BUILD="$(COMPARE_BUILD):NODRYRUN=true" main && \
 	        $(MAKE) $(MFLAGS) $(MAKE_LOG_FLAGS) -r -R -f $(topdir)/make/Init.gmk \
 	            SPEC=$(spec) HAS_SPEC=true ACTUAL_TOPDIR=$(topdir) \
-	            COMPARE_BUILD="$(COMPARE_BUILD)" post-compare-build && \
+	            COMPARE_BUILD="$(COMPARE_BUILD):NODRYRUN=true" post-compare-build && \
 	    ) \
 	  ) true ) \
 	  $(eval TARGET_DONE=true) \


### PR DESCRIPTION
COMPARE_BUILD will fail to run the compare stage, since re-applying an applied patch does not work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259559](https://bugs.openjdk.java.net/browse/JDK-8259559): COMPARE_BUILD can't compare patch files


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2025/head:pull/2025`
`$ git checkout pull/2025`
