### PR TITLE
8259956: jdk.jfr.internal.ChunkInputStream#available should return the sum of remaining available bytes

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -29,22 +29,23 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 final class ChunkInputStream extends InputStream {
-    private final List<RepositoryChunk> chunks;
-    private int nextIndex = 0;
+    private final Iterator<RepositoryChunk> chunks;
     private long unstreamedSize = 0;
     private RepositoryChunk currentChunk;
     private InputStream stream;
 
-    ChunkInputStream(List<RepositoryChunk> inputChunks) throws IOException {
-        chunks = new ArrayList<>(inputChunks.size());
-        for (RepositoryChunk c : inputChunks) {
+    ChunkInputStream(List<RepositoryChunk> chunks) throws IOException {
+        List<RepositoryChunk> l = new ArrayList<>(chunks.size());
+        for (RepositoryChunk c : chunks) {
             c.use(); // keep alive while we're reading.
-            chunks.add(c);
+            l.add(c);
             unstreamedSize += c.getSize();
         }
+        this.chunks = l.iterator();
         nextStream();
     }
 
@@ -68,10 +69,10 @@ final class ChunkInputStream extends InputStream {
     }
 
     private boolean nextChunk() {
-        if (nextIndex >= chunks.size()) {
+        if (!chunks.hasNext()) {
             return false;
         }
-        currentChunk = chunks.get(nextIndex++);
+        currentChunk = chunks.next();
         return true;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -45,6 +45,7 @@ final class ChunkInputStream extends InputStream {
             l.add(c);
             unstreamedSize += c.getSize();
         }
+
         this.chunks = l.iterator();
         nextStream();
     }

--- a/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package jdk.jfr.api.consumer;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Recording;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+
+/**
+ * @test TestChunkInputStreamAvailable
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.api.consumer.TestChunkInputStreamAvailable
+ */
+public class TestChunkInputStreamAvailable {
+
+    public static void main(String[] args) throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(EventNames.JavaThreadStatistics)
+             .withPeriod(Duration.ofMillis(100));
+            r.start();
+            File repository = Path.of(System.getProperty("jdk.jfr.repository")).toFile();
+            for (int i = 0; i < 5; i++) {
+                TimeUnit.SECONDS.sleep(1);
+                try (Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot()) {
+                    InputStream stream = snapshot.getStream(null, null);
+                    File[] jfrs = repository.listFiles(f -> f.getName().endsWith(".jfr"));
+                    Arrays.sort(jfrs);
+
+                    int size = 0;
+                    // the last file isn't counted in
+                    for (int j = 0; j < jfrs.length - 1; j++) {
+                        size += (int)jfrs[j].length();
+                    }
+                    Asserts.assertEquals(stream.available(), size);
+                    int rc = new Random().nextInt(size);
+                    int left = size - rc;
+                    while (rc-- > 0) {
+                         stream.read();
+                    }
+                    Asserts.assertEquals(stream.available(), left);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,13 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+/**
+ * @test TestChunkInputStreamAvailable
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.api.consumer.TestChunkInputStreamAvailable
+ */
 package jdk.jfr.api.consumer;
 
 import java.io.File;
@@ -34,13 +41,6 @@ import jdk.jfr.Recording;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.EventNames;
 
-/**
- * @test TestChunkInputStreamAvailable
- * @key jfr
- * @requires vm.hasJFR
- * @library /test/lib
- * @run main/othervm jdk.jfr.api.consumer.TestChunkInputStreamAvailable
- */
 public class TestChunkInputStreamAvailable {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
@@ -28,47 +28,29 @@
  */
 package jdk.jfr.api.consumer;
 
-import java.io.File;
 import java.io.InputStream;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
-import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.test.lib.Asserts;
-import jdk.test.lib.jfr.EventNames;
 
 public class TestChunkInputStreamAvailable {
 
     public static void main(String[] args) throws Exception {
         try (Recording r = new Recording()) {
-            r.enable(EventNames.JavaThreadStatistics)
-             .withPeriod(Duration.ofMillis(100));
             r.start();
-            File repository = Path.of(System.getProperty("jdk.jfr.repository")).toFile();
-            for (int i = 0; i < 5; i++) {
-                TimeUnit.SECONDS.sleep(1);
-                try (Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot()) {
-                    InputStream stream = snapshot.getStream(null, null);
-                    File[] jfrs = repository.listFiles(f -> f.getName().endsWith(".jfr"));
-                    Arrays.sort(jfrs);
-
-                    int size = 0;
-                    // the last file isn't counted in
-                    for (int j = 0; j < jfrs.length - 1; j++) {
-                        size += (int)jfrs[j].length();
-                    }
-                    Asserts.assertEquals(stream.available(), size);
-                    int rc = new Random().nextInt(size);
-                    int left = size - rc;
-                    while (rc-- > 0) {
-                         stream.read();
-                    }
-                    Asserts.assertEquals(stream.available(), left);
+            try (Recording s = new Recording()) {
+                s.start();
+                s.stop();
+            }
+            r.stop();
+            try (InputStream stream = r.getStream(null, null)) {
+                int left = stream.available();
+                Asserts.assertEquals(r.getSize(), (long) left);
+                while (stream.read() != -1) {
+                    left--;
+                    Asserts.assertEquals(left, stream.available());
                 }
+                Asserts.assertEquals(0, left);
             }
         }
     }


### PR DESCRIPTION
Could I have a review of this small fix?

In the current implementation, ChunkInputStream#available only returns the available size of the current stream, which is strange for the user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259956](https://bugs.openjdk.java.net/browse/JDK-8259956): jdk.jfr.internal.ChunkInputStream#available should return the sum of remaining available bytes


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2138/head:pull/2138`
`$ git checkout pull/2138`
