### PR TITLE
8257212: (bf spec) Clarify byte order of the buffer returned by CharBuffer.subsequence(int,int)

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1835,9 +1835,10 @@ public abstract class $Type$Buffer
      * content of this buffer is mutable then modifications to one buffer will
      * cause the other to be modified.  The new buffer's capacity will be that
      * of this buffer, its position will be
-     * {@code position()}&nbsp;+&nbsp;{@code start}, and its limit will be
-     * {@code position()}&nbsp;+&nbsp;{@code end}.  The new buffer will be
-     * direct if, and only if, this buffer is direct, and it will be read-only
+     * {@code position()}&nbsp;+&nbsp;{@code start}, its limit will be
+     * {@code position()}&nbsp;+&nbsp;{@code end}, and its byte order
+     * will be identical to that of this buffer. The new buffer will be direct
+     * if, and only if, this buffer is direct, and it will be read-only
      * if, and only if, this buffer is read-only.  </p>
      *
      * @param  start

--- a/test/jdk/java/nio/Buffer/Order-X.java.template
+++ b/test/jdk/java/nio/Buffer/Order-X.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/Order-X.java.template
+++ b/test/jdk/java/nio/Buffer/Order-X.java.template
@@ -37,6 +37,10 @@ public class Order$Type$ extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+#if[char]
+        ck(buf.subSequence(buf.position(), buf.remaining()).order(), expected);
+        ck(buf.subSequence(buf.position(), buf.position()).order(), expected);
+#end[char]
     }
 
     static void ck$Type$Buffer() {
@@ -52,5 +56,27 @@ public class Order$Type$ extends Order {
         buf = $Type$Buffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ck$Type$Buffer(buf, nord);
+#if[char]
+        buf = $Type$Buffer.wrap("abcdefghijk");
+        ck(buf.order(), nord);
+        ck$Type$Buffer(buf, nord);
+
+        buf = $Type$Buffer.wrap("abcdefghijk", 0, 5);
+        ck(buf.order(), nord);
+        ck$Type$Buffer(buf, nord);
+
+        buf = $Type$Buffer.wrap(array).subSequence(0, LENGTH);
+        ck(buf.order(), nord);
+        ck$Type$Buffer(buf, nord);
+
+        buf = ByteBuffer.wrap(new byte[LENGTH]).as$Type$Buffer();
+        ck(buf.order(), be);
+        ck$Type$Buffer(buf, be);
+
+        buf = ByteBuffer.wrap(new byte[LENGTH]).order(le).as$Type$Buffer();
+        ck(buf.order(), le);
+        ck$Type$Buffer(buf, le);
+#end[char]
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderChar.java
+++ b/test/jdk/java/nio/Buffer/OrderChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderChar.java
+++ b/test/jdk/java/nio/Buffer/OrderChar.java
@@ -37,6 +37,10 @@ public class OrderChar extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+        ck(buf.subSequence(buf.position(), buf.remaining()).order(), expected);
+        ck(buf.subSequence(buf.position(), buf.position()).order(), expected);
+
     }
 
     static void ckCharBuffer() {
@@ -52,5 +56,27 @@ public class OrderChar extends Order {
         buf = CharBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckCharBuffer(buf, nord);
+
+        buf = CharBuffer.wrap("abcdefghijk");
+        ck(buf.order(), nord);
+        ckCharBuffer(buf, nord);
+
+        buf = CharBuffer.wrap("abcdefghijk", 0, 5);
+        ck(buf.order(), nord);
+        ckCharBuffer(buf, nord);
+
+        buf = CharBuffer.wrap(array).subSequence(0, LENGTH);
+        ck(buf.order(), nord);
+        ckCharBuffer(buf, nord);
+
+        buf = ByteBuffer.wrap(new byte[LENGTH]).asCharBuffer();
+        ck(buf.order(), be);
+        ckCharBuffer(buf, be);
+
+        buf = ByteBuffer.wrap(new byte[LENGTH]).order(le).asCharBuffer();
+        ck(buf.order(), le);
+        ckCharBuffer(buf, le);
+
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderDouble.java
+++ b/test/jdk/java/nio/Buffer/OrderDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderDouble.java
+++ b/test/jdk/java/nio/Buffer/OrderDouble.java
@@ -37,6 +37,10 @@ public class OrderDouble extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+
+
+
     }
 
     static void ckDoubleBuffer() {
@@ -52,5 +56,27 @@ public class OrderDouble extends Order {
         buf = DoubleBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckDoubleBuffer(buf, nord);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderFloat.java
+++ b/test/jdk/java/nio/Buffer/OrderFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderFloat.java
+++ b/test/jdk/java/nio/Buffer/OrderFloat.java
@@ -37,6 +37,10 @@ public class OrderFloat extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+
+
+
     }
 
     static void ckFloatBuffer() {
@@ -52,5 +56,27 @@ public class OrderFloat extends Order {
         buf = FloatBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckFloatBuffer(buf, nord);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderInt.java
+++ b/test/jdk/java/nio/Buffer/OrderInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderInt.java
+++ b/test/jdk/java/nio/Buffer/OrderInt.java
@@ -37,6 +37,10 @@ public class OrderInt extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+
+
+
     }
 
     static void ckIntBuffer() {
@@ -52,5 +56,27 @@ public class OrderInt extends Order {
         buf = IntBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckIntBuffer(buf, nord);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderLong.java
+++ b/test/jdk/java/nio/Buffer/OrderLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderLong.java
+++ b/test/jdk/java/nio/Buffer/OrderLong.java
@@ -37,6 +37,10 @@ public class OrderLong extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+
+
+
     }
 
     static void ckLongBuffer() {
@@ -52,5 +56,27 @@ public class OrderLong extends Order {
         buf = LongBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckLongBuffer(buf, nord);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     }
 }
+

--- a/test/jdk/java/nio/Buffer/OrderShort.java
+++ b/test/jdk/java/nio/Buffer/OrderShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/Buffer/OrderShort.java
+++ b/test/jdk/java/nio/Buffer/OrderShort.java
@@ -37,6 +37,10 @@ public class OrderShort extends Order {
         ck(buf.asReadOnlyBuffer().order(), expected);
         ck(buf.duplicate().order(), expected);
         ck(buf.slice().order(), expected);
+
+
+
+
     }
 
     static void ckShortBuffer() {
@@ -52,5 +56,27 @@ public class OrderShort extends Order {
         buf = ShortBuffer.allocate(LENGTH);
         ck(buf.order(), nord);
         ckShortBuffer(buf, nord);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     }
 }
+


### PR DESCRIPTION
Specification for CharBuffer::subSequence was missing clarification on the byte order of the returned CharBuffer. The returned order will always be the same as that of the original buffer. For example, subSequence() called on a CharBuffer with Little-Endian Byte Order will return a CharBuffer of Little-Endian Order. The specification has been changed to reflect this.

In addition to this, some additional testing was added to improve test coverage of this behavior. Testing for the Byte Order of different types of Buffer is generated via the template Order-X.java.template which serves to verify the original Byte Order of a Buffer and subsequently verify that the same Byte Order is present after operations such as CharBuffer::subSequence

CSR: https://bugs.openjdk.java.net/browse/JDK-8259638

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257212](https://bugs.openjdk.java.net/browse/JDK-8257212): (bf spec) Clarify byte order of the buffer returned by CharBuffer.subsequence(int,int)


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2049/head:pull/2049`
`$ git checkout pull/2049`
