### PR TITLE
8259609: C2: optimize long range checks in long counted loops

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -918,6 +918,7 @@ Node* MaxNode::build_min_max(Node* a, Node* b, bool is_max, bool is_unsigned, co
   bool is_int = gvn.type(a)->isa_int();
   assert(is_int || gvn.type(a)->isa_long(), "int or long inputs");
   assert(is_int == (gvn.type(b)->isa_int() != NULL), "inconsistent inputs");
+  BasicType bt = is_int ? T_INT: T_LONG;
   Node* hook = NULL;
   if (gvn.is_IterGVN()) {
     // Make sure a and b are not destroyed
@@ -926,48 +927,23 @@ Node* MaxNode::build_min_max(Node* a, Node* b, bool is_max, bool is_unsigned, co
     hook->init_req(1, b);
   }
   Node* res = NULL;
-  if (!is_unsigned) {
+  if (is_int && !is_unsigned) {
     if (is_max) {
-      if (is_int) {
-        res =  gvn.transform(new MaxINode(a, b));
-        assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
-      } else {
-        Node* cmp = gvn.transform(new CmpLNode(a, b));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveLNode(bol, a, b, t->is_long()));
-      }
+      res =  gvn.transform(new MaxINode(a, b));
+      assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
     } else {
-      if (is_int) {
-        Node* res =  gvn.transform(new MinINode(a, b));
-        assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
-      } else {
-        Node* cmp = gvn.transform(new CmpLNode(b, a));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveLNode(bol, a, b, t->is_long()));
-      }
+      Node* res =  gvn.transform(new MinINode(a, b));
+      assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
     }
   } else {
+    Node* cmp = NULL;
     if (is_max) {
-      if (is_int) {
-        Node* cmp = gvn.transform(new CmpUNode(a, b));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveINode(bol, a, b, t->is_int()));
-      } else {
-        Node* cmp = gvn.transform(new CmpULNode(a, b));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveLNode(bol, a, b, t->is_long()));
-      }
+      cmp = gvn.transform(CmpNode::make(a, b, bt, is_unsigned));
     } else {
-      if (is_int) {
-        Node* cmp = gvn.transform(new CmpUNode(b, a));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveINode(bol, a, b, t->is_int()));
-      } else {
-        Node* cmp = gvn.transform(new CmpULNode(b, a));
-        Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-        res = gvn.transform(new CMoveLNode(bol, a, b, t->is_long()));
-      }
+      cmp = gvn.transform(CmpNode::make(b, a, bt, is_unsigned));
     }
