### PR TITLE
JDK-8260222: remove unused _thread member SymbolTableLookup

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -348,7 +348,6 @@ Symbol* SymbolTable::new_symbol(const Symbol* sym, int begin, int end) {
 
 class SymbolTableLookup : StackObj {
 private:
-  Thread* _thread;
   uintx _hash;
   int _len;
   const char* _str;


### PR DESCRIPTION
The class SymbolTableLookup has an unused member _thread. This could be removed.
See also the related sonar finding (claiming an uninitialized field) :

https://sonarcloud.io/project/issues?id=jdk&open=AXaE0c2j8L9hkQskF8y_&resolved=false&types=BUG

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260222](https://bugs.openjdk.java.net/browse/JDK-8260222): remove unused _thread member SymbolTableLookup


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2180/head:pull/2180`
`$ git checkout pull/2180`
