### PR TITLE
6606673: Path2D.Double, Path2D.Float and GeneralPath ctors throw exception when initialCapacity is negative

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/GeneralPath.java
+++ b/src/java.desktop/share/classes/java/awt/geom/GeneralPath.java
@@ -66,6 +66,8 @@ public final class GeneralPath extends Path2D.Float {
      * path to be defined.
      *
      * @param rule the winding rule
+     * @throws IllegalArgumentException if {@code rule} is not either
+     *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
      * @see #WIND_EVEN_ODD
      * @see #WIND_NON_ZERO
      * @since 1.2
@@ -85,6 +87,10 @@ public final class GeneralPath extends Path2D.Float {
      * @param rule the winding rule
      * @param initialCapacity the estimate for the number of path segments
      *                        in the path
+     * @throws IllegalArgumentException if {@code rule} is not either
+     *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
+     * @throws NegativeArraySizeException if {@code initialCapacity} is
+     *         negative
      * @see #WIND_EVEN_ODD
      * @see #WIND_NON_ZERO
      * @since 1.2
@@ -100,6 +106,7 @@ public final class GeneralPath extends Path2D.Float {
      * taken from the specified {@code Shape} object.
      *
      * @param s the specified {@code Shape} object
+     * @throws NullPointerException if {@code s} is {@code null}
      * @since 1.2
      */
     public GeneralPath(Shape s) {

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -128,6 +128,9 @@ public abstract class Path2D implements Shape, Cloneable {
      * @param rule the winding rule
      * @param initialTypes the size to make the initial array to
      *                     store the path segment types
+     * @throws IllegalArgumentException if {@code rule} is not either
+     *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
+     * @throws NegativeArraySizeException if {@code initialTypes} is negative
      * @since 1.6
      */
     /* private protected */
@@ -207,6 +210,8 @@ public abstract class Path2D implements Shape, Cloneable {
          * require the interior of the path to be defined.
          *
          * @param rule the winding rule
+         * @throws IllegalArgumentException if {@code rule} is not either
+         *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
          * @see #WIND_EVEN_ODD
          * @see #WIND_NON_ZERO
          * @since 1.6
@@ -226,6 +231,10 @@ public abstract class Path2D implements Shape, Cloneable {
          * @param rule the winding rule
          * @param initialCapacity the estimate for the number of path segments
          *                        in the path
+         * @throws IllegalArgumentException if {@code rule} is not either
+         *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
+         * @throws NegativeArraySizeException if {@code initialCapacity} is
+         *         negative
          * @see #WIND_EVEN_ODD
          * @see #WIND_NON_ZERO
          * @since 1.6
@@ -242,6 +251,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * taken from the specified {@code Shape} object.
          *
          * @param s the specified {@code Shape} object
+         * @throws NullPointerException if {@code s} is {@code null}
          * @since 1.6
          */
         public Float(Shape s) {
@@ -258,6 +268,7 @@ public abstract class Path2D implements Shape, Cloneable {
          *
          * @param s the specified {@code Shape} object
          * @param at the specified {@code AffineTransform} object
+         * @throws NullPointerException if {@code s} is {@code null}
          * @since 1.6
          */
         public Float(Shape s, AffineTransform at) {
@@ -1101,6 +1112,8 @@ public abstract class Path2D implements Shape, Cloneable {
          * require the interior of the path to be defined.
          *
          * @param rule the winding rule
+         * @throws IllegalArgumentException if {@code rule} is not either
+         *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
          * @see #WIND_EVEN_ODD
          * @see #WIND_NON_ZERO
          * @since 1.6
@@ -1120,6 +1133,10 @@ public abstract class Path2D implements Shape, Cloneable {
          * @param rule the winding rule
          * @param initialCapacity the estimate for the number of path segments
          *                        in the path
+         * @throws IllegalArgumentException if {@code rule} is not either
+         *         {@link #WIND_EVEN_ODD} or {@link #WIND_NON_ZERO}
+         * @throws NegativeArraySizeException if {@code initialCapacity} is
+         *         negative
          * @see #WIND_EVEN_ODD
          * @see #WIND_NON_ZERO
          * @since 1.6
@@ -1136,6 +1153,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * taken from the specified {@code Shape} object.
          *
          * @param s the specified {@code Shape} object
+         * @throws NullPointerException if {@code s} is {@code null}
          * @since 1.6
          */
         public Double(Shape s) {
@@ -1152,6 +1170,7 @@ public abstract class Path2D implements Shape, Cloneable {
          *
          * @param s the specified {@code Shape} object
          * @param at the specified {@code AffineTransform} object
+         * @throws NullPointerException if {@code s} is {@code null}
          * @since 1.6
          */
         public Double(Shape s, AffineTransform at) {

--- a/test/jdk/java/awt/geom/GeneralPath/GeneralPathExceptions.java
+++ b/test/jdk/java/awt/geom/GeneralPath/GeneralPathExceptions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.geom.GeneralPath;
+
+import static java.awt.geom.Path2D.WIND_EVEN_ODD;
+import static java.awt.geom.Path2D.WIND_NON_ZERO;
+
+/*
+ * @test
+ * @bug 6606673
+ * @summary The test checks if correct exceptions are thrown by the constructors
+ */
+public final class GeneralPathExceptions {
+
+    public static void main(String[] args) {
+        try {
+            new GeneralPath(null);
+            throw new RuntimeException("NullPointerException is expected");
+        } catch (NullPointerException ignore) {
+            // expected
+        }
+
+        try {
+            new GeneralPath(-1);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+        try {
+            new GeneralPath(-1, 0);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+
+        try {
+            new GeneralPath(WIND_EVEN_ODD, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+        try {
+            new GeneralPath(WIND_NON_ZERO, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+    }
+}

--- a/test/jdk/java/awt/geom/Path2D/Path2DExceptions.java
+++ b/test/jdk/java/awt/geom/Path2D/Path2DExceptions.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.geom.Path2D;
+
+import static java.awt.geom.Path2D.WIND_EVEN_ODD;
+import static java.awt.geom.Path2D.WIND_NON_ZERO;
+
+/*
+ * @test
+ * @bug 6606673
+ * @summary The test checks if correct exceptions are thrown by the constructors
+ */
+public final class Path2DExceptions {
+
+    public static void main(String[] args) {
+        testFloat();
+        testDouble();
+    }
+
+    private static void testFloat() {
+        try {
+            new Path2D.Float(null);
+            throw new RuntimeException("NullPointerException is expected");
+        } catch (NullPointerException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Float(null, null);
+            throw new RuntimeException("NullPointerException is expected");
+        } catch (NullPointerException ignore) {
+            // expected
+        }
+
+        try {
+            new Path2D.Float(-1);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Float(-1, 0);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+
+        try {
+            new Path2D.Float(WIND_EVEN_ODD, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Float(WIND_NON_ZERO, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+    }
+
+    private static void testDouble() {
+        try {
+            new Path2D.Double(null);
+            throw new RuntimeException("NullPointerException is expected");
+        } catch (NullPointerException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Double(null, null);
+            throw new RuntimeException("NullPointerException is expected");
+        } catch (NullPointerException ignore) {
+            // expected
+        }
+
+        try {
+            new Path2D.Double(-1);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Double(-1, 0);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignore) {
+            // expected
+        }
+
+        try {
+            new Path2D.Double(WIND_EVEN_ODD, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+        try {
+            new Path2D.Double(WIND_NON_ZERO, -1);
+            throw new RuntimeException("NegativeArraySizeException is expected");
+        } catch (NegativeArraySizeException ignore) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
The specification for Path2D.Double, Path2D.Float and GeneralPath constructors is updated. NegativeArraySizeException, IllegalArgumentException and NullPointerException are added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6606673](https://bugs.openjdk.java.net/browse/JDK-6606673): Path2D.Double, Path2D.Float and GeneralPath ctors throw exception when initialCapacity is negative


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2174/head:pull/2174`
`$ git checkout pull/2174`
