### PR TITLE
8260010: UTF8ZipCoder not thread-safe since JDK-8243469

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -225,9 +225,15 @@ class ZipCoder {
                 byte b = a[off];
                 if (b < 0) {
                     // Non-ASCII, fall back to decoding a String
-                    String s = JLA.newStringUTF8NoRepl(a, end - len, end);
+                    // We avoid using decoder() here since the UTF8ZipCoder is
+                    // shared and that decoder is not thread safe.
+                    // We also avoid the JLA.newStringUTF8NoRepl variant at
+                    // this point to avoid throwing exceptions eagerly when
+                    // opening ZipFiles (exceptions are expected when accessing
+                    // malformed entries.)
+                    String s = new String(a, end - len, len, UTF_8.INSTANCE);
                     h = s.hashCode();
-                    if (s.charAt(len - 1) != '/') {
+                    if (s.charAt(s.length() - 1) != '/') {
                         h = 31 * h + '/';
                     }
                     return h;

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -224,8 +224,13 @@ class ZipCoder {
             while (off < end) {
                 byte b = a[off];
                 if (b < 0) {
-                    // Non-ASCII, fall back to decoder loop
-                    return normalizedHashDecode(h, a, off, end);
+                    // Non-ASCII, fall back to decoding a String
+                    String s = JLA.newStringUTF8NoRepl(a, end - len, end);
+                    h = s.hashCode();
+                    if (s.charAt(len - 1) != '/') {
+                        h = 31 * h + '/';
+                    }
+                    return h;
                 } else {
                     h = 31 * h + b;
                     off++;

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -231,12 +231,7 @@ class ZipCoder {
                     // this point to avoid throwing exceptions eagerly when
                     // opening ZipFiles (exceptions are expected when accessing
                     // malformed entries.)
-                    String s = new String(a, end - len, len, UTF_8.INSTANCE);
-                    h = s.hashCode();
-                    if (s.charAt(s.length() - 1) != '/') {
-                        h = 31 * h + '/';
-                    }
-                    return h;
+                    return normalizedHash(new String(a, end - len, len, UTF_8.INSTANCE));
                 } else {
                     h = 31 * h + b;
                     off++;


### PR DESCRIPTION
This patch resolves a thread-safety issue where the singleton UTF8ZipCoder is erroneously using a shared CharsetDecoder when the fast-path fails. It needs to go via creating a new String like before JDK-8243469

This should resolve a rare issue when doing a lot of jar scanning in parallel on jar/zip files (with at least some non-ASCII entries), but I've not managed to create a test that reliably reproduce the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260010](https://bugs.openjdk.java.net/browse/JDK-8260010): UTF8ZipCoder not thread-safe since JDK-8243469


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2163/head:pull/2163`
`$ git checkout pull/2163`
