### PR TITLE
8259943: FileDescriptor.close0 does not handle EINTR

### DIFF
--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -164,7 +164,12 @@ fileDescriptorClose(JNIEnv *env, jobject this)
         }
     } else {
         int result;
+#if defined(_AIX)
+        /* AIX allows close to be restarted after EINTR */
         RESTARTABLE(close(fd), result);
+#else
+        result = close(fd);
+#endif
         if (result == -1) {
             JNU_ThrowIOExceptionWithLastError(env, "close failed");
         }

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -170,7 +170,7 @@ fileDescriptorClose(JNIEnv *env, jobject this)
 #else
         result = close(fd);
 #endif
-        if (result == -1) {
+        if (result == -1 && errno != EINTR) {
             JNU_ThrowIOExceptionWithLastError(env, "close failed");
         }
     }

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,8 +162,12 @@ fileDescriptorClose(JNIEnv *env, jobject this)
             dup2(devnull, fd);
             close(devnull);
         }
-    } else if (close(fd) == -1) {
-        JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        int result;
+        RESTARTABLE(close(fd), result);
+        if (result == -1) {
+            JNU_ThrowIOExceptionWithLastError(env, "close failed");
+        }
     }
 }
 
@@ -234,7 +238,9 @@ jlong
 handleGetLength(FD fd)
 {
     struct stat64 sb;
-    if (fstat64(fd, &sb) == 0) {
+    int result;
+    RESTARTABLE(fstat64(fd, &sb), result);
+    if (result == 0) {
         return sb.st_size;
     } else {
         return -1;


### PR DESCRIPTION
Please review this small change to handle `EINTR` from `close()` in `fileDescriptorClose()`. The function `handleGetLength()` is also changed to handle `EINTR` from `fstat64()` to match other uses of `fstat64()` in the file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259943](https://bugs.openjdk.java.net/browse/JDK-8259943): FileDescriptor.close0 does not handle EINTR


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 047dac0b35ecdf70fb22623d0ec15cd8e0fbc4c1
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2173/head:pull/2173`
`$ git checkout pull/2173`
