### PR TITLE
8260053: Optimize Tokens' use of Names

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -25,17 +25,14 @@
 
 package com.sun.tools.javac.parser;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import com.sun.tools.javac.api.Formattable;
 import com.sun.tools.javac.api.Messages;
 import com.sun.tools.javac.parser.Tokens.Token.Tag;
-import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.Name;
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Filter;
-import com.sun.tools.javac.util.ListBuffer;
-import com.sun.tools.javac.util.Names;
+import com.sun.tools.javac.util.*;
 
 /** A class that defines codes/utilities for Java source tokens
  *  returned from lexical analysis.
@@ -52,15 +49,7 @@ public class Tokens {
     /**
      * Keyword array. Maps name indices to Token.
      */
-    private final TokenKind[] key;
-
-    /**  The number of the last entered keyword.
-     */
-    private int maxKey = 0;
-
-    /** The names of all tokens.
-     */
-    private Name[] tokenName;
+    private Map<String, TokenKind> keywords = new HashMap<>();
 
     public static final Context.Key<Tokens> tokensKey = new Context.Key<>();
 
@@ -74,17 +63,11 @@ public class Tokens {
     protected Tokens(Context context) {
         context.put(tokensKey, this);
         names = Names.instance(context);
-        tokenName = names.tokenName;
-        for (Name n : tokenName) {
-            if (n != null && n.getIndex() > maxKey)
-                maxKey = n.getIndex();
-        }
-
-        key = new TokenKind[maxKey+1];
-        for (int i = 0; i <= maxKey; i++) key[i] = TokenKind.IDENTIFIER;
         for (TokenKind t : TokenKind.values()) {
-            if (t.name != null)
-                key[tokenName[t.ordinal()].getIndex()] = t;
+            if (t.name != null) {
+                names.fromString(t.name);
+                keywords.put(t.name, t);
+            }
         }
     }
 
@@ -94,11 +77,13 @@ public class Tokens {
      * identifier token is returned.
      */
     TokenKind lookupKind(Name name) {
-        return (name.getIndex() > maxKey) ? TokenKind.IDENTIFIER : key[name.getIndex()];
+        TokenKind t = keywords.get(name.toString());
+        return (t != null) ? t : TokenKind.IDENTIFIER;
     }
 
     TokenKind lookupKind(String name) {
-        return lookupKind(names.fromString(name));
+        TokenKind t = keywords.get(name);
+        return (t != null) ? t : TokenKind.IDENTIFIER;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Tokens {
 
     /** The names of all tokens.
      */
-    private Name[] tokenName = new Name[TokenKind.values().length];
+    private Name[] tokenName;
 
     public static final Context.Key<Tokens> tokensKey = new Context.Key<>();
 
@@ -74,11 +74,10 @@ public class Tokens {
     protected Tokens(Context context) {
         context.put(tokensKey, this);
         names = Names.instance(context);
-        for (TokenKind t : TokenKind.values()) {
-            if (t.name != null)
-                enterKeyword(t.name, t);
-            else
-                tokenName[t.ordinal()] = null;
+        tokenName = names.tokenName;
+        for (Name n : tokenName) {
+            if (n != null && n.getIndex() > maxKey)
+                maxKey = n.getIndex();
         }
 
         key = new TokenKind[maxKey+1];
@@ -87,12 +86,6 @@ public class Tokens {
             if (t.name != null)
                 key[tokenName[t.ordinal()].getIndex()] = t;
         }
-    }
-
-    private void enterKeyword(String s, TokenKind token) {
-        Name n = names.fromString(s);
-        tokenName[token.ordinal()] = n;
-        if (n.getIndex() > maxKey) maxKey = n.getIndex();
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -25,6 +25,8 @@
 
 package com.sun.tools.javac.util;
 
+import com.sun.tools.javac.parser.Tokens.TokenKind;
+
 /**
  * Access to the compiler's name table.  Standard names are defined,
  * as well as methods to create new names.
@@ -46,6 +48,9 @@ public class Names {
         }
         return instance;
     }
+
+    // the names about TokenKind
+    public final Name[] tokenName = new Name[TokenKind.values().length];
 
     // operators and punctuation
     public final Name asterisk;
@@ -219,6 +224,15 @@ public class Names {
     public Names(Context context) {
         Options options = Options.instance(context);
         table = createTable(options);
+
+        // set the names about TokenKind
+        for (TokenKind tokenKind : TokenKind.values()) {
+            Name tempName = null;
+            if (tokenKind.name != null) {
+                tempName = fromString(tokenKind.name);
+            }
+            tokenName[tokenKind.ordinal()] = tempName;
+        }
 
         // operators and punctuation
         asterisk = fromString("*");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -25,8 +25,6 @@
 
 package com.sun.tools.javac.util;
 
-import com.sun.tools.javac.parser.Tokens.TokenKind;
-
 /**
  * Access to the compiler's name table.  Standard names are defined,
  * as well as methods to create new names.
@@ -48,9 +46,6 @@ public class Names {
         }
         return instance;
     }
-
-    // the names about TokenKind
-    public final Name[] tokenName = new Name[TokenKind.values().length];
 
     // operators and punctuation
     public final Name asterisk;
@@ -224,15 +219,6 @@ public class Names {
     public Names(Context context) {
         Options options = Options.instance(context);
         table = createTable(options);
-
-        // set the names about TokenKind
-        for (TokenKind tokenKind : TokenKind.values()) {
-            Name tempName = null;
-            if (tokenKind.name != null) {
-                tempName = fromString(tokenKind.name);
-            }
-            tokenName[tokenKind.ordinal()] = tempName;
-        }
 
         // operators and punctuation
         asterisk = fromString("*");


### PR DESCRIPTION
Hi all,

This patch initializes the names about `TokenKind` at the beginning of the constructor of the class `Names`. As a result, the `Tokens.maxKey` and the length of the array `Tokens.key` become small. By using this patch, the length of the array `Tokens.key` is changed from 4280 to 383.

The original discussion is at [compiler-dev](https://mail.openjdk.java.net/pipermail/compiler-dev/2021-January/016126.html).

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260053](https://bugs.openjdk.java.net/browse/JDK-8260053): Optimize Tokens' use of Names


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2169/head:pull/2169`
`$ git checkout pull/2169`
