### PR TITLE
8257236: can't use var with a class named Z

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Wrap.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Wrap.java
@@ -107,11 +107,16 @@ abstract class Wrap implements GeneralWrap {
                 // }
                 // in do_it method:
                 //return do_itAux();
+                //find an unused name:
+                String scratchName = "$";
+                while (winit.wrapped().contains(scratchName)) {
+                    scratchName += "$";
+                }
                 Wrap waux = new CompoundWrap(
-                        "    private static <Z> Z ", DOIT_METHOD_NAME + "Aux", "() throws Throwable {\n",
-                        wtype, brackets + " ", wname, "_ =\n        ", winit, semi(winit),
-                        "        @SuppressWarnings(\"unchecked\") Z ", wname, "__ = (Z)", wname, "_;\n",
-                        "        return ", wname, "__;\n",
+                        "    private static <" + scratchName + "> " + scratchName +" ", DOIT_METHOD_NAME + "Aux", "() throws Throwable {\n",
+                        wtype, brackets + " ", scratchName, "_ =\n        ", winit, semi(winit),
+                        "        @SuppressWarnings(\"unchecked\") ", scratchName, " ", scratchName, "__ = (", scratchName, ")", scratchName, "_;\n",
+                        "        return ", scratchName, "__;\n",
                         "}"
                 );
                 components.add(waux);

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144903 8177466 8191842 8211694 8213725 8239536
+ * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236
  * @summary Tests for EvaluationState.variables
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -400,6 +400,13 @@ public class VariablesTest extends KullaTesting {
         assertEval("r15a.add(\"a\");");
         assertEval("var r15b = r15a.get(0);");
         assertEval("r15b", "\"a\"");
+        assertEval("class Z { }");
+        assertEval("var r16a = new Z();");
+        assertEval("var r16b = (Runnable) () -> {int r16b_; int r16b__;};");
+        assertEval("class $ { }");
+        assertEval("var r16c = new $();");
+        assertEval("$ r16d() { return null; }");
+        assertEval("var r16d = r16d();");
     }
 
     public void test8191842() {


### PR DESCRIPTION
To implements the local variable type inference, JShell needs to generate a few code snippets, which include an auxiliary type parameter and local variables. The name of the type parameter and variables may currently clash with names in the initializer of the variable. The proposal here is to generate a synthetic name, which won't clash with anything in the var's initializer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257236](https://bugs.openjdk.java.net/browse/JDK-8257236): can't use var with a class named Z


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2047/head:pull/2047`
`$ git checkout pull/2047`
