### PR TITLE
8260029: aarch64: fix typo in verify_oop_array

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1340,10 +1340,10 @@ class StubGenerator: public StubCodeGenerator {
       __ ldr(temp, Address(a, rscratch2, Address::lsl(exact_log2(size))));
       __ verify_oop(temp);
     } else {
-      __ ldrw(r16, Address(a, rscratch2, Address::lsl(exact_log2(size))));
+      __ ldrw(temp, Address(a, rscratch2, Address::lsl(exact_log2(size))));
       __ decode_heap_oop(temp); // calls verify_oop
     }
-    __ add(rscratch2, rscratch2, size);
+    __ add(rscratch2, rscratch2, 1);
     __ b(loop);
     __ bind(end);
   }


### PR DESCRIPTION
In aarch64 verify_oop_array, we scan over array at 'a' for 'count' oops, verifying each one. The step for the loop should be one for each oop instead of 'size'. We may miss verifying some oops in the array if we set the step to 'size'. Also, we should use 'temp' instead of r16 for the compressed oop case. Register r16 defined but not used in this function.

Tier1-3 tested with linux-aarch64 fastdebug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260029](https://bugs.openjdk.java.net/browse/JDK-8260029): aarch64: fix typo in verify_oop_array


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Contributors
 * Zhuxuan Ni `<nizhuxuan@huawei.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2175/head:pull/2175`
`$ git checkout pull/2175`
