### PR TITLE
8256111: Create implementation for NSAccessibilityStaticText protocol

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -46,13 +46,14 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:4];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:6];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
     [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
-
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"hyperlink"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
 }
 
 /*

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -34,9 +34,9 @@
 @interface CommonTextAccessibility : CommonComponentAccessibility {
 
 }
-- (NSString *)accessibilityValueAttribute;
+- (nullable NSString *)accessibilityValueAttribute;
 - (NSRange)accessibilityVisibleCharacterRangeAttribute;
-- (NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
+- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
 @end
 
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef COMMON_TEXT_ACCESSIBILITY
+#define COMMON_TEXT_ACCESSIBILITY
+
+#import "CommonComponentAccessibility.h"
+#import "JavaAccessibilityUtilities.h"
+
+#import <AppKit/NSAccessibility.h>
+
+@interface CommonTextAccessibility : CommonComponentAccessibility {
+
+}
+- (NSString *)accessibilityValueAttribute;
+- (NSRange)accessibilityVisibleCharacterRangeAttribute;
+- (NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
+@end
+
+#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "CommonTextAccessibility.h"
+#import "ThreadUtilities.h"
+#import "JNIUtilities.h"
+
+#define DEFAULT_RANGE NSMakeRange(0, 0)
+#define DEFAULT_RECT NSMakeRect(0, 0, 0, 0)
+
+static jclass sjc_CAccessibility = NULL;
+static jmethodID sjm_getAccessibleText = NULL;
+#define GET_ACCESSIBLETEXT_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleText, sjc_CAccessibility, "getAccessibleText", \
+              "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleText;", ret);
+
+static jclass sjc_CAccessibleText = NULL;
+#define GET_CACCESSIBLETEXT_CLASS() \
+    GET_CLASS(sjc_CAccessibleText, "sun/lwawt/macosx/CAccessibleText");
+#define GET_CACCESSIBLETEXT_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(sjc_CAccessibleText, "sun/lwawt/macosx/CAccessibleText", ret);
+
+static jmethodID sjm_getAccessibleEditableText = NULL;
+#define GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(ret) \
+    GET_CACCESSIBLETEXT_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleEditableText, sjc_CAccessibleText, "getAccessibleEditableText", \
+              "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleEditableText;", ret);
+
+/*
+ * Converts an int array to an NSRange wrapped inside an NSValue
+ * takes [start, end] values and returns [start, end - start]
+ */
+static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
+    jint *values = (*env)->GetIntArrayElements(env, array, 0);
+    if (values == NULL) {
+        NSLog(@"%s failed calling GetIntArrayElements", __FUNCTION__);
+        return DEFAULT_RANGE;
+    };
+    return NSMakeRange(values[0], values[1] - values[0]);
+}
+
+@implementation CommonTextAccessibility
+
+- (NSString *)accessibilityValueAttribute
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+    if ([[self accessibilityRoleAttribute] isEqualToString:NSAccessibilityStaticTextRole]) {
+        jobject axName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                           sjm_getAccessibleName, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+        if (axName != NULL) {
+            NSString* str = JNFJavaToNSString(env, axName);
+            (*env)->DeleteLocalRef(env, axName);
+            return str;
+        }
+        // value is still nil if no accessibleName for static text. Below, try to get the accessibleText.
+    }
+
+    GET_ACCESSIBLETEXT_METHOD_RETURN(@"");
+    jobject axText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                      sjm_getAccessibleText, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axText == NULL) return nil;
+    (*env)->DeleteLocalRef(env, axText);
+
+    GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(nil);
+    jobject axEditableText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
+                       sjm_getAccessibleEditableText, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axEditableText == NULL) return nil;
+
+    DECLARE_STATIC_METHOD_RETURN(jm_getTextRange, sjc_CAccessibleText, "getTextRange",
+                    "(Ljavax/accessibility/AccessibleEditableText;IILjava/awt/Component;)Ljava/lang/String;", nil);
+    jobject jrange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getTextRange,
+                       axEditableText, 0, getAxTextCharCount(env, axEditableText, fComponent), fComponent);
+    CHECK_EXCEPTION();
+    NSString *string = JNFJavaToNSString(env, jrange); // AWT_THREADING Safe (AWTRunLoop)
+
+    (*env)->DeleteLocalRef(env, jrange);
+    (*env)->DeleteLocalRef(env, axEditableText);
+
+    if (string == nil) string = @"";
+    return string;
+}
+
+- (NSRange)accessibilityVisibleCharacterRangeAttribute
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(DEFAULT_RANGE);
+    DECLARE_STATIC_METHOD_RETURN(jm_getVisibleCharacterRange, sjc_CAccessibleText, "getVisibleCharacterRange",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[I", DEFAULT_RANGE);
+    jintArray axTextRange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
+                 jm_getVisibleCharacterRange, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
+    if (axTextRange == NULL) return DEFAULT_RANGE;
+
+    return javaIntArrayToNSRange(env, axTextRange);
+}
+
+- (NSString *)accessibilityStringForRangeAttribute:(NSRange)range
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getStringForRange, sjc_CAccessibleText, "getStringForRange",
+                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)Ljava/lang/String;", nil);
+    jstring jstringForRange = (jstring)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getStringForRange,
+                            fAccessible, fComponent, range.location, range.length); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
+    if (jstringForRange == NULL) return @"";
+    NSString* str = JNFJavaToNSString(env, jstringForRange);
+    (*env)->DeleteLocalRef(env, jstringForRange);
+    return str;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
@@ -64,7 +64,7 @@ static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
 
 @implementation CommonTextAccessibility
 
