### PR TITLE
JDK-8260030: Improve stringStream buffer handling

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -411,7 +411,7 @@ char* stringStream::as_string(bool c_heap) const {
 }
 
 stringStream::~stringStream() {
-  if (_is_fixed == false && _buffer != _small_buffer) {
+  if (!_is_fixed && _buffer != _small_buffer) {
     FREE_C_HEAP_ARRAY(char, _buffer);
   }
 }

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -310,46 +310,66 @@ void outputStream::print_data(void* data, size_t len, bool with_ascii) {
   }
 }
 
-stringStream::stringStream(size_t initial_size) : outputStream() {
-  buffer_length = initial_size;
-  buffer        = NEW_C_HEAP_ARRAY(char, buffer_length, mtInternal);
-  buffer_pos    = 0;
-  buffer_fixed  = false;
+stringStream::stringStream(size_t initial_capacity) :
+  outputStream(),
+  _buffer(_small_buffer),
+  _written(0),
+  _capacity(sizeof(_small_buffer)),
+  _is_fixed(false)
+{
+  if (initial_capacity > _capacity) {
+    grow(initial_capacity);
+  }
   zero_terminate();
 }
 
 // useful for output to fixed chunks of memory, such as performance counters
-stringStream::stringStream(char* fixed_buffer, size_t fixed_buffer_size) : outputStream() {
-  buffer_length = fixed_buffer_size;
-  buffer        = fixed_buffer;
-  buffer_pos    = 0;
-  buffer_fixed  = true;
+stringStream::stringStream(char* fixed_buffer, size_t fixed_buffer_size) :
+  outputStream(),
+  _buffer(fixed_buffer),
+  _written(0),
+  _capacity(fixed_buffer_size),
+  _is_fixed(true)
+{
   zero_terminate();
+}
+
+// Grow backing buffer to desired capacity. Don't call for fixed buffers
+void stringStream::grow(size_t new_capacity) {
+  assert(new_capacity > _capacity, "Sanity");
+  assert(new_capacity > sizeof(_small_buffer), "Sanity");
+  assert(!_is_fixed, "Don't call for caller provided buffers");
+  if (_buffer == _small_buffer) {
+    _buffer = NEW_C_HEAP_ARRAY(char, new_capacity, mtInternal);
+    _capacity = new_capacity;
+    if (_written > 0) {
+      ::memcpy(_buffer, _small_buffer, _written);
+    }
+    zero_terminate();
+  } else {
+    _buffer = REALLOC_C_HEAP_ARRAY(char, _buffer, new_capacity, mtInternal);
+    _capacity = new_capacity;
+  }
 }
 
 void stringStream::write(const char* s, size_t len) {
   size_t write_len = len;               // number of non-null bytes to write
-  size_t end = buffer_pos + len + 1;    // position after write and final '\0'
-  if (end > buffer_length) {
-    if (buffer_fixed) {
+  size_t end = _written + len + 1;    // position after write and final '\0'
+  if (end > _capacity) {
+    if (_is_fixed) {
       // if buffer cannot resize, silently truncate
-      end = buffer_length;
-      write_len = end - buffer_pos - 1; // leave room for the final '\0'
+      write_len = _capacity - _written - 1; // leave room for the final '\0'
     } else {
       // For small overruns, double the buffer.  For larger ones,
       // increase to the requested size.
-      if (end < buffer_length * 2) {
-        end = buffer_length * 2;
-      }
-      buffer = REALLOC_C_HEAP_ARRAY(char, buffer, end, mtInternal);
-      buffer_length = end;
+      grow(MAX2(end, _capacity * 2));
     }
   }
   // invariant: buffer is always null-terminated
-  guarantee(buffer_pos + write_len + 1 <= buffer_length, "stringStream oob");
+  guarantee(_written + write_len + 1 <= _capacity, "stringStream oob");
   if (write_len > 0) {
-    memcpy(buffer + buffer_pos, s, write_len);
-    buffer_pos += write_len;
+    memcpy(_buffer + _written, s, write_len);
+    _written += write_len;
     zero_terminate();
   }
 
@@ -360,21 +380,21 @@ void stringStream::write(const char* s, size_t len) {
 }
 
 void stringStream::zero_terminate() {
-  assert(buffer != NULL &&
-         buffer_pos < buffer_length, "sanity");
-  buffer[buffer_pos] = '\0';
+  assert(_buffer != NULL &&
+         _written < _capacity, "sanity");
+  _buffer[_written] = '\0';
 }
 
 void stringStream::reset() {
-  buffer_pos = 0; _precount = 0; _position = 0;
+  _written = 0; _precount = 0; _position = 0;
   zero_terminate();
 }
 
 char* stringStream::as_string(bool c_heap) const {
   char* copy = c_heap ?
-    NEW_C_HEAP_ARRAY(char, buffer_pos + 1, mtInternal) : NEW_RESOURCE_ARRAY(char, buffer_pos + 1);
-  strncpy(copy, buffer, buffer_pos);
-  copy[buffer_pos] = 0;  // terminating null
+    NEW_C_HEAP_ARRAY(char, _written + 1, mtInternal) : NEW_RESOURCE_ARRAY(char, _written + 1);
+  strncpy(copy, _buffer, _written);
+  copy[_written] = 0;  // terminating null
   if (c_heap) {
     // Need to ensure our content is written to memory before we return
     // the pointer to it.
@@ -384,8 +404,8 @@ char* stringStream::as_string(bool c_heap) const {
 }
 
 stringStream::~stringStream() {
-  if (buffer_fixed == false && buffer != NULL) {
-    FREE_C_HEAP_ARRAY(char, buffer);
+  if (_is_fixed == false && _buffer != NULL && _buffer != _small_buffer) {
+    FREE_C_HEAP_ARRAY(char, _buffer);
   }
 }
 

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -87,7 +87,6 @@ class outputStream : public ResourceObj {
    // sizing
    int width()    const { return _width;    }
    int position() const { return _position; }
-   int newlines() const { return _newlines; }
    julong count() const { return _precount + _position; }
    void set_count(julong count) { _precount = count - _position; }
    void set_position(int pos)   { _position = pos; }
@@ -192,12 +191,11 @@ class ttyUnlocker: StackObj {
 // for writing to strings; buffer will expand automatically.
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
- protected:
   char*  _buffer;
-  size_t _written;
+  size_t _written;  // Number of characters written, excluding termin. zero
   size_t _capacity;
   const bool _is_fixed;
-  char   _small_buffer[32];
+  char   _small_buffer[48];
 
   // Grow backing buffer to desired capacity.
   void grow(size_t new_capacity);

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -193,10 +193,14 @@ class ttyUnlocker: StackObj {
 // Buffer will always be zero-terminated.
 class stringStream : public outputStream {
  protected:
-  char*  buffer;
-  size_t buffer_pos;
-  size_t buffer_length;
-  bool   buffer_fixed;
+  char*  _buffer;
+  size_t _written;
+  size_t _capacity;
+  const bool _is_fixed;
+  char   _small_buffer[32];
+
+  // Grow backing buffer to desired capacity.
+  void grow(size_t new_capacity);
 
   // zero terminate at buffer_pos.
   void zero_terminate();
@@ -204,7 +208,7 @@ class stringStream : public outputStream {
  public:
   // Create a stringStream using an internal buffer of initially initial_bufsize size;
   // will be enlarged on demand. There is no maximum cap.
-  stringStream(size_t initial_bufsize = 256);
+  stringStream(size_t initial_capacity = 0);
   // Creates a stringStream using a caller-provided buffer. Will truncate silently if
   // it overflows.
   stringStream(char* fixed_buffer, size_t fixed_buffer_size);
@@ -212,8 +216,8 @@ class stringStream : public outputStream {
   virtual void write(const char* c, size_t len);
   // Return number of characters written into buffer, excluding terminating zero and
   // subject to truncation in static buffer mode.
-  size_t      size() const { return buffer_pos; }
-  const char* base() const { return buffer; }
+  size_t      size() const { return _written; }
+  const char* base() const { return _buffer; }
   void  reset();
   // copy to a resource, or C-heap, array as requested
   char* as_string(bool c_heap = false) const;


### PR DESCRIPTION
stringStream objects are used as temporary string buffers a lot in hotspot. When investigating JDK-8259710, I found that a large majority of the stringStreams created never use the backing buffer fully; about 70% of all streams write less than 32 characters.

stringStream creates an backing buffer, C-heap allocated, with a default size of 256 characters. Some things could be improved:

- add a small in-object buffer for the first n characters to be written. This would avoid or at least delay allocation of the backing buffer from C-heap, at the expense of slightly increased object size and one memcpy when switching over to C-heap. Note that if the backing buffer is smaller than what now is the default size, the total footprint will go down despite the increased object size.

- Delaying allocation of the backing buffer would be good for the many cases where stringStream objects are created as temporary objects without being actually used, see eg. compile.hpp `class PrintInliningBuffer`

- Besides all that, the code could benefit from a little grooming (using modern style syntax etc).

----

This patch:

- renames members of stringStream to conform to common syntax (eg leading underscores) and to be clearer
- Uses initialization lists
- Factors out buffer growth code from stringStream::write() to a new function stringStream::grow()
- Introduces a new object-internal mini buffer, `stringStream::_small_buffer`, sized 32 bytes, which is initially used for all writes

This patch drastically reduces the number of malloc calls done from this class. The internal buffer size of 32byte seems a good cut-off. Running some unrelated test program (no tracing active), I see a reduction in the number of malloc calls from stringStream from ~211K malloc calls down to 53K (debug VM). In a release VM, it drops from ~85K down to about 1K. The reason is that `stringStream` is used in a ton of places as a temporary stack allocated object, to write very minimal text snippets to.

I also tweaked the associated gtest to test more thoroughly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260030](https://bugs.openjdk.java.net/browse/JDK-8260030): Improve stringStream buffer handling


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 4a869bba011a5557aa3e8dfb568e5833c35d3054
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to cced1e7955419ce3c1459e79d0ff0e27e5c355c7


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2160/head:pull/2160`
`$ git checkout pull/2160`
