### PR TITLE
8259820: JShell does not handle -source 8 properly

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
@@ -70,6 +70,7 @@ import com.sun.tools.javac.code.ClassFinder;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
@@ -215,11 +216,13 @@ class TaskFactory {
                      //additional cleanup: purge the REPL package:
                      Symtab syms = Symtab.instance(context);
                      Names names = Names.instance(context);
-                     PackageSymbol repl = syms.getPackage(syms.unnamedModule, names.fromString(Util.REPL_PACKAGE));
+                     ModuleSymbol replModule = syms.java_base == syms.noModule ? syms.noModule
+                                                                               : syms.unnamedModule;
+                     PackageSymbol repl = syms.getPackage(replModule, names.fromString(Util.REPL_PACKAGE));
                      if (repl != null) {
                          for (ClassSymbol clazz : syms.getAllClasses()) {
                              if (clazz.packge() == repl) {
-                                 syms.removeClass(syms.unnamedModule, clazz.flatName());
+                                 syms.removeClass(replModule, clazz.flatName());
                              }
                          }
                          repl.members_field = null;

--- a/test/langtools/jdk/jshell/SourceLevelTest.java
+++ b/test/langtools/jdk/jshell/SourceLevelTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8259820
+ * @summary Check JShell can handle -source 8
+ * @run testng SourceLevelTest
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SourceLevelTest extends ReplToolTesting {
+
+    @DataProvider(name="sourceLevels")
+    public Object[][] sourceLevels() {
+        return new Object[][] {
+            new Object[] {"8"},
+            new Object[] {"11"}
+        };
+    }
+
+    @Test(dataProvider="sourceLevels")
+    public void testSourceLevel(String sourceLevel) {
+        test(new String[] {"-C", "-source", "-C", sourceLevel},
+                (a) -> assertCommand(a, "1 + 1", "$1 ==> 2"),
+                (a) -> assertCommand(a, "1 + 2", "$2 ==> 3")
+        );
+    }
+
+}

--- a/test/langtools/jdk/jshell/SourceLevelTest.java
+++ b/test/langtools/jdk/jshell/SourceLevelTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8259820
  * @summary Check JShell can handle -source 8
+ * @modules jdk.jshell
  * @run testng SourceLevelTest
  */
 


### PR DESCRIPTION
When running JShell with `-C-source -C8`, only one (non-import) snippet can be processed. This is because, when cleaning javac state, the `REPL` package is looked up in the unnamed package, but with `-source 8`, there is no unnamed package, so the `REPL` package is not found and cleared properly. The proposed solution is to use `noModule` when running in non-module mode (i.e. with `-source 8`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259820](https://bugs.openjdk.java.net/browse/JDK-8259820): JShell does not handle -source 8 properly


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2097/head:pull/2097`
`$ git checkout pull/2097`
