### PR TITLE
8260212: Shenandoah: resolve-only UpdateRefsMode is not used

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -248,9 +248,6 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahHeap* heap, Shenand
     switch (UPDATE_REFS) {
     case NONE:
       break;
-    case RESOLVE:
-      obj = ShenandoahBarrierSet::resolve_forwarded_not_null(obj);
-      break;
     case SIMPLE:
       // We piggy-back reference updating to the marking tasks.
       obj = heap->update_with_forwarded_not_null(p, obj);

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
@@ -34,7 +34,6 @@
 
 enum UpdateRefsMode {
   NONE,       // No reference updating
-  RESOLVE,    // Only a resolve (no reference updating)
   SIMPLE,     // Reference updating using simple store
   CONCURRENT  // Reference updating using CAS
 };
@@ -144,20 +143,6 @@ private:
 
 public:
   ShenandoahMarkRefsDedupClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
-    ShenandoahMarkRefsSuperClosure(q, rp) {};
-
-  virtual void do_oop(narrowOop* p) { do_oop_work(p); }
-  virtual void do_oop(oop* p)       { do_oop_work(p); }
-  virtual bool do_metadata()        { return false; }
-};
-
-class ShenandoahMarkResolveRefsClosure : public ShenandoahMarkRefsSuperClosure {
-private:
-  template <class T>
-  inline void do_oop_work(T* p)     { work<T, RESOLVE, NO_DEDUP>(p); }
-
-public:
-  ShenandoahMarkResolveRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
     ShenandoahMarkRefsSuperClosure(q, rp) {};
 
   virtual void do_oop(narrowOop* p) { do_oop_work(p); }


### PR DESCRIPTION
The only "use" is `ShenandoahMarkResolveRefsClosure`, which is unused itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260212](https://bugs.openjdk.java.net/browse/JDK-8260212): Shenandoah: resolve-only UpdateRefsMode is not used


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2177/head:pull/2177`
`$ git checkout pull/2177`
