### PR TITLE
8259774: samplethreads option  does not work for jfr thread sampler

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,11 @@ NO_TRANSITION_END
 
 NO_TRANSITION(void, jfr_set_sample_threads(JNIEnv* env, jobject jvm, jboolean sampleThreads))
   JfrOptionSet::set_sample_threads(sampleThreads);
+  if (JNI_TRUE == sampleThreads) {
+    JfrThreadSampling::enroll_thread_sampler();
+  } else {
+    JfrThreadSampling::disenroll_thread_sampler();
+  }
 NO_TRANSITION_END
 
 NO_TRANSITION(void, jfr_set_stack_depth(JNIEnv* env, jobject jvm, jint depth))

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -644,4 +644,18 @@ void JfrThreadSampling::set_native_sample_interval(size_t period) {
 
 void JfrThreadSampling::on_javathread_suspend(JavaThread* thread) {
   JfrThreadSampler::on_javathread_suspend(thread);
+}
+
+void JfrThreadSampling::enroll_thread_sampler() {
+  if (_instance == NULL) {
+    return;
+  }
+  instance()._sampler->enroll();
+}
+
+void JfrThreadSampling::disenroll_thread_sampler() {
+  if (_instance == NULL) {
+    return;
+  }
+  instance()._sampler->disenroll();
 }

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.hpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,8 @@ class JfrThreadSampling : public JfrCHeapObj {
   static void set_java_sample_interval(size_t period);
   static void set_native_sample_interval(size_t period);
   static void on_javathread_suspend(JavaThread* thread);
+  static void enroll_thread_sampler();
+  static void disenroll_thread_sampler();
 };
 
 #endif // SHARE_JFR_PERIODIC_SAMPLING_JFRTHREADSAMPLER_HPP

--- a/test/jdk/jdk/jfr/startupargs/TestSampleThreadsOption.java
+++ b/test/jdk/jdk/jfr/startupargs/TestSampleThreadsOption.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package jdk.jfr.startupargs;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main jdk.jfr.startupargs.TestSampleThreadsOption
+ */
+public class TestSampleThreadsOption {
+    private static final String START_FLIGHT_RECORDING = "-XX:StartFlightRecording";
+    private static final String FLIGHT_RECORDER_OPTIONS = "-XX:FlightRecorderOptions";
+
+    public static void main(String[] args) throws Throwable {
+        String recording = START_FLIGHT_RECORDING + "=filename=recording.jfr,dumponexit=true";
+
+        // turn on
+        List<RecordedEvent> events;
+        events = testWithJFROption(FLIGHT_RECORDER_OPTIONS + "=samplethreads=true", recording, Main.class.getName());
+        List<String> names = events.stream()
+                .map(e -> e.getEventType().getName())
+                .filter(eventName -> eventName.equals(EventNames.ExecutionSample) || eventName.equals(EventNames.NativeMethodSample))
+                .collect(Collectors.toList());
+        Asserts.assertTrue(names.size() != 0, "must be");
+
+        // turn off
+        events = testWithJFROption(FLIGHT_RECORDER_OPTIONS + "=samplethreads=false", recording, Main.class.getName());
+        names = events.stream()
+                .map(e -> e.getEventType().getName())
+                .filter(eventName -> eventName.equals(EventNames.ExecutionSample) || eventName.equals(EventNames.NativeMethodSample))
+                .collect(Collectors.toList());
+        Asserts.assertTrue(names.size() == 0, "must be");
+
+    }
+
+    private static List<RecordedEvent> testWithJFROption(String... options) throws Throwable {
+        ProcessBuilder pb = ProcessTools.createTestJvm(options);
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+
+        Path dumpPath = Paths.get(".", "recording.jfr");
+        Asserts.assertTrue(Files.isRegularFile(dumpPath), "No recording dumped " + dumpPath);
+        List<RecordedEvent> events = RecordingFile.readAllEvents(dumpPath);
+        return events;
+    }
+
+    private static class Main {
+        public static void main(String... args) {
+            for (int i = 0; i < 500000; i++) {
+                System.out.println(new Object().hashCode() * new Object().hashCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi,

Please help review this minor change that lets the JFR option
`samplethreads` works.

In the current implementation, no matter whether `samplethreads`
option is turned on or off, it will not affect thread sampling. 
The sampler completely ignores it. This patch will address this 
problem and let the sampler aware of this option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259774](https://bugs.openjdk.java.net/browse/JDK-8259774): samplethreads option does not work for jfr thread sampler


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2079/head:pull/2079`
`$ git checkout pull/2079`
