### PR TITLE
JDK-8255464: Cannot access ModuleTree in a CompilationUnitTree

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/CompilationUnitTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/CompilationUnitTree.java
@@ -29,16 +29,29 @@ import java.util.List;
 import javax.tools.JavaFileObject;
 
 /**
- * Represents the abstract syntax tree for compilation units (source
- * files) and package declarations (package-info.java).
+ * Represents the abstract syntax tree for ordinary compilation units
+ * and modular compilation units.
  *
  * @jls 7.3 Compilation Units
  * @jls 7.4 Package Declarations
+ * @jls 7.7 Module Declarations
  *
  * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface CompilationUnitTree extends Tree {
+
+    /**
+     * Returns the module tree associated with this compilation unit,
+     * or {@code null} if there is no module declaration.
+     * @return the module tree
+     * @implSpec This implementation throws {@code UnsupportedOperationException}
+     * @since 17
+     */
+     default ModuleTree getModule() {
+         throw new UnsupportedOperationException();
+     }
+
     /**
      * Returns the annotations listed on any package declaration
      * at the head of this compilation unit, or {@code null} if there
@@ -64,15 +77,18 @@ public interface CompilationUnitTree extends Tree {
     PackageTree getPackage();
 
     /**
-     * Returns the import declarations appearing in this compilation unit.
+     * Returns the import declarations appearing in this compilation unit,
+     * or an empty list if there are no import declarations.
      * @return the import declarations
      */
     List<? extends ImportTree> getImports();
 
     /**
-     * Returns the type declarations appearing in this compilation unit.
+     * Returns the type declarations appearing in this compilation unit,
+     * or an empty list if there are no type declarations.
      * The list may also include empty statements resulting from
      * extraneous semicolons.
+     * A modular compilation unit does not contain any type declarations.
      * @return the type declarations
      */
     List<? extends Tree> getTypeDecls();
