### PR TITLE
8260042: G1 Post-cleanup liveness printing occurs too early

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1331,11 +1331,6 @@ void G1ConcurrentMark::cleanup() {
     _g1h->heap_region_iterate(&cl);
   }
 
-  if (log_is_enabled(Trace, gc, liveness)) {
-    G1PrintRegionLivenessInfoClosure cl("Post-Cleanup");
-    _g1h->heap_region_iterate(&cl);
-  }
-
   verify_during_pause(G1HeapVerifier::G1VerifyCleanup, VerifyOption_G1UsePrevMarking, "Cleanup after");
 
   // We need to make this be a "collection" so any collection pause that

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1103,6 +1103,11 @@ void G1Policy::record_concurrent_mark_cleanup_end() {
   G1CollectionSetCandidates* candidates = G1CollectionSetChooser::build(_g1h->workers(), _g1h->num_regions());
   _collection_set->set_candidates(candidates);
 
+  if (log_is_enabled(Trace, gc, liveness)) {
+    G1PrintRegionLivenessInfoClosure cl("Post-Cleanup");
+    _g1h->heap_region_iterate(&cl);
+  }
+
   bool mixed_gc_pending = next_gc_should_be_mixed("request mixed gcs", "request young-only gcs");
   if (!mixed_gc_pending) {
     clear_collection_set_candidates();


### PR DESCRIPTION
Hi all,

  can I have reviews for this small change that fixes position of the Post-cleanup liveness printing, causing wrong gc efficiencies to be printed?

I.e. due to some older changes, the calculation of gc efficiences got moved below the printing of the Post-cleanup liveness which should be about these values. This change corrects that.

Note that there is a sister issue about not printing the gc efficiencies in the "Post-Marking" phase. This is not scope of this change.

Testing: manual testing that values are correct, hs-tier1+2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260042](https://bugs.openjdk.java.net/browse/JDK-8260042): G1 Post-cleanup liveness printing occurs too early


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2168/head:pull/2168`
`$ git checkout pull/2168`
