### PR TITLE
8255531: MethodHandles::permuteArguments throws NPE when duplicating dropped arguments

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
@@ -301,7 +301,7 @@ final class LambdaFormBuffer {
             int argp = firstChange, exprp = 0;
             for (int i = firstChange; i < arity; i++) {
                 Name name = names[i];
-                if (name.isParam()) {
+                if (name != null && name.isParam()) {
                     names[argp++] = name;
                 } else {
                     exprs[exprp++] = name;

--- a/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
@@ -63,6 +63,8 @@ public class MethodHandlesPermuteArgumentsTest extends test.java.lang.invoke.Met
         testBadReorderIndex();
         testReturnTypeMismatch();
         testReorderTypeMismatch();
+
+        testPermuteWithEmpty();
     }
 
     public void testPermuteArguments(int max, Class<?> type1, int t2c, Class<?> type2, int dilution) throws Throwable {
@@ -225,6 +227,12 @@ public class MethodHandlesPermuteArgumentsTest extends test.java.lang.invoke.Met
         MethodType newType = MethodType.methodType(void.class, double.class, String.class);
         assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 0, 1),
                 IllegalArgumentException.class, ".*parameter types do not match after reorder.*");
+    }
+
+    // for JDK-8255531
+    private void testPermuteWithEmpty() {
+        MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class));
+        MethodHandles.permuteArguments(mh, MethodType.methodType(void.class, int.class), 0, 0);
     }
 
     private interface RunnableX {


### PR DESCRIPTION
Hi,

This small patch fixes the NPE in the following case:

    MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class));
    MethodHandles.permuteArguments(mh, MethodType.methodType(void.class, int.class), 0, 0);
    
If a parameter name was changed by a lambda form edit, `LambdaForm::endEdit` will try to sort the names that fall into the old range of parameter names (starting from `firstChanged` and up to `arity` in the code) to make sure that non-parameter names (`exprs`) properly appear after parameter names. But, if a parameter was dropped, and there are no non-paramter names, a `null` will fall into the range that is being sorted, and the call to `name.isParam()` in the sorting algorithm will result in an NPE.

We can just add a `name != null` check there, since `null` is definitely not a parameter. However, we still need to do the loop in order to get an accurate `exprp` value, which is later used to adjust the `arity` after sorting (there are other ways to get there that don't involve copying the extra `null`, but they are more convoluted, so I elected to go for this solution).

Thanks,
Jorn

Testing: tier1-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255531](https://bugs.openjdk.java.net/browse/JDK-8255531): MethodHandles::permuteArguments throws NPE when duplicating dropped arguments


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2054/head:pull/2054`
`$ git checkout pull/2054`
