### PR TITLE
8259572: [test] Fix SSL tests after JDK-8237578 to properly handle SocketExceptions

### DIFF
--- a/test/jdk/java/net/httpclient/InvalidSSLContextTest.java
+++ b/test/jdk/java/net/httpclient/InvalidSSLContextTest.java
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.net.SocketException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -173,8 +174,8 @@ public class InvalidSSLContextTest {
                         s.startHandshake();
                         s.close();
                         Assert.fail("SERVER: UNEXPECTED ");
-                    } catch (SSLException he) {
-                        System.out.println("SERVER: caught expected " + he);
+                    } catch (SSLException | SocketException se) {
+                        System.out.println("SERVER: caught expected " + se);
                     } catch (IOException e) {
                         System.out.println("SERVER: caught: " + e);
                         if (!sslServerSocket.isClosed()) {

--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -44,6 +44,7 @@ import java.io.OutputStream;
 import java.security.Security;
 import java.util.Arrays;
 
+import java.net.SocketException;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLServerSocket;
@@ -86,10 +87,10 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
             se.printStackTrace(System.out);
         } catch (InterruptedIOException ioe) {
             // must have been interrupted, no harm
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             // The client side may have closed the socket.
             System.out.println("Server SSLException:");
-            ssle.printStackTrace(System.out);
+            se.printStackTrace(System.out);
         } catch (Exception e) {
             System.out.println("Server exception:");
             e.printStackTrace(System.out);


### PR DESCRIPTION
JDK-8237578 exposes some SocketExceptions directly which were previously wrapped inside an SSLException. The change updated one test to take this new behaviour into account (i.e. TrustTrustedCert.java) but apparently missed other tests.

The fix for the other tests is similar like the fix for TrustTrustedCert.java in JDK-8237578:
```
- } catch (SSLException ssle) {
+ } catch (SSLException | SocketException se) {
             if (!expectFail) {
-                throw ssle;
+                throw se;
             } // Otherwise, ignore.
         } 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259572](https://bugs.openjdk.java.net/browse/JDK-8259572): [test] Fix SSL tests after JDK-8237578 to properly handle SocketExceptions


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2029/head:pull/2029`
`$ git checkout pull/2029`
