### PR TITLE
8259583: Remove unused decode_env::_codeBuffer

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -57,7 +57,6 @@ static const char decode_instructions_virtual_name[] = "decode_instructions_virt
 class decode_env {
  private:
   outputStream* _output;      // where the disassembly is directed to
-  CodeBuffer*   _codeBuffer;  // != NULL only when decoding a CodeBuffer
   CodeBlob*     _codeBlob;    // != NULL only when decoding a CodeBlob
   nmethod*      _nm;          // != NULL only when decoding a nmethod
 


### PR DESCRIPTION
SonarCloud instance reports that decode_env::_codeBuffer field is not initialized in constructor. But really, the field is never used after [JDK-8222079](https://bugs.openjdk.java.net/browse/JDK-8222079).

Additional testing:
 - [x] No grep hits for `_codeBuffer` in `src/`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259583](https://bugs.openjdk.java.net/browse/JDK-8259583): Remove unused decode_env::_codeBuffer


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2034/head:pull/2034`
`$ git checkout pull/2034`
