### PR TITLE
8259266: com/sun/jdi/JdbOptions.java failed with "RuntimeException: 'prop[boo] = >foo 2<' missing from stdout/stderr"

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -485,11 +485,10 @@ class VMConnection {
                                                       //   printDirect()
             }
         } catch (IOException ex) {
-            String s = ex.getMessage();
-            if (!s.startsWith("Bad file number")) {
+            if (!ex.getMessage().equalsIgnoreCase("stream closed")) {
                   throw ex;
             }
-            // else we got a Bad file number IOException which just means
+            // else we got a "Stream closed" IOException which just means
             // that the debuggee has gone away.  We'll just treat it the
             // same as if we got an EOF.
         }


### PR DESCRIPTION
Looks like "Bad file number" message was used long time ago.
Now the message for this IOException can be "Stream Closed" or "Stream closed"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259266](https://bugs.openjdk.java.net/browse/JDK-8259266): com/sun/jdi/JdbOptions.java failed with "RuntimeException: 'prop[boo] = >foo 2<' missing from stdout/stderr"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2067/head:pull/2067`
`$ git checkout pull/2067`
