### PR TITLE
8260043: Reduce allocation in sun.net.www.protocol.jar.Handler.parseURL

### DIFF
--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -225,51 +225,6 @@ public final class ParseUtil {
         return sb.toString();
     }
 
-    /**
-     * Returns a canonical version of the specified string.
-     */
-    public static String canonizeString(String file, int bangSlash) {
-        int len = file.length()-bangSlash;
-        if (len == 0 || (file.indexOf("./", bangSlash) == -1 && file.charAt(file.length() - 1) != '.')) {
-            return file;
-        } else {
-            String before = file.substring(0, bangSlash);
-            String after = file.substring(bangSlash);
-            return before + doCanonize(after);
-        }
-    }
-
-    private static String doCanonize(String file) {
-        int i, lim;
-
-        // Remove embedded /../
-        while ((i = file.indexOf("/../")) >= 0) {
-            if ((lim = file.lastIndexOf('/', i - 1)) >= 0) {
-                file = file.substring(0, lim) + file.substring(i + 3);
-            } else {
-                file = file.substring(i + 3);
-            }
-        }
-        // Remove embedded /./
-        while ((i = file.indexOf("/./")) >= 0) {
-            file = file.substring(0, i) + file.substring(i + 2);
-        }
-        // Remove trailing ..
-        while (file.endsWith("/..")) {
-            i = file.indexOf("/..");
-            if ((lim = file.lastIndexOf('/', i - 1)) >= 0) {
-                file = file.substring(0, lim+1);
-            } else {
-                file = file.substring(0, i);
-            }
-        }
-        // Remove trailing .
-        if (file.endsWith("/."))
-            file = file.substring(0, file.length() -1);
-
-        return file;
-    }
-
     public static URL fileToEncodedURL(File file)
         throws MalformedURLException
     {

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -228,12 +228,14 @@ public final class ParseUtil {
     /**
      * Returns a canonical version of the specified string.
      */
-    public static String canonizeString(String file) {
-        int len = file.length();
-        if (len == 0 || (file.indexOf("./") == -1 && file.charAt(len - 1) != '.')) {
+    public static String canonizeString(String file, int bangSlash) {
+        int len = file.length()-bangSlash;
+        if (len == 0 || (file.indexOf("./", bangSlash) == -1 && file.charAt(file.length() - 1) != '.')) {
             return file;
         } else {
-            return doCanonize(file);
+            String before = file.substring(0, bangSlash);
+            String after = file.substring(bangSlash);
+            return before + doCanonize(after);
         }
     }
 

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
@@ -27,7 +27,6 @@ package sun.net.www.protocol.jar;
 
 import java.io.IOException;
 import java.net.*;
-import sun.net.www.ParseUtil;
 
 /*
  * Jar URL Handler
@@ -166,7 +165,7 @@ public class Handler extends java.net.URLStreamHandler {
 
             // Canonize the result after the bangslash
             int bangSlash = indexOfBangSlash(file);
-            file = ParseUtil.canonizeString(file, bangSlash);
+            file = canonicalizeString(file, bangSlash);
         }
         setURL(url, "jar", "", -1, file, ref);
     }
@@ -212,5 +211,52 @@ public class Handler extends java.net.URLStreamHandler {
             }
         }
         return (ctxFile + spec);
+    }
+
+    /**
+     * Returns a version of the specified string with
+     * canonicalization applied starting from position {@code off}
+     */
+    private static String canonicalizeString(String file, int off) {
+        int len = file.length();
+        if (off >= len || (file.indexOf("./", off) == -1 && file.charAt(len - 1) != '.')) {
+            return file;
+        } else {
+            // Defer substring and concat until canonicalization is required
+            String before = file.substring(0, off);
+            String after = file.substring(off);
+            return before + doCanonize(after);
+        }
+    }
+
+    private static String doCanonize(String file) {
+        int i, lim;
+
+        // Remove embedded /../
+        while ((i = file.indexOf("/../")) >= 0) {
+            if ((lim = file.lastIndexOf('/', i - 1)) >= 0) {
+                file = file.substring(0, lim) + file.substring(i + 3);
+            } else {
+                file = file.substring(i + 3);
+            }
+        }
+        // Remove embedded /./
+        while ((i = file.indexOf("/./")) >= 0) {
+            file = file.substring(0, i) + file.substring(i + 2);
+        }
+        // Remove trailing ..
+        while (file.endsWith("/..")) {
+            i = file.indexOf("/..");
+            if ((lim = file.lastIndexOf('/', i - 1)) >= 0) {
+                file = file.substring(0, lim+1);
+            } else {
+                file = file.substring(0, i);
+            }
+        }
+        // Remove trailing .
+        if (file.endsWith("/."))
+            file = file.substring(0, file.length() -1);
+
+        return file;
     }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
@@ -166,10 +166,7 @@ public class Handler extends java.net.URLStreamHandler {
 
             // Canonize the result after the bangslash
             int bangSlash = indexOfBangSlash(file);
-            String toBangSlash = file.substring(0, bangSlash);
-            String afterBangSlash = file.substring(bangSlash);
-            afterBangSlash = ParseUtil.canonizeString(afterBangSlash);
-            file = toBangSlash + afterBangSlash;
+            file = ParseUtil.canonizeString(file, bangSlash);
         }
         setURL(url, "jar", "", -1, file, ref);
     }

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
@@ -163,7 +163,7 @@ public class Handler extends java.net.URLStreamHandler {
         } else if (!refOnly) {
             file = parseContextSpec(url, spec);
 
-            // Canonize the result after the bangslash
+            // Canonicalize the result after the bangslash
             int bangSlash = indexOfBangSlash(file);
             file = canonicalizeString(file, bangSlash);
         }

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/Handler.java
@@ -225,11 +225,11 @@ public class Handler extends java.net.URLStreamHandler {
             // Defer substring and concat until canonicalization is required
             String before = file.substring(0, off);
             String after = file.substring(off);
-            return before + doCanonize(after);
+            return before + doCanonicalize(after);
         }
     }
 
-    private static String doCanonize(String file) {
+    private static String doCanonicalize(String file) {
         int i, lim;
 
         // Remove embedded /../


### PR DESCRIPTION
By moving string splitting and concatenation into the canonizeString utility, we can defer allocation until we determine that canonization is required. This saves two string allocations and a string concat for the common case where canonization is not required.

As a refactoring, move ParseUtil.canonizeString/doCanonize into Handler since that's the only call site.

Finally, let's rename the method to canonizalizeString, since canonization is an rather unrelated term. 

/issue 8260043

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260043](https://bugs.openjdk.java.net/browse/JDK-8260043): Reduce allocation in sun.net.www.protocol.jar.Handler.parseURL


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to f4b543d6f1765df5032b2dba950f04962cf55ab5


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2167/head:pull/2167`
`$ git checkout pull/2167`
