### PR TITLE
JDK-8259727: Remove redundant "target" arguments to methods in Links

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -110,13 +110,13 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         Content link;
         if (pkg.isUnnamed()) {
             link = links.createLink(HtmlIds.UNNAMED_PACKAGE_ANCHOR,
-                    contents.defaultPackageLabel, "", "");
+                    contents.defaultPackageLabel, "");
         } else {
             String parsedPackageName = utils.parsePackageName(pkg);
             Content packageNameContent = getPackageLabel(parsedPackageName);
             packageNameContent.add(".*");
             link = links.createLink(DocLink.fragment(parsedPackageName),
-                    packageNameContent, "", "");
+                    packageNameContent, "");
             PackageElement abbrevPkg = configuration.workArounds.getAbbreviatedPackageElement(pkg);
             printedPackageHeaders.add(abbrevPkg);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -690,7 +690,7 @@ public class HtmlDocletWriter {
         boolean included = utils.isIncluded(mdle);
         if (included) {
             DocLink targetLink = new DocLink(pathToRoot.resolve(docPaths.moduleSummary(mdle)));
-            Content link = links.createLink(targetLink, label, "", "");
+            Content link = links.createLink(targetLink, label, "");
             if (flags.contains(ElementFlag.PREVIEW) && label != contents.moduleLabel) {
                 link = new ContentBuilder(
                         link,
@@ -737,7 +737,7 @@ public class HtmlDocletWriter {
                     .resolve(DocPaths.SOURCE_OUTPUT)
                     .resolve(docPaths.forClass(te));
             Content content = links.createLink(href
-                    .fragment(SourceToHTMLConverter.getAnchorName(utils, element)), label, "", "");
+                    .fragment(SourceToHTMLConverter.getAnchorName(utils, element)), label, "");
             htmltree.add(content);
         } else {
             htmltree.add(label);
@@ -802,7 +802,7 @@ public class HtmlDocletWriter {
                     (label == null) || label.isEmpty() ? defaultLabel : label,
                     strong,
                     resources.getText("doclet.Href_Class_Or_Interface_Title",
-                        utils.getPackageName(packageElement)), "", true);
+                        utils.getPackageName(packageElement)), true);
             }
         }
         return null;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -115,8 +115,7 @@ public class LinkFactoryImpl extends LinkFactory {
                                 filename.fragment(classLinkInfo.where),
                                 label,
                                 classLinkInfo.isStrong,
-                                title,
-                                classLinkInfo.target));
+                                title));
                         if (flags.contains(ElementFlag.PREVIEW)) {
                             link.add(HtmlTree.SUP(m_writer.links.createLink(
                                     filename.fragment(m_writer.htmlIds.forPreviewSection(target).name()),

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -246,10 +246,6 @@ public class LinkInfoImpl extends LinkInfo {
      */
     public Element targetMember;
 
-    /**
-     * The value of the target.
-     */
-    public String target = "";
     public  final Utils utils;
     /**
      * Construct a LinkInfo object.
@@ -320,15 +316,6 @@ public class LinkInfoImpl extends LinkInfo {
      */
     public LinkInfoImpl strong(boolean strong) {
         this.isStrong = strong;
-        return this;
-    }
-
-    /**
-     * Set the target to be used for the link.
-     * @param target the target name.
-     */
-    public LinkInfoImpl target(String target) {
-        this.target = target;
         return this;
     }
 
@@ -451,7 +438,6 @@ public class LinkInfoImpl extends LinkInfo {
         return "LinkInfoImpl{" +
                 "context=" + context +
                 ", where=" + where +
-                ", target=" + target +
                 super.toString() + '}';
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -209,11 +209,11 @@ public class Navigation {
                 addPageLabel(tree, contents.classLabel, true);
                 if (options.classUse()) {
                     addContentToTree(tree, links.createLink(DocPaths.PACKAGE_USE,
-                            contents.useLabel, "", ""));
+                            contents.useLabel, ""));
                 }
                 if (options.createTree()) {
                     addContentToTree(tree, links.createLink(DocPaths.PACKAGE_TREE,
-                            contents.treeLabel, "", ""));
+                            contents.treeLabel, ""));
                 }
                 addDeprecatedLink(tree);
                 addPreviewLink(tree);
@@ -231,7 +231,7 @@ public class Navigation {
                 }
                 if (options.createTree()) {
                     addContentToTree(tree, links.createLink(DocPaths.PACKAGE_TREE,
-                            contents.treeLabel, "", ""));
+                            contents.treeLabel, ""));
                 }
                 addDeprecatedLink(tree);
                 addPreviewLink(tree);
@@ -777,7 +777,7 @@ public class Navigation {
     private void addOverviewLink(Content tree) {
         if (options.createOverview()) {
             tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.INDEX),
-                    contents.overviewLabel, "", "")));
+                    contents.overviewLabel, "")));
         }
     }
 
