### PR TITLE
JDK-8259949: x86 32-bit build fails when -fcf-protection is passed in the compiler flags

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -684,9 +684,21 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   # CFLAGS PER CPU
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     # COMMON to gcc and clang
+    AC_MSG_CHECKING([if $1 is x86])
     if test "x$FLAGS_CPU" = xx86; then
-      # Force compatibility with i586 on 32 bit intel platforms.
-      $1_CFLAGS_CPU="-march=i586"
+      AC_MSG_RESULT([yes])
+      AC_MSG_CHECKING([if control flow protection is enabled by additional compiler flags])
+      if echo "${EXTRA_CFLAGS}${EXTRA_CXXFLAGS}${EXTRA_ASFLAGS}" | ${GREP} -q 'fcf-protection' ; then
+        # cf-protection requires CMOV and thus i686
+        $1_CFLAGS_CPU="-march=i686"
+        AC_MSG_RESULT([yes, forcing ${$1_CFLAGS_CPU}])
+      else
+        # Force compatibility with i586 on 32 bit intel platforms.
+        $1_CFLAGS_CPU="-march=i586"
+        AC_MSG_RESULT([no, forcing ${$1_CFLAGS_CPU}])
+      fi
+    else
+      AC_MSG_RESULT([no])
     fi
   fi
 


### PR DESCRIPTION
The latest GCC fails if -fcf-protection is used with an x86 (32-bit) target that doesn't support CMOV:

https://gcc.gnu.org/git/?p=gcc.git;a=blobdiff;f=gcc/config/i386/i386-options.c;h=a70f6edf7b0bfa6994db372c2507dbacb5526646;hp=6819a04238965f0ad63b10323823caa2fb8b147c;hb=77d372abec0fbf2cfe922e3140ee3410248f979e;hpb=5ebdd53534db25401473db5f6a0ad30f41410241

At least back to OpenJDK 11, the JDK build forces -march=i586 and the build fails with '-fcf-protection is not compatible with this target'

This patch uses -march=i686 instead if -fcf-protection is detected in the compiler flags. It also makes it clear which is being set in the configure output, rather than silently setting the flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259949](https://bugs.openjdk.java.net/browse/JDK-8259949): x86 32-bit build fails when -fcf-protection is passed in the compiler flags


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2153/head:pull/2153`
`$ git checkout pull/2153`
