### PR TITLE
8259511: java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java failed with "RuntimeException: Test failed: 20 failure(s)"

### DIFF
--- a/test/jdk/java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java
@@ -388,7 +388,7 @@ public class TestMainKeyWindow
             MenuBar mb = new MenuBar();
             mb.add(new Menu("Hello"));
             frame.setMenuBar(mb);
-            frame.setBounds(400, 180, 1068, 821);
+            frame.setBounds(400, 180, 300, 300);
             frame.setVisible(true);
             frame.toFront();
             Thread.sleep(20_000);

--- a/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.c
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_setup(JNIEnv *env, jclass cl)
     JNF_COCOA_ENTER(env);
 
     void (^block)() = ^(){
-        NSScreen *mainScreen = [NSScreen mainScreen];
+        NSScreen *mainScreen = [[NSScreen screens] objectAtIndex:0];
         NSRect screenFrame = [mainScreen frame];
         NSRect frame = NSMakeRect(130, screenFrame.size.height - 280, 200, 100);
 
@@ -60,7 +60,7 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_setup(JNIEnv *env, jclass cl)
         colorPanel = [[NSColorPanel sharedColorPanel] retain];
         [colorPanel setReleasedWhenClosed: YES];
         colorPanel.restorable = NO;
-        [colorPanel setFrameTopLeftPoint: NSMakePoint(130, screenFrame.size.height - 300)];
+        [colorPanel setFrame:NSMakeRect(130, screenFrame.size.height - 500, 200, 200) display:NO];
         // Java coordinates are 100, 400
         [colorPanel makeKeyAndOrderFront: nil];
     };


### PR DESCRIPTION
This test failed on the system where the wrong resolution was used(too small). Looks like that resolution was set by one of the tests and was not reset back because of a misconfigured automatic system reboot. I have checked that the initial version of the test works fine on our "clean" systems. But would like to tweak the test anyway just in case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259511](https://bugs.openjdk.java.net/browse/JDK-8259511): java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java failed with "RuntimeException: Test failed: 20 failure(s)"


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2113/head:pull/2113`
`$ git checkout pull/2113`
