### PR TITLE
8259799: vmTestbase/nsk/jvmti/Breakpoint/breakpoint001 is incorrect

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,8 +170,8 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     }
 
     for (i=0; i<METH_NUM; i++)
-        if (strcmp(methNam,METHODS[i][0]) == 0 &&
-                strcmp(methSig,METHODS[i][1]) == 0) {
+        if (strcmp(methNam, METHODS[i][0]) == 0 &&
+                strcmp(methSig, METHODS[i][1]) == 0) {
             NSK_DISPLAY2("CHECK PASSED: method name: \"%s\"\tsignature: \"%s\"\n",
                 methNam, methSig);
             if (checkStatus == PASSED)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,8 +170,8 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     }
 
     for (i=0; i<METH_NUM; i++)
-        if (strcmp(methNam,METHODS[i][0]) &&
-                strcmp(methSig,METHODS[i][1])) {
+        if (strcmp(methNam,METHODS[i][0]) == 0 &&
+                strcmp(methSig,METHODS[i][1]) == 0) {
             NSK_DISPLAY2("CHECK PASSED: method name: \"%s\"\tsignature: \"%s\"\n",
                 methNam, methSig);
             if (checkStatus == PASSED)


### PR DESCRIPTION
est vmTestbase/nsk/jvmti/Breakpoint/breakpoint001 has incorrect check of strcmp results here:

  for (i=0; i<METH_NUM; i++)
        if (strcmp(methNam,METHODS[i][0]) &&
                strcmp(methSig,METHODS[i][1])) {
            printf("CHECK PASSED: method name: \"%s\"\tsignature: \"%s\" %d\n",
                   methNam, methSig, i);
            if (checkStatus == PASSED)
                bpEvents[i]++;
            break;
        }

So test passed when both strcmp (name,sig) are not zero.

The test passes only because there are 2 methods that are checked and it increases counters for "incorrect" methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259799](https://bugs.openjdk.java.net/browse/JDK-8259799): vmTestbase/nsk/jvmti/Breakpoint/breakpoint001 is incorrect


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2084/head:pull/2084`
`$ git checkout pull/2084`
