### PR TITLE
8259954: gc/shenandoah/mxbeans tests fail with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -159,7 +159,12 @@ public class TestChurnNotifications {
 
         System.gc();
 
-        Thread.sleep(1000);
+        // Wait until notifications start arriving, and then wait some more
+        // to catch the ones arriving late.
+        while (churnBytes.get() == 0) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(5000);
 
         long actual = churnBytes.get();
 

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -148,7 +148,12 @@ public class TestPauseNotifications {
             sink = new int[size];
         }
 
-        Thread.sleep(1000);
+        // Wait until notifications start arriving, and then wait some more
+        // to catch the ones arriving late.
+        while (pausesDuration.get() == 0) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(5000);
 
         long pausesActual = pausesDuration.get();
         long cyclesActual = cyclesDuration.get();


### PR DESCRIPTION
See the bug report for initial observation. The key thing is that the asynchronous GC notifications can arrive late, and they do arrive late with `-Xcomp`, because all that code is now waiting for compilation. The answer is to wait a bit smarter.

Additional testing:
 - [x] `gc/shenandoah/mxbeans` default mode
 - [x] `gc/shenandoah/mxbeans` with `-Xcomp`
 - [x] `gc/shenandoah/mxbeans` with `-Xint`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259954](https://bugs.openjdk.java.net/browse/JDK-8259954): gc/shenandoah/mxbeans tests fail with -Xcomp


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2179/head:pull/2179`
`$ git checkout pull/2179`
