### PR TITLE
8260250: Duplicate check in DebugInformationRecorder::recorders_frozen

### DIFF
--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -397,7 +397,7 @@ void DebugInformationRecorder::end_scopes(int pc_offset, bool is_safepoint) {
 
 #ifdef ASSERT
 bool DebugInformationRecorder::recorders_frozen() {
-  return _oop_recorder->is_complete() || _oop_recorder->is_complete();
+  return _oop_recorder->is_complete();
 }
 
 void DebugInformationRecorder::mark_recorders_frozen() {


### PR DESCRIPTION
SonarCloud instance reports the bug here:
  Identical sub-expressions on both sides of operator "||".

```
bool DebugInformationRecorder::recorders_frozen() {
  return _oop_recorder->is_complete() || _oop_recorder->is_complete();
}
```

It seems to be this way since JDK-6964458. I don't see why it is this way. I think the intent was to check and freeze these two recorders:

```
class OopRecorder : public ResourceObj {
 private:
  ValueRecorder<jobject> _oops;
  ValueRecorder<Metadata*> _metadata;
```

...but they are in `OopRecorder` already, and so we already get what we want with a single call:

```
#ifdef ASSERT
  bool is_complete() {
    assert(_oops.is_complete() == _metadata.is_complete(), "must agree");
    return _oops.is_complete();
  }
#endif
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260250](https://bugs.openjdk.java.net/browse/JDK-8260250): Duplicate check in DebugInformationRecorder::recorders_frozen


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2187/head:pull/2187`
`$ git checkout pull/2187`
