### PR TITLE
8259924: GitHub actions fail on Linux x86_32 with "Could not configure libc6:i386"

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -632,12 +632,14 @@ jobs:
 
       # Roll in the multilib environment and its dependencies.
       # Some multilib libraries do not have proper inter-dependencies, so we have to
-      # install their dependencies manually.
+      # install their dependencies manually. Additionally, installing libc6 libraries
+      # ahead of the bulk of other packages solves potential circularity problems.
       - name: Install dependencies
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install gcc-10-multilib g++-10-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo apt-get install gcc-10-multilib g++-10-multilib libc6:i386 libc6-dev:i386
+          sudo apt-get install libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure


### PR DESCRIPTION
When `libc6*:i386` packages are installed as the dependency of other packages, they seem to run into configure problems. It helps to install them ahead of the bulk of the packages to resolve this.

Current Linux x86 jobs fail like this:

```
E: Could not configure 'libc6:i386'.
E: Could not perform immediate configuration on 'libgcc-s1:i386'. Please see man 5 apt.conf under APT::Immediate-Configure for details. (2)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259924](https://bugs.openjdk.java.net/browse/JDK-8259924): GitHub actions fail on Linux x86_32 with "Could not configure libc6:i386"


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2128/head:pull/2128`
`$ git checkout pull/2128`
