### PR TITLE
8259928: compiler/jvmci tests fail with -Xint

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -379,18 +379,13 @@ public class VMProps implements Callable<Map<String, String>> {
             case Parallel:
             case G1:
                 // These GCs are supported with AOT
-                break;
+                return "true";
             default:
-                // Every other GC is not supported
-                return "false";
+                break;
         }
 
-        // AOT needs JVMCI compiler, which is not available in interpreter mode
-        if (vmCompMode().equals("Xint")) {
-            return "false";
-        }
-
-        return "true";
+        // Every other GC is not supported
+        return "false";
     }
 
     /*

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -244,6 +244,11 @@ public class VMProps implements Callable<Map<String, String>> {
           return "false";
         }
 
+        // Interpreted mode cannot enable JVMCI
+        if (vmCompMode().equals("Xint")) {
+          return "false";
+        }
+
         return "true";
     }
 
@@ -374,13 +379,18 @@ public class VMProps implements Callable<Map<String, String>> {
             case Parallel:
             case G1:
                 // These GCs are supported with AOT
-                return "true";
-            default:
                 break;
+            default:
+                // Every other GC is not supported
+                return "false";
         }
 
-        // Every other GC is not supported
-        return "false";
+        // AOT needs JVMCI compiler, which is not available in interpreter mode
+        if (vmCompMode().equals("Xint")) {
+            return "false";
+        }
+
+        return "true";
     }
 
     /*


### PR DESCRIPTION
I was getting Zero VM close to run tier1, and before that I wanted to see that tier{1,2} pass with -Xint. Some test are failing due to timeouts, but compiler/jvmci tests cannot run with -Xint at all. (Zero avoids this by not having VM feature flags "jvmci").

If you run the VM with `-Xint` and JVMCI, this would happen:

```
$ build/linux-x86_64-server-fastdebug/images/jdk/bin/java -Xint -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
OpenJDK 64-Bit Server VM warning: JVMCI Compiler disabled due to -Xint.
```

Additional testing:
 - [x] `compiler/jvmci` with `TEST_VM_OPTS=-Xint` (now disabled)
 - [x] `compiler/jvmci` with default options (still run and pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259928](https://bugs.openjdk.java.net/browse/JDK-8259928): compiler/jvmci tests fail with -Xint


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2132/head:pull/2132`
`$ git checkout pull/2132`