@@ -84,8 +100,8 @@ public interface CompilationUnitTree extends Tree {
     JavaFileObject getSourceFile();
 
     /**
-     * Returns the line map for this compilation unit, if available.
-     * Returns {@code null} if the line map is not available.
+     * Returns the line map for this compilation unit, if available,
+     * or {@code null} if the line map is not available.
      * @return the line map for this compilation unit
      */
     LineMap getLineMap();

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -146,6 +146,7 @@ public class TreeScanner<R,P> implements TreeVisitor<R,P> {
         R r = scan(node.getPackage(), p);
         r = scanAndReduce(node.getImports(), p, r);
         r = scanAndReduce(node.getTypeDecls(), p, r);
+        r = scanAndReduce(node.getModule(), p, r);
         return r;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -554,6 +554,11 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
 
         @DefinedBy(Api.COMPILER_TREE)
+        public JCModuleDecl getModule() {
+            return getModuleDecl();
+        }
+
+        @DefinedBy(Api.COMPILER_TREE)
         public JCPackageDecl getPackage() {
             // PackageDecl must be the first entry if it exists
             if (!defs.isEmpty() && defs.head.hasTag(PACKAGEDEF))
@@ -593,9 +598,12 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         @DefinedBy(Api.COMPILER_TREE)
         public List<JCTree> getTypeDecls() {
             List<JCTree> typeDefs;
-            for (typeDefs = defs; !typeDefs.isEmpty(); typeDefs = typeDefs.tail)
-                if (!typeDefs.head.hasTag(PACKAGEDEF) && !typeDefs.head.hasTag(IMPORT))
+            for (typeDefs = defs; !typeDefs.isEmpty(); typeDefs = typeDefs.tail) {
+                if (!typeDefs.head.hasTag(MODULEDEF)
+                        && !typeDefs.head.hasTag(PACKAGEDEF) && !typeDefs.head.hasTag(IMPORT)) {
                     break;
+                }
+            }
             return typeDefs;
         }
         @Override @DefinedBy(Api.COMPILER_TREE)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -460,6 +460,7 @@ public class Pretty extends JCTree.Visitor {
             if (tree.directives == null) {
                 print(";");
             } else {
+                print(" ");
                 printBlock(tree.directives);
             }
             println();

--- a/test/langtools/tools/javac/tree/CompilationUnitTreeTest.java
+++ b/test/langtools/tools/javac/tree/CompilationUnitTreeTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255464
+ * @summary Cannot access ModuleTree in a CompilationUnitTree
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ */
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTool;
+
+public class CompilationUnitTreeTest {
+    public static void main(String... args) throws Exception {
+        new CompilationUnitTreeTest().run();
+    }
+
+    PrintStream out = System.err;
+    int errors;
+
+    void run() throws Exception {
+        testModuleCompilationUnit();
+        testOrdinaryCompilationUnit();
+        if (errors > 0) {
+            out.println(errors + " errors");
+            throw new Exception(errors + " errors");
+        }
+    }
+
+    void testModuleCompilationUnit() throws IOException {
+        out.println("Test ModuleCompilationUnit");
+        CompilationUnitTree cut = parse("import java.util.*; module m { }");
+        checkTree("package", cut.getPackage(),     null);
+        checkList("imports", cut.getImports(),      List.of("IMPORT import java.util.*;"));
+        checkList("type decls", cut.getTypeDecls(), List.of());
+        checkTree("module", cut.getModule(),       "MODULE module m { }");
+    }
+
+    void testOrdinaryCompilationUnit() throws IOException {
+        out.println("Test OrdinaryCompilationUnit");
+        CompilationUnitTree cut = parse("package p; import java.util.*; public class C { };");
+        checkTree("package",    cut.getPackage(),  "PACKAGE package p;");
+        checkList("imports",    cut.getImports(),   List.of("IMPORT import java.util.*;"));
+        checkList("type decls", cut.getTypeDecls(), List.of("CLASS public class C { }", "EMPTY_STATEMENT ;"));
+        checkTree("module",     cut.getModule(),   null);
+    }
+
+    void checkTree(String label, Tree tree, String expect) {
+        String f = tree == null ? null
+                : tree.getKind() + " " + tree.toString().trim().replaceAll("\\s+", " ");
+        if (Objects.equals(f, expect)) {
+            out.println("  " + label + " OK: " + expect);
+        } else {
+            out.println("  " + label + " error");
+            out.println("    expect: " + expect);
+            out.println("     found: " + f);
+            errors++;
+        }
+    }
+
+    void checkList(String label, List<? extends Tree> trees, List<String> expect) {
+        Objects.requireNonNull(expect);
+        if (trees == null) {
+            out.println("  " + label + " error: list is null");
+            errors++;
+            return;
+        }
+        if (trees.size() != expect.size()) {
+            out.println("  " + label + " error: list size mismatch");
+            out.println("    expect: " + expect.size());
+            out.println("     found: " + trees.size());
+            errors++;
+        }
+        // compare entries in both lists
+        for (int i = 0; i < Math.min(trees.size(), expect.size()); i++) {
+            Tree ti = trees.get(i);
+            String ei = expect.get(i);
+            checkTree(label + "[" + i + "]", ti, ei);
+        }
+        // show any excess entries in expect list
+        for (int i = trees.size(); i < expect.size(); i++) {
+            String ei = expect.get(i);
+            out.println("    " + label + "[" + i + "]: expect: " + ei);
+        }
+        // show any excess entries in trees list
+        for (int i = expect.size(); i < trees.size(); i++) {
+            Tree ti = trees.get(i);
+            String fi = ti == null ? null : ti.getKind() + " " + ti.toString();
+            out.println("    " + label + "[" + i + "]: found: " + fi);
+        }
+    }
+
+    CompilationUnitTree parse(String text) throws IOException {
+        JavacTool tool = JavacTool.create();
+        JavacTask ct = tool.getTask(null, null, null,
+                null, null, List.of(new MyFileObject(text)));
+        return ct.parse().iterator().next();
+    }
+
+    static class MyFileObject extends SimpleJavaFileObject {
+
+        private final String text;
+
+        public MyFileObject(String text) {
+            super(URI.create("fo:/Test.java"), JavaFileObject.Kind.SOURCE);
+            this.text = text;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return text;
+        }
+    }
+}


### PR DESCRIPTION
Please review a small change to add an overdue missing method to access the `ModuleTree` when a `CompilationUnitTree` represents a modular compilation unit.

CSR is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255464](https://bugs.openjdk.java.net/browse/JDK-8255464): Cannot access ModuleTree in a CompilationUnitTree


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2155/head:pull/2155`
`$ git checkout pull/2155`
