### PR TITLE
8259576: Misplaced curly brace in Matcher::find_shared_post_visit

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2404,9 +2404,9 @@ void Matcher::find_shared_post_visit(Node* n, uint opcode) {
       n->set_req(2, n->in(3));
       n->del_req(3);
       break;
+    }
     default:
       break;
-    }
   }
 }
 


### PR DESCRIPTION
SonarCloud demo instance reports the issue here:

```
    case Op_VectorMaskCmp: {
      n->set_req(1, new BinaryNode(n->in(1), n->in(2)));
      n->set_req(2, n->in(3));
      n->del_req(3);
      break;
    default: // <----- ERROR
      break;
    }
```

"The direct parent of this switch-label is not the body of a switch statement."

This is added by JDK-8223347, and it is an obviously misplaced curly-brace. It is innocuous in current code, but may become problematic as more cases are added to the switch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259576](https://bugs.openjdk.java.net/browse/JDK-8259576): Misplaced curly brace in Matcher::find_shared_post_visit


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2031/head:pull/2031`
`$ git checkout pull/2031`
