### PR TITLE
8259925: [Vector API] Unreasonable IndexOutOfBoundsException message when length < vlen

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -71,7 +71,7 @@ import java.util.Objects;
         switch (VectorIntrinsics.VECTOR_ACCESS_OOB_CHECK) {
             case 0: return ix; // no range check
             case 1: return Objects.checkFromIndexSize(ix, vlen, length);
-            case 2: return Objects.checkIndex(ix, length - (vlen - 1));
+            case 2: return Objects.checkIndex(ix, Math.max(0, length - (vlen - 1)));
             default: throw new InternalError();
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -70,8 +70,14 @@ import java.util.Objects;
     static int checkFromIndexSize(int ix, int vlen, int length) {
         switch (VectorIntrinsics.VECTOR_ACCESS_OOB_CHECK) {
             case 0: return ix; // no range check
-            case 1: return Objects.checkFromIndexSize(ix, vlen, length);
-            case 2: return Objects.checkIndex(ix, Math.max(0, length - (vlen - 1)));
+            case 1: // fall-through
+            case 2:
+                if (ix < 0 || ix > length - vlen) {
+                    String msg = String.format("Range [%d, %d + %d) out of bounds for length %d",
+                                                ix, ix, vlen, length);
+                    throw new IndexOutOfBoundsException(msg);
+                }
+                return ix;
             default: throw new InternalError();
         }
     }


### PR DESCRIPTION
Hi all,

For this reproducer:

```
import jdk.incubator.vector.ByteVector;
import jdk.incubator.vector.VectorSpecies;

public class Test {
    static final VectorSpecies<Byte> SPECIES_128 = ByteVector.SPECIES_128;
    static byte[] a = new byte[8];
    static byte[] b = new byte[8];

    public static void main(String[] args) {
        ByteVector av = ByteVector.fromArray(SPECIES_128, a, 0);
        av.intoArray(b, 0);
        System.out.println("b: " + b[0]);
    }
}
```

The following IndexOutOfBoundsException message (length -7) is unreasonable.

```
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length -7
```

It might be better to fix it like this.

```
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259925](https://bugs.openjdk.java.net/browse/JDK-8259925): [Vector API] Unreasonable IndexOutOfBoundsException message when length < vlen


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2127/head:pull/2127`
`$ git checkout pull/2127`
