### PR TITLE
8259846: [BACKOUT] JDK-8259278 Optimize Vector API slice and unslice operations

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3006,16 +3006,6 @@ void MacroAssembler::vaddss(XMMRegister dst, XMMRegister nds, AddressLiteral src
   }
 }
 
-void MacroAssembler::vpaddb(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch) {
-  assert(UseAVX > 0, "requires some form of AVX");
-  if (reachable(src)) {
-    Assembler::vpaddb(dst, nds, as_Address(src), vector_len);
-  } else {
-    lea(rscratch, src);
-    Assembler::vpaddb(dst, nds, Address(rscratch, 0), vector_len);
-  }
-}
-
 void MacroAssembler::vpaddd(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch) {
   assert(UseAVX > 0, "requires some form of AVX");
   if (reachable(src)) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1241,7 +1241,6 @@ public:
 
   void vpaddb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpaddb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
-  void vpaddb(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch);
 
   void vpaddw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpaddw(XMMRegister dst, XMMRegister nds, Address src, int vector_len);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -607,21 +607,6 @@ class StubGenerator: public StubCodeGenerator {
     __ emit_data(0x37363534, relocInfo::none, 0);
     __ emit_data(0x3B3A3938, relocInfo::none, 0);
     __ emit_data(0x3F3E3D3C, relocInfo::none, 0);
-    return start;
-  }
-
-  address generate_vector_byte_shuffle_mask(const char *stub_name) {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", stub_name);
-    address start = __ pc();
-    __ emit_data(0x70707070, relocInfo::none, 0);
-    __ emit_data(0x70707070, relocInfo::none, 0);
-    __ emit_data(0x70707070, relocInfo::none, 0);
-    __ emit_data(0x70707070, relocInfo::none, 0);
-    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
-    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
-    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
-    __ emit_data(0xF0F0F0F0, relocInfo::none, 0);
     return start;
   }
 
@@ -3981,7 +3966,6 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::x86::_vector_64_bit_mask = generate_vector_custom_i32("vector_64_bit_mask", Assembler::AVX_512bit,
                                                                         0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
     StubRoutines::x86::_vector_int_shuffle_mask = generate_vector_mask("vector_int_shuffle_mask", 0x03020100);
-    StubRoutines::x86::_vector_byte_shuffle_mask = generate_vector_byte_shuffle_mask("vector_byte_shuffle_mask");
     StubRoutines::x86::_vector_short_shuffle_mask = generate_vector_mask("vector_short_shuffle_mask", 0x01000100);
     StubRoutines::x86::_vector_long_shuffle_mask = generate_vector_mask_long_double("vector_long_shuffle_mask", 0x00000001, 0x0);
     StubRoutines::x86::_vector_byte_perm_mask = generate_vector_byte_perm_mask("vector_byte_perm_mask");

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -808,17 +808,6 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_vector_byte_shuffle_mask(const char *stub_name) {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", stub_name);
-    address start = __ pc();
-    __ emit_data64(0x7070707070707070, relocInfo::none);
-    __ emit_data64(0x7070707070707070, relocInfo::none);
-    __ emit_data64(0xF0F0F0F0F0F0F0F0, relocInfo::none);
-    __ emit_data64(0xF0F0F0F0F0F0F0F0, relocInfo::none);
-    return start;
-  }
-
   address generate_fp_mask(const char *stub_name, int64_t mask) {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", stub_name);
@@ -6839,7 +6828,6 @@ address generate_avx_ghash_processBlocks() {
     StubRoutines::x86::_vector_64_bit_mask = generate_vector_custom_i32("vector_64_bit_mask", Assembler::AVX_512bit,
                                                                         0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
     StubRoutines::x86::_vector_int_shuffle_mask = generate_vector_mask("vector_int_shuffle_mask", 0x0302010003020100);
-    StubRoutines::x86::_vector_byte_shuffle_mask = generate_vector_byte_shuffle_mask("vector_byte_shuffle_mask");
     StubRoutines::x86::_vector_short_shuffle_mask = generate_vector_mask("vector_short_shuffle_mask", 0x0100010001000100);
     StubRoutines::x86::_vector_long_shuffle_mask = generate_vector_mask("vector_long_shuffle_mask", 0x0000000100000000);
     StubRoutines::x86::_vector_long_sign_mask = generate_vector_mask("vector_long_sign_mask", 0x8000000000000000);

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ address StubRoutines::x86::_vector_short_to_byte_mask = NULL;
 address StubRoutines::x86::_vector_int_to_byte_mask = NULL;
 address StubRoutines::x86::_vector_int_to_short_mask = NULL;
 address StubRoutines::x86::_vector_all_bits_set = NULL;
-address StubRoutines::x86::_vector_byte_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_short_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_int_shuffle_mask = NULL;
 address StubRoutines::x86::_vector_long_shuffle_mask = NULL;

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,6 @@ class x86 {
   static address _vector_32_bit_mask;
   static address _vector_64_bit_mask;
   static address _vector_int_shuffle_mask;
-  static address _vector_byte_shuffle_mask;
   static address _vector_short_shuffle_mask;
   static address _vector_long_shuffle_mask;
   static address _vector_iota_indices;
@@ -279,10 +278,6 @@ class x86 {
 
   static address vector_int_shuffle_mask() {
     return _vector_int_shuffle_mask;
-  }
-
-  static address vector_byte_shuffle_mask() {
-    return _vector_byte_shuffle_mask;
   }
 
   static address vector_short_shuffle_mask() {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1354,7 +1354,6 @@ Assembler::Width widthForType(BasicType bt) {
   static address vector_long_sign_mask() { return StubRoutines::x86::vector_long_sign_mask(); }
   static address vector_all_bits_set() { return StubRoutines::x86::vector_all_bits_set(); }
   static address vector_int_to_short_mask() { return StubRoutines::x86::vector_int_to_short_mask(); }
-  static address vector_byte_shufflemask() { return StubRoutines::x86::vector_byte_shuffle_mask(); }
   static address vector_short_shufflemask() { return StubRoutines::x86::vector_short_shuffle_mask(); }
   static address vector_int_shufflemask() { return StubRoutines::x86::vector_int_shuffle_mask(); }
   static address vector_long_shufflemask() { return StubRoutines::x86::vector_long_shuffle_mask(); }
@@ -1692,9 +1691,9 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
         return false; // Implementation limitation due to how shuffle is loaded
       } else if (size_in_bits == 256 && UseAVX < 2) {
         return false; // Implementation limitation
-      } else if (bt == T_BYTE && size_in_bits > 256 && !VM_Version::supports_avx512_vbmi())  {
+      } else if (bt == T_BYTE && size_in_bits >= 256 && !VM_Version::supports_avx512_vbmi())  {
         return false; // Implementation limitation
-      } else if (bt == T_SHORT && size_in_bits > 256 && !VM_Version::supports_avx512bw())  {
+      } else if (bt == T_SHORT && size_in_bits >= 256 && !VM_Version::supports_avx512bw())  {
         return false; // Implementation limitation
       }
       break;
@@ -7501,24 +7500,13 @@ instruct rearrangeB(vec dst, vec shuffle) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rearrangeB_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
+instruct rearrangeB_avx(vec dst, vec src, vec shuffle) %{
   predicate(vector_element_basic_type(n) == T_BYTE &&
             vector_length(n) == 32 && !VM_Version::supports_avx512_vbmi());
   match(Set dst (VectorRearrange src shuffle));
-  effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
-  format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
+  format %{ "vector_rearrange $dst, $shuffle, $src" %}
   ins_encode %{
-    assert(UseAVX >= 2, "required");
-    // Swap src into vtmp1
-    __ vperm2i128($vtmp1$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, 1);
-    // Shuffle swapped src to get entries from other 128 bit lane
-    __ vpshufb($vtmp1$$XMMRegister, $vtmp1$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
-    // Shuffle original src to get entries from self 128 bit lane
-    __ vpshufb($dst$$XMMRegister, $src$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
-    // Create a blend mask by setting high bits for entries coming from other lane in shuffle
-    __ vpaddb($vtmp2$$XMMRegister, $shuffle$$XMMRegister, ExternalAddress(vector_byte_shufflemask()), Assembler::AVX_256bit, $scratch$$Register);
-    // Perform the blend
-    __ vpblendvb($dst$$XMMRegister, $dst$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister, Assembler::AVX_256bit);
+    __ vpshufb($dst$$XMMRegister, $shuffle$$XMMRegister, $src$$XMMRegister, Assembler::AVX_256bit);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7539,40 +7527,26 @@ instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
 
 instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+            vector_length(n) <= 8 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
     // Create a byte shuffle mask from short shuffle mask
     // only byte shuffle instruction available on these platforms
-    int vlen_in_bytes = vector_length_in_bytes(this);
-    if (vlen_in_bytes <= 8) {
-      // Multiply each shuffle by two to get byte index
-      __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
-      __ psllw($vtmp$$XMMRegister, 1);
 
-      // Duplicate to create 2 copies of byte index
-      __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
-      __ psllw($dst$$XMMRegister, 8);
-      __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
+    // Multiply each shuffle by two to get byte index
+    __ pmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister);
+    __ psllw($vtmp$$XMMRegister, 1);
 
-      // Add one to get alternate byte index
-      __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
-      __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
-    } else {
-      int vlen_enc = vector_length_encoding(this);
-      // Multiply each shuffle by two to get byte index
-      __ vpmovzxbw($vtmp$$XMMRegister, $src$$XMMRegister, vlen_enc);
-      __ vpsllw($vtmp$$XMMRegister, $vtmp$$XMMRegister, 1, vlen_enc);
+    // Duplicate to create 2 copies of byte index
+    __ movdqu($dst$$XMMRegister, $vtmp$$XMMRegister);
+    __ psllw($dst$$XMMRegister, 8);
+    __ por($dst$$XMMRegister, $vtmp$$XMMRegister);
 
-      // Duplicate to create 2 copies of byte index
-      __ vpsllw($dst$$XMMRegister, $vtmp$$XMMRegister,  8, vlen_enc);
-      __ vpor($dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, vlen_enc);
-
-      // Add one to get alternate byte index
-      __ vpaddb($dst$$XMMRegister, $dst$$XMMRegister, ExternalAddress(vector_short_shufflemask()), vlen_enc, $scratch$$Register);
-    }
+    // Add one to get alternate byte index
+    __ movdqu($vtmp$$XMMRegister, ExternalAddress(vector_short_shufflemask()), $scratch$$Register);
+    __ paddb($dst$$XMMRegister, $vtmp$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7585,28 +7559,6 @@ instruct rearrangeS(vec dst, vec shuffle) %{
   ins_encode %{
     assert(UseSSE >= 4, "required");
     __ pshufb($dst$$XMMRegister, $shuffle$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rearrangeS_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) == 16 && !VM_Version::supports_avx512bw());
-  match(Set dst (VectorRearrange src shuffle));
-  effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
-  format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
-  ins_encode %{
-    assert(UseAVX >= 2, "required");
-    // Swap src into vtmp1
-    __ vperm2i128($vtmp1$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, 1);
-    // Shuffle swapped src to get entries from other 128 bit lane
-    __ vpshufb($vtmp1$$XMMRegister, $vtmp1$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
-    // Shuffle original src to get entries from self 128 bit lane
-    __ vpshufb($dst$$XMMRegister, $src$$XMMRegister, $shuffle$$XMMRegister, Assembler::AVX_256bit);
-    // Create a blend mask by setting high bits for entries coming from other lane in shuffle
-    __ vpaddb($vtmp2$$XMMRegister, $shuffle$$XMMRegister, ExternalAddress(vector_byte_shufflemask()), Assembler::AVX_256bit, $scratch$$Register);
-    // Perform the blend
-    __ vpblendvb($dst$$XMMRegister, $dst$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister, Assembler::AVX_256bit);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector slice(int origin) {
-        return (Byte128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte128Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte128Vector unslice(int origin) {
-        return (Byte128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte128Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector slice(int origin) {
-        return (Byte256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte256Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte256Vector unslice(int origin) {
-        return (Byte256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte256Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector slice(int origin) {
-        return (Byte512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte512Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte512Vector unslice(int origin) {
-        return (Byte512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte512Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector slice(int origin) {
-        return (Byte64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte64Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public Byte64Vector unslice(int origin) {
-        return (Byte64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Byte64Shuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector slice(int origin) {
-        return (ByteMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         ByteMaxShuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public ByteMaxVector unslice(int origin) {
-        return (ByteMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         ByteMaxShuffle Iota = iotaShuffle();
+         VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((byte)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1981,11 +1981,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     ByteVector sliceTemplate(int origin, Vector<Byte> v1) {
         ByteVector that = (ByteVector) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Byte> Iota = iotaShuffle();
-        VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return ((ByteVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        byte[] a0 = this.vec();
+        byte[] a1 = that.vec();
+        byte[] res = new byte[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -2007,17 +2010,6 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     public abstract
     ByteVector slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    ByteVector sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Byte> Iota = iotaShuffle();
-        VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2032,12 +2024,21 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     unsliceTemplate(int origin, Vector<Byte> w, int part) {
         ByteVector that = (ByteVector) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Byte> Iota = iotaShuffle();
-        VectorMask<Byte> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((byte)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return ((ByteVector)w).blend(this.rearrange(Iota), BlendMask);
+        byte[] slice = this.vec();
+        byte[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -2066,19 +2067,6 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     @Override
     public abstract
     ByteVector unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    ByteVector
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Byte> Iota = iotaShuffle();
-        VectorMask<Byte> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((byte)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector slice(int origin) {
-        return (Double128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double128Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double128Vector unslice(int origin) {
-        return (Double128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double128Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector slice(int origin) {
-        return (Double256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double256Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double256Vector unslice(int origin) {
-        return (Double256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double256Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector slice(int origin) {
-        return (Double512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double512Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double512Vector unslice(int origin) {
-        return (Double512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double512Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector slice(int origin) {
-        return (Double64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double64Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public Double64Vector unslice(int origin) {
-        return (Double64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Double64Shuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector slice(int origin) {
-        return (DoubleMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         DoubleMaxShuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((double)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public DoubleMaxVector unslice(int origin) {
-        return (DoubleMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         DoubleMaxShuffle Iota = iotaShuffle();
+         VectorMask<Double> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((double)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector slice(int origin) {
-        return (Float128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float128Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public Float128Vector unslice(int origin) {
-        return (Float128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float128Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector slice(int origin) {
-        return (Float256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float256Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public Float256Vector unslice(int origin) {
-        return (Float256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float256Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector slice(int origin) {
-        return (Float512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float512Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public Float512Vector unslice(int origin) {
-        return (Float512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float512Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector slice(int origin) {
-        return (Float64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float64Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public Float64Vector unslice(int origin) {
-        return (Float64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Float64Shuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,7 +381,14 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector slice(int origin) {
-        return (FloatMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         FloatMaxShuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -402,7 +409,14 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public FloatMaxVector unslice(int origin) {
-        return (FloatMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         FloatMaxShuffle Iota = iotaShuffle();
+         VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((float)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1906,11 +1906,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
     FloatVector sliceTemplate(int origin, Vector<Float> v1) {
         FloatVector that = (FloatVector) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Float> Iota = iotaShuffle();
-        VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return ((FloatVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        float[] a0 = this.vec();
+        float[] a1 = that.vec();
+        float[] res = new float[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -1932,17 +1935,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
     public abstract
     FloatVector slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    FloatVector sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Float> Iota = iotaShuffle();
-        VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((float)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1957,12 +1949,21 @@ public abstract class FloatVector extends AbstractVector<Float> {
     unsliceTemplate(int origin, Vector<Float> w, int part) {
         FloatVector that = (FloatVector) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Float> Iota = iotaShuffle();
-        VectorMask<Float> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((float)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return ((FloatVector)w).blend(this.rearrange(Iota), BlendMask);
+        float[] slice = this.vec();
+        float[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -1991,19 +1992,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     public abstract
     FloatVector unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    FloatVector
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Float> Iota = iotaShuffle();
-        VectorMask<Float> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((float)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector slice(int origin) {
-        return (Int128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int128Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public Int128Vector unslice(int origin) {
-        return (Int128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int128Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector slice(int origin) {
-        return (Int256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int256Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public Int256Vector unslice(int origin) {
-        return (Int256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int256Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector slice(int origin) {
-        return (Int512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int512Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public Int512Vector unslice(int origin) {
-        return (Int512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int512Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector slice(int origin) {
-        return (Int64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int64Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public Int64Vector unslice(int origin) {
-        return (Int64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Int64Shuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector slice(int origin) {
-        return (IntMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         IntMaxShuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public IntMaxVector unslice(int origin) {
-        return (IntMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         IntMaxShuffle Iota = iotaShuffle();
+         VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((int)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1980,11 +1980,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
     IntVector sliceTemplate(int origin, Vector<Integer> v1) {
         IntVector that = (IntVector) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Integer> Iota = iotaShuffle();
-        VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return ((IntVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        int[] a0 = this.vec();
+        int[] a1 = that.vec();
+        int[] res = new int[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -2006,17 +2009,6 @@ public abstract class IntVector extends AbstractVector<Integer> {
     public abstract
     IntVector slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    IntVector sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Integer> Iota = iotaShuffle();
-        VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((int)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2031,12 +2023,21 @@ public abstract class IntVector extends AbstractVector<Integer> {
     unsliceTemplate(int origin, Vector<Integer> w, int part) {
         IntVector that = (IntVector) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Integer> Iota = iotaShuffle();
-        VectorMask<Integer> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((int)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return ((IntVector)w).blend(this.rearrange(Iota), BlendMask);
+        int[] slice = this.vec();
+        int[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -2065,19 +2066,6 @@ public abstract class IntVector extends AbstractVector<Integer> {
     @Override
     public abstract
     IntVector unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    IntVector
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Integer> Iota = iotaShuffle();
-        VectorMask<Integer> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((int)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,14 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector slice(int origin) {
-        return (Long128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long128Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -398,7 +405,14 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public Long128Vector unslice(int origin) {
-        return (Long128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long128Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,14 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector slice(int origin) {
-        return (Long256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long256Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -398,7 +405,14 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public Long256Vector unslice(int origin) {
-        return (Long256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long256Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,14 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector slice(int origin) {
-        return (Long512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long512Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -398,7 +405,14 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public Long512Vector unslice(int origin) {
-        return (Long512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long512Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,14 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector slice(int origin) {
-        return (Long64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long64Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -398,7 +405,14 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public Long64Vector unslice(int origin) {
-        return (Long64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Long64Shuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,14 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector slice(int origin) {
-        return (LongMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         LongMaxShuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -398,7 +405,14 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public LongMaxVector unslice(int origin) {
-        return (LongMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         LongMaxShuffle Iota = iotaShuffle();
+         VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((long)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1851,11 +1851,14 @@ public abstract class LongVector extends AbstractVector<Long> {
     LongVector sliceTemplate(int origin, Vector<Long> v1) {
         LongVector that = (LongVector) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Long> Iota = iotaShuffle();
-        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return ((LongVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        long[] a0 = this.vec();
+        long[] a1 = that.vec();
+        long[] res = new long[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -1877,17 +1880,6 @@ public abstract class LongVector extends AbstractVector<Long> {
     public abstract
     LongVector slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    LongVector sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Long> Iota = iotaShuffle();
-        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -1902,12 +1894,21 @@ public abstract class LongVector extends AbstractVector<Long> {
     unsliceTemplate(int origin, Vector<Long> w, int part) {
         LongVector that = (LongVector) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Long> Iota = iotaShuffle();
-        VectorMask<Long> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((long)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return ((LongVector)w).blend(this.rearrange(Iota), BlendMask);
+        long[] slice = this.vec();
+        long[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -1936,19 +1937,6 @@ public abstract class LongVector extends AbstractVector<Long> {
     @Override
     public abstract
     LongVector unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    LongVector
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Long> Iota = iotaShuffle();
-        VectorMask<Long> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((long)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector slice(int origin) {
-        return (Short128Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short128Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public Short128Vector unslice(int origin) {
-        return (Short128Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short128Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector slice(int origin) {
-        return (Short256Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short256Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public Short256Vector unslice(int origin) {
-        return (Short256Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short256Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector slice(int origin) {
-        return (Short512Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short512Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public Short512Vector unslice(int origin) {
-        return (Short512Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short512Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector slice(int origin) {
-        return (Short64Vector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short64Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public Short64Vector unslice(int origin) {
-        return (Short64Vector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         Short64Shuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,14 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector slice(int origin) {
-        return (ShortMaxVector) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         ShortMaxShuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -408,7 +415,14 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public ShortMaxVector unslice(int origin) {
-        return (ShortMaxVector) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         ShortMaxShuffle Iota = iotaShuffle();
+         VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast((short)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1981,11 +1981,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
     ShortVector sliceTemplate(int origin, Vector<Short> v1) {
         ShortVector that = (ShortVector) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Short> Iota = iotaShuffle();
-        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return ((ShortVector)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        short[] a0 = this.vec();
+        short[] a1 = that.vec();
+        short[] res = new short[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -2007,17 +2010,6 @@ public abstract class ShortVector extends AbstractVector<Short> {
     public abstract
     ShortVector slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    ShortVector sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Short> Iota = iotaShuffle();
-        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2032,12 +2024,21 @@ public abstract class ShortVector extends AbstractVector<Short> {
     unsliceTemplate(int origin, Vector<Short> w, int part) {
         ShortVector that = (ShortVector) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Short> Iota = iotaShuffle();
-        VectorMask<Short> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((short)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return ((ShortVector)w).blend(this.rearrange(Iota), BlendMask);
+        short[] slice = this.vec();
+        short[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -2066,19 +2067,6 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @Override
     public abstract
     ShortVector unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    ShortVector
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<Short> Iota = iotaShuffle();
-        VectorMask<Short> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((short)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2250,11 +2250,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ sliceTemplate(int origin, Vector<$Boxtype$> v1) {
         $abstractvectortype$ that = ($abstractvectortype$) v1;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
-        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return (($abstractvectortype$)v1).rearrange(Iota).blend(this.rearrange(Iota), BlendMask);
+        $type$[] a0 = this.vec();
+        $type$[] a1 = that.vec();
+        $type$[] res = new $type$[a0.length];
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        System.arraycopy(a0, origin, res, 0, firstPart);
+        System.arraycopy(a1, 0, res, firstPart, origin);
+        return vectorFactory(res);
     }
 
     /**
@@ -2276,17 +2279,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     public abstract
     $abstractvectortype$ slice(int origin);
 
-    /*package-private*/
-    final
-    @ForceInline
-    $abstractvectortype$ sliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
-        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
-        Iota = iotaShuffle(origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
-
     /**
      * {@inheritDoc} <!--workaround-->
      */
@@ -2301,12 +2293,21 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     unsliceTemplate(int origin, Vector<$Boxtype$> w, int part) {
         $abstractvectortype$ that = ($abstractvectortype$) w;
         that.check(this);
-        Objects.checkIndex(origin, length());
-        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
-        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast(($type$)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return (($abstractvectortype$)w).blend(this.rearrange(Iota), BlendMask);
+        $type$[] slice = this.vec();
+        $type$[] res = that.vec().clone();
+        int vlen = res.length;
+        int firstPart = vlen - origin;
+        switch (part) {
+        case 0:
+            System.arraycopy(slice, 0, res, origin, firstPart);
+            break;
+        case 1:
+            System.arraycopy(slice, firstPart, res, 0, origin);
+            break;
+        default:
+            throw wrongPartForSlice(part);
+        }
+        return vectorFactory(res);
     }
 
     /*package-private*/
@@ -2335,19 +2336,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @Override
     public abstract
     $abstractvectortype$ unslice(int origin);
-
-    /*package-private*/
-    final
-    @ForceInline
-    $abstractvectortype$
-    unsliceTemplate(int origin) {
-        Objects.checkIndex(origin, length());
-        VectorShuffle<$Boxtype$> Iota = iotaShuffle();
-        VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast(($type$)(origin))));
-        Iota = iotaShuffle(-origin, 1, true);
-        return vspecies().zero().blend(this.rearrange(Iota), BlendMask);
-    }
 
     private ArrayIndexOutOfBoundsException
     wrongPartForSlice(int part) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,14 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ slice(int origin) {
-        return ($vectortype$) super.sliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         $shuffletype$ Iota = iotaShuffle();
+         VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(VLENGTH-origin))));
+         Iota = iotaShuffle(origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override
@@ -414,7 +421,14 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public $vectortype$ unslice(int origin) {
-        return ($vectortype$) super.unsliceTemplate(origin);  // specialize
+       if ((origin < 0) || (origin >= VLENGTH)) {
+         throw new ArrayIndexOutOfBoundsException("Index " + origin + " out of bounds for vector length " + VLENGTH);
+       } else {
+         $shuffletype$ Iota = iotaShuffle();
+         VectorMask<$Boxtype$> BlendMask = Iota.toVector().compare(VectorOperators.GE, (broadcast(($type$)(origin))));
+         Iota = iotaShuffle(-origin, 1, true);
+         return ZERO.blend(this.rearrange(Iota), BlendMask);
+       }
     }
 
     @Override


### PR DESCRIPTION
This reverts commit a6b2162f5400b4596afa5b88219c9cb55dcdb729.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Temporary failure when trying to retrieve information on issue `8259846`.


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2103/head:pull/2103`
`$ git checkout pull/2103`
