### PR TITLE
8259872: (fs) Use NtQueryDirectoryInformation instead of FindFirst/FindNext implementation of DirectoryStream (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileKey.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileKey.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.fs;
+
+/**
+ * Container for volume/file id to uniquely identify file.
+ */
+
+class WindowsFileKey {
+    private final int volSerialNumber;
+    private final long fileId;
+
+    WindowsFileKey(int volSerialNumber, long fileId) {
+        this.volSerialNumber = volSerialNumber;
+        this.fileId = fileId;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int)(volSerialNumber ^ (volSerialNumber >>> 16)) +
+               (int)(fileId ^ (fileId >>> 32));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+        if (!(obj instanceof WindowsFileKey))
+            return false;
+        WindowsFileKey other = (WindowsFileKey)obj;
+        return (this.volSerialNumber == other.volSerialNumber) && (this.fileId == other.fileId);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(volId=")
+          .append(Integer.toHexString(volSerialNumber))
+          .append(",fileId=")
+          .append(Long.toHexString(fileId))
+          .append(')');
+        return sb.toString();
+    }
+}

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -275,6 +275,38 @@ class WindowsNativeDispatcher {
      */
     static native void FindClose(long handle) throws WindowsException;
 
+    static QueryDirectoryInformation OpenNtQueryDirectoryInformation(String path, NativeBuffer buffer) throws WindowsException {
+        NativeBuffer pathBuffer = asNativeBuffer(path);
+        try {
+            QueryDirectoryInformation data = new QueryDirectoryInformation();
+            OpenNtQueryDirectoryInformation0(pathBuffer.address(), buffer.address(), buffer.size(), data);
+            return data;
+        } finally {
+            pathBuffer.release();
+        }
+    }
+    static class QueryDirectoryInformation {
+        private long handle;
+        private int volSerialNumber;
+
+        private QueryDirectoryInformation() { }
+        public long handle()         { return handle; }
+        public int volSerialNumber() { return volSerialNumber; }
+    }
+    private static native void OpenNtQueryDirectoryInformation0(long lpFileName, long buffer, int bufferSize, QueryDirectoryInformation obj)
+        throws WindowsException;
+
+    static boolean NextNtQueryDirectoryInformation(QueryDirectoryInformation data, NativeBuffer buffer) throws WindowsException {
+        return NextNtQueryDirectoryInformation0(data.handle(), buffer.address(), buffer.size());
+    }
+
+    private static native boolean NextNtQueryDirectoryInformation0(long handle, long buffer, int bufferSize)
+        throws WindowsException;
+
+    static void CloseNtQueryDirectoryInformation(QueryDirectoryInformation data) throws WindowsException {
+        CloseHandle(data.handle);
+    }
+
     /**
      * GetFileInformationByHandle(
      *   HANDLE hFile,

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -38,6 +38,8 @@
 #include "jni_util.h"
 #include "jlong.h"
 
+#include "ntifs_min.h"
+
 #include "sun_nio_fs_WindowsNativeDispatcher.h"
 
 /**
@@ -49,6 +51,9 @@ static jfieldID findFirst_attributes;
 
 static jfieldID findStream_handle;
 static jfieldID findStream_name;
+
+static jfieldID queryDirectoryInformation_handle;
+static jfieldID queryDirectoryInformation_volSerialNumber;
 
 static jfieldID volumeInfo_fsName;
 static jfieldID volumeInfo_volName;
@@ -71,6 +76,13 @@ static jfieldID completionStatus_error;
 static jfieldID completionStatus_bytesTransferred;
 static jfieldID completionStatus_completionKey;
 
+typedef NTSYSCALLAPI NTSTATUS(NTAPI* NtQueryDirectoryFile_Proc) (HANDLE, HANDLE, PIO_APC_ROUTINE,
+    PVOID, PIO_STATUS_BLOCK, PVOID, ULONG, FILE_INFORMATION_CLASS, BOOLEAN, PUNICODE_STRING, BOOLEAN);
+typedef ULONG(NTAPI* RtlNtStatusToDosError_Proc) (NTSTATUS);
+
+static NtQueryDirectoryFile_Proc NtQueryDirectoryFile_func;
+static RtlNtStatusToDosError_Proc RtlNtStatusToDosError_func;
+
 static void throwWindowsException(JNIEnv* env, DWORD lastError) {
     jobject x = JNU_NewObjectByName(env, "sun/nio/fs/WindowsException",
         "(I)V", lastError);
@@ -87,6 +99,7 @@ JNIEXPORT void JNICALL
 Java_sun_nio_fs_WindowsNativeDispatcher_initIDs(JNIEnv* env, jclass this)
 {
     jclass clazz;
+    HMODULE h;
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$FirstFile");
     CHECK_NULL(clazz);
@@ -103,6 +116,13 @@ Java_sun_nio_fs_WindowsNativeDispatcher_initIDs(JNIEnv* env, jclass this)
     CHECK_NULL(findStream_handle);
     findStream_name = (*env)->GetFieldID(env, clazz, "name", "Ljava/lang/String;");
     CHECK_NULL(findStream_name);
+
+    clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$QueryDirectoryInformation");
+    CHECK_NULL(clazz);
+    queryDirectoryInformation_handle = (*env)->GetFieldID(env, clazz, "handle", "J");
+    CHECK_NULL(queryDirectoryInformation_handle);
+    queryDirectoryInformation_volSerialNumber = (*env)->GetFieldID(env, clazz, "volSerialNumber", "I");;
+    CHECK_NULL(queryDirectoryInformation_volSerialNumber);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$VolumeInformation");
     CHECK_NULL(clazz);
@@ -148,6 +168,16 @@ Java_sun_nio_fs_WindowsNativeDispatcher_initIDs(JNIEnv* env, jclass this)
     CHECK_NULL(completionStatus_bytesTransferred);
     completionStatus_completionKey = (*env)->GetFieldID(env, clazz, "completionKey", "J");
     CHECK_NULL(completionStatus_completionKey);
+
+    // get handle to ntdll
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        L"ntdll.dll", &h) != 0)
+    {
+        NtQueryDirectoryFile_func =
+            (NtQueryDirectoryFile_Proc)GetProcAddress(h, "NtQueryDirectoryFile");
+        RtlNtStatusToDosError_func =
+            (RtlNtStatusToDosError_Proc)GetProcAddress(h, "RtlNtStatusToDosError");
+    }
 }
 
 JNIEXPORT jlong JNICALL
@@ -413,6 +443,118 @@ Java_sun_nio_fs_WindowsNativeDispatcher_FindClose(JNIEnv* env, jclass this,
     if (FindClose(h) == 0) {
         throwWindowsException(env, GetLastError());
     }
+}
+
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_OpenNtQueryDirectoryInformation0(JNIEnv* env, jclass this,
+    jlong address, jlong bufferAddress, jint bufferSize, jobject obj)
+{
+    LPCWSTR lpFileName = jlong_to_ptr(address);
+    BOOL ok;
+    BY_HANDLE_FILE_INFORMATION info;
+    HANDLE handle;
+    NTSTATUS status;
+    ULONG win32ErrorCode;
+    IO_STATUS_BLOCK ioStatusBlock;
+
+    if ((NtQueryDirectoryFile_func == NULL) || (RtlNtStatusToDosError_func == NULL)) {
+        JNU_ThrowInternalError(env, "Should not get here");
+        return;
+    }
+
+    handle = CreateFileW(lpFileName, FILE_LIST_DIRECTORY,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (handle == INVALID_HANDLE_VALUE) {
+        throwWindowsException(env, GetLastError());
+        return;
+    }
+
+    status = NtQueryDirectoryFile_func(
+        handle, // FileHandle
+        NULL, // Event
+        NULL, // ApcRoutine
+        NULL, // ApcContext
+        &ioStatusBlock, // IoStatusBlock
+        jlong_to_ptr(bufferAddress), // FileInformation
+        bufferSize, // Length
+        FileIdFullDirectoryInformation, // FileInformationClass
+        FALSE, // ReturnSingleEntry
+        NULL, // FileName
+        FALSE); // RestartScan
+
+    if (!NT_SUCCESS(status)) {
+        /*
+        * NtQueryDirectoryFile returns STATUS_INVALID_PARAMETER when
+        * asked to enumerate an invalid directory (ie it is a file
+        * instead of a directory).  Verify that is the actual cause
+        * of the error.
+        */
+        if (status == STATUS_INVALID_PARAMETER) {
+            DWORD attributes = GetFileAttributesW(lpFileName);
+            if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+                status = STATUS_NOT_A_DIRECTORY;
+            }
+        }
+
+        win32ErrorCode = RtlNtStatusToDosError_func(status);
+        throwWindowsException(env, win32ErrorCode);
+        CloseHandle(handle);
+        return;
+    }
+
+    // This call allows retrieving the volume ID of this directory (and all its entries)
+    ok = GetFileInformationByHandle(handle, &info);
+    if (!ok) {
+        throwWindowsException(env, GetLastError());
+        CloseHandle(handle);
+        return;
+    }
+
+    (*env)->SetLongField(env, obj, queryDirectoryInformation_handle, ptr_to_jlong(handle));
+    (*env)->SetIntField(env, obj, queryDirectoryInformation_volSerialNumber, info.dwVolumeSerialNumber);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_NextNtQueryDirectoryInformation0(JNIEnv* env, jclass this,
+    jlong handle, jlong address, jint size)
+{
+    HANDLE h = (HANDLE)jlong_to_ptr(handle);
+    ULONG win32ErrorCode;
+    IO_STATUS_BLOCK ioStatusBlock;
+    NTSTATUS status;
+
+    if ((NtQueryDirectoryFile_func == NULL) || (RtlNtStatusToDosError_func == NULL)) {
+        JNU_ThrowInternalError(env, "Should not get here");
+        return JNI_FALSE;
+    }
+
+    status = NtQueryDirectoryFile_func(
+        h, // FileHandle
+        NULL, // Event
+        NULL, // ApcRoutine
+        NULL, // ApcContext
+        &ioStatusBlock, // IoStatusBlock
+        jlong_to_ptr(address), // FileInformation
+        size, // Length
+        FileIdFullDirectoryInformation, // FileInformationClass
+        FALSE, // ReturnSingleEntry
+        NULL, // FileName
+        FALSE); // RestartScan
+
+    if (NT_SUCCESS(status)) {
+        return JNI_TRUE;
+    }
+
+    // Normal completion: no more files in directory
+    if (status == STATUS_NO_MORE_FILES) {
+        return JNI_FALSE;
+    }
+
+    win32ErrorCode = RtlNtStatusToDosError_func(status);
+    throwWindowsException(env, win32ErrorCode);
+    return JNI_FALSE;
 }
 
 

