### PR TITLE
8259679: GitHub actions should use MSVC 14.28

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1022,7 +1022,7 @@ jobs:
         run: >
           Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
           'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet
-          --add Microsoft.VisualStudio.Component.VC.14.27.x86.x64'
+          --add Microsoft.VisualStudio.Component.VC.14.28.x86.x64'
 
       - name: Configure
         run: >
@@ -1033,7 +1033,7 @@ jobs:
           $env:GTEST = cygpath "$env:GITHUB_WORKSPACE/gtest" ;
           & bash configure
           --with-conf-name=windows-x64
-          --with-msvc-toolset-version=14.27
+          --with-msvc-toolset-version=14.28
           ${{ matrix.flags }}
           --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA"
           --with-version-build=0


### PR DESCRIPTION
Current Windows GH Actions fails with:

```
configure: using /cygdrive/c/progra~2/micros~1/2019/Enterprise/vc/auxiliary/build/vcvarsx86_amd64.bat
configure: Setting extracted environment variables for x86_64
checking that Visual Studio variables have been correctly extracted... ok
checking for cl... [not found]
configure: error: Could not find a C compiler.
configure exiting with result code 1
```

I managed to figure out that MSVC build 14.27 is not really available. 14.28 is available instead. Note that Windows AArch64 build block already uses 14.28 in the same manner, so this change not only fixes the GH actions, it also keeps both blocks consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259679](https://bugs.openjdk.java.net/browse/JDK-8259679): GitHub actions should use MSVC 14.28


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2126/head:pull/2126`
`$ git checkout pull/2126`
