### PR TITLE
8259840: [Vector API] Fix an assert in Assembler::vpmovzxbw if UseAVX=0

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1687,9 +1687,6 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       }
       break;
     case Op_VectorLoadShuffle:
-      if (bt == T_SHORT && vlen == 8 && UseAVX == 0) {
-        return false; // Implementation limitation
-      }
     case Op_VectorRearrange:
       if(vlen == 2) {
         return false; // Implementation limitation due to how shuffle is loaded
@@ -7542,7 +7539,7 @@ instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
 
 instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 4 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+            vector_length(n) <= 8 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
@@ -7566,12 +7563,13 @@ instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
 %}
 
 instruct loadShuffleS_avx(vec dst, vec src, vec vtmp, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_SHORT && (vector_length(n) == 8 || vector_length(n) == 16) &&
-            UseAVX > 0 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+  predicate(vector_element_basic_type(n) == T_SHORT &&
+            vector_length(n) == 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
+    assert(UseAVX >= 2, "required");
     int vlen_enc = vector_length_encoding(this);
     // Multiply each shuffle by two to get byte index
     __ vpmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister, vlen_enc);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1687,6 +1687,9 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       }
       break;
     case Op_VectorLoadShuffle:
+      if (bt == T_SHORT && vlen == 8 && UseAVX == 0) {
+        return false; // Implementation limitation
+      }
     case Op_VectorRearrange:
       if(vlen == 2) {
         return false; // Implementation limitation due to how shuffle is loaded
@@ -7539,40 +7542,47 @@ instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
 
 instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+            vector_length(n) <= 4 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
     // Create a byte shuffle mask from short shuffle mask
     // only byte shuffle instruction available on these platforms
-    int vlen_in_bytes = vector_length_in_bytes(this);
-    if (vlen_in_bytes <= 8) {
-      // Multiply each shuffle by two to get byte index
-      __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
-      __ psllw($vtmp$$XMMRegister, 1);
+    // Multiply each shuffle by two to get byte index
+    __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
+    __ psllw($vtmp$$XMMRegister, 1);
 
-      // Duplicate to create 2 copies of byte index
-      __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
-      __ psllw($dst$$XMMRegister, 8);
-      __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
+    // Duplicate to create 2 copies of byte index
+    __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
+    __ psllw($dst$$XMMRegister, 8);
+    __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
 
-      // Add one to get alternate byte index
-      __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
-      __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
-    } else {
-      int vlen_enc = vector_length_encoding(this);
-      // Multiply each shuffle by two to get byte index
-      __ vpmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister, vlen_enc);
-      __ vpsllw($vtmp$$XMMRegister, $vtmp$$XMMRegister, 1, vlen_enc);
+    // Add one to get alternate byte index
+    __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
+    __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
-      // Duplicate to create 2 copies of byte index
-      __ vpsllw($dst$$XMMRegister, $vtmp$$XMMRegister,  8, vlen_enc);
-      __ vpor($dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
+instruct loadShuffleS_avx(vec dst, vec src, vec vtmp, rRegP scratch) %{
+  predicate(vector_element_basic_type(n) == T_SHORT && (vector_length(n) == 8 || vector_length(n) == 16) &&
+            UseAVX > 0 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+  match(Set dst (VectorLoadShuffle src));
+  effect(TEMP dst, TEMP vtmp, TEMP scratch);
+  format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    // Multiply each shuffle by two to get byte index
+    __ vpmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister, vlen_enc);
+    __ vpsllw($vtmp$$XMMRegister, $vtmp$$XMMRegister, 1, vlen_enc);
 
-      // Add one to get alternate byte index
-      __ vpaddb($dst$$XMMRegister, $dst$$XMMRegister, ExternalAddress(vector_short_shufflemask()), vlen_enc, $scratch$$Register);
-    }
+    // Duplicate to create 2 copies of byte index
+    __ vpsllw($dst$$XMMRegister, $vtmp$$XMMRegister,  8, vlen_enc);
+    __ vpor($dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
+
+    // Add one to get alternate byte index
+    __ vpaddb($dst$$XMMRegister, $dst$$XMMRegister, ExternalAddress(vector_short_shufflemask()), vlen_enc, $scratch$$Register);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
Hi all,

This assert was observed when running jdk/incubator/vector/ShortMaxVectorTests.java with -XX:UseAVX=0.

```
#
#  Internal Error (/home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/assembler_x86.cpp:4263), pid=19129, tid=19145
#  Error: assert(vector_len == AVX_128bit? VM_Version::supports_avx() : vector_len == AVX_256bit? VM_Version::supports_avx2() : vector_len == AVX_512bit? VM_Version::supports_avx512bw() : 0) failed
#

Stack: [0x00007f4c095fa000,0x00007f4c096fb000],  sp=0x00007f4c096f5d40,  free space=1007k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x5e0ab6]  Assembler::vpmovzxbw(XMMRegisterImpl*, XMMRegisterImpl*, int)+0x136
V  [libjvm.so+0x41d0dd]  loadShuffleSNode::emit(CodeBuffer&, PhaseRegAlloc*) const+0x3ad
V  [libjvm.so+0x13ea963]  PhaseOutput::scratch_emit_size(Node const*)+0x423
V  [libjvm.so+0x13e1b44]  PhaseOutput::shorten_branches(unsigned int*)+0x2a4
V  [libjvm.so+0x13f25aa]  PhaseOutput::Output()+0xb8a
V  [libjvm.so+0x96a003]  Compile::Code_Gen()+0x443
V  [libjvm.so+0x97303a]  Compile::Compile(ciEnv*, ciMethod*, int, bool, bool, bool, bool, DirectiveSet*)+0x178a
```

The reason is that loadShuffleS should not use vpmovzxbw when -XX:UseAVX=0.
The fix splits loadShuffleS's AVX code-gen logic into loadShuffleS_avx.

Testing:
  - jdk/incubator/vector on an AVX512 machine with UseAVX=3/2/1/0, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259840](https://bugs.openjdk.java.net/browse/JDK-8259840): [Vector API] Fix an assert in Assembler::vpmovzxbw if UseAVX=0


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2100/head:pull/2100`
`$ git checkout pull/2100`
