### PR TITLE
8259707: LDAP channel binding does not work with StartTLS extension

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -117,7 +117,7 @@ import javax.security.sasl.SaslException;
   * @author Rosanna Lee
   * @author Jagane Sundar
   */
-public final class Connection implements Runnable, HandshakeCompletedListener {
+public final class Connection implements Runnable {
 
     private static final boolean debug = false;
     private static final int dump = 0; // > 0 r, > 1 rw
@@ -357,7 +357,7 @@ public final class Connection implements Runnable, HandshakeCompletedListener {
                 param.setEndpointIdentificationAlgorithm("LDAPS");
                 sslSocket.setSSLParameters(param);
             }
-            sslSocket.addHandshakeCompletedListener(this);
+            setHandshakeCompletedListener(sslSocket);
             if (connectTimeout > 0) {
                 int socketTimeout = sslSocket.getSoTimeout();
                 sslSocket.setSoTimeout(connectTimeout); // reuse full timeout value
@@ -653,13 +653,13 @@ public final class Connection implements Runnable, HandshakeCompletedListener {
                             ldr = ldr.next;
                         }
                     }
-                    if (isTlsConnection()) {
+                    if (isTlsConnection() && tlsHandshakeListener != null) {
                         if (closureReason != null) {
                             CommunicationException ce = new CommunicationException();
                             ce.setRootCause(closureReason);
-                            tlsHandshakeCompleted.completeExceptionally(ce);
+                            tlsHandshakeListener.tlsHandshakeCompleted.completeExceptionally(ce);
                         } else {
-                            tlsHandshakeCompleted.cancel(false);
+                            tlsHandshakeListener.tlsHandshakeCompleted.cancel(false);
                         }
                     }
                     sock = null;
@@ -1027,45 +1027,57 @@ public final class Connection implements Runnable, HandshakeCompletedListener {
         return buf;
     }
 
-    private final CompletableFuture<X509Certificate> tlsHandshakeCompleted =
-            new CompletableFuture<>();
-
-    @Override
-    public void handshakeCompleted(HandshakeCompletedEvent event) {
-        try {
-            X509Certificate tlsServerCert = null;
-            Certificate[] certs;
-            if (event.getSocket().getUseClientMode()) {
-                certs = event.getPeerCertificates();
-            } else {
-                certs = event.getLocalCertificates();
-            }
-            if (certs != null && certs.length > 0 &&
-                    certs[0] instanceof X509Certificate) {
-                tlsServerCert = (X509Certificate) certs[0];
-            }
-            tlsHandshakeCompleted.complete(tlsServerCert);
-        } catch (SSLPeerUnverifiedException ex) {
-            CommunicationException ce = new CommunicationException();
-            ce.setRootCause(closureReason);
-            tlsHandshakeCompleted.completeExceptionally(ex);
-        }
-    }
-
     public boolean isTlsConnection() {
         return (sock instanceof SSLSocket) || isUpgradedToStartTls;
     }
 
+    private HandshakeListener tlsHandshakeListener;
+
+    synchronized public void setHandshakeCompletedListener(SSLSocket sslSocket) {
+        if (tlsHandshakeListener != null)
+            tlsHandshakeListener.tlsHandshakeCompleted.cancel(false);
+
+        tlsHandshakeListener = new HandshakeListener();
+        sslSocket.addHandshakeCompletedListener(tlsHandshakeListener);
+    }
+
     public X509Certificate getTlsServerCertificate()
-            throws SaslException {
+        throws SaslException {
         try {
-            if (isTlsConnection())
-                return tlsHandshakeCompleted.get();
+            if (isTlsConnection() && tlsHandshakeListener != null)
+                return tlsHandshakeListener.tlsHandshakeCompleted.get();
         } catch (InterruptedException iex) {
             throw new SaslException("TLS Handshake Exception ", iex);
         } catch (ExecutionException eex) {
             throw new SaslException("TLS Handshake Exception ", eex.getCause());
         }
         return null;
+    }
+
+    private class HandshakeListener implements HandshakeCompletedListener {
+
+        private CompletableFuture<X509Certificate> tlsHandshakeCompleted =
+                new CompletableFuture<>();
+        @Override
+        public void handshakeCompleted(HandshakeCompletedEvent event) {
+            try {
+                X509Certificate tlsServerCert = null;
+                Certificate[] certs;
+                if (event.getSocket().getUseClientMode()) {
+                    certs = event.getPeerCertificates();
+                } else {
+                    certs = event.getLocalCertificates();
+                }
+                if (certs != null && certs.length > 0 &&
+                        certs[0] instanceof X509Certificate) {
+                    tlsServerCert = (X509Certificate) certs[0];
+                }
+                tlsHandshakeCompleted.complete(tlsServerCert);
+            } catch (SSLPeerUnverifiedException ex) {
+                CommunicationException ce = new CommunicationException();
+                ce.setRootCause(closureReason);
+                tlsHandshakeCompleted.completeExceptionally(ex);
+            }
+        }
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1053,7 +1053,7 @@ public final class Connection implements Runnable, HandshakeCompletedListener {
     }
 
     public boolean isTlsConnection() {
-        return sock instanceof SSLSocket;
+        return (sock instanceof SSLSocket) || isUpgradedToStartTls;
     }
 
     public X509Certificate getTlsServerCertificate()

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1031,7 +1031,12 @@ public final class Connection implements Runnable {
         return (sock instanceof SSLSocket) || isUpgradedToStartTls;
     }
 
-    private HandshakeListener tlsHandshakeListener;
+    /*
+     * tlsHandshakeListener can be created for initial secure connection
+     * and updated by StartTLS extended operation. It is used later by LdapClient
+     * to create TLS Channel Binding data on the base of TLS server certificate
+     */
+    private volatile HandshakeListener tlsHandshakeListener;
 
     synchronized public void setHandshakeCompletedListener(SSLSocket sslSocket) {
         if (tlsHandshakeListener != null)
@@ -1056,7 +1061,7 @@ public final class Connection implements Runnable {
 
     private class HandshakeListener implements HandshakeCompletedListener {
 
-        private CompletableFuture<X509Certificate> tlsHandshakeCompleted =
+        private final CompletableFuture<X509Certificate> tlsHandshakeCompleted =
                 new CompletableFuture<>();
         @Override
         public void handshakeCompleted(HandshakeCompletedEvent event) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -351,7 +351,7 @@ final public class StartTlsResponseImpl extends StartTlsResponse {
                 System.out.println(
                         "StartTLS: Calling sslSocket.startHandshake");
             }
-            sslSocket.addHandshakeCompletedListener(ldapConnection);
+            ldapConnection.setHandshakeCompletedListener(sslSocket);
             sslSocket.startHandshake();
             if (debug) {
                 System.out.println(

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -351,6 +351,7 @@ final public class StartTlsResponseImpl extends StartTlsResponse {
                 System.out.println(
                         "StartTLS: Calling sslSocket.startHandshake");
             }
+            sslSocket.addHandshakeCompletedListener(ldapConnection);
             sslSocket.startHandshake();
             if (debug) {
                 System.out.println(


### PR DESCRIPTION
Please review a small patch to enable LDAP TLS Channel Binding with StartTLS Extension.
Test from the bug report and jtreg javax/naming tests are passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259707](https://bugs.openjdk.java.net/browse/JDK-8259707): LDAP channel binding does not work with StartTLS extension


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to d2f470e795c31240d3ef7b53e453b7930d1e604d
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2085/head:pull/2085`
`$ git checkout pull/2085`
