### PR TITLE
8260256: Leftover Thread uses after JDK-8223657

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -348,7 +348,6 @@ Symbol* SymbolTable::new_symbol(const Symbol* sym, int begin, int end) {
 
 class SymbolTableLookup : StackObj {
 private:
-  Thread* _thread;
   uintx _hash;
   int _len;
   const char* _str;
@@ -551,10 +550,9 @@ void SymbolTable::verify() {
 
 // Dumping
 class DumpSymbol : StackObj {
-  Thread* _thr;
   outputStream* _st;
 public:
-  DumpSymbol(Thread* thr, outputStream* st) : _thr(thr), _st(st) {}
+  DumpSymbol(outputStream* st) : _st(st) {}
   bool operator()(Symbol** value) {
     assert(value != NULL, "expected valid value");
     assert(*value != NULL, "value should point to a symbol");
@@ -575,7 +573,7 @@ void SymbolTable::dump(outputStream* st, bool verbose) {
     Thread* thr = Thread::current();
     ResourceMark rm(thr);
     st->print_cr("VERSION: 1.1");
-    DumpSymbol ds(thr, st);
+    DumpSymbol ds(st);
     if (!_local_table->try_scan(thr, ds)) {
       log_info(symboltable)("dump unavailable at this moment");
     }


### PR DESCRIPTION
JDK-8223657 cleaned up Thread arguments in SymbolTable, but there are some leftovers. Notably, SonarCloud reports that SymbolTableLookup::_thread is not initialized. I looked for `Thread` usages in `symbolTable.cpp`, and it seems only these two are missing. Maybe @coleenp can spot even more omissions somewhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260256](https://bugs.openjdk.java.net/browse/JDK-8260256): Leftover Thread uses after JDK-8223657


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2188/head:pull/2188`
`$ git checkout pull/2188`
