### PR TITLE
7146776: deadlock between URLStreamHandler.getHostAddress and file.Handler.openconnection

### DIFF
--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -810,10 +810,12 @@ public final class URL implements java.io.Serializable {
     }
 
     /**
-     * @return Returns the address of the host represented by this URL.
-     *         A {@link SecurityException} or an {@link UnknownHostException}
-     *         while getting the host address will result in this method returning
-     *         {@code null}
+     * Returns the address of the host represented by this URL.
+     * A {@link SecurityException} or an {@link UnknownHostException}
+     * while getting the host address will result in this method returning
+     * {@code null}
+     *
+     * @return an {@link InetAddress} representing the host
      */
     synchronized InetAddress getHostAddress() {
         if (hostAddress != null) {

--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ public final class URL implements java.io.Serializable {
      * The host's IP address, used in equals and hashCode.
      * Computed on demand. An uninitialized or unknown hostAddress is null.
      */
-    transient InetAddress hostAddress;
+    private transient InetAddress hostAddress;
 
     /**
      * The URLStreamHandler for this URL.
@@ -808,6 +808,29 @@ public final class URL implements java.io.Serializable {
             this.authority = authority;
         }
     }
+
+    /**
+     * @return Returns the address of the host represented by this URL.
+     *         A {@link SecurityException} or an {@link UnknownHostException}
+     *         while getting the host address will result in this method returning
+     *         {@code null}
+     */
+    synchronized InetAddress getHostAddress() {
+        if (hostAddress != null) {
+            return hostAddress;
+        }
+
+        if (host == null || host.isEmpty()) {
+            return null;
+        }
+        try {
+            hostAddress = InetAddress.getByName(host);
+        } catch (UnknownHostException | SecurityException ex) {
+            return null;
+        }
+        return hostAddress;
+    }
+
 
     /**
      * Gets the query part of this {@code URL}.

--- a/src/java.base/share/classes/java/net/URLStreamHandler.java
+++ b/src/java.base/share/classes/java/net/URLStreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -443,23 +443,8 @@ public abstract class URLStreamHandler {
      * IP address.
      * @since 1.3
      */
-    protected synchronized InetAddress getHostAddress(URL u) {
-        if (u.hostAddress != null)
-            return u.hostAddress;
-
-        String host = u.getHost();
-        if (host == null || host.isEmpty()) {
-            return null;
-        } else {
-            try {
-                u.hostAddress = InetAddress.getByName(host);
-            } catch (UnknownHostException ex) {
-                return null;
-            } catch (SecurityException se) {
-                return null;
-            }
-        }
-        return u.hostAddress;
+    protected InetAddress getHostAddress(URL u) {
+        return u.getHostAddress();
     }
 
     /**


### PR DESCRIPTION
As noted by the reporter in the comments of https://bugs.openjdk.java.net/browse/JDK-7146776, the `URLStreamHandler` in its `getHostAddress` is incorrectly synchronizing on the `URLStreamHandler` instance, instead of synchronizing on the `URL` instance that is being passed to that method.

The implementation of `URLStreamHandler#getHostAddress` checks for the (package private) `hostAddress` member of the passed `URL` and if it isn't set then does a DNS lookup to get the address and finally sets the `hostAddress` member of the `URL` to this returned address. The access to `hostAddress` of `URL` needs to be `synchronized` since it can be updated (in a different thread) in the `URL#set` methods.

The commit here removes the synchronization from the `URLStreamHandler#getHostAddress` and moves the entire implementation into a new (package private) `URL#getHostAddress` method and then calls this new method from the `URLStreamHandler#getHostAddress`. I decided to do it this way instead of just leaving the implementation in `URLStreamHandler#getHostAddress` and synchronizing on the passed `URL` instance, since IMO, this makes it much more easier to see (in one place within the `URL` class) what the synchronization requirements are when dealing with the `hostAddress`. Furthermore, this now allows the `hostAddress` to be made a `private` member (which I have done in this commit) instead of the previous package private access. I checked that no other code tries to access this package private `URL#hostAddress`.

I can't think of an easy way to add a jtreg test for this change, so I haven't added one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7146776](https://bugs.openjdk.java.net/browse/JDK-7146776): deadlock between URLStreamHandler.getHostAddress and file.Handler.openconnection


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2109/head:pull/2109`
`$ git checkout pull/2109`
