### PR TITLE
8258805: Japanese characters not entered by mouse click on Windows 10

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -363,7 +363,7 @@ final class WInputMethod extends InputMethodAdapter
 
         // IME is going to be disabled commit the composition string
         if (hasCompositionString) {
-            endCompositionNative(context, COMMIT_INPUT);
+            endComposition();
         }
     }
 

--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,6 +360,11 @@ final class WInputMethod extends InputMethodAdapter
         }
         isActive = false;
         hasCompositionString = isCompositionStringAvailable(context);
+
+        // IME is going to be disabled commit the composition string
+        if (hasCompositionString) {
+            endCompositionNative(context, COMMIT_INPUT);
+        }
     }
 
     /**


### PR DESCRIPTION
Problem description:
The IME behaviour has changed starting from recent Windows 10 builds. In particular if the complex characters (Japanese, Chinese, etc.) are entered to some component and the focus is transferred to another component (which does not support the IM) the IM is disabled and the unconfirmed composition string gets discarded.
On previous Windows versions in the same situation the composition string is not discarded.

Fix:
It is necessary to take care of unconfirmed composition string once the IME is going to be disabled.

Testing:
All our automated regression and JCK tests passed with the proposed change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258805](https://bugs.openjdk.java.net/browse/JDK-8258805): Japanese characters not entered by mouse click on Windows 10


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2142/head:pull/2142`
`$ git checkout pull/2142`
