### PR TITLE
8259622: TreeMap.computeIfAbsent deviates from spec

### DIFF
--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -575,8 +575,12 @@ public class TreeMap<K,V>
                     t = t.left;
                 else if (cmp > 0)
                     t = t.right;
-                else
+                else {
+                    if (t.value == null) {
+                        t.value = callMappingFunctionWithCheck(key, mappingFunction);
+                    }
                     return t.value;
+                }
             } while (t != null);
         } else {
             Objects.requireNonNull(key);
@@ -589,8 +593,12 @@ public class TreeMap<K,V>
                     t = t.left;
                 else if (cmp > 0)
                     t = t.right;
-                else
+                else {
+                    if (t.value == null) {
+                        t.value = callMappingFunctionWithCheck(key, mappingFunction);
+                    }
                     return t.value;
+                }
             } while (t != null);
         }
         newValue = callMappingFunctionWithCheck(key, mappingFunction);

--- a/test/jdk/java/util/Map/InPlaceOpsCollisions.java
+++ b/test/jdk/java/util/Map/InPlaceOpsCollisions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Map/InPlaceOpsCollisions.java
+++ b/test/jdk/java/util/Map/InPlaceOpsCollisions.java
@@ -257,6 +257,20 @@ public class InPlaceOpsCollisions extends MapWithCollisionsProviders {
         testComputeIfAbsent(map, desc, keys, (k) -> null);
     }
 
+    @Test(dataProvider = "nullValueFriendlyMaps")
+    void testComputeIfAbsentOverwriteNull(String desc, Supplier<Map<Object, Object>> ms) {
+        Map<Object, Object> map = ms.get();
+        map.put("key", null);
+        assertEquals(map.size(), 1, desc + ": size != 1");
+        assertTrue(map.containsKey("key"), desc + ": does not have key");
+        assertNull(map.get("key"), desc + ": value is not null");
+        Object result = map.computeIfAbsent("key", k -> "value"); // must rewrite
+        assertEquals(result, "value", desc + ": computeIfAbsent result is not 'value'");
+        assertEquals(map.size(), 1, desc + ": size != 1");
+        assertTrue(map.containsKey("key"), desc + ": does not have key");
+        assertEquals(map.get("key"), "value", desc + ": value is not 'value'");
+    }
+
     private static <T> void testComputeIfPresent(Map<T, T> map, String desc, T[] keys,
             BiFunction<T, T, T> mappingFunction) {
         // remove a third of the keys


### PR DESCRIPTION
Handle TreeMap::computeIfAbsent when previous mapping with null value existed (in this case spec requires to overwrite the existing mapping)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259622](https://bugs.openjdk.java.net/browse/JDK-8259622): TreeMap.computeIfAbsent deviates from spec


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 8f63db7281c2905c3eb62181c99f5d968630289a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2058/head:pull/2058`
`$ git checkout pull/2058`
