### PR TITLE
8260048: Shenandoah: ShenandoahMarkingContext asserts are unnecessary

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -29,13 +29,11 @@
 #include "gc/shenandoah/shenandoahMarkingContext.hpp"
 
 inline bool ShenandoahMarkingContext::mark_strong(oop obj, bool& was_upgraded) {
-  shenandoah_assert_not_forwarded(NULL, obj);
-  return (! allocated_after_mark_start(obj)) && _mark_bit_map.mark_strong(cast_from_oop<HeapWord*>(obj), was_upgraded);
+  return (!allocated_after_mark_start(obj)) && _mark_bit_map.mark_strong(cast_from_oop<HeapWord*>(obj), was_upgraded);
 }
 
 inline bool ShenandoahMarkingContext::mark_weak(oop obj) {
-  shenandoah_assert_not_forwarded(NULL, obj);
-  return (! allocated_after_mark_start(obj)) && _mark_bit_map.mark_weak(cast_from_oop<HeapWord *>(obj));
+  return (!allocated_after_mark_start(obj)) && _mark_bit_map.mark_weak(cast_from_oop<HeapWord *>(obj));
 }
 
 inline bool ShenandoahMarkingContext::is_marked(oop obj) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -29,11 +29,11 @@
 #include "gc/shenandoah/shenandoahMarkingContext.hpp"
 
 inline bool ShenandoahMarkingContext::mark_strong(oop obj, bool& was_upgraded) {
-  return (!allocated_after_mark_start(obj)) && _mark_bit_map.mark_strong(cast_from_oop<HeapWord*>(obj), was_upgraded);
+  return !allocated_after_mark_start(obj) && _mark_bit_map.mark_strong(cast_from_oop<HeapWord*>(obj), was_upgraded);
 }
 
 inline bool ShenandoahMarkingContext::mark_weak(oop obj) {
-  return (!allocated_after_mark_start(obj)) && _mark_bit_map.mark_weak(cast_from_oop<HeapWord *>(obj));
+  return !allocated_after_mark_start(obj) && _mark_bit_map.mark_weak(cast_from_oop<HeapWord *>(obj));
 }
 
 inline bool ShenandoahMarkingContext::is_marked(oop obj) const {


### PR DESCRIPTION
There are two `shenandoah_assert_not_forwarded` asserts that are not necessary in `mark_{strong,weak}`, because the only caller [already asserts](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp#L272) this higher-level invariant. There is no need to check it in `ShenandoahMarkingContext` once again. This simplifies the fastpath in fastdebug builds.

Additional testing:
 - [x] `hotspot_gc_shenandoah`
 - [x] `tier1`, `tier2` with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260048](https://bugs.openjdk.java.net/browse/JDK-8260048): Shenandoah: ShenandoahMarkingContext asserts are unnecessary


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2164/head:pull/2164`
`$ git checkout pull/2164`
