### PR TITLE
8260025: Missing comma in VM_Version_Ext::_family_id_amd

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_ext_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_ext_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -739,7 +739,7 @@ const char* const VM_Version_Ext::_family_id_amd[ExtendedFamilyIdLength_AMD] = {
   "",
   "",
   "Opteron/Athlon64",
-  "Opteron QC/Phenom"  // Barcelona et.al.
+  "Opteron QC/Phenom",  // Barcelona et.al.
   "",
   "",
   "",


### PR DESCRIPTION
HotSpot cannot identify Zen (family 17h) processor. You can see this problem in flight record as below:

```
java -XX:StartFlightRecording=filename=test.jfr --version
```

`(null)` in `cpu` and `<unknown>` in `Family` should be `Zen`.

```
$ jfr print --events jdk.CPUInformation test.jfr
jdk.CPUInformation {
  startTime = 15:59:37.207
  cpu = "AMD (null) (HT) SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 SSE4A AMD64"
  description = "Brand: AMD Ryzen 3 3300X 4-Core Processor , Vendor: AuthenticAMD
Family: <unknown> (0x17), Model: <unknown> (0x71), Stepping: 0x0
Ext. family: 0x8, Ext. model: 0x7, Type: 0x0, Signature: 0x00870f10
Features: ebx: 0x00020800, ecx: 0xfed83203, edx: 0x178bfbff
Ext. features: eax: 0x00870f10, ebx: 0x20000000, ecx: 0x004003f3, edx: 0x2fd3fbff
Supports: On-Chip FPU, Virtual Mode Extensions, Debugging Extensions, Page Size Extensions, Time Stamp Counter, Model Specific Registers, Physical Address Extension, Machine Check Exceptions, CMPXCHG8B Instruction, On-Chip APIC, Fast System Call, Memory Type Range Registers, Page Global Enable, Machine Check Architecture, Conditional Mov Instruction, Page Attribute Table, 36-bit Page Size Extension, CLFLUSH Instruction, Intel Architecture MMX Technology, Fast Float Point Save and Restore, Streaming SIMD extensions, Streaming SIMD extensions 2, Hyper Threading, Streaming SIMD Extensions 3, PCLMULQDQ, Supplemental Streaming SIMD Extensions 3, Fused Multiply-Add, CMPXCHG16B, Streaming SIMD extensions 4.1, Streaming SIMD extensions 4.2, MOVBE, Popcount instruction, AESNI, XSAVE, OSXSAVE, AVX, F16C, LAHF/SAHF instruction support, Core multi-processor leagacy mode, Advanced Bit Manipulations: LZCNT, SSE4A: MOVNTSS, MOVNTSD, EXTRQ, INSERTQ, Misaligned SSE mode, SYSCALL/SYSRET, Execute Disable Bit, RDTSCP, Intel 64 Architecture"
  sockets = 1
  cores = 2
  hwThreads = 2
}
```

It is caused by missing comma after `Opteron QC/Phenom`. So I think the fix is trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260025](https://bugs.openjdk.java.net/browse/JDK-8260025): Missing comma in VM_Version_Ext::_family_id_amd


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2158/head:pull/2158`
`$ git checkout pull/2158`