+    Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
+    res = gvn.transform(CMoveNode::make(NULL, bol, a, b, t));
   }
   if (hook != NULL) {
     hook->destruct(&gvn);
@@ -979,12 +955,8 @@ Node* MaxNode::build_min_max_diff_with_zero(Node* a, Node* b, bool is_max, const
   bool is_int = gvn.type(a)->isa_int();
   assert(is_int || gvn.type(a)->isa_long(), "int or long inputs");
   assert(is_int == (gvn.type(b)->isa_int() != NULL), "inconsistent inputs");
-  Node* zero = NULL;
-  if (is_int) {
-    zero = gvn.intcon(0);
-  } else {
-    zero = gvn.longcon(0);
-  }
+  BasicType bt = is_int ? T_INT: T_LONG;
+  Node* zero = gvn.integercon(0, bt);
   Node* hook = NULL;
   if (gvn.is_IterGVN()) {
     // Make sure a and b are not destroyed
@@ -992,32 +964,15 @@ Node* MaxNode::build_min_max_diff_with_zero(Node* a, Node* b, bool is_max, const
     hook->init_req(0, a);
     hook->init_req(1, b);
   }
-  Node* res = NULL;
+  Node* cmp = NULL;
   if (is_max) {
-    if (is_int) {
-      Node* cmp = gvn.transform(new CmpINode(a, b));
-      Node* sub = gvn.transform(new SubINode(a, b));
-      Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-      res = gvn.transform(new CMoveINode(bol, sub, zero, t->is_int()));
-    } else {
-      Node* cmp = gvn.transform(new CmpLNode(a, b));
-      Node* sub = gvn.transform(new SubLNode(a, b));
-      Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-      res = gvn.transform(new CMoveLNode(bol, sub, zero, t->is_long()));
-    }
+    cmp = gvn.transform(CmpNode::make(a, b, bt, false));
   } else {
-    if (is_int) {
-      Node* cmp = gvn.transform(new CmpINode(b, a));
-      Node* sub = gvn.transform(new SubINode(a, b));
-      Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-      res = gvn.transform(new CMoveINode(bol, sub, zero, t->is_int()));
-    } else {
-      Node* cmp = gvn.transform(new CmpLNode(b, a));
-      Node* sub = gvn.transform(new SubLNode(a, b));
-      Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
-      res = gvn.transform(new CMoveLNode(bol, sub, zero, t->is_long()));
-    }
+    cmp = gvn.transform(CmpNode::make(b, a, bt, false));
   }
+  Node* sub = gvn.transform(SubNode::make(a, b, bt));
+  Node* bol = gvn.transform(new BoolNode(cmp, BoolTest::lt));
+  Node* res = gvn.transform(CMoveNode::make(NULL, bol, sub, zero, t));
   if (hook != NULL) {
     hook->destruct(&gvn);
   }

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -606,7 +606,9 @@ class Invariance : public StackObj {
 // Returns true if the predicate of iff is in "scale*iv + offset u< load_range(ptr)" format
 // Note: this function is particularly designed for loop predication. We require load_range
 //       and offset to be loop invariant computed on the fly by "invar"
-bool IdealLoopTree::is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, Invariance& invar) const {
+bool IdealLoopTree::is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, BasicType bt, Node *iv, Node *&range,
+                                      Node *&offset,
+                                      jlong &scale) const {
   if (!is_loop_exit(iff)) {
     return false;
   }
@@ -621,33 +623,45 @@ bool IdealLoopTree::is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, Invari
     return false;
   }
   const CmpNode *cmp = bol->in(1)->as_Cmp();
-  if (cmp->Opcode() != Op_CmpU) {
+  if (!(cmp->is_Cmp() && cmp->operates_on(bt, false))) {
     return false;
   }
-  Node* range = cmp->in(2);
-  if (range->Opcode() != Op_LoadRange && !iff->is_RangeCheck()) {
-    const TypeInt* tint = phase->_igvn.type(range)->isa_int();
-    if (tint == NULL || tint->empty() || tint->_lo < 0) {
+  range = cmp->in(2);
+  if (range->Opcode() != Op_LoadRange) {
+    const TypeInteger* tinteger = phase->_igvn.type(range)->isa_integer(bt);
+    if (tinteger == NULL || tinteger->empty() || tinteger->lo_as_long() < 0) {
       // Allow predication on positive values that aren't LoadRanges.
       // This allows optimization of loops where the length of the
       // array is a known value and doesn't need to be loaded back
       // from the array.
       return false;
     }
+  } else {
+    assert(bt == T_INT, "no LoadRange for longs");
   }
-  if (!invar.is_invariant(range)) {
+  scale  = 0;
+  offset = NULL;
+  if (!phase->is_scaled_iv_plus_offset(cmp->in(1), iv, &scale, &offset, bt)) {
     return false;
   }
-  Node *iv     = _head->as_CountedLoop()->phi();
-  int   scale  = 0;
+  return true;
+}
+
+bool IdealLoopTree::is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, Invariance& invar) const {
+  Node* range = NULL;
   Node *offset = NULL;
-  if (!phase->is_scaled_iv_plus_offset(cmp->in(1), iv, &scale, &offset)) {
+  jlong scale = 0;
+  Node *iv = _head->as_BaseCountedLoop()->phi();
+  if (is_range_check_if(iff, phase, T_INT, iv, range, offset, scale)) {
+    if (!invar.is_invariant(range)) {
     return false;
   }
   if (offset && !invar.is_invariant(offset)) { // offset must be invariant
     return false;
   }
   return true;
+}
+  return false;
 }
 
 //------------------------------rc_predicate-----------------------------------

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1064,7 +1064,7 @@ Node *PhaseIdealLoop::split_if_with_blocks_pre( Node *n ) {
 
   // If the loop is a candidate for range check elimination,
   // delay splitting through it's phi until a later loop optimization
-  if (n_blk->is_CountedLoop()) {
+  if (n_blk->is_BaseCountedLoop()) {
     IdealLoopTree *lp = get_loop(n_blk);
     if (lp && lp->_rce_candidate) {
       return n;

--- a/src/hotspot/share/opto/mulnode.hpp
+++ b/src/hotspot/share/opto/mulnode.hpp
@@ -41,7 +41,7 @@ class PhaseTransform;
 class MulNode : public Node {
   virtual uint hash() const;
 public:
-  MulNode( Node *in1, Node *in2 ): Node(0,in1,in2) {
+  MulNode(Node *in1, Node *in2): Node(NULL,in1,in2) {
     init_class_id(Class_Mul);
   }
 
@@ -75,6 +75,10 @@ public:
   // Supplied function to return the multiplicative opcode
   virtual int mul_opcode() const = 0;
 
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return false;
+  }
 };
 
 //------------------------------MulINode---------------------------------------
@@ -91,6 +95,10 @@ public:
   int mul_opcode() const { return Op_MulI; }
   const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_INT;
+  }
 };
 
 //------------------------------MulLNode---------------------------------------
@@ -107,6 +115,10 @@ public:
   int mul_opcode() const { return Op_MulL; }
   const Type *bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_LONG;
+  }
 };
 
 
@@ -185,30 +197,49 @@ public:
   virtual uint ideal_reg() const { return Op_RegL; }
 };
 
+class LShiftNode : public Node {
+public:
+  LShiftNode(Node *in1, Node *in2) : Node(NULL,in1,in2) {
+    init_class_id(Class_LShift);
+  }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return false;
+  }
+};
+
 //------------------------------LShiftINode------------------------------------
 // Logical shift left
-class LShiftINode : public Node {
+class LShiftINode : public LShiftNode {
 public:
-  LShiftINode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  LShiftINode(Node *in1, Node *in2) : LShiftNode(in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_INT;
+  }
 };
 
 //------------------------------LShiftLNode------------------------------------
 // Logical shift left
-class LShiftLNode : public Node {
+class LShiftLNode : public LShiftNode {
 public:
-  LShiftLNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  LShiftLNode(Node *in1, Node *in2) : LShiftNode(in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   const Type *bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_LONG;
+  }
 };
 
 

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -94,6 +94,7 @@ class LockNode;
 class LongCountedLoopNode;
 class LongCountedLoopEndNode;
 class LoopNode;
+class LShiftNode;
 class MachBranchNode;
 class MachCallDynamicJavaNode;
 class MachCallJavaNode;
@@ -742,6 +743,7 @@ public:
     DEFINE_CLASS_ID(Halt,     Node, 15)
     DEFINE_CLASS_ID(Opaque1,  Node, 16)
     DEFINE_CLASS_ID(Move,     Node, 17)
+    DEFINE_CLASS_ID(LShift,   Node, 18)
 
     _max_classes  = ClassMask_Move
   };
@@ -871,6 +873,7 @@ public:
   DEFINE_CLASS_QUERY(LoadStoreConditional)
   DEFINE_CLASS_QUERY(Lock)
   DEFINE_CLASS_QUERY(Loop)
+  DEFINE_CLASS_QUERY(LShift)
   DEFINE_CLASS_QUERY(Mach)
   DEFINE_CLASS_QUERY(MachBranch)
   DEFINE_CLASS_QUERY(MachCall)

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -62,6 +62,10 @@ public:
   virtual const Type *add_id() const = 0;
 
   static SubNode* make(Node* in1, Node* in2, BasicType bt);
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return false;
+  }
 };
 
 
@@ -77,6 +81,10 @@ public:
   const Type *add_id() const { return TypeInt::ZERO; }
   const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_INT;
+  }
 };
 
 //------------------------------SubLNode---------------------------------------
@@ -90,6 +98,10 @@ public:
   const Type *add_id() const { return TypeLong::ZERO; }
   const Type *bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
+  virtual bool operates_on(BasicType bt, bool signed_int) const {
+    assert(bt == T_INT || bt == T_LONG, "unsupported");
+    return bt == T_LONG;
+  }
 };
 
 // NOTE: SubFPNode should be taken away and replaced by add and negate

