### PR TITLE
8260272: bash configure --prefix does not work after JDK-8257679

### DIFF
--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -176,10 +176,10 @@ AC_DEFUN([UTIL_FIXUP_EXECUTABLE],
     # space.
     [ if [[ "$OPENJDK_BUILD_OS" = "windows" && input =~ ^$FIXPATH ]]; then
       line="${input#$FIXPATH }"
-      prefix="$FIXPATH "
+      fixpath_prefix="$FIXPATH "
     else
       line="$input"
-      prefix=""
+      fixpath_prefix=""
     fi ]
     path="${line%% *}"
     arguments="${line#"$path"}"
@@ -247,11 +247,11 @@ AC_DEFUN([UTIL_FIXUP_EXECUTABLE],
 
     # Now we have a usable command as new_path, with arguments in arguments
     if test "x$OPENJDK_BUILD_OS" = "xwindows"; then
-      if test "x$prefix" = x; then
-        # Only mess around if prefix was not given
+      if test "x$fixpath_prefix" = x; then
+        # Only mess around if fixpath_prefix was not given
         UTIL_CHECK_WINENV_EXEC_TYPE("$new_path")
         if test "x$RESULT" = xwindows; then
-          prefix="$FIXPATH "
+          fixpath_prefix="$FIXPATH "
           # make sure we have an .exe suffix (but not two)
           new_path="${new_path%.exe}.exe"
         else
@@ -262,11 +262,11 @@ AC_DEFUN([UTIL_FIXUP_EXECUTABLE],
     fi
 
     if test "x$3" = xNOFIXPATH; then
-      prefix=""
+      fixpath_prefix=""
     fi
 
     # Now join together the path and the arguments once again
-    new_complete="$prefix$new_path$arguments"
+    new_complete="$fixpath_prefix$new_path$arguments"
     $1="$new_complete"
   fi
 ])


### PR DESCRIPTION
```bash
$ bash configure --prefix=/home/hedongbo/jdk-release
$ make install
...
Creating CDS archive for jdk image
Creating CDS-NOCOOPS archive for jdk image
Installing jdk image into /jvm/openjdk-17-internal
and creating 60 links from /bin into the jdk.
/bin/mkdir: cannot create directory '/jvm': Permission denied
make[3]: *** [install] Error 1
Install.gmk:36: recipe for target 'install' failed
make/Main.gmk:786: recipe for target 'install' failed
make[2]: *** [install] Error 2

ERROR: Build failed for target 'install' in configuration 'linux-x86_64-server-release' (exit code 2)
Stopping sjavac server

=== Make failed targets repeated here ===
Install.gmk:36: recipe for target 'install' failed
make/Main.gmk:786: recipe for target 'install' failed
=== End of repeated output ===

Hint: Try searching the build log for the name of the first failed target.
Hint: See doc/building.html#troubleshooting for assistance.

/home/hedongbo/myprojects/github/jdk.bak/make/Init.gmk:310: recipe for target 'main' failed
make[1]: *** [main] Error 2
/home/hedongbo/myprojects/github/jdk.bak/make/Init.gmk:186: recipe for target 'install' failed
make: *** [install] Error 2
```




The reason is that the prefix variable used in `make/autoconf/util_paths.m4` conflicts with the prefix used in `make/autoconf/spec.gmk.in:780`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260272](https://bugs.openjdk.java.net/browse/JDK-8260272): bash configure --prefix does not work after JDK-8257679


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2189/head:pull/2189`
`$ git checkout pull/2189`
