### PR TITLE
8256895: Add support for RFC 8954: Online Certificate Status Protocol (OCSP) Nonce Extension

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPNonceExtension.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPNonceExtension.java
@@ -93,7 +93,7 @@ public final class OCSPNonceExtension extends Extension {
                     nonceData).toByteArray();
         } else {
             throw new IllegalArgumentException(
-                    "Length of nonce must be at least 1 byte and can be upto 32 bytes");
+                    "Length of nonce must be at least 1 byte and can be up to 32 bytes");
         }
     }
 
@@ -123,7 +123,7 @@ public final class OCSPNonceExtension extends Extension {
      * @param isCritical a boolean flag indicating whether the criticality bit
      *      is set for this extension
      * @param incomingNonce The nonce data to be set for the extension.  This
-     *      must be a non-null array of at least one byte long and can be upto
+     *      must be a non-null array of at least one byte long and can be up to
      *      32 bytes.
      *
      * @throws IOException if any errors happen during encoding of the
@@ -140,13 +140,13 @@ public final class OCSPNonceExtension extends Extension {
         Objects.requireNonNull(incomingNonce, "Nonce data must be non-null");
         // RFC 8954, section 2.1: the length of the nonce MUST be at least 1 octet
         // and can be up to 32 octets.
-        if (incomingNonce.length > 0 && incomingNonce.length <=32) {
+        if (incomingNonce.length > 0 && incomingNonce.length <= 32) {
             this.nonceData = incomingNonce.clone();
             this.extensionValue = new DerValue(DerValue.tag_OctetString,
                     nonceData).toByteArray();
         } else {
             throw new IllegalArgumentException(
-                    "Nonce data must be at least 1 byte and can be upto 32 bytes in length");
+                    "Nonce data must be at least 1 byte and can be up to 32 bytes in length");
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPNonceExtension.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPNonceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,14 +76,16 @@ public final class OCSPNonceExtension extends Extension {
      *
      * @throws IOException if any errors happen during encoding of the
      *      extension.
-     * @throws IllegalArgumentException if length is not a positive integer.
+     * @throws IllegalArgumentException if length is not in the range of 1 to 32.
      */
     public OCSPNonceExtension(boolean isCritical, int length)
             throws IOException {
         this.extensionId = PKIXExtensions.OCSPNonce_Id;
         this.critical = isCritical;
 
-        if (length > 0) {
+        // RFC 8954, section 2.1: the length of the nonce MUST be at least 1 octet
+        // and can be up to 32 octets.
+        if (length > 0 && length <= 32) {
             SecureRandom rng = new SecureRandom();
             this.nonceData = new byte[length];
             rng.nextBytes(nonceData);
@@ -91,7 +93,7 @@ public final class OCSPNonceExtension extends Extension {
                     nonceData).toByteArray();
         } else {
             throw new IllegalArgumentException(
-                    "Length must be a positive integer");
+                    "Length of nonce must be at least 1 byte and can be upto 32 bytes");
         }
     }
 
@@ -121,12 +123,13 @@ public final class OCSPNonceExtension extends Extension {
      * @param isCritical a boolean flag indicating whether the criticality bit
      *      is set for this extension
      * @param incomingNonce The nonce data to be set for the extension.  This
-     *      must be a non-null array of at least one byte long.
+     *      must be a non-null array of at least one byte long and can be upto
+     *      32 bytes.
      *
      * @throws IOException if any errors happen during encoding of the
      *      extension.
-     * @throws IllegalArgumentException if the incomingNonce length is not a
-     *      positive integer.
+     * @throws IllegalArgumentException if the incomingNonce length is not
+     *      in the range of 1 to 32.
      * @throws NullPointerException if the incomingNonce is null.
      */
     public OCSPNonceExtension(boolean isCritical, byte[] incomingNonce)
@@ -135,13 +138,15 @@ public final class OCSPNonceExtension extends Extension {
         this.critical = isCritical;
 
         Objects.requireNonNull(incomingNonce, "Nonce data must be non-null");
-        if (incomingNonce.length > 0) {
+        // RFC 8954, section 2.1: the length of the nonce MUST be at least 1 octet
+        // and can be up to 32 octets.
+        if (incomingNonce.length > 0 && incomingNonce.length <=32) {
             this.nonceData = incomingNonce.clone();
             this.extensionValue = new DerValue(DerValue.tag_OctetString,
                     nonceData).toByteArray();
         } else {
             throw new IllegalArgumentException(
-                    "Nonce data must be at least 1 byte in length");
+                    "Nonce data must be at least 1 byte and can be upto 32 bytes in length");
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -755,11 +755,10 @@ class RevocationChecker extends PKIXRevocationChecker {
 
                             if (ocspExtensions.size() > 0) {
                                 tmpExtensions = new ArrayList<Extension>(ocspExtensions);
+                                tmpExtensions.add(nonceExt);
                             } else {
-                                tmpExtensions = new ArrayList<Extension>();
+                                tmpExtensions = List.of(nonceExt);
                             }
-
-                            tmpExtensions.add(nonceExt);
 
                             if (debug != null) {
                                 debug.println("Default nonce has been created in the OCSP extensions");

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -746,7 +746,7 @@ class RevocationChecker extends PKIXRevocationChecker {
                         null, -1);
                 }
 
-                List<Extension> tmpExtensions = Collections.<Extension>emptyList();
+                List<Extension> tmpExtensions = null;
                 if (rp.ocspNonce) {
                     if (nonce == null) {
                         try {

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -746,12 +746,19 @@ class RevocationChecker extends PKIXRevocationChecker {
                         null, -1);
                 }
 
-                List<Extension> tmpExtensions = new ArrayList<Extension>();
+                List<Extension> tmpExtensions = Collections.<Extension>emptyList();
                 if (rp.ocspNonce) {
                     if (nonce == null) {
                         try {
                             // create the 16-byte nonce by default
                             Extension nonceExt = new OCSPNonceExtension(DEFAULT_NONCE_BYTES);
+
+                            if (ocspExtensions.size() > 0) {
+                                tmpExtensions = new ArrayList<Extension>(ocspExtensions);
+                            } else {
+                                tmpExtensions = new ArrayList<Extension>();
+                            }
+
                             tmpExtensions.add(nonceExt);
 
                             if (debug != null) {
@@ -759,7 +766,7 @@ class RevocationChecker extends PKIXRevocationChecker {
                             }
                         } catch (IOException e) {
                             throw new CertPathValidatorException("Failed to create the default nonce " +
-                                    "in OCSP entensions");
+                                    "in OCSP extensions", e);
                         }
                     } else {
                         throw new CertPathValidatorException("Application provided nonce cannot be " +

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -110,12 +110,7 @@ class RevocationChecker extends PKIXRevocationChecker {
         // jdk.security.certpath.ocspNonce=true.
         if (rp.ocspNonce) {
             try {
-                List<Extension> tmpExtensions = Collections.<Extension>emptyList();
-                Extension nonceExt = new OCSPNonceExtension(DEFAULT_NONCE_BYTES);
-
-                tmpExtensions = new ArrayList<Extension>();
-                tmpExtensions.add(nonceExt);
-                setOcspExtensions(tmpExtensions);
+                setOcspExtensions(List.of(new OCSPNonceExtension(DEFAULT_NONCE_BYTES)));
                 ocspExtensions = getOcspExtensions();
 
                 if (debug != null) {

--- a/test/jdk/java/security/cert/PKIXRevocationChecker/UnitTest.java
+++ b/test/jdk/java/security/cert/PKIXRevocationChecker/UnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,8 @@
 
 /**
  * @test
- * @bug 6854712 7171570 8010748 8025287 8256895
+ * @bug 6854712 7171570 8010748 8025287
  * @summary Basic unit test for PKIXRevocationChecker
- * @modules java.base/sun.security.util
- *          java.base/sun.security.x509
  */
 
 import java.io.ByteArrayInputStream;
@@ -37,12 +35,9 @@ import java.net.URI;
 import java.security.cert.*;
 import java.security.cert.PKIXRevocationChecker.Option;
 import java.util.*;
-import sun.security.util.ObjectIdentifier;
-import sun.security.x509.PKIXExtensions;
 
 public class UnitTest {
 
-    private static final int DEFAULT_NONCE_BYTES = 16;
     public static void main(String[] args) throws Exception {
 
         CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
@@ -110,36 +105,6 @@ public class UnitTest {
         if (first == second) {
             throw new Exception("FAILED: CertPathCheckers not new instances");
         }
-
-        System.setProperty("jdk.security.certpath.ocspNonce", "true");
-        cpv = CertPathValidator.getInstance("PKIX");
-        cpc = cpv.getRevocationChecker();
-        prc = (PKIXRevocationChecker)cpc;
-
-        prc.init(false);
-
-        System.out.println("Testing that getOcspExtensions returns non-empty list if " +
-                           "system property jdk.security.certpath.ocspNonce=true");
-        requireNotEmpty(prc.getOcspExtensions(), "getOcspExtensions()");
-
-        List<Extension> ocspExtensions;
-        byte[] nonce = null;
-        ocspExtensions = prc.getOcspExtensions();
-
-        for (Extension ext : ocspExtensions) {
-            if (ext.getId().equals(PKIXExtensions.OCSPNonce_Id.toString())) {
-                nonce = ext.getValue();
-            }
-        }
-
-        if (nonce == null) {
-            throw new Exception("FAILED: default nonce should be set in OCSP extensions");
-        } else {
-            // tag + length + default nonce 16 bytes
-            if (nonce.length != DEFAULT_NONCE_BYTES + 2) {
-                throw new Exception("FAILED: default nonce should not be " + nonce.length + " bytes long");
-            }
-        }
     }
 
     static void requireNull(Object o, String msg) throws Exception {
@@ -157,12 +122,6 @@ public class UnitTest {
     static void requireEmpty(List<?> l, String msg) throws Exception {
         if (!l.isEmpty()) {
             throw new Exception("FAILED: " + msg +" must return an empty list");
-        }
-    }
-
-    static void requireNotEmpty(List<?> l, String msg) throws Exception {
-        if (l.isEmpty()) {
-            throw new Exception("FAILED: " + msg +" must return a non-empty list");
         }
     }
 

--- a/test/jdk/java/security/cert/PKIXRevocationChecker/UnitTest.java
+++ b/test/jdk/java/security/cert/PKIXRevocationChecker/UnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,10 @@
 
 /**
  * @test
- * @bug 6854712 7171570 8010748 8025287
+ * @bug 6854712 7171570 8010748 8025287 8256895
  * @summary Basic unit test for PKIXRevocationChecker
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.x509
  */
 
 import java.io.ByteArrayInputStream;
@@ -35,9 +37,12 @@ import java.net.URI;
 import java.security.cert.*;
 import java.security.cert.PKIXRevocationChecker.Option;
 import java.util.*;
+import sun.security.util.ObjectIdentifier;
+import sun.security.x509.PKIXExtensions;
 
 public class UnitTest {
 
+    private static final int DEFAULT_NONCE_BYTES = 16;
     public static void main(String[] args) throws Exception {
 
         CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
@@ -105,6 +110,36 @@ public class UnitTest {
         if (first == second) {
             throw new Exception("FAILED: CertPathCheckers not new instances");
         }
+
+        System.setProperty("jdk.security.certpath.ocspNonce", "true");
+        cpv = CertPathValidator.getInstance("PKIX");
+        cpc = cpv.getRevocationChecker();
+        prc = (PKIXRevocationChecker)cpc;
+
+        prc.init(false);
+
+        System.out.println("Testing that getOcspExtensions returns non-empty list if " +
+                           "system property jdk.security.certpath.ocspNonce=true");
+        requireNotEmpty(prc.getOcspExtensions(), "getOcspExtensions()");
+
+        List<Extension> ocspExtensions;
+        byte[] nonce = null;
+        ocspExtensions = prc.getOcspExtensions();
+
+        for (Extension ext : ocspExtensions) {
+            if (ext.getId().equals(PKIXExtensions.OCSPNonce_Id.toString())) {
+                nonce = ext.getValue();
+            }
+        }
+
+        if (nonce == null) {
+            throw new Exception("FAILED: default nonce should be set in OCSP extensions");
+        } else {
+            // tag + length + default nonce 16 bytes
+            if (nonce.length != DEFAULT_NONCE_BYTES + 2) {
+                throw new Exception("FAILED: default nonce should not be " + nonce.length + " bytes long");
+            }
+        }
     }
 
     static void requireNull(Object o, String msg) throws Exception {
@@ -122,6 +157,12 @@ public class UnitTest {
     static void requireEmpty(List<?> l, String msg) throws Exception {
         if (!l.isEmpty()) {
             throw new Exception("FAILED: " + msg +" must return an empty list");
+        }
+    }
+
+    static void requireNotEmpty(List<?> l, String msg) throws Exception {
+        if (l.isEmpty()) {
+            throw new Exception("FAILED: " + msg +" must return a non-empty list");
         }
     }
 

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8232019
+ * @bug 8232019 8256895
  * @summary Interoperability tests with LuxTrust Global Root 2 CA
  * @build ValidatePathWithParams
  * @run main/othervm -Djava.security.debug=certpath LuxTrustCA OCSP
@@ -173,6 +173,7 @@ public class LuxTrustCA {
 
     public static void main(String[] args) throws Exception {
 
+        System.setProperty("jdk.security.certpath.ocspNonce", "true");
         ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
 
         if (args.length >= 1 && "CRL".equalsIgnoreCase(args[0])) {

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SSLCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SSLCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8243320
+ * @bug 8243320 8256895
  * @summary Interoperability tests with SSL.com's RSA, EV RSA, and ECC CA
  * @build ValidatePathWithParams
  * @run main/othervm -Djava.security.debug=certpath SSLCA OCSP
@@ -47,6 +47,7 @@ public class SSLCA {
 
     public static void main(String[] args) throws Exception {
 
+        System.setProperty("jdk.security.certpath.ocspNonce", "true");
         ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
         boolean ocspEnabled = false;
 

--- a/test/jdk/sun/security/provider/certpath/Extensions/OCSPNonceExtensionTests.java
+++ b/test/jdk/sun/security/provider/certpath/Extensions/OCSPNonceExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8046321
+ * @bug 8046321 8256895
  * @summary Unit tests for OCSPNonceExtension objects
  * @modules java.base/sun.security.provider.certpath
  *          java.base/sun.security.util
@@ -190,6 +190,12 @@ public class OCSPNonceExtensionTests {
                 try {
                     Extension zeroLenNonce = new OCSPNonceExtension(0);
                     throw new RuntimeException("Accepted a zero length nonce");
+                } catch (IllegalArgumentException iae) { }
+
+                // Length of the nonce exceeds the maximum 32 bytes
+                try {
+                    Extension bigLenNonce = new OCSPNonceExtension(33);
+                    throw new RuntimeException("Accepted a larger than 32 bytes of nonce");
                 } catch (IllegalArgumentException iae) { }
 
                 // Valid input to constructor


### PR DESCRIPTION
This enhancement adds support for the nonce extension in OCSP request extensions by system property jdk.security.certpath.ocspNonce.

Please review the CSR at:
https://bugs.openjdk.java.net/browse/JDK-8257766

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256895](https://bugs.openjdk.java.net/browse/JDK-8256895): Add support for RFC 8954: Online Certificate Status Protocol (OCSP) Nonce Extension


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to 26254d5933dfa7d3834bdff5aecf11fd95085c5f
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to a14a2bdba4fba3a2c1f47d59bcff05d1d39ec667


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2039/head:pull/2039`
`$ git checkout pull/2039`
