### PR TITLE
8259962: Shenandoah: task queue statistics is inconsistent after JDK-8255019

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -79,6 +79,8 @@ void ShenandoahSTWMark::mark() {
   uint nworkers = heap->workers()->active_workers();
   task_queues()->reserve(nworkers);
 
+  TASKQUEUE_STATS_ONLY(task_queues()->reset_taskqueue_stats());
+
   {
     // Mark
     StrongRootsScope scope(nworkers);


### PR DESCRIPTION
I believe `ShenandoahSTWMark` misses the TQ stats reset after the takeover from concurrent cycle. See the stack trace and events info in the bug.

Additional testing:
 - [x] Linux x86_64, failing tests now pass
 - [x] Linux x86_64 `hotspot_gc_shenandoah`
 - [x]  Linux x86_64 `tier1` with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259962](https://bugs.openjdk.java.net/browse/JDK-8259962): Shenandoah: task queue statistics is inconsistent after JDK-8255019


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2141/head:pull/2141`
`$ git checkout pull/2141`
