### PR TITLE
8236490: Compiler bug relating to @NonNull annotation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,6 +153,10 @@ public class TypeAnnotationPosition {
     // use that value to determine the exception table index.
     // When read from class file, this holds
     private int exception_index = Integer.MIN_VALUE;
+
+    // The exception start position.
+    // Corresponding to the start_pc in the exception table.
+    private int exceptionStartPos = Integer.MIN_VALUE;
 
     // If this type annotation is within a lambda expression,
     // store a pointer to the lambda expression tree in order
@@ -322,20 +326,22 @@ public class TypeAnnotationPosition {
     public int getCatchType() {
         Assert.check(hasCatchType(),
                      "exception_index does not contain valid catch info");
-        return ((-this.exception_index) - 1) & 0xff ;
+        return (-this.exception_index) - 1;
     }
 
     public int getStartPos() {
-        Assert.check(hasCatchType(),
-                     "exception_index does not contain valid catch info");
-        return ((-this.exception_index) - 1) >> 8 ;
+        Assert.check(exceptionStartPos >= 0,
+                     "exceptionStartPos does not contain valid start position");
+        return this.exceptionStartPos;
     }
 
     public void setCatchInfo(final int catchType, final int startPos) {
         Assert.check(!hasExceptionIndex(),
                      "exception_index is already set");
         Assert.check(catchType >= 0, "Expected a valid catch type");
-        this.exception_index = -((catchType | startPos << 8) + 1);
+        Assert.check(startPos >= 0, "Expected a valid start position");
+        this.exception_index = -(catchType + 1);
+        this.exceptionStartPos = startPos;
     }
 
     /**

--- a/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8236490
+ * @summary If the exception class index in constant pool exceeds 256,
+ *          the type annotations in conresponding catch expression should be compiled successfully.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8236490
+ */
+
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+
+public class T8236490 extends TestRunner {
+    ToolBox tb;
+
+    public T8236490() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new T8236490().runTests();
+    }
+
+    @Test
+    public void testTypeAnnotationInCatchExpression() throws Exception {
+        // Generate a class which contains more than 256 constant pool entries
+        // and the exception class index in constant pool exceeds 256.
+        // The code is shown as below:
+        // import java.lang.annotation.ElementType;
+        // import java.lang.annotation.Target;
+        // public class Test8236490 {
+        //     private class Test0 {}
+        //     ... many classes ...
+        //     private class Test299 {}
+        //     @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+        //     private @interface AnnotationTest {}
+        //     public void test() {
+        //         Test0 test0 = new Test0();
+        //         ... many variables ...
+        //         Test299 test299 = new Test299();
+        //         try {
+        //             System.out.println("Hello");
+        //         } catch (@AnnotationTest Exception e) {}
+        //     }
+        // }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("""
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Target;
+                public class Test8236490 {
+                """);
+        for (int i = 0; i < 300; i++) {
+            stringBuilder.append("    private class Test" + i + " {}\n");
+        }
+        stringBuilder.append("""
+                    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+                    private @interface AnnotationTest {}
+                    public void test() {
+                """);
+        for (int i = 0; i < 300; i++) {
+            stringBuilder.append("        Test" + i + " test" + i + " = new Test" + i + "();\n");
+        }
+        stringBuilder.append("""
+                        try {
+                            System.out.println("Hello");
+                        } catch (@AnnotationTest Exception e) {}
+                    }
+                }
+                """);
+
+        new JavacTask(tb)
+                .sources(stringBuilder.toString())
+                .outdir(".")
+                .run();
+    }
+}


### PR DESCRIPTION
Hi all,

If the exception class index in constant pool exceeds 256, the `exception_index` in `TypeAnnotationPosition` will not work as expected. Please see the following code:

```
    public void setCatchInfo(final int catchType, final int startPos) {
        Assert.check(!hasExceptionIndex(),
                     "exception_index is already set");
        Assert.check(catchType >= 0, "Expected a valid catch type");
        this.exception_index = -((catchType | startPos << 8) + 1);  // <------------------------------
    }
```

If `catchType` > 256, which means the 8-15 bits is useful, the ` -((catchType | startPos << 8) + 1);` would override these bits.

This patch separates the `startPos` into a new field `exceptionStartPos` to solve the bug. And a test case is added.

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236490](https://bugs.openjdk.java.net/browse/JDK-8236490): Compiler bug relating to @NonNull annotation


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2060/head:pull/2060`
`$ git checkout pull/2060`