--- a/src/java.base/windows/native/libnio/fs/ntifs_min.h
+++ b/src/java.base/windows/native/libnio/fs/ntifs_min.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef _NTIFS_MIN_
+#define _NTIFS_MIN_
+
+/*
+ * Copy necessary structures and definitions out of the Windows DDK
+ * to enable calling NtQueryDirectoryFile()
+ */
+
+typedef LONG NTSTATUS;
+#define NT_SUCCESS(Status)  (((NTSTATUS)(Status)) >= 0)
+
+typedef struct _UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWCH   Buffer;
+} UNICODE_STRING;
+typedef UNICODE_STRING *PUNICODE_STRING;
+typedef const UNICODE_STRING *PCUNICODE_STRING;
+
+typedef enum _FILE_INFORMATION_CLASS {
+    FileDirectoryInformation = 1,
+    FileFullDirectoryInformation,
+    FileBothDirectoryInformation,
+    FileBasicInformation,
+    FileStandardInformation,
+    FileInternalInformation,
+    FileEaInformation,
+    FileAccessInformation,
+    FileNameInformation,
+    FileRenameInformation,
+    FileLinkInformation,
+    FileNamesInformation,
+    FileDispositionInformation,
+    FilePositionInformation,
+    FileFullEaInformation,
+    FileModeInformation,
+    FileAlignmentInformation,
+    FileAllInformation,
+    FileAllocationInformation,
+    FileEndOfFileInformation,
+    FileAlternateNameInformation,
+    FileStreamInformation,
+    FilePipeInformation,
+    FilePipeLocalInformation,
+    FilePipeRemoteInformation,
+    FileMailslotQueryInformation,
+    FileMailslotSetInformation,
+    FileCompressionInformation,
+    FileObjectIdInformation,
+    FileCompletionInformation,
+    FileMoveClusterInformation,
+    FileQuotaInformation,
+    FileReparsePointInformation,
+    FileNetworkOpenInformation,
+    FileAttributeTagInformation,
+    FileTrackingInformation,
+    FileIdBothDirectoryInformation,
+    FileIdFullDirectoryInformation,
+    FileValidDataLengthInformation,
+    FileShortNameInformation,
+    FileIoCompletionNotificationInformation,
+    FileIoStatusBlockRangeInformation,
+    FileIoPriorityHintInformation,
+    FileSfioReserveInformation,
+    FileSfioVolumeInformation,
+    FileHardLinkInformation,
+    FileProcessIdsUsingFileInformation,
+    FileNormalizedNameInformation,
+    FileNetworkPhysicalNameInformation,
+    FileIdGlobalTxDirectoryInformation,
+    FileIsRemoteDeviceInformation,
+    FileAttributeCacheInformation,
+    FileNumaNodeInformation,
+    FileStandardLinkInformation,
+    FileRemoteProtocolInformation,
+    FileMaximumInformation
+} FILE_INFORMATION_CLASS, *PFILE_INFORMATION_CLASS;
+
+typedef struct _FILE_ID_FULL_DIR_INFORMATION {
+    ULONG         NextEntryOffset;
+    ULONG         FileIndex;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER EndOfFile;
+    LARGE_INTEGER AllocationSize;
+    ULONG         FileAttributes;
+    ULONG         FileNameLength;
+    ULONG         EaSize;
+    LARGE_INTEGER FileId;
+    WCHAR         FileName[1];
+} FILE_ID_FULL_DIR_INFORMATION, *PFILE_ID_FULL_DIR_INFORMATION;
+
+typedef struct _IO_STATUS_BLOCK {
+    union {
+        NTSTATUS Status;
+        PVOID Pointer;
+    } u;
+    ULONG_PTR Information;
+} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
+
+typedef VOID
+(NTAPI *PIO_APC_ROUTINE)(
+    IN PVOID ApcContext,
+    IN PIO_STATUS_BLOCK IoStatusBlock,
+    IN ULONG Reserved);
+
+NTSYSCALLAPI
+NTSTATUS
+NTAPI
+NtQueryDirectoryFile(
+    _In_ HANDLE FileHandle,
+    _In_opt_ HANDLE Event,
+    _In_opt_ PIO_APC_ROUTINE ApcRoutine,
+    _In_opt_ PVOID ApcContext,
+    _Out_ PIO_STATUS_BLOCK IoStatusBlock,
+    _Out_ PVOID FileInformation,
+    _In_ ULONG Length,
+    _In_ FILE_INFORMATION_CLASS FileInformationClass,
+    _In_ BOOLEAN ReturnSingleEntry,
+    _In_opt_ PUNICODE_STRING FileName,
+    _In_ BOOLEAN RestartScan
+);
+
+ULONG
+NTAPI
+RtlNtStatusToDosError(
+    NTSTATUS Status
+);
+
+#define STATUS_NO_MORE_FILES             ((NTSTATUS)0x80000006L)
+#define STATUS_NOT_A_DIRECTORY           ((NTSTATUS)0xC0000103L)
+
+#endif  // _NTIFS_MIN_


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259872](https://bugs.openjdk.java.net/browse/JDK-8259872): (fs) Use NtQueryDirectoryInformation  instead of FindFirst/FindNext implementation of DirectoryStream (win)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2122/head:pull/2122`
`$ git checkout pull/2122`
