### PR TITLE
8259773: Incorrect encoding of AVX-512 kmovq instruction

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -2440,7 +2440,7 @@ void Assembler::kmovql(Address dst, KRegister src) {
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   vex_prefix(dst, 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
-  emit_int8((unsigned char)0x90);
+  emit_int8((unsigned char)0x91);
   emit_operand((Register)src, dst);
 }
 


### PR DESCRIPTION
While working on a prototype for supporting opmask register allocation encountered this bug.

Encoding for following instruction[1] which spills the value of an opmask register into memory should have 0x91 as the opcode instead of 0x90.

KMOVQ Address , K1.

[1] https://www.felixcloutier.com/x86/kmovw:kmovb:kmovq:kmovd

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259773](https://bugs.openjdk.java.net/browse/JDK-8259773): Incorrect encoding of AVX-512 kmovq instruction


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2078/head:pull/2078`
`$ git checkout pull/2078`
