### PR TITLE
8259631: Reapply pattern match instanceof use in HttpClientImpl

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -158,8 +158,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         }
 
         private void shutdown() {
-            if (delegate instanceof ExecutorService) {
-                ExecutorService service = (ExecutorService)delegate;
+            if (delegate instanceof ExecutorService service) {
                 PrivilegedAction<?> action = () -> {
                     service.shutdown();
                     return null;


### PR DESCRIPTION
Hi,

The proposed change adds back [1] `instanceof` pattern match use to `HttpClientImpl` class. It was previously removed by [JDK-8258696](https://bugs.openjdk.java.net/browse/JDK-8258696) due to docs build failure.

Aleksei

[1] `git rollback be41468c --no-commit`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259631](https://bugs.openjdk.java.net/browse/JDK-8259631): Reapply pattern match instanceof use in HttpClientImpl


### Reviewers
 * @avivmu (no known github.com user name / role)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2051/head:pull/2051`
`$ git checkout pull/2051`
