### PR TITLE
8259565: Zero: compiler/runtime/criticalnatives fails because CriticalJNINatives is not supported

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "assembler_zero.inline.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "runtime/stubCodeGenerator.hpp"
@@ -43,4 +44,7 @@ void VM_Version::initialize() {
     warning("Prefetching is not available for a Zero VM");
   }
   FLAG_SET_DEFAULT(AllocatePrefetchDistance, 0);
+
+  // Not implemented
+  UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/test/hotspot/jtreg/compiler/runtime/criticalnatives/argumentcorruption/CheckLongArgs.java
+++ b/test/hotspot/jtreg/compiler/runtime/criticalnatives/argumentcorruption/CheckLongArgs.java
@@ -24,7 +24,7 @@
 
 /* @test
  * @bug 8167409
- * @requires (os.arch != "aarch64") & (os.arch != "arm")
+ * @requires (os.arch != "aarch64") & (os.arch != "arm") & (vm.flavor != "zero")
  * @run main/othervm/native -Xcomp -XX:+CriticalJNINatives compiler.runtime.criticalnatives.argumentcorruption.CheckLongArgs
  */
 package compiler.runtime.criticalnatives.argumentcorruption;

--- a/test/hotspot/jtreg/compiler/runtime/criticalnatives/lookup/LookUp.java
+++ b/test/hotspot/jtreg/compiler/runtime/criticalnatives/lookup/LookUp.java
@@ -24,7 +24,7 @@
 
 /* @test
  * @bug 8167408
- * @requires (os.arch != "aarch64") & (os.arch != "arm")
+ * @requires (os.arch != "aarch64") & (os.arch != "arm") & (vm.flavor != "zero")
  * @run main/othervm/native -Xcomp -XX:+CriticalJNINatives compiler.runtime.criticalnatives.lookup.LookUp
  */
 package compiler.runtime.criticalnatives.lookup;


### PR DESCRIPTION
Zero does not support CriticalJNINatives (and that flag is going away soon), and so the tests are failing with:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-run-test TEST=compiler/runtime/criticalnatives/
java.lang.Exception: critical native lookup failed
at compiler.runtime.criticalnatives.argumentcorruption.CheckLongArgs.check(CheckLongArgs.java:58)
at compiler.runtime.criticalnatives.argumentcorruption.CheckLongArgs.test(CheckLongArgs.java:48)
at compiler.runtime.criticalnatives.argumentcorruption.CheckLongArgs.main(CheckLongArgs.java:38)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:567)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:831)
```

There are similar issues for AArch64 (JDK-8191129) and ARM32 (JDK-8213794). Zero needs the same.

Additional testing:
 - [x] Linux x86_64 Zero `compiler/runtime/criticalnatives` (now skipped)
 - [x] Linux x86_64 Server `compiler/runtime/criticalnatives` (still run and pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259565](https://bugs.openjdk.java.net/browse/JDK-8259565): Zero: compiler/runtime/criticalnatives fails because CriticalJNINatives is not supported


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2027/head:pull/2027`
`$ git checkout pull/2027`
