### PR TITLE
8226810: Failed to launch JVM because of NullPointerException occured on System.props

### DIFF
--- a/make/data/charsetmapping/stdcs-windows
+++ b/make/data/charsetmapping/stdcs-windows
@@ -2,6 +2,7 @@
 #   generate these charsets into sun.nio.cs
 #
 GBK
+GB18030
 Johab
 MS1255
 MS1256


### PR DESCRIPTION
Hi,

Please review this small change which enables the GB18030 charset to be built into java.base 

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8226810](https://bugs.openjdk.java.net/browse/JDK-8226810): Failed to launch JVM because of NullPointerException occured on System.props


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2053/head:pull/2053`
`$ git checkout pull/2053`
