### PR TITLE
JDK-8260200 G1: Remove unnecessary update in FreeRegionList::remove_starting_at

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.cpp
@@ -236,31 +236,33 @@ void FreeRegionList::remove_starting_at(HeapRegion* first, uint num_regions) {
   DEBUG_ONLY(uint old_length = length();)
 
   HeapRegion* curr = first;
+  HeapRegion* prev = curr->prev();
+  if (prev == NULL) {
+    assert_free_region_list(_head == curr, "invariant");
+  } else {
+    assert_free_region_list(_head != curr, "invariant");
+  }
+  HeapRegion* next = curr->next();
+  if (next == NULL) {
+    assert_free_region_list(_tail == curr, "invariant");
+  } else {
+    assert_free_region_list(_tail != curr, "invariant");
+  }
   uint count = 0;
   while (count < num_regions) {
     verify_region(curr);
-    HeapRegion* next = curr->next();
-    HeapRegion* prev = curr->prev();
+    next = curr->next();
 
+    assert_free_region_list(_head != next, "invariant");
+    if (next != NULL) {
+      assert_free_region_list(next->prev() != NULL, "invariant");
+      assert_free_region_list(_tail != curr, "invariant");
+    }
     assert(count < num_regions,
            "[%s] should not come across more regions "
            "pending for removal than num_regions: %u",
            name(), num_regions);
 
-    if (prev == NULL) {
-      assert_free_region_list(_head == curr, "invariant");
-      _head = next;
-    } else {
-      assert_free_region_list(_head != curr, "invariant");
-      prev->set_next(next);
-    }
-    if (next == NULL) {
-      assert_free_region_list(_tail == curr, "invariant");
-      _tail = prev;
-    } else {
-      assert_free_region_list(_tail != curr, "invariant");
-      next->set_prev(prev);
-    }
     if (_last == curr) {
       _last = NULL;
     }
@@ -274,6 +276,17 @@ void FreeRegionList::remove_starting_at(HeapRegion* first, uint num_regions) {
     decrease_length(curr->node_index());
 
     curr = next;
+  }
+
+  if (prev == NULL) {
+    _head = next;
+  } else {
+    prev->set_next(next);
+  }
+  if (next == NULL) {
+    _tail = prev;
+  } else {
+    next->set_prev(prev);
   }
 
   assert(count == num_regions,

--- a/src/hotspot/share/gc/g1/heapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.cpp
@@ -238,18 +238,22 @@ void FreeRegionList::remove_starting_at(HeapRegion* first, uint num_regions) {
 
   // prev points to the node right before first or null when first == _head
   HeapRegion* const prev = first->prev();
+  // next points to the node right after first or null when first == _tail,
+  // and after the while loop below, next should point to the next node right
+  // after the removed sublist, or null if the sublist contains _tail.
+  HeapRegion* next = first->next();
+#ifdef ASSERT
   if (prev == NULL) {
     assert_free_region_list(_head == first, "invariant");
   } else {
     assert_free_region_list(_head != first, "invariant");
   }
-  // next points to the node right after first or null when first == _tail
-  HeapRegion* next = first->next();
   if (next == NULL) {
     assert_free_region_list(_tail == first, "invariant");
   } else {
     assert_free_region_list(_tail != first, "invariant");
   }
+#endif
   HeapRegion* curr = first;
   uint count = 0;
   while (count < num_regions) {

--- a/src/hotspot/share/gc/g1/heapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.cpp
@@ -231,23 +231,26 @@ void FreeRegionList::remove_starting_at(HeapRegion* first, uint num_regions) {
   check_mt_safety();
   assert_free_region_list(num_regions >= 1, "pre-condition");
   assert_free_region_list(!is_empty(), "pre-condition");
+  assert_free_region_list(length() >= num_regions, "pre-condition");
 
   verify_optional();
   DEBUG_ONLY(uint old_length = length();)
 
-  HeapRegion* curr = first;
-  HeapRegion* prev = curr->prev();
+  // prev points to the node right before first or null when first == _head
+  HeapRegion* const prev = first->prev();
   if (prev == NULL) {
-    assert_free_region_list(_head == curr, "invariant");
+    assert_free_region_list(_head == first, "invariant");
   } else {
-    assert_free_region_list(_head != curr, "invariant");
+    assert_free_region_list(_head != first, "invariant");
   }
-  HeapRegion* next = curr->next();
+  // next points to the node right after first or null when first == _tail
+  HeapRegion* next = first->next();
   if (next == NULL) {
-    assert_free_region_list(_tail == curr, "invariant");
+    assert_free_region_list(_tail == first, "invariant");
   } else {
-    assert_free_region_list(_tail != curr, "invariant");
+    assert_free_region_list(_tail != first, "invariant");
   }
+  HeapRegion* curr = first;
   uint count = 0;
   while (count < num_regions) {
     verify_region(curr);
@@ -258,10 +261,6 @@ void FreeRegionList::remove_starting_at(HeapRegion* first, uint num_regions) {
       assert_free_region_list(next->prev() != NULL, "invariant");
       assert_free_region_list(_tail != curr, "invariant");
     }
-    assert(count < num_regions,
-           "[%s] should not come across more regions "
-           "pending for removal than num_regions: %u",
-           name(), num_regions);
 
     if (_last == curr) {
       _last = NULL;

--- a/src/hotspot/share/gc/g1/heapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.cpp
@@ -231,7 +231,7 @@ void FreeRegionList::add_ordered(FreeRegionList* from_list) {
 void FreeRegionList::verify_region_to_remove(HeapRegion* curr, HeapRegion* next) {
   assert_free_region_list(_head != next, "invariant");
   if (next != NULL) {
-    assert_free_region_list(next->prev() != NULL, "invariant");
+    assert_free_region_list(next->prev() == curr, "invariant");
     assert_free_region_list(_tail != curr, "invariant");
   } else {
     assert_free_region_list(_tail == curr, "invariant");

--- a/src/hotspot/share/gc/g1/heapRegionSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.hpp
@@ -227,6 +227,7 @@ public:
   // are taken care of separately, to allow a rebuild.
   void abandon();
 
+  void verify_region_to_remove(HeapRegion* curr, HeapRegion* next) NOT_DEBUG_RETURN;
   // Remove all (contiguous) regions from first to first + num_regions -1 from
   // this list.
   // Num_regions must be >= 1.

--- a/src/hotspot/share/gc/g1/heapRegionSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionSet.hpp
@@ -184,6 +184,7 @@ private:
   void add_list_common_start(FreeRegionList* from_list);
   void add_list_common_end(FreeRegionList* from_list);
 
+  void verify_region_to_remove(HeapRegion* curr, HeapRegion* next) NOT_DEBUG_RETURN;
 protected:
   // See the comment for HeapRegionSetBase::clear()
   virtual void clear();
@@ -227,7 +228,6 @@ public:
   // are taken care of separately, to allow a rebuild.
   void abandon();
 
-  void verify_region_to_remove(HeapRegion* curr, HeapRegion* next) NOT_DEBUG_RETURN;
   // Remove all (contiguous) regions from first to first + num_regions -1 from
   // this list.
   // Num_regions must be >= 1.


### PR DESCRIPTION
optimize FreeRegionList::remove_starting_at by removing unnecessary reading and setting

FreeRegionList::remove_starting_at(...) traverses from a node and removes subsequent N nodes from free list. But when traverses the free list, it removes nodes one by one by setting the prev and next pointers of prev and next node. it's not necessary do these settings for every node, as we can remove target nodes at once and just set prev and next pointers for just 2 nodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260200](https://bugs.openjdk.java.net/browse/JDK-8260200): G1: Remove unnecessary update in FreeRegionList::remove_starting_at


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 5b0fed14b86af058d6df442fca7b7659d0cfb9fb
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2181/head:pull/2181`
`$ git checkout pull/2181`