@@ -787,7 +787,7 @@ public class Navigation {
                 ModuleElement mdle = configuration.modules.first();
                 boolean included = configuration.utils.isIncluded(mdle);
                 tree.add(HtmlTree.LI((included)
-                        ? links.createLink(pathToRoot.resolve(configuration.docPaths.moduleSummary(mdle)), contents.moduleLabel, "", "")
+                        ? links.createLink(pathToRoot.resolve(configuration.docPaths.moduleSummary(mdle)), contents.moduleLabel, "")
                         : contents.moduleLabel));
             } else if (!configuration.modules.isEmpty()) {
                 addPageLabel(tree, contents.moduleLabel, true);
@@ -846,21 +846,21 @@ public class Navigation {
             DocPath docPath = packages.size() == 1 && configuration.getSpecifiedTypeElements().isEmpty()
                     ? pathToRoot.resolve(configuration.docPaths.forPackage(packages.get(0)).resolve(DocPaths.PACKAGE_TREE))
                     : pathToRoot.resolve(DocPaths.OVERVIEW_TREE);
-            tree.add(HtmlTree.LI(links.createLink(docPath, contents.treeLabel, "", "")));
+            tree.add(HtmlTree.LI(links.createLink(docPath, contents.treeLabel, "")));
         }
     }
 
     private void addDeprecatedLink(Content tree) {
         if (configuration.conditionalPages.contains(HtmlConfiguration.ConditionalPage.DEPRECATED)) {
             tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.DEPRECATED_LIST),
-                    contents.deprecatedLabel, "", "")));
+                    contents.deprecatedLabel, "")));
         }
     }
 
     private void addPreviewLink(Content tree) {
         if (configuration.conditionalPages.contains(HtmlConfiguration.ConditionalPage.PREVIEW)) {
             tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(DocPaths.PREVIEW_LIST),
-                    contents.previewLabel, "", "")));
+                    contents.previewLabel, "")));
         }
     }
 
@@ -870,7 +870,7 @@ public class Navigation {
                     (options.splitIndex()
                             ? DocPaths.INDEX_FILES.resolve(DocPaths.indexN(1))
                             : DocPaths.INDEX_ALL)),
-                    contents.indexLabel, "", "")));
+                    contents.indexLabel, "")));
         }
     }
 
@@ -885,7 +885,7 @@ public class Navigation {
                 helpfilenm = DocPath.create(file.getName());
             }
             tree.add(HtmlTree.LI(links.createLink(pathToRoot.resolve(helpfilenm),
-                    contents.helpLabel, "", "")));
+                    contents.helpLabel, "")));
         }
     }
 
