### PR TITLE
8074101: Add verification that all tasks are actually claimed during roots processing

### DIFF
--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -106,7 +106,8 @@ void G1RootProcessor::process_strong_roots(OopClosure* oops,
   // CodeCache is already processed in java roots
   // refProcessor is not needed since we are inside a safe point
   _process_strong_tasks.all_tasks_completed(n_workers(),
-      G1RP_PS_CodeCache_oops_do, G1RP_PS_refProcessor_oops_do);
+                                            G1RP_PS_CodeCache_oops_do,
+                                            G1RP_PS_refProcessor_oops_do);
 }
 
 // Adaptor to pass the closures to all the roots in the VM.

--- a/src/hotspot/share/gc/g1/g1RootProcessor.hpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.hpp
@@ -53,10 +53,7 @@ class G1RootProcessor : public StackObj {
   OopStorageSetStrongParState<false, false> _oop_storage_set_strong_par_state;
 
   enum G1H_process_roots_tasks {
-    G1RP_PS_Universe_oops_do,
-    G1RP_PS_Management_oops_do,
     G1RP_PS_ClassLoaderDataGraph_oops_do,
-    G1RP_PS_jvmti_oops_do,
     G1RP_PS_CodeCache_oops_do,
     AOT_ONLY(G1RP_PS_aot_oops_do COMMA)
     G1RP_PS_refProcessor_oops_do,

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -98,10 +98,6 @@ void SerialHeap::young_process_roots(StrongRootsScope* scope,
   process_roots(scope, SO_ScavengeCodeCache, root_closure,
                 cld_closure, cld_closure, &mark_code_closure);
 
-  if (_process_strong_tasks->try_claim_task(GCH_PS_younger_gens)) {
-
-  }
-
   rem_set()->at_younger_refs_iterate();
   old_gen()->younger_refs_iterate(old_gen_closure, scope->n_threads());
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -819,8 +819,10 @@ void GenCollectedHeap::process_roots(StrongRootsScope* scope,
   Threads::possibly_parallel_oops_do(is_par, strong_roots, roots_from_code_p);
 
 #if INCLUDE_AOT
-  if (UseAOT && _process_strong_tasks->try_claim_task(GCH_PS_aot_oops_do)) {
-    AOTLoader::oops_do(strong_roots);
+  if (_process_strong_tasks->try_claim_task(GCH_PS_aot_oops_do)) {
+    if (UseAOT) {
+      AOTLoader::oops_do(strong_roots);
+    }
   }
 #endif
   if (_process_strong_tasks->try_claim_task(GCH_PS_OopStorageSet_oops_do)) {

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -109,7 +109,6 @@ protected:
     GCH_PS_ClassLoaderDataGraph_oops_do,
     GCH_PS_CodeCache_oops_do,
     AOT_ONLY(GCH_PS_aot_oops_do COMMA)
-    GCH_PS_younger_gens,
     // Leave this one last.
     GCH_PS_NumElements
   };

--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -369,8 +369,10 @@ void SubTasksDone::clear() {
 }
 
 void SubTasksDone::all_tasks_completed_impl(uint n_threads,
-      uint skipped[], size_t skipped_size) {
+                                            uint skipped[],
+                                            size_t skipped_size) {
 #ifdef ASSERT
+  // all non-skipped tasks are claimed
   for (uint i = 0; i < _n_tasks; ++i) {
     if (_tasks[i] == 0) {
       auto is_skipped = false;
@@ -382,6 +384,12 @@ void SubTasksDone::all_tasks_completed_impl(uint n_threads,
       }
       assert(is_skipped, "%d not claimed.", i);
     }
+  }
+  // all skipped tasks are *not* claimed
+  for (size_t i = 0; i < skipped_size; ++i) {
+    auto task_index = skipped[i];
+    assert(task_index < _n_tasks, "Array in range.");
+    assert(_tasks[task_index] == 0, "%d is both claimed and skipped.", task_index);
   }
 #endif
   uint observed = _threads_completed;

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -303,9 +303,6 @@ class SubTasksDone: public CHeapObj<mtInternal> {
   volatile uint* _tasks;
   uint _n_tasks;
   volatile uint _threads_completed;
-#ifdef ASSERT
-  volatile uint _claimed;
-#endif
 
   // Set all tasks to unclaimed.
   void clear();

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHARED_WORKGROUP_HPP
 
 #include "memory/allocation.hpp"
+#include "metaprogramming/enableIf.hpp"
 #include "metaprogramming/logical.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/thread.hpp"
@@ -308,8 +309,7 @@ class SubTasksDone: public CHeapObj<mtInternal> {
   // Set all tasks to unclaimed.
   void clear();
 
-  void all_tasks_completed_impl(uint n_threads,
-        uint skipped[], size_t skipped_size);
+  void all_tasks_completed_impl(uint n_threads, uint skipped[], size_t skipped_size);
 
   NONCOPYABLE(SubTasksDone);
 
@@ -327,17 +327,18 @@ public:
   // to be within the range of "this".
   bool try_claim_task(uint t);
 
-  // The calling thread asserts that it has attempted to claim all the
-  // tasks that it will try to claim.  Every thread in the parallel task
-  // must execute this.  (When the last thread does so, the task array is
-  // cleared.)
+  // The calling thread asserts that it has attempted to claim all the tasks
+  // that it will try to claim.  Tasks that is meant to be skipped must be
+  // explicitly passed as extra arguments using the variadic version below.
+  // Every thread in the parallel task must execute this.  (When the last
+  // thread does so, the task array is cleared.)
   //
   // n_threads - Number of threads executing the sub-tasks.
-  // followed by vararg skipped tasks
   void all_tasks_completed(uint n_threads) {
     all_tasks_completed_impl(n_threads, nullptr, 0);
   }
 
+  // Augmented by variadic args, each for a skipped task.
   template<typename T0, typename... Ts,
           ENABLE_IF(Conjunction<std::is_same<T0, Ts>...>::value)>
   void all_tasks_completed(uint n_threads, T0 first_skipped, Ts... more_skipped) {

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -328,10 +328,10 @@ public:
   bool try_claim_task(uint t);
 
   // The calling thread asserts that it has attempted to claim all the tasks
-  // that it will try to claim.  Tasks that is meant to be skipped must be
-  // explicitly passed as extra arguments using the variadic version below.
-  // Every thread in the parallel task must execute this.  (When the last
-  // thread does so, the task array is cleared.)
+  // that it will try to claim.  Tasks that are meant to be skipped must be
+  // explicitly passed as extra arguments. Every thread in the parallel task
+  // must execute this.  (When the last thread does so, the task array is
+  // cleared.)
   //
   // n_threads - Number of threads executing the sub-tasks.
   void all_tasks_completed(uint n_threads) {

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -546,10 +546,12 @@ public:
                    Universe::heap()->uses_stack_watermark_barrier()) {}
 
   void work(uint worker_id) {
-    if (_do_lazy_roots && _subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_LAZY_ROOT_PROCESSING)) {
-      Tracer t("lazy partial thread root processing");
-      ParallelSPCleanupThreadClosure cl;
-      Threads::threads_do(&cl);
+    if (_subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_LAZY_ROOT_PROCESSING)) {
+      if (_do_lazy_roots) {
+        Tracer t("lazy partial thread root processing");
+        ParallelSPCleanupThreadClosure cl;
+        Threads::threads_do(&cl);
+      }
     }
 
     if (_subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_UPDATE_INLINE_CACHES)) {


### PR DESCRIPTION
The first commit removes some obsolete enum items, while the second commit adds the verification logic. Commit 2 introduces some "empty" task claims for the verification logic, explicitly marked in the comments.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8074101](https://bugs.openjdk.java.net/browse/JDK-8074101): Add verification that all tasks are actually claimed during roots processing


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 4d14781786e8824eeeaad11e5f1ed154e0c25884
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2046/head:pull/2046`
`$ git checkout pull/2046`
