### PR TITLE
8259942: Enable customizations in CompileJavaModules.gmk and Main.gmk

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -86,7 +86,7 @@ CreateHkTargets = \
 ################################################################################
 # Include module specific build settings
 
--include $(TOPDIR)/make/modules/$(MODULE)/Java.gmk
+-include Java.gmk
 
 ################################################################################
 # Setup the main compilation

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -187,6 +187,7 @@ JAVA_TARGETS := $(addsuffix -java, $(JAVA_MODULES))
 define DeclareCompileJavaRecipe
   $1-java:
 	+($(CD) $(TOPDIR)/make && $(MAKE) $(MAKE_ARGS) \
+	$(patsubst %,-I%/modules/$1,$(PHASE_MAKEDIRS)) \
 	    -f CompileJavaModules.gmk MODULE=$1)
 endef
 

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -150,9 +150,7 @@ define DeclareRecipeForModuleMakefile
   $2-$$($1_TARGET_SUFFIX):
 	+($(CD) $(TOPDIR)/make && $(MAKE) $(MAKE_ARGS) \
 	    -f ModuleWrapper.gmk -I $$(TOPDIR)/make/common/modules  \
-	    $$(addprefix -I, $$(PHASE_MAKEDIRS) \
-	        $$(addsuffix /modules/$2, $$(PHASE_MAKEDIRS)) \
-	    ) \
+	    $$(patsubst %,-I%/modules/$2,$$(PHASE_MAKEDIRS)) \
 	    MODULE=$2 MAKEFILE_PREFIX=$$($1_FILE_PREFIX) $$($1_EXTRA_ARGS))
 
 endef


### PR DESCRIPTION
Ensure make files look on the include path or in PHASE_MAKEDIRS for
customizations.

Change also adds a tidy-up that improves readability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259942](https://bugs.openjdk.java.net/browse/JDK-8259942): Enable customizations in CompileJavaModules.gmk and Main.gmk


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2134/head:pull/2134`
`$ git checkout pull/2134`
