### PR TITLE
JDK-8259897: gtest os.dll_address_to_function_and_library_name_vm fails on AIX

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -748,15 +748,5 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
       EXPECT_EQ(tmp[10], 'X');
       LOG("%s", output);
     }
-
-    // Pointer (probably) outside function, should show at least the library name
-    addr -= 10;
-    st.reset();
-    EXPECT_TRUE(os::print_function_and_library_name(&st, addr,
-                                                    provide_scratch_buffer ? tmp : NULL,
-                                                    sizeof(tmp),
-                                                    shorten_paths, demangle));
-    EXPECT_CONTAINS(output, "jvm"); // "jvm.dll" or "libjvm.so" or similar
-    LOG("%s", output);
   }
 }


### PR DESCRIPTION
This is trivial. The test tries to come up with a pointer slightly outside a function but still inside a library, and then to resolve it to a valid library name. This is shaky. On AIX, the pointer had been a function descriptor, stored separately from the code sections, so this won't work.

I removed this part of the test, since this is shaky and relies on UB.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259897](https://bugs.openjdk.java.net/browse/JDK-8259897): gtest os.dll_address_to_function_and_library_name_vm fails on AIX


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2156/head:pull/2156`
`$ git checkout pull/2156`
