### PR TITLE
8258917: NativeMemoryTracking is handled by launcher inconsistenly

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -284,9 +284,8 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
                                jvmpath, sizeof(jvmpath),
                                jvmcfg,  sizeof(jvmcfg));
 
-    if (!IsJavaArgs()) {
-        SetJvmEnvironment(argc,argv);
-    }
+    /* Set env. Must be done before LoadJavaVM. */
+    SetJvmEnvironment(argc, argv);
 
     ifn.CreateJavaVM = 0;
     ifn.GetDefaultJavaVMInitArgs = 0;
@@ -806,6 +805,7 @@ static void
 SetJvmEnvironment(int argc, char **argv) {
 
     static const char*  NMT_Env_Name    = "NMT_LEVEL_";
+    const char* NMT_Arg_Name = IsJavaArgs() ? "-J-XX:NativeMemoryTracking=" : "-XX:NativeMemoryTracking=";
     int i;
     /* process only the launcher arguments */
     for (i = 0; i < argc; i++) {
@@ -835,10 +835,10 @@ SetJvmEnvironment(int argc, char **argv) {
          * The argument is passed to the JVM, which will check validity.
          * The JVM is responsible for removing the env variable.
          */
-        if (JLI_StrCCmp(arg, "-XX:NativeMemoryTracking=") == 0) {
+        if (JLI_StrCCmp(arg, NMT_Arg_Name) == 0) {
             int retval;
             // get what follows this parameter, include "="
-            size_t pnlen = JLI_StrLen("-XX:NativeMemoryTracking=");
+            size_t pnlen = JLI_StrLen(NMT_Arg_Name);
             if (JLI_StrLen(arg) > pnlen) {
                 char* value = arg + pnlen;
                 size_t pbuflen = pnlen + JLI_StrLen(value) + 10; // 10 max pid digits

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -817,8 +817,8 @@ SetJvmEnvironment(int argc, char **argv) {
          *   as -version or -h), or an argument that indicates the following
          *   arguments are for the application (i.e. the main class name, or
          *   the -jar argument).
-         * Non-java launchers:
-         *   All "-J" arguments are translated to VM args (see TranslateApplicationArgs).
+         * Other launchers (IsJavaArgs()):
+         *   All arguments have to be scanned to see if it is a -J argument.
          */
         if (!IsJavaArgs() && i > 0) {
             char *prev = argv[i - 1];

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -811,13 +811,16 @@ SetJvmEnvironment(int argc, char **argv) {
     for (i = 0; i < argc; i++) {
         char *arg = argv[i];
         /*
-         * Since this must be a VM flag we stop processing once we see
-         * an argument the launcher would not have processed beyond (such
-         * as -version or -h), or an argument that indicates the following
-         * arguments are for the application (i.e. the main class name, or
-         * the -jar argument).
+         * Java launcher (!IsJavaArgs()):
+         *   Since this must be a VM flag we stop processing once we see
+         *   an argument the launcher would not have processed beyond (such
+         *   as -version or -h), or an argument that indicates the following
+         *   arguments are for the application (i.e. the main class name, or
+         *   the -jar argument).
+         * Non-java launchers:
+         *   All "-J" arguments are translated to VM args (see TranslateApplicationArgs).
          */
-        if (i > 0) {
+        if (!IsJavaArgs() && i > 0) {
             char *prev = argv[i - 1];
             // skip non-dash arg preceded by class path specifiers
             if (*arg != '-' && IsWhiteSpaceOption(prev)) {

--- a/test/jdk/tools/launcher/TestSpecialArgs.java
+++ b/test/jdk/tools/launcher/TestSpecialArgs.java
@@ -254,8 +254,13 @@ public class TestSpecialArgs extends TestHelper {
 
     @Test
     void testNMTTools() throws FileNotFoundException {
-        // tools (non-java launchers) should handle NTM (no "wrong launcher" warning)
-        TestResult tr = doExec(jarCmd, "-J-XX:NativeMemoryTracking=summary", "--help");
+        TestResult tr;
+        // Tools (non-java launchers) should handle NTM (no "wrong launcher" warning).
+        tr = doExec(jarCmd, "-J-XX:NativeMemoryTracking=summary", "--help");
+        ensureNoWarnings(tr);
+
+        // And java terminal args (like "--help") don't stop "-J" args parsing.
+        tr = doExec(jarCmd, "--help", "-J-XX:NativeMemoryTracking=summary");
         ensureNoWarnings(tr);
     }
 

--- a/test/jdk/tools/launcher/TestSpecialArgs.java
+++ b/test/jdk/tools/launcher/TestSpecialArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7124089 7131021 8042469 8066185 8074373
+ * @bug 7124089 7131021 8042469 8066185 8074373 8258917
  * @summary Checks for Launcher special flags, such as MacOSX specific flags,
  *          and JVM NativeMemoryTracking flags.
  * @modules jdk.compiler
@@ -249,6 +249,13 @@ public class TestSpecialArgs extends TestHelper {
 
         // Make sure we handle correctly the module long form (--module=)
         tr = doExec(javaCmd, "-XX:NativeMemoryTracking=summary", "--module=jdk.compiler/com.sun.tools.javac.Main", "--help");
+        ensureNoWarnings(tr);
+    }
+
+    @Test
+    void testNMTTools() throws FileNotFoundException {
+        // tools (non-java launchers) should handle NTM (no "wrong launcher" warning)
+        TestResult tr = doExec(jarCmd, "-J-XX:NativeMemoryTracking=summary", "--help");
         ensureNoWarnings(tr);
     }
 


### PR DESCRIPTION
The fix adds NMT handling for non-java launchers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258917](https://bugs.openjdk.java.net/browse/JDK-8258917): NativeMemoryTracking is handled by launcher inconsistenly


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to 53e876e9737c2b35f477cce88386f51219d5573d


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2106/head:pull/2106`
`$ git checkout pull/2106`
