### PR TITLE
JDK-8260022: [ppc] os::print_function_and_library_name shall resolve function descriptors transparently

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -26,6 +26,7 @@
 #ifndef CPU_PPC_ASSEMBLER_PPC_HPP
 #define CPU_PPC_ASSEMBLER_PPC_HPP
 
+#include "asm/assembler.hpp"
 #include "asm/register.hpp"
 
 // Address is an abstraction used to represent a memory location

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -496,6 +496,6 @@ bool os::platform_print_native_stack(outputStream* st, void* context, char *buf,
 }
 
 // HAVE_FUNCTION_DESCRIPTORS
-void* os::resolve_function_descriptor_to_code_pointer(void* p) {
+void* os::resolve_function_descriptor(void* p) {
   return ((const FunctionDescriptor*)p)->entry();
 }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -25,6 +25,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "assembler_ppc.hpp"
 #include "asm/assembler.inline.hpp"
 #include "classfile/classLoader.hpp"
 #include "classfile/systemDictionary.hpp"
@@ -492,4 +493,9 @@ int os::extra_bang_size_in_bytes() {
 bool os::platform_print_native_stack(outputStream* st, void* context, char *buf, int buf_size) {
   AixNativeCallstack::print_callstack_for_context(st, (const ucontext_t*)context, true, buf, (size_t) buf_size);
   return true;
+}
+
+// HAVE_FUNCTION_DESCRIPTORS
+void* os::resolve_function_descriptor_to_code_pointer(void* p) {
+  return ((const FunctionDescriptor*)p)->entry();
 }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
@@ -32,8 +32,11 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
-#define PLATFORM_PRINT_NATIVE_STACK 1
-static bool platform_print_native_stack(outputStream* st, void* context,
-                                        char *buf, int buf_size);
+  #define PLATFORM_PRINT_NATIVE_STACK 1
+  static bool platform_print_native_stack(outputStream* st, void* context,
+                                          char *buf, int buf_size);
+
+  #define HAVE_FUNCTION_DESCRIPTORS 1
+  static void* resolve_function_descriptor_to_code_pointer(void* p);
 
 #endif // OS_CPU_AIX_PPC_OS_AIX_PPC_HPP

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
@@ -37,6 +37,6 @@
                                           char *buf, int buf_size);
 
   #define HAVE_FUNCTION_DESCRIPTORS 1
-  static void* resolve_function_descriptor_to_code_pointer(void* p);
+  static void* resolve_function_descriptor(void* p);
 
 #endif // OS_CPU_AIX_PPC_OS_AIX_PPC_HPP

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -501,6 +501,6 @@ int os::extra_bang_size_in_bytes() {
 }
 
 // HAVE_FUNCTION_DESCRIPTORS
-void* os::resolve_function_descriptor_to_code_pointer(void* p) {
+void* os::resolve_function_descriptor(void* p) {
   return ((const FunctionDescriptor*)p)->entry();
 }

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -25,6 +25,7 @@
 
 // no precompiled headers
 #include "jvm.h"
+#include "assembler_ppc.hpp"
 #include "asm/assembler.inline.hpp"
 #include "classfile/classLoader.hpp"
 #include "classfile/systemDictionary.hpp"
@@ -497,4 +498,9 @@ void os::verify_stack_alignment() {
 int os::extra_bang_size_in_bytes() {
   // PPC does not require the additional stack bang.
   return 0;
+}
+
+// HAVE_FUNCTION_DESCRIPTORS
+void* os::resolve_function_descriptor_to_code_pointer(void* p) {
+  return ((const FunctionDescriptor*)p)->entry();
 }

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -500,7 +500,8 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-// HAVE_FUNCTION_DESCRIPTORS
+#ifdef HAVE_FUNCTION_DESCRIPTORS
 void* os::resolve_function_descriptor(void* p) {
   return ((const FunctionDescriptor*)p)->entry();
 }
+#endif

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
@@ -32,4 +32,7 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
+  #define HAVE_FUNCTION_DESCRIPTORS 1
+  static void* resolve_function_descriptor_to_code_pointer(void* p);
+
 #endif // OS_CPU_LINUX_PPC_OS_LINUX_PPC_HPP

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
@@ -32,7 +32,10 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
+#ifndef VM_LITTLE_ENDIAN
+  // ppc (not ppcle) has function descriptors
   #define HAVE_FUNCTION_DESCRIPTORS 1
-  static void* resolve_function_descriptor_to_code_pointer(void* p);
+  static void* resolve_function_descriptor(void* p);
+#endif
 
 #endif // OS_CPU_LINUX_PPC_OS_LINUX_PPC_HPP

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
@@ -32,7 +32,7 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
-#ifndef VM_LITTLE_ENDIAN
+#if !defined(ABI_ELFv2)
   // ppc (not ppcle) has function descriptors
   #define HAVE_FUNCTION_DESCRIPTORS 1
   static void* resolve_function_descriptor(void* p);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -897,8 +897,24 @@ bool os::print_function_and_library_name(outputStream* st,
     buflen = O_BUFLEN;
   }
   int offset = 0;
-  const bool have_function_name = dll_address_to_function_name(addr, p, buflen,
-                                                               &offset, demangle);
+  bool have_function_name = dll_address_to_function_name(addr, p, buflen,
+                                                         &offset, demangle);
+  bool is_function_descriptor = false;
+#ifdef HAVE_FUNCTION_DESCRIPTORS
+  // When we deal with a function descriptor instead of a real code pointer, try to
+  // resolve it. There is a small chance that a random pointer given to this function
+  // may just happen to look like a valid descriptor, but this is rare and worth the
+  // risk to see resolved function names. But we will print a little suffix to mark
+  // this as a function descriptor for the reader (see below).
+  if (!have_function_name && os::is_readable_pointer(addr)) {
+    address addr2 = (address)os::resolve_function_descriptor_to_code_pointer(addr);
+    if (have_function_name = is_function_descriptor =
+        dll_address_to_function_name(addr2, p, buflen, &offset, demangle)) {
+      addr = addr2;
+    }
+  }
+#endif // HANDLE_FUNCTION_DESCRIPTORS
+
   if (have_function_name) {
     // Print function name, optionally demangled
     if (demangle && strip_arguments) {
@@ -933,6 +949,12 @@ bool os::print_function_and_library_name(outputStream* st,
       st->print("+%d", offset);
     }
   }
+
+  // Write a trailing marker if this was a function descriptor
+  if (have_function_name && is_function_descriptor) {
+    st->print_raw(" (FD)");
+  }
+
   return have_function_name || have_library_name;
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -907,7 +907,7 @@ bool os::print_function_and_library_name(outputStream* st,
   // risk to see resolved function names. But we will print a little suffix to mark
   // this as a function descriptor for the reader (see below).
   if (!have_function_name && os::is_readable_pointer(addr)) {
-    address addr2 = (address)os::resolve_function_descriptor_to_code_pointer(addr);
+    address addr2 = (address)os::resolve_function_descriptor(addr);
     if (have_function_name = is_function_descriptor =
         dll_address_to_function_name(addr2, p, buflen, &offset, demangle)) {
       addr = addr2;


### PR DESCRIPTION
When function descriptors are fed to os::print_function_and_library_name() to get debug output, it would be very helpful to transparently handle the case where the address is not a code pointer but a function descriptor.

Of the official OpenJDK platforms this affects only ppc, but also includes at least ia64 for those who maintain ports to that platform.

Fixing this will also fix the display of signal handlers on linux ppc which still show up without function names after JDK-8258606.

Before:
```
695 Signal Handlers:
696    SIGSEGV: 0x00000fff8d0f4348 in libjvm.so+34882376, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
697     SIGBUS: 0x00000fff8d0f4348 in libjvm.so+34882376, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
698     SIGFPE: 0x00000fff8d0f4348 in libjvm.so+34882376, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
699    SIGPIPE: 0x00000fff8d0e0158 in libjvm.so+34799960, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
700    SIGXFSZ: 0x00000fff8d0e0158 in libjvm.so+34799960, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
701     SIGILL: 0x00000fff8d0f4348 in libjvm.so+34882376, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
702    SIGUSR2: 0x00000fff8d0e0098 in libjvm.so+34799768, sa_mask[0]=00000000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
703     SIGHUP: 0x00000fff8d0e0080 in libjvm.so+34799744, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
704     SIGINT: 0x00000fff8d0e0080 in libjvm.so+34799744, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
705    SIGTERM: 0x00000fff8d0e0080 in libjvm.so+34799744, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
706    SIGQUIT: 0x00000fff8d0e0080 in libjvm.so+34799744, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
707    SIGTRAP: 0x00000fff8d0f4348 in libjvm.so+34882376, sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
```

Now:
```
693 Signal Handlers:
694    SIGSEGV: crash_handler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
695     SIGBUS: crash_handler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
696     SIGFPE: crash_handler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
697    SIGPIPE: javaSignalHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
698    SIGXFSZ: javaSignalHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
699     SIGILL: crash_handler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
700    SIGUSR2: SR_handler in libjvm.so (FD), sa_mask[0]=00000000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
701     SIGHUP: UserHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
702     SIGINT: UserHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
703    SIGTERM: UserHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
704    SIGQUIT: UserHandler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
705    SIGTRAP: crash_handler in libjvm.so (FD), sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
```

The patch also adds a little trailing marker `(FD)` as an indication for the developer that this had been a function descriptor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260022](https://bugs.openjdk.java.net/browse/JDK-8260022): [ppc] os::print_function_and_library_name shall resolve function descriptors transparently


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 9cedffac379c3d8a4124ad2ca89176fc38972263
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2157/head:pull/2157`
`$ git checkout pull/2157`
