### PR TITLE
8249245: assert(((((JfrTraceIdBits::load(klass)) & ((JfrTraceIdEpoch::this_epoch_method_and_class_bits()))) != 0))) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.inline.hpp
@@ -83,7 +83,7 @@ inline traceid JfrTraceIdLoadBarrier::load(const Method* method) {
 inline traceid JfrTraceIdLoadBarrier::load(const Klass* klass, const Method* method) {
    assert(klass != NULL, "invariant");
    assert(method != NULL, "invariant");
-   if (METHOD_FLAG_NOT_USED_THIS_EPOCH(method)) {
+   if (should_tag(method)) {
      SET_METHOD_AND_CLASS_USED_THIS_EPOCH(klass);
      SET_METHOD_FLAG_USED_THIS_EPOCH(method);
      assert(METHOD_AND_CLASS_USED_THIS_EPOCH(klass), "invariant");
@@ -112,7 +112,7 @@ inline traceid JfrTraceIdLoadBarrier::load_leakp(const Klass* klass, const Metho
   assert(METHOD_AND_CLASS_USED_THIS_EPOCH(klass), "invariant");
   assert(method != NULL, "invariant");
   assert(klass == method->method_holder(), "invariant");
-  if (METHOD_FLAG_NOT_USED_THIS_EPOCH(method)) {
+  if (should_tag(method)) {
     // the method is already logically tagged, just like the klass,
     // but because of redefinition, the latest Method*
     // representation might not have a reified tag.


### PR DESCRIPTION
Greetings,

please help review this small adjustment. Full details in the bug.

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249245](https://bugs.openjdk.java.net/browse/JDK-8249245): assert(((((JfrTraceIdBits::load(klass)) & ((JfrTraceIdEpoch::this_epoch_method_and_class_bits()))) != 0))) failed: invariant


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2116/head:pull/2116`
`$ git checkout pull/2116`
