### PR TITLE
8259706: C2 compilation fails with assert(vtable_index == Method::invalid_vtable_index) failed: correct sentinel value

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3328,8 +3328,13 @@ bool LibraryCallKit::inline_unsafe_newArray(bool uninitialized) {
     // ensuing call will throw an exception, or else it
     // will cache the array klass for next time.
     PreserveJVMState pjvms(this);
-    CallJavaNode* slow_call = uninitialized ? generate_method_call_virtual(vmIntrinsics::_allocateUninitializedArray) :
-                                              generate_method_call_static(vmIntrinsics::_newArray);
+    CallJavaNode* slow_call = NULL;
+    if (uninitialized) {
+      // Generate optimized virtual call (holder class 'Unsafe' is final)
+      slow_call = generate_method_call(vmIntrinsics::_allocateUninitializedArray, false, false);
+    } else {
+      slow_call = generate_method_call_static(vmIntrinsics::_newArray);
+    }
     Node* slow_result = set_results_for_java_call(slow_call);
     // this->control() comes from set_results_for_java_call
     result_reg->set_req(_slow_path, control());


### PR DESCRIPTION
When trying to backport [JDK-8259339](https://bugs.openjdk.java.net/browse/JDK-8259339) to JDK 11u, I've hit an assert on Sparc that triggers because the slow virtual call to `Unsafe.allocateUninitializedArray0` could be optimized to a static call since the `Unsafe` class is final.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259706](https://bugs.openjdk.java.net/browse/JDK-8259706): C2 compilation fails with assert(vtable_index == Method::invalid_vtable_index) failed: correct sentinel value


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2062/head:pull/2062`
`$ git checkout pull/2062`