@@ -918,7 +918,7 @@ public class Navigation {
                 .setId(HtmlIds.NAVBAR_TOP)
                 .add(HtmlTree.DIV(HtmlStyle.skipNav,
                         links.createLink(HtmlIds.SKIP_NAVBAR_TOP, skipNavLinks,
-                                skipNavLinks.toString(), "")));
+                                skipNavLinks.toString())));
         Content aboutContent = userHeader;
         boolean addSearch = options.createIndex();
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
@@ -60,22 +60,21 @@ public class Links {
      */
     public Content createLink(HtmlId id, Content label) {
         DocLink l = DocLink.fragment(id.name());
-        return createLink(l, label, "", "");
+        return createLink(l, label, "");
     }
 
     /**
-     * Creates a link of the form {@code <a href="#id" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="#id" title="title">label</a>}.
      *
      * @param id     the id to which the link will be created
      * @param label  the content for the link
      * @param title  the title for the link
-     * @param target the target for the link, or null
      *
      * @return a content tree for the link
      */
-    public Content createLink(HtmlId id, Content label, String title, String target) {
+    public Content createLink(HtmlId id, Content label, String title) {
         DocLink l = DocLink.fragment(id.name());
-        return createLink(l, label, title, target);
+        return createLink(l, label, title);
     }
 
     /**
@@ -86,7 +85,7 @@ public class Links {
      * @return a content tree for the link
      */
     public Content createLink(DocPath path, String label) {
-        return createLink(path, new StringContent(label), false, "", "");
+        return createLink(path, new StringContent(label), false, "");
     }
 
     /**
@@ -97,11 +96,11 @@ public class Links {
      * @return a content tree for the link
      */
     public Content createLink(DocPath path, Content label) {
-        return createLink(path, label, "", "");
+        return createLink(path, label, "");
     }
 
     /**
-     * Creates a link of the form {@code <a href="path" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="path" title="title">label</a>}.
      * If {@code strong} is set, the label will be wrapped in
      *      {@code <span style="typeNameLink">...</span>}.
      *
@@ -109,25 +108,22 @@ public class Links {
      * @param label     the content for the link
      * @param strong    whether to wrap the {@code label} in a SPAN element
      * @param title     the title for the link
-     * @param target    the target for the link, or null
      * @return a content tree for the link
      */
-    public Content createLink(DocPath path, Content label, boolean strong,
-            String title, String target) {
-        return createLink(new DocLink(path), label, strong, title, target);
+    public Content createLink(DocPath path, Content label, boolean strong, String title) {
+        return createLink(new DocLink(path), label, strong, title);
     }
 
     /**
-     * Creates a link of the form {@code <a href="path" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="path" title="title">label</a>}.
      *
      * @param path      the path for the link
      * @param label     the content for the link
      * @param title     the title for the link
-     * @param target    the target for the link, or null
      * @return a content tree for the link
      */
-    public Content createLink(DocPath path, Content label, String title, String target) {
-        return createLink(new DocLink(path), label, title, target);
+    public Content createLink(DocPath path, Content label, String title) {
+        return createLink(new DocLink(path), label, title);
     }
 
     /**
@@ -138,31 +134,27 @@ public class Links {
      * @return a content tree for the link
      */
     public Content createLink(DocLink link, Content label) {
-        return createLink(link, label, "", "");
+        return createLink(link, label, "");
     }
 
     /**
-     * Creates a link of the form {@code <a href="path" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="path" title="title">label</a>}.
      *
      * @param link      the details for the link
      * @param label     the content for the link
      * @param title     the title for the link
-     * @param target    the target for the link, or null
      * @return a content tree for the link
      */
-    public Content createLink(DocLink link, Content label, String title, String target) {
+    public Content createLink(DocLink link, Content label, String title) {
         HtmlTree anchor = HtmlTree.A(link.relativizeAgainst(file).toString(), label);
         if (title != null && title.length() != 0) {
             anchor.put(HtmlAttr.TITLE, title);
-        }
-        if (target != null && target.length() != 0) {
-            anchor.put(HtmlAttr.TARGET, target);
         }
         return anchor;
     }
 
     /**
-     * Creates a link of the form {@code <a href="link" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="link" title="title" >label</a>}.
      * If {@code strong} is set, the label will be wrapped in
      *      {@code <span style="typeNameLink">...</span>}.
      *
@@ -170,16 +162,15 @@ public class Links {
      * @param label     the content for the link
      * @param strong    whether to wrap the {@code label} in a SPAN element
      * @param title     the title for the link
-     * @param target    the target for the link, or null
      * @return a content tree for the link
      */
     public Content createLink(DocLink link, Content label, boolean strong,
-            String title, String target) {
-        return createLink(link, label, strong, title, target, false);
+                              String title) {
+        return createLink(link, label, strong, title, false);
     }
 
     /**
-     * Creates a link of the form {@code <a href="link" title="title" target="target">label</a>}.
+     * Creates a link of the form {@code <a href="link" title="title">label</a>}.
      * If {@code strong} is set, the label will be wrapped in
      *      {@code <span style="typeNameLink">...</span>}.
      *
@@ -187,12 +178,11 @@ public class Links {
      * @param label      the content for the link
      * @param strong     whether to wrap the {@code label} in a SPAN element
      * @param title      the title for the link
-     * @param target     the target for the link, or null
      * @param isExternal is the link external to the generated documentation
      * @return a content tree for the link
      */
     public Content createLink(DocLink link, Content label, boolean strong,
-            String title, String target, boolean isExternal) {
+                              String title, boolean isExternal) {
         Content body = label;
         if (strong) {
             body = HtmlTree.SPAN(HtmlStyle.typeNameLink, body);
@@ -200,9 +190,6 @@ public class Links {
         HtmlTree l = HtmlTree.A(link.relativizeAgainst(file).toString(), body);
         if (title != null && title.length() != 0) {
             l.put(HtmlAttr.TITLE, title);
-        }
-        if (target != null && target.length() != 0) {
-            l.put(HtmlAttr.TARGET, target);
         }
         if (isExternal) {
             l.setStyle(HtmlStyle.externalLink);


### PR DESCRIPTION
Please remove a simple change to eliminate a now-unused parameter from various methods on `Links`, to set the `target` attribute of a link.

In times past, when frames were used to display pages, the `target` attribute was used to specify the target frame to use when clicking the link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259727](https://bugs.openjdk.java.net/browse/JDK-8259727): Remove redundant "target" arguments to methods in Links


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2068/head:pull/2068`
`$ git checkout pull/2068`
