### PR TITLE
8259488: Shenandoah: Missing timing tracking for STW CLD root processing

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -112,6 +112,7 @@ void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do_impl(Cl
       _semaphore.claim_all();
     }
   } else {
+    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
     f(clds);
   }
 }


### PR DESCRIPTION
Please review this trivial patch that adds missing timing tracking for STW CLD root processing.

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259488](https://bugs.openjdk.java.net/browse/JDK-8259488): Shenandoah: Missing timing tracking for STW CLD root processing


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2165/head:pull/2165`
`$ git checkout pull/2165`
