### PR TITLE
8259629: aarch64 builds fail after JDK-8258932

### DIFF
--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -1040,7 +1040,10 @@ class NEONReduceInstruction(Instruction):
 
     def cstr(self):
         buf = Instruction.cstr(self) + str(self.dstSIMDreg)
-        buf = '%s, __ T%s, %s);' % (buf, self.arrangement, self.srcSIMDreg)
+        if self._name == "fmaxp" or self._name == "fminp":
+            buf = '%s, %s, __ %s);' % (buf, self.srcSIMDreg, self.arrangement[1:])
+        else:
+            buf = '%s, __ T%s, %s);' % (buf, self.arrangement, self.srcSIMDreg)
         return buf
 
     def astr(self):

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -540,10 +540,10 @@
     __ sminv(v19, __ T8H, v20);                        //       sminv   h19, v20.8H
     __ sminv(v15, __ T4S, v16);                        //       sminv   s15, v16.4S
     __ fminv(v0, __ T4S, v1);                          //       fminv   s0, v1.4S
-    __ fmaxp(v4, __ T2S, v5);                          //       fmaxp   s4, v5.2S
-    __ fmaxp(v20, __ T2D, v21);                        //       fmaxp   d20, v21.2D
-    __ fminp(v11, __ T2S, v12);                        //       fminp   s11, v12.2S
-    __ fminp(v29, __ T2D, v30);                        //       fminp   d29, v30.2D
+    __ fmaxp(v4, v5, __ S);                            //       fmaxp   s4, v5.2S
+    __ fmaxp(v20, v21, __ D);                          //       fmaxp   d20, v21.2D
+    __ fminp(v11, v12, __ S);                          //       fminp   s11, v12.2S
+    __ fminp(v29, v30, __ D);                          //       fminp   d29, v30.2D
 
 // TwoRegNEONOp
     __ absr(v15, __ T8B, v16);                         //       abs     v15.8B, v16.8B


### PR DESCRIPTION
This fixes aarch64 builds failure after JDK-8258932.
It is caused by the mismatched call `fmaxp/fminp` in `AssemblerAArch64` tests to the definitions in `assembler_aarch64.hpp`.

Verified with `gtest-1.8.1` and `make test TEST="gtest"`, `linux-aarch64-server-slowdebug`.
Both builds and tests are good, the results of `gtest` on my aarch64 server:
```
Finished running test 'gtest:all/server'
Test report is stored in build/linux-aarch64-server-slowdebug/test-results/gtest_all_server

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   gtest:all/server                                    807   807     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-aarch64-server-slowdebug'
```

The `gtest` was not configured during tests in `JDK-8258932`, so it did not execute previously.
I'm really sorry for my carelessness and producing a serious BUG.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259629](https://bugs.openjdk.java.net/browse/JDK-8259629): aarch64 builds fail after JDK-8258932


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2052/head:pull/2052`
`$ git checkout pull/2052`