-- (NSString *)accessibilityValueAttribute
+- (nullable NSString *)accessibilityValueAttribute
 {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CACCESSIBILITY_CLASS_RETURN(nil);
@@ -123,7 +123,7 @@ static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
     return javaIntArrayToNSRange(env, axTextRange);
 }
 
-- (NSString *)accessibilityStringForRangeAttribute:(NSRange)range
+- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)range
 {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CACCESSIBLETEXT_CLASS_RETURN(nil);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef STATIC_TEXT_ACCESSIBILITY
+#define STATIC_TEXT_ACCESSIBILITY
+
+#import "CommonTextAccessibility.h"
+
+#import <AppKit/NSAccessibility.h>
+
+
+@interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
+
+};
+- (nullable NSString *)accessibilityAttributedString:(NSRange)range;
+- (nullable NSString *)accessibilityValue;
+- (NSRange)accessibilityVisibleCharacterRange;
+@end
+#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "StaticTextAccessibility.h"
+
+@implementation StaticTextAccessibility
+
+- (nullable NSString *)accessibilityAttributedString:(NSRange)range
+{
+    return [self accessibilityStringForRangeAttribute:range];
+}
+
+- (nullable NSString *)accessibilityValue
+{
+    return [self accessibilityValueAttribute];
+}
+
+- (NSRange)accessibilityVisibleCharacterRange
+{
+    return [self accessibilityVisibleCharacterRangeAttribute];
+}
+
+@end


### PR DESCRIPTION
Create implementation for NSAccessibilityStaticText protocol

For testing that Label accessibility works fine, I have used something like https://docs.oracle.com/javase/tutorial/uiswing/examples/components/LabelDemoProject/src/components/LabelDemo.java. I also tried few other labels with html text. I have verified that the Voice Over output for JLables is same before and after this change.

The class CommonTextAccessibility has most of the code taken from JavaTextAccessibility. Only the functions needed for StaticTextAccessibility have been taken as of now. Few more (not all) functions will be added to this class from JavaTextAccessiblity when work is done for NavigableStaticText or TextField, TextArea, Text, Password etc accessibility roles.

I could not see AccessibleRole.HYPERLINK or "hyperlink" role being used anywhere. As we are reworking the implementation, I have included both roles "label" and "hyperlink" as of now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256111](https://bugs.openjdk.java.net/browse/JDK-8256111): Create implementation for NSAccessibilityStaticText protocol


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 662680b435529b7c483815ac4b927f4ee7982219
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2147/head:pull/2147`
`$ git checkout pull/2147`
