### PR TITLE
8248437: HTML regression (doclint: <svg>, title)

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -470,7 +470,6 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                         // <script> may or may not be allowed, depending on --allow-script-in-comments
                         // but we allow it here, and rely on a separate scanner to detect all uses
                         // of JavaScript, including <script> tags, and use in attributes, etc.
-                    case STYLE:
                     case SVG:
                         // <svg> tag is allowed but no separate scanner hasn't been implemented.
                         break;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -301,13 +301,17 @@ public enum HtmlTag {
     STRONG(BlockType.INLINE, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT)),
 
-    STYLE(BlockType.OTHER, EndKind.REQUIRED),
+    STYLE(BlockType.OTHER, EndKind.REQUIRED,
+            EnumSet.of(Flag.SKIP_CONTENT)),
 
     SUB(BlockType.INLINE, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT, Flag.NO_NEST)),
 
     SUP(BlockType.INLINE, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT, Flag.NO_NEST)),
+
+    SVG(BlockType.OTHER, EndKind.REQUIRED,
+            EnumSet.of(Flag.SKIP_CONTENT)),
 
     TABLE(BlockType.BLOCK, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT),
@@ -432,6 +436,7 @@ public enum HtmlTag {
         ACCEPTS_BLOCK,
         ACCEPTS_INLINE,
         EXPECT_CONTENT,
+        SKIP_CONTENT,
         NO_NEST
     }
 
@@ -608,7 +613,7 @@ public enum HtmlTag {
             switch (blockType) {
                 case BLOCK:
                 case INLINE:
-                    return (t.blockType == BlockType.INLINE);
+                    return (t.blockType == BlockType.INLINE || t.flags.contains(Flag.SKIP_CONTENT));
                 case OTHER:
                     // OTHER tags are invalid in doc comments, and will be
                     // reported separately, so silently accept/ignore any content

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -301,8 +301,7 @@ public enum HtmlTag {
     STRONG(BlockType.INLINE, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT)),
 
-    STYLE(BlockType.OTHER, EndKind.REQUIRED,
-            EnumSet.of(Flag.SKIP_CONTENT)),
+    STYLE(BlockType.OTHER, EndKind.REQUIRED),
 
     SUB(BlockType.INLINE, EndKind.REQUIRED,
             EnumSet.of(Flag.EXPECT_CONTENT, Flag.NO_NEST)),

--- a/test/langtools/tools/doclint/html/OtherTagsTest.java
+++ b/test/langtools/tools/doclint/html/OtherTagsTest.java
@@ -20,6 +20,8 @@ public class OtherTagsTest {
      *  <meta>
      *  <noframes> </noframes>
      *  <script> </script>
+     *  <style type="text/css">p { color: blue; }</style>
+     *  <svg width="10" height="10"><circle cx="5" cy="5" r="5"/></svg>
      *  <title> </title>
      */
     public void knownInvalidTags() { }

--- a/test/langtools/tools/doclint/html/OtherTagsTest.java
+++ b/test/langtools/tools/doclint/html/OtherTagsTest.java
@@ -20,7 +20,6 @@ public class OtherTagsTest {
      *  <meta>
      *  <noframes> </noframes>
      *  <script> </script>
-     *  <style type="text/css">p { color: blue; }</style>
      *  <svg width="10" height="10"><circle cx="5" cy="5" r="5"/></svg>
      *  <title> </title>
      */

--- a/test/langtools/tools/doclint/html/OtherTagsTest.out
+++ b/test/langtools/tools/doclint/html/OtherTagsTest.out
@@ -22,7 +22,7 @@ OtherTagsTest.java:20: error: element not allowed in documentation comments: <me
 OtherTagsTest.java:21: error: tag not supported in HTML5: noframes
      *  <noframes> </noframes>
         ^
-OtherTagsTest.java:23: error: element not allowed in documentation comments: <title>
+OtherTagsTest.java:25: error: element not allowed in documentation comments: <title>
      *  <title> </title>
         ^
 9 errors

--- a/test/langtools/tools/doclint/html/OtherTagsTest.out
+++ b/test/langtools/tools/doclint/html/OtherTagsTest.out
@@ -22,7 +22,7 @@ OtherTagsTest.java:20: error: element not allowed in documentation comments: <me
 OtherTagsTest.java:21: error: tag not supported in HTML5: noframes
      *  <noframes> </noframes>
         ^
-OtherTagsTest.java:25: error: element not allowed in documentation comments: <title>
+OtherTagsTest.java:24: error: element not allowed in documentation comments: <title>
      *  <title> </title>
         ^
 9 errors


### PR DESCRIPTION
HTML5 is supported in javadoc.  However, doclint doesn’t accept the use of `<svg>` tag described as javadoc comments.  The changes consist of

- Skip attribute and content checks for <svg>.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8248437](https://bugs.openjdk.java.net/browse/JDK-8248437): HTML regression (doclint: <svg>, title)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2159/head:pull/2159`
`$ git checkout pull/2159`
