### PR TITLE
8013527: calling MethodHandles.lookup on itself leads to errors

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1155,7 +1155,7 @@ abstract class MethodHandleImpl {
             return null;
         }
         MethodHandle directMh = DirectMethodHandle.make(direct);
-        directMh = MethodHandles.insertArguments(directMh, 
+        directMh = MethodHandles.insertArguments(directMh,
                 directMh.type().parameterCount() - 1, /* last parameter */
                 callerClass);
         return new WrappedMember(directMh, mh.type(),

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -226,7 +226,7 @@ public class MethodHandleProxies {
     }
 
     private static MethodHandle bindCaller(MethodHandle target, Class<?> hostClass) {
-        return MethodHandleImpl.bindCaller(target, hostClass).withVarargs(target.isVarargsCollector());
+        return MethodHandleImpl.bindCaller(null, target, hostClass).withVarargs(target.isVarargsCollector());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -118,6 +118,10 @@ public class MethodHandles {
         return new Lookup(Reflection.getCallerClass());
     }
 
+    private static Lookup lookup(Class<?> caller) {
+        return new Lookup(caller);
+    }
+
     /**
      * This reflected$lookup method is the alternate implementation of
      * the lookup method when being invoked by reflection.
@@ -4008,7 +4012,7 @@ return mh1;
 
             assert boundCaller.hasFullPrivilegeAccess();
 
-            MethodHandle cbmh = MethodHandleImpl.bindCaller(mh, boundCaller.lookupClass);
+            MethodHandle cbmh = MethodHandleImpl.bindCaller(method, mh, boundCaller.lookupClass);
             // Note: caller will apply varargs after this step happens.
             return cbmh;
         }

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -478,8 +478,8 @@ public final class Constructor<T> extends Executable {
         Class<?> caller = override ? null : Reflection.getCallerClass();
         return newInstanceWithCaller(initargs, !override, caller);
     }
-    
-    private T newInstance(Object[] initargs, Class<?> caller) 
+
+    private T newInstance(Object[] initargs, Class<?> caller)
             throws InstantiationException, IllegalAccessException,
             InvocationTargetException{
         return newInstanceWithCaller(initargs, !override, caller);

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -478,6 +478,12 @@ public final class Constructor<T> extends Executable {
         Class<?> caller = override ? null : Reflection.getCallerClass();
         return newInstanceWithCaller(initargs, !override, caller);
     }
+    
+    private T newInstance(Object[] initargs, Class<?> caller) 
+            throws InstantiationException, IllegalAccessException,
+            InvocationTargetException{
+        return newInstanceWithCaller(initargs, !override, caller);
+    }
 
     /* package-private */
     T newInstanceWithCaller(Object[] args, boolean checkAccess, Class<?> caller)

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -417,7 +417,7 @@ class Field extends AccessibleObject implements Member {
         }
         return getFieldAccessor(obj).get(obj);
     }
-    
+
     private Object get(Object obj, Class<?> caller)
         throws IllegalArgumentException, IllegalAccessException
     {
@@ -503,7 +503,7 @@ class Field extends AccessibleObject implements Member {
         }
         return getFieldAccessor(obj).getByte(obj);
     }
-    
+
     private byte getByte(Object obj, Class<?> caller)
             throws IllegalArgumentException, IllegalAccessException
     {

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -417,6 +417,15 @@ class Field extends AccessibleObject implements Member {
         }
         return getFieldAccessor(obj).get(obj);
     }
+    
+    private Object get(Object obj, Class<?> caller)
+        throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).get(obj);
+    }
 
     /**
      * Gets the value of a static or instance {@code boolean} field.
@@ -452,6 +461,15 @@ class Field extends AccessibleObject implements Member {
         return getFieldAccessor(obj).getBoolean(obj);
     }
 
+    private boolean getBoolean(Object obj, Class<?> caller)
+        throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getBoolean(obj);
+    }
+
     /**
      * Gets the value of a static or instance {@code byte} field.
      *
@@ -481,6 +499,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getByte(obj);
+    }
+    
+    private byte getByte(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         return getFieldAccessor(obj).getByte(obj);
@@ -522,6 +549,15 @@ class Field extends AccessibleObject implements Member {
         return getFieldAccessor(obj).getChar(obj);
     }
 
+    private char getChar(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getChar(obj);
+    }
+
     /**
      * Gets the value of a static or instance field of type
      * {@code short} or of another primitive type convertible to
@@ -553,6 +589,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getShort(obj);
+    }
+
+    private short getShort(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         return getFieldAccessor(obj).getShort(obj);
@@ -594,6 +639,15 @@ class Field extends AccessibleObject implements Member {
         return getFieldAccessor(obj).getInt(obj);
     }
 
+    private int getInt(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getInt(obj);
+    }
+
     /**
      * Gets the value of a static or instance field of type
      * {@code long} or of another primitive type convertible to
@@ -625,6 +679,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getLong(obj);
+    }
+
+    private long getLong(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         return getFieldAccessor(obj).getLong(obj);
@@ -666,6 +729,15 @@ class Field extends AccessibleObject implements Member {
         return getFieldAccessor(obj).getFloat(obj);
     }
 
+    private float getFloat(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getFloat(obj);
+    }
+
     /**
      * Gets the value of a static or instance field of type
      * {@code double} or of another primitive type convertible to
@@ -697,6 +769,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        return getFieldAccessor(obj).getDouble(obj);
+    }
+
+    private double getDouble(Object obj, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         return getFieldAccessor(obj).getDouble(obj);
@@ -792,6 +873,15 @@ class Field extends AccessibleObject implements Member {
         getFieldAccessor(obj).set(obj, value);
     }
 
+    private void set(Object obj, Object value, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).set(obj, value);
+    }
+
     /**
      * Sets the value of a field as a {@code boolean} on the specified object.
      * This method is equivalent to
@@ -824,6 +914,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setBoolean(obj, z);
+    }
+
+    private void setBoolean(Object obj, boolean z, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         getFieldAccessor(obj).setBoolean(obj, z);
@@ -866,6 +965,15 @@ class Field extends AccessibleObject implements Member {
         getFieldAccessor(obj).setByte(obj, b);
     }
 
+    private void setByte(Object obj, byte b, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setByte(obj, b);
+    }
+
     /**
      * Sets the value of a field as a {@code char} on the specified object.
      * This method is equivalent to
@@ -898,6 +1006,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setChar(obj, c);
+    }
+
+    private void setChar(Object obj, char c, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         getFieldAccessor(obj).setChar(obj, c);
@@ -940,6 +1057,15 @@ class Field extends AccessibleObject implements Member {
         getFieldAccessor(obj).setShort(obj, s);
     }
 
+    private void setShort(Object obj, short s, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setShort(obj, s);
+    }
+
     /**
      * Sets the value of a field as an {@code int} on the specified object.
      * This method is equivalent to
@@ -972,6 +1098,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setInt(obj, i);
+    }
+
+    private void setInt(Object obj, int i, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         getFieldAccessor(obj).setInt(obj, i);
@@ -1014,6 +1149,15 @@ class Field extends AccessibleObject implements Member {
         getFieldAccessor(obj).setLong(obj, l);
     }
 
+    private void setLong(Object obj, long l, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setLong(obj, l);
+    }
+
     /**
      * Sets the value of a field as a {@code float} on the specified object.
      * This method is equivalent to
@@ -1051,6 +1195,15 @@ class Field extends AccessibleObject implements Member {
         getFieldAccessor(obj).setFloat(obj, f);
     }
 
+    private void setFloat(Object obj, float f, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setFloat(obj, f);
+    }
+
     /**
      * Sets the value of a field as a {@code double} on the specified object.
      * This method is equivalent to
@@ -1083,6 +1236,15 @@ class Field extends AccessibleObject implements Member {
     {
         if (!override) {
             Class<?> caller = Reflection.getCallerClass();
+            checkAccess(caller, obj);
+        }
+        getFieldAccessor(obj).setDouble(obj, d);
+    }
+
+    private void setDouble(Object obj, double d, Class<?> caller)
+            throws IllegalArgumentException, IllegalAccessException
+    {
+        if (!override) {
             checkAccess(caller, obj);
         }
         getFieldAccessor(obj).setDouble(obj, d);

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -566,6 +566,22 @@ public final class Method extends Executable {
         return ma.invoke(obj, args);
     }
 
+    private Object invoke(Object obj, Object[] args, Class<?> caller)
+        throws IllegalAccessException, IllegalArgumentException,
+            InvocationTargetException
+    {
+        if (!override) {
+            checkAccess(caller, clazz,
+                    Modifier.isStatic(modifiers) ? null : obj.getClass(),
+                    modifiers);
+        }
+        MethodAccessor ma = methodAccessor;            // read volatile
+        if (ma == null) {
+            ma = acquireMethodAccessor();
+        }
+        return ma.invoke(obj, args);
+    }
+
     /**
      * Returns {@code true} if this method is a bridge
      * method; returns {@code false} otherwise.

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -566,22 +566,6 @@ public final class Method extends Executable {
         return ma.invoke(obj, args);
     }
 
-    private Object invoke(Object obj, Object[] args, Class<?> caller)
-        throws IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException
-    {
-        if (!override) {
-            checkAccess(caller, clazz,
-                    Modifier.isStatic(modifiers) ? null : obj.getClass(),
-                    modifiers);
-        }
-        MethodAccessor ma = methodAccessor;            // read volatile
-        if (ma == null) {
-            ma = acquireMethodAccessor();
-        }
-        return ma.invoke(obj, args);
-    }
-
     /**
      * Returns {@code true} if this method is a bridge
      * method; returns {@code false} otherwise.


### PR DESCRIPTION
While this approach works, it has it's limitations, especially around `java.lang.reflect.Method.invoke`.

`Method.invoke` can in turn also call a `@CallerSensitive` method - which will ignore all frames associated with that reflective call.  
So, there needs to exist a frame that somewhat resembles the lookup class if MethodHandles are used to call `Method.invoke`.

For now, the old injected invoker mechanism is used for `Method.invoke`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8013527](https://bugs.openjdk.java.net/browse/JDK-8013527): calling MethodHandles.lookup on itself leads to errors


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2117/head:pull/2117`
`$ git checkout pull/2117`
