### PR TITLE
8239894: Xserver crashes when the wrong high refresh rate is used

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -386,7 +386,10 @@ public final class X11GraphicsDevice extends GraphicsDevice
 
     @Override
     public synchronized DisplayMode[] getDisplayModes() {
-        if (!isFullScreenSupported()) {
+        if (!isFullScreenSupported()
+                || ((X11GraphicsEnvironment) GraphicsEnvironment
+                            .getLocalGraphicsEnvironment()).runningXinerama()) {
+            // only the current mode will be returned
             return super.getDisplayModes();
         }
         ArrayList<DisplayMode> modes = new ArrayList<DisplayMode>();

--- a/src/java.desktop/unix/native/common/awt/systemscale/systemScale.c
+++ b/src/java.desktop/unix/native/common/awt/systemscale/systemScale.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,169 +24,7 @@
  */
 
 #include "systemScale.h"
-#include "jni.h"
-#include "jni_util.h"
-#include "jvm_md.h"
-#include <dlfcn.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-
-typedef void* g_settings_schema_source_get_default();
-typedef void* g_settings_schema_source_ref(void *);
-typedef void g_settings_schema_source_unref(void *);
-typedef void* g_settings_schema_source_lookup(void *, char *, int);
-typedef int g_settings_schema_has_key(void *, char *);
-typedef void* g_settings_new_full(void *, void *, char *);
-typedef void* g_settings_get_value(void *, char *);
-typedef int g_variant_is_of_type(void *, char *);
-typedef unsigned long g_variant_n_children(void *);
-typedef void* g_variant_get_child_value(void *, unsigned long);
-typedef void  g_variant_unref(void *);
-typedef char*  g_variant_get_string(void *, unsigned long *);
-typedef int  g_variant_get_int32(void *);
-typedef double  g_variant_get_double(void *);
-
-static g_settings_schema_has_key* fp_g_settings_schema_has_key;
-static g_settings_new_full* fp_g_settings_new_full;
-static g_settings_get_value* fp_g_settings_get_value;
-static g_variant_is_of_type* fp_g_variant_is_of_type;
-static g_variant_n_children* fp_g_variant_n_children;
-static g_variant_get_child_value* fp_g_variant_get_child_value;
-static g_variant_get_string* fp_g_variant_get_string;
-static g_variant_get_int32* fp_g_variant_get_int32;
-static g_variant_get_double* fp_g_variant_get_double;
-static g_variant_unref* fp_g_variant_unref;
-
-static void* get_schema_value(char *name, char *key) {
-    static void *lib_handle;
-    static int initialized = 0;
-    static void * default_schema;
-    static g_settings_schema_source_lookup* schema_lookup;
-    void *schema = NULL, *fp = NULL;
-    if (!initialized) {
-        initialized = 1;
-        lib_handle = dlopen(JNI_LIB_NAME("gio-2.0"), RTLD_GLOBAL | RTLD_LAZY);
-        if (!lib_handle) {
-            CHECK_NULL_RETURN(lib_handle =
-                          dlopen(VERSIONED_JNI_LIB_NAME("gio-2.0", "0"),
-                                                RTLD_GLOBAL | RTLD_LAZY), NULL);
-        }
-        CHECK_NULL_RETURN(fp_g_settings_schema_has_key =
-                          (g_settings_schema_has_key*)
-                          dlsym(lib_handle, "g_settings_schema_has_key"), NULL);
-        CHECK_NULL_RETURN(fp_g_settings_new_full =
-                          (g_settings_new_full*)
-                          dlsym(lib_handle, "g_settings_new_full"), NULL);
-        CHECK_NULL_RETURN(fp_g_settings_get_value =
-                          (g_settings_get_value*)
-                          dlsym(lib_handle, "g_settings_get_value"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_is_of_type =
-                          (g_variant_is_of_type*)
-                          dlsym(lib_handle, "g_variant_is_of_type"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_n_children =
-                          (g_variant_n_children*)
-                          dlsym(lib_handle, "g_variant_n_children"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_get_child_value =
-                          (g_variant_get_child_value*)
-                          dlsym(lib_handle, "g_variant_get_child_value"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_get_string =
-                          (g_variant_get_string*)
-                          dlsym(lib_handle, "g_variant_get_string"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_get_int32 =
-                          (g_variant_get_int32*)
-                          dlsym(lib_handle, "g_variant_get_int32"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_get_double =
-                          (g_variant_get_double*)
-                          dlsym(lib_handle, "g_variant_get_double"), NULL);
-        CHECK_NULL_RETURN(fp_g_variant_unref =
-                          (g_variant_unref*)
-                          dlsym(lib_handle, "g_variant_unref"), NULL);
-
-        fp = dlsym(lib_handle, "g_settings_schema_source_get_default");
-        if (fp) {
-            default_schema = ((g_settings_schema_source_get_default*)fp)();
-        }
-        if (default_schema) {
-            fp = dlsym(lib_handle, "g_settings_schema_source_ref");
-            if (fp) {
-                ((g_settings_schema_source_ref*)fp)(default_schema);
-            }
-        }
-        schema_lookup = (g_settings_schema_source_lookup*)
-                           dlsym(lib_handle, "g_settings_schema_source_lookup");
-    }
-
-    if (!default_schema || !schema_lookup) {
-        return NULL;
-    }
-
-    schema = schema_lookup(default_schema, name, 1);
-    if (schema) {
-        if (fp_g_settings_schema_has_key(schema, key)) {
-            void *settings = fp_g_settings_new_full(schema, NULL, NULL);
-            if (settings) {
-                return fp_g_settings_get_value(settings, key);
-            }
-        }
-    }
-    return NULL;
-}
-
-
-static double getDesktopScale(char *output_name) {
-    double result = -1;
-    if(output_name) {
-        void *value = get_schema_value("com.ubuntu.user-interface",
-                                                                "scale-factor");
-        if (value) {
-            if(fp_g_variant_is_of_type(value, "a{si}")) {
-                int num = fp_g_variant_n_children(value);
-                int i = 0;
-                while (i < num) {
-                    void *entry = fp_g_variant_get_child_value(value, i++);
-                    if (entry) {
-                        void *screen = fp_g_variant_get_child_value(entry, 0);
-                        void *scale = fp_g_variant_get_child_value(entry, 1);
-                        if (screen && scale) {
-                            char *name = fp_g_variant_get_string(screen, NULL);
-                            if (name && !strcmp(name, output_name)) {
-                                result = fp_g_variant_get_int32(scale) / 8.;
-                            }
-                            fp_g_variant_unref(screen);
-                            fp_g_variant_unref(scale);
-                        }
-                        fp_g_variant_unref(entry);
-                    }
-                    if (result > 0) {
-                        break;
-                    }
-                }
-            }
-            fp_g_variant_unref(value);
-        }
-        if (result > 0) {
-            value = get_schema_value("com.canonical.Unity.Interface",
-                                                           "text-scale-factor");
-            if (value && fp_g_variant_is_of_type(value, "d")) {
-                result *= fp_g_variant_get_double(value);
-                fp_g_variant_unref(value);
-            }
-        }
-    }
-
-    if (result <= 0) {
-        void *value = get_schema_value("org.gnome.desktop.interface",
-                                                         "text-scaling-factor");
-        if (value && fp_g_variant_is_of_type(value, "d")) {
-            result = fp_g_variant_get_double(value);
-            fp_g_variant_unref(value);
-        }
-    }
-
-    return result;
-
-}
 
 static int getScale(const char *name) {
     char *uiScale = getenv(name);
@@ -200,10 +38,8 @@ static int getScale(const char *name) {
     return -1;
 }
 
-double getNativeScaleFactor(char *output_name) {
+double getNativeScaleFactor() {
     static int scale = -2.0;
-    double native_scale = 0;
-    int gdk_scale = 0;
 
     if (scale == -2) {
         scale = getScale("J2D_UISCALE");
@@ -213,13 +49,5 @@ double getNativeScaleFactor(char *output_name) {
         return scale;
     }
 
-    native_scale = getDesktopScale(output_name);
-
-    if (native_scale <= 0) {
-        native_scale = 1;
-    }
-
-    gdk_scale = getScale("GDK_SCALE");
-
-    return gdk_scale > 0 ? native_scale * gdk_scale : native_scale;
+    return getScale("GDK_SCALE");
 }

--- a/src/java.desktop/unix/native/common/awt/systemscale/systemScale.h
+++ b/src/java.desktop/unix/native/common/awt/systemscale/systemScale.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 #include <signal.h>
 #include <stdlib.h>
 
-double getNativeScaleFactor(char *output_name);
+double getNativeScaleFactor();
 
 #endif
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1718,7 +1718,7 @@ Java_sun_awt_X11GraphicsDevice_getCurrentDisplayMode
 
     AWT_LOCK();
 
-    if (!usingXinerama && screen < ScreenCount(awt_display)) {
+    if (screen < ScreenCount(awt_display)) {
 
         config = awt_XRRGetScreenInfo(awt_display,
                                       RootWindow(awt_display, screen));
@@ -1768,7 +1768,7 @@ Java_sun_awt_X11GraphicsDevice_enumDisplayModes
 
     AWT_LOCK();
 
-    if (!usingXinerama && XScreenCount(awt_display) > 0) {
+    if (XScreenCount(awt_display) > 0) {
 
         XRRScreenConfiguration *config;
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1718,49 +1718,7 @@ Java_sun_awt_X11GraphicsDevice_getCurrentDisplayMode
 
     AWT_LOCK();
 
-    if (usingXinerama && XScreenCount(awt_display) > 0) {
-        XRRScreenResources *res = awt_XRRGetScreenResources(awt_display,
-                                                    RootWindow(awt_display, 0));
-        if (res) {
-            if (res->noutput > screen) {
-                XRROutputInfo *output_info = awt_XRRGetOutputInfo(awt_display,
-                                                     res, res->outputs[screen]);
-                if (output_info) {
-                    if (output_info->crtc) {
-                        XRRCrtcInfo *crtc_info =
-                                    awt_XRRGetCrtcInfo (awt_display, res,
-                                                        output_info->crtc);
-                        if (crtc_info) {
-                            if (crtc_info->mode) {
-                                int i;
-                                for (i = 0; i < res->nmode; i++) {
-                                    XRRModeInfo *mode = &res->modes[i];
-                                    if (mode->id == crtc_info->mode) {
-                                        float rate = 0;
-                                        if (mode->hTotal && mode->vTotal) {
-                                             rate = ((float)mode->dotClock /
-                                                    ((float)mode->hTotal *
-                                                    (float)mode->vTotal));
-                                        }
-                                        displayMode = X11GD_CreateDisplayMode(
-                                                           env,
-                                                           mode->width,
-                                                           mode->height,
-                                                           BIT_DEPTH_MULTI,
-                                                           (int)(rate +.2));
-                                        break;
-                                    }
-                                }
-                            }
-                            awt_XRRFreeCrtcInfo(crtc_info);
-                        }
-                    }
-                    awt_XRRFreeOutputInfo(output_info);
-                }
-            }
-            awt_XRRFreeScreenResources(res);
-        }
-    } else {
+    if (!usingXinerama && screen < ScreenCount(awt_display)) {
 
         config = awt_XRRGetScreenInfo(awt_display,
                                       RootWindow(awt_display, screen));
@@ -1810,45 +1768,8 @@ Java_sun_awt_X11GraphicsDevice_enumDisplayModes
 
     AWT_LOCK();
 
-    if (usingXinerama && XScreenCount(awt_display) > 0) {
-        XRRScreenResources *res = awt_XRRGetScreenResources(awt_display,
-                                                    RootWindow(awt_display, 0));
-        if (res) {
-           if (res->noutput > screen) {
-                XRROutputInfo *output_info = awt_XRRGetOutputInfo(awt_display,
-                                                     res, res->outputs[screen]);
-                if (output_info) {
-                    int i;
-                    for (i = 0; i < output_info->nmode; i++) {
-                        RRMode m = output_info->modes[i];
-                        int j;
-                        XRRModeInfo *mode;
-                        for (j = 0; j < res->nmode; j++) {
-                            mode = &res->modes[j];
-                            if (mode->id == m) {
-                                 float rate = 0;
-                                 if (mode->hTotal && mode->vTotal) {
-                                     rate = ((float)mode->dotClock /
-                                                   ((float)mode->hTotal *
-                                                          (float)mode->vTotal));
-                                 }
-                                 X11GD_AddDisplayMode(env, arrayList,
-                                        mode->width, mode->height,
-                                              BIT_DEPTH_MULTI, (int)(rate +.2));
-                                 if ((*env)->ExceptionCheck(env)) {
-                                     goto ret0;
-                                 }
-                                 break;
-                            }
-                        }
-                    }
-ret0:
-                    awt_XRRFreeOutputInfo(output_info);
-                }
-            }
-            awt_XRRFreeScreenResources(res);
-        }
-    } else {
+    if (!usingXinerama && XScreenCount(awt_display) > 0) {
+
         XRRScreenConfiguration *config;
 
         config = awt_XRRGetScreenInfo(awt_display,
@@ -2006,42 +1927,6 @@ Java_sun_awt_X11GraphicsDevice_exitFullScreenExclusive
  * End DisplayMode/FullScreen support
  */
 
-static char *get_output_screen_name(JNIEnv *env, int screen) {
-#ifdef NO_XRANDR
-    return NULL;
-#else
-    if (!awt_XRRGetScreenResources || !awt_XRRGetOutputInfo) {
-        return NULL;
-    }
-    char *name = NULL;
-    AWT_LOCK();
-    int scr = 0, out = 0;
-    if (usingXinerama && XScreenCount(awt_display) > 0) {
-        out = screen;
-    } else {
-        scr = screen;
-    }
-
-    XRRScreenResources *res = awt_XRRGetScreenResources(awt_display,
-                                                  RootWindow(awt_display, scr));
-    if (res) {
-       if (res->noutput > out) {
-            XRROutputInfo *output_info = awt_XRRGetOutputInfo(awt_display,
-                                                        res, res->outputs[out]);
-            if (output_info) {
-                if (output_info->name) {
-                    name = strdup(output_info->name);
-                }
-                awt_XRRFreeOutputInfo(output_info);
-            }
-        }
-        awt_XRRFreeScreenResources(res);
-    }
-    AWT_UNLOCK();
-    return name;
-#endif /* NO_XRANDR */
-}
-
 /*
  * Class:     sun_awt_X11GraphicsDevice
  * Method:    getNativeScaleFactor
@@ -2050,11 +1935,6 @@ static char *get_output_screen_name(JNIEnv *env, int screen) {
 JNIEXPORT jdouble JNICALL
 Java_sun_awt_X11GraphicsDevice_getNativeScaleFactor
     (JNIEnv *env, jobject this, jint screen) {
-    // in case of Xinerama individual screen scales are not supported
-    char *name = get_output_screen_name(env, usingXinerama ? 0 : screen);
-    double scale = getNativeScaleFactor(name);
-    if (name) {
-        free(name);
-    }
-    return scale;
+
+    return getNativeScaleFactor();
 }

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -811,7 +811,7 @@ SplashGetScaledImageName(const char* jarName, const char* fileName,
 #ifndef __linux__
     return JNI_FALSE;
 #endif
-    *scaleFactor = (float)getNativeScaleFactor(NULL);
+    *scaleFactor = (float)getNativeScaleFactor();
     return GetScaledImageName(fileName, scaledImgName, scaleFactor, scaledImageNameLength);
 }
 


### PR DESCRIPTION
We use two different approaches to listing the display modes on the system:
 - For single-screen configuration use version 1.1 protocol XRRGetScreenInfo/XRRConfigRates/XRRConfigSizes
 - For multi-screen configuration use version 1.2 protocol: XRRGetScreenResources/XRRGetOutputInfo/XRRModeInfo

Unfortunately, the current code does not work for some specific double scan modes, it doubles the real refresh rate. If this refresh rate will be passed to the Xserver later it could hang/crash.

The same bug existed in xrandr utility before version 1.4:
https://bugs.freedesktop.org/show_bug.cgi?id=37043
https://gitlab.freedesktop.org/xorg/app/xrandr/commit/7fd4f18b649f22fad4dbf9fc64b69b3e7f172207

As suggested in the bug report I have tried to unify the code for single and multiscreen systems and use updated code currently used on the multiscreen.

But unfortunately, I have found that the multi-screen code is even more broken. The problematic code is this:

```
    int scr = 0, out = 0;
    if (usingXinerama && XScreenCount(awt_display) > 0) {
        out = screen;
    } else {
        scr = screen;
    }
```
The idea of the code is: if the passed screen is Xinerama index used by the java2d, then the "scr" will be zero, and "out" will be the "virtual" index for that screen. If the screen is X11 screen then "src" will be the correct screen and "out" will be zero.

The problem is that the code assumes that xrandr expect the "virtual" index as the "out" parameter, but this is not. This parameter is the index of the "output" such as DP1, DP2, other ports/etc.

So sometimes the code works when the first screen is connected to the first port on the video card and the second screen to the second port, otherwise, we just report data for the wrong screen or report nothing.

I did not found a reliable way to map Xinerama srceens to the xrandr. It is better to rework the java2d to use the xrandr instead of xinerama.

As a fix, I suggest dropping the code which uses the incorrect mapping screen->output. This includes the code related to the display modes added in the JDK-8167486 + JDK-8022810, and also the code related to the calculation of scale factor from the "ubuntu property" which does not work on the recent ubuntu version after migration to gnome3 added in the JDK-8149115

I will file a separate two bugs to reimplement this functionality, most probably the "display modes" will be implementing when we fully migrate to the xrandr, and calculation of the scale factor will be implemented via the gtk library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239894](https://bugs.openjdk.java.net/browse/JDK-8239894): Xserver crashes when the wrong high refresh rate is used


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2136/head:pull/2136`
`$ git checkout pull/2136`
