### PR TITLE
8259851: Use boolean type for tasks in SubTasksDone

### DIFF
--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -353,7 +353,7 @@ void WorkGangBarrierSync::abort() {
 
 SubTasksDone::SubTasksDone(uint n) :
   _tasks(NULL), _n_tasks(n), _threads_completed(0) {
-  _tasks = NEW_C_HEAP_ARRAY(uint, n, mtInternal);
+  _tasks = NEW_C_HEAP_ARRAY(bool, n, mtInternal);
   clear();
 }
 
@@ -363,7 +363,7 @@ bool SubTasksDone::valid() {
 
 void SubTasksDone::clear() {
   for (uint i = 0; i < _n_tasks; i++) {
-    _tasks[i] = 0;
+    _tasks[i] = false;
   }
   _threads_completed = 0;
 }
@@ -374,7 +374,7 @@ void SubTasksDone::all_tasks_completed_impl(uint n_threads,
 #ifdef ASSERT
   // all non-skipped tasks are claimed
   for (uint i = 0; i < _n_tasks; ++i) {
-    if (_tasks[i] == 0) {
+    if (!_tasks[i]) {
       auto is_skipped = false;
       for (size_t j = 0; j < skipped_size; ++j) {
         if (i == skipped[j]) {
@@ -389,7 +389,7 @@ void SubTasksDone::all_tasks_completed_impl(uint n_threads,
   for (size_t i = 0; i < skipped_size; ++i) {
     auto task_index = skipped[i];
     assert(task_index < _n_tasks, "Array in range.");
-    assert(_tasks[task_index] == 0, "%d is both claimed and skipped.", task_index);
+    assert(!_tasks[task_index], "%d is both claimed and skipped.", task_index);
   }
 #endif
   uint observed = _threads_completed;
@@ -407,17 +407,11 @@ void SubTasksDone::all_tasks_completed_impl(uint n_threads,
 
 bool SubTasksDone::try_claim_task(uint t) {
   assert(t < _n_tasks, "bad task id.");
-  uint old = _tasks[t];
-  if (old == 0) {
-    old = Atomic::cmpxchg(&_tasks[t], 0u, 1u);
-  }
-  bool res = old == 0;
-  return res;
+  return !_tasks[t] && !Atomic::cmpxchg(&_tasks[t], false, true);
 }
 
-
 SubTasksDone::~SubTasksDone() {
-  FREE_C_HEAP_ARRAY(uint, _tasks);
+  FREE_C_HEAP_ARRAY(bool, _tasks);
 }
 
 // *** SequentialSubTasksDone

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -302,7 +302,7 @@ public:
 // enumeration type.
 
 class SubTasksDone: public CHeapObj<mtInternal> {
-  volatile uint* _tasks;
+  volatile bool* _tasks;
   uint _n_tasks;
   volatile uint _threads_completed;
 


### PR DESCRIPTION
Changing `uint` to `bool` in `SubTasksDone`, since atomic operations on `bool` are well supported.

Tested: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259851](https://bugs.openjdk.java.net/browse/JDK-8259851): Use boolean type for tasks in SubTasksDone


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2131/head:pull/2131`
`$ git checkout pull/2131`