--- a/test/hotspot/jtreg/compiler/rangechecks/TestLongRangeCheck.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestLongRangeCheck.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8259609
+ * @summary C2: optimize long range checks in long counted loops
+ * @requires vm.compiler2.enabled
+ * @requires vm.compMode != "Xcomp"
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.util
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm -ea -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-BackgroundCompilation TestLongRangeCheck
+ *
+ */
+
+import jdk.internal.util.Preconditions;
+import sun.hotspot.WhiteBox;
+import java.lang.reflect.Method;
+import compiler.whitebox.CompilerWhiteBoxTest;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.lang.reflect.InvocationTargetException;
+
+public class TestLongRangeCheck {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+     private static void assertIsCompiled(Method m) {
+         if (!WHITE_BOX.isMethodCompiled(m) || WHITE_BOX.getMethodCompilationLevel(m) != CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {
+             throw new RuntimeException("should still be compiled");
+         }
+    }
+    
+     private static void assertIsNotCompiled(Method m) {
+         if (WHITE_BOX.isMethodCompiled(m) && WHITE_BOX.getMethodCompilationLevel(m) == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {
+             throw new RuntimeException("should have been deoptimized");
+         }
+    }
+
+    private static void compile(Method m) {
+        WHITE_BOX.enqueueMethodForCompilation(m, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        assertIsCompiled(m);
+    }
+
+    public static ClassLoader newClassLoader() {
+        try {
+            return new URLClassLoader(new URL[] {
+                    Paths.get(System.getProperty("test.classes",".")).toUri().toURL(),
+            }, null);
+        } catch (MalformedURLException e){
+            throw new RuntimeException("Unexpected URL conversion failure", e);
+        }
+    }
+
+    private static void test(String method, long start, long stop, long length, long offset) throws Exception {
+        Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class);
+        m.invoke(null, start, stop, length, offset); // run once so all classes are loaded
+        compile(m);
+
+        m.invoke(null, start, stop, length, offset);
+        assertIsCompiled(m);
+        try {
+            m.invoke(null, start-1, stop, length, offset);
+            throw new RuntimeException("should have thrown");
+        } catch(InvocationTargetException e) {
+            if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                throw new RuntimeException("unexpected exception");
+            }
+        }
+        assertIsNotCompiled(m);
+
+        m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class);
+        m.invoke(null, start, stop, length, offset); // run once so all classes are loaded
+        compile(m);
+        assertIsCompiled(m);
+
+        m.invoke(null, start, stop, length, offset);
+        assertIsCompiled(m);
+        try {
+            m.invoke(null, stop, stop + 100, length, offset);
+            throw new RuntimeException("should have thrown");
+        } catch(InvocationTargetException e) {
+            if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                throw new RuntimeException("unexpected exception");
+            }
+        }
+        assertIsNotCompiled(m);
+
+        m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class);
+        m.invoke(null, start, stop, length, offset); // run once so all classes are loaded
+        compile(m);
+
+        m.invoke(null, start, stop, length, offset);
+        assertIsCompiled(m);
+        try {
+            m.invoke(null, start, stop+1, length, offset);
+            throw new RuntimeException("should have thrown");
+        } catch(InvocationTargetException e) {
+            if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                throw new RuntimeException("unexpected exception");
+            }
+        }
+        assertIsNotCompiled(m);
+    }
+    
+    
+    public static void main(String[] args) throws Exception {
+
+        test("testStridePosScalePos", 0, 100, 100, 0);
+
+        test("testStrideNegScaleNeg", 0, 100, 100, 100);
+
+        test("testStrideNegScalePos", 0, 100, 100, 0);
+
+        test("testStridePosScaleNeg", 0, 100, 100, 99);
+
+        test("testStridePosScalePosNotOne", 0, 100, 1090, 0);
+
+        test("testStrideNegScaleNegNotOne", 0, 100, 1090, 1100);
+
+        test("testStrideNegScalePosNotOne", 0, 100, 1090, 0);
+
+        test("testStridePosScaleNegNotOne", 0, 100, 1090, 1089);
+
+        long v = ((long)Integer.MAX_VALUE / 10000) * 250000;
+        
+        test("testStridePosNotOneScalePos", -v, v, v * 2, v);
+
+        test("testStrideNegNotOneScaleNeg", -v, v, v * 2, v);
+
+        test("testStrideNegNotOneScalePos", -v, v, v * 2, v);
+
+        test("testStridePosNotOneScaleNeg", -v, v, v * 2, v-1);
+
+        // offset causes overflow
+        
+        Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePos", long.class, long.class, long.class, long.class);
+        m.invoke(null, 0, 100, 100, 0);
+        compile(m);
+
+        m.invoke(null, 0, 100, 100, 0);
+        assertIsCompiled(m);
+        try {
+            m.invoke(null, 0, 100, 100, Long.MAX_VALUE - 50);
+            throw new RuntimeException("should have thrown");
+        } catch(InvocationTargetException e) {
+            if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                throw new RuntimeException("unexpected exception");
+            }
+        }
+        assertIsNotCompiled(m);
+
+        // Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStrideNegScalePosOverflow", long.class, long.class, long.class, long.class);
+        // m.invoke(null, 0, 100, 0x200000L * 100, 0); // run once so all classes are loaded
+        // compile(m);
+
+        // m.invoke(null, 0, 100, 0x200000L * 100, 0);
+        // assertIsCompiled(m);
+        // try {
+        //     long start = 0x40000000000L;
+        //     long stop = 0x60000000000L + 1;
+        //     m.invoke(null, start, stop, 0x50000000000L, 0);
+        //     throw new RuntimeException("should have thrown");
+        // } catch(InvocationTargetException e) {
+        //     if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+        //         throw new RuntimeException("unexpected exception");
+        //     }
+        // }
+        // assertIsNotCompiled(m);
+    }
+
+    public static void testStridePosScalePos(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+/*
+        for (long i = start; i < stop;) {
+            long stride = Long.max(Integer.MAX_VALUE, stop - start);
+            int j = 0;
+            for (; j < stride; j++) {
+                int l = (int)Long.min(Integer.MAX_VALUE, Long.max(length - (scale * i + offset), 0));
+                Objects.checkIndex(scale * j, l);
+            }
+            i += j;
+        }
+*/
+
+    }
+
+    public static void testStrideNegScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = stop; i > start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegScalePos(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = 1;
+        for (long i = stop-1; i >= start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStridePosScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStridePosScalePosNotOne(long start, long stop, long length, long offset) {
+        final long scale = 11;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegScaleNegNotOne(long start, long stop, long length, long offset) {
+        final long scale = -11;
+        final long stride = 1;
+        for (long i = stop; i > start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegScalePosNotOne(long start, long stop, long length, long offset) {
+        final long scale = 11;
+        final long stride = 1;
+        for (long i = stop-1; i >= start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStridePosScaleNegNotOne(long start, long stop, long length, long offset) {
+        final long scale = -11;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStridePosNotOneScalePos(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = Integer.MAX_VALUE / 10000;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegNotOneScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = Integer.MAX_VALUE / 10000;
+        for (long i = stop; i > start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegNotOneScalePos(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = Integer.MAX_VALUE / 10000;
+        for (long i = stop-1; i >= start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStridePosNotOneScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = Integer.MAX_VALUE / 10000;
+        for (long i = start; i < stop; i += stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+        }
+    }
+
+    public static void testStrideNegScalePosOverflow(long start, long stop, long length, long offset) {
+        final long scale = 0x200000;
+        final long stride = 1;
+        for (long i = stop-1; i >= start; i -= stride) {
+            Preconditions.checkIndex(scale * i + offset, length, null);
+            if (i == 0x60000000000L) {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
JDK-8255150 makes it possible for java code to explicitly perform a
range check on long values. JDK-8223051 provides a transformation of
long counted loops into loop nests with an inner int counted
loop. With this change I propose transforming long range checks that
operate on the iv of a long counted loop into range checks that
operate on the iv of the int inner loop once it has been
created. Existing range check eliminations can then kick in.

Transformation of range checks is piggy backed on the loop nest
creation for 2 reasons:

- pattern matching range checks is easier right before the loop nest
  is created

- the number of iterations of the inner loop is adjusted so scale *
  inner_iv doesn't overflow

C2 has logic to delay some split if transformations so they don't
break the scale * iv + offset pattern. I reused that logic for long
range checks and had to relax what's considered a range check because
initially a range check from Object.checkIndex() may include a test
for range > 0 that needs a round of loop opts to be hoisted. I realize
there's some code duplication but I didn't see a way to share logic
between IdealLoopTree::may_have_range_check()
IdealLoopTree::policy_range_check() that would feel right.

I realize the comment in PhaseIdealLoop::transform_long_range_checks()
is scary. FWIW, it's not as complicated as it looks. I found drawing
the range covered by the entire long loop and the range covered by the
inner loop help see how range checks can be transformed. Then the
comment helps make sure all cases are covered and verify the generated
code actually covers all of them.

One issue is overflow. I think the fact that inner_iv * scale doesn't
overflow helps simplify thing. One possible overflow is that of scale
* upper + offset which is handled by forcing all range checks in that
case to deoptimize. I don't think other case of overflow needs special
handling.

This was tested with a Memory Segment micro benchmark (and patched
Memory Segment support to take advantage of the new checkIndex
intrinsic, both provided by Maurizio). Range checks in the micro
benchmark are properly optimized (and performance increases
significantly).

