### PR TITLE
JDK-8260273: DataOutputStream writeChars optimization

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -300,8 +300,9 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         int len = s.length();
         for (int i = 0 ; i < len ; i++) {
             int v = s.charAt(i);
-            out.write((v >>> 8) & 0xFF);
-            out.write((v >>> 0) & 0xFF);
+            writeBuffer[0] = (byte)(v >>> 8);
+            writeBuffer[1] = (byte)(v >>> 0);
+            out.write(writeBuffer, 0, 2);
         }
         incCount(len * 2);
     }

--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class DataOutputStreamTest {
 
     public enum BasicType {CHAR, SHORT, INT, STRING}
-    @Param({"CHAR", "SHORT", "INT", /* "STRING"*/}) BasicType basicType;
+    @Param({"CHAR", "SHORT", "INT", "STRING"}) BasicType basicType;
 
     @Param({"4096"}) int size;
     final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(size);


### PR DESCRIPTION
this is minor optimization following JDK-8254078.
based on my tests with jmh, it has better performance when apply following patch:

diff --git a/src/java.base/share/classes/java/io/DataOutputStream.java b/src/java.base/share/classes/java/io/DataOutputStream.java
index 9a9a687403c..4ea497fc7c0 100644
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -300,8 +300,9 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         int len = s.length();
         for (int i = 0 ; i < len ; i++) {
             int v = s.charAt(i);
- out.write((v >>> 8) & 0xFF);
- out.write((v >>> 0) & 0xFF);
+ writeBuffer[0] = (byte)(v >>> 8);
+ writeBuffer[1] = (byte)(v >>> 0);
+ out.write(writeBuffer, 0, 2);
         }
         incCount(len * 2);
     }

Basically, it has better performance when apply above patch:

// without writeChars optimization patch, (-XX:-UseBiasedLocking)
Benchmark (basicType) (size) Mode Cnt Score Error Units
DataOutputStreamTest.dataOutputStreamOverBufferedFileStream STRING 4096 avgt 6 115.208 ± 0.327 us/op
DataOutputStreamTest.dataOutputStreamOverByteArray STRING 4096 avgt 6 276.795 ± 0.449 us/op
DataOutputStreamTest.dataOutputStreamOverRawFileStream STRING 4096 avgt 6 12356.969 ± 22.427 us/op

// with writeChars optimization patch, (-XX:-UseBiasedLocking)
Benchmark (basicType) (size) Mode Cnt Score Error Units
DataOutputStreamTest.dataOutputStreamOverBufferedFileStream STRING 4096 avgt 6 133.706 ± 0.274 us/op
DataOutputStreamTest.dataOutputStreamOverByteArray STRING 4096 avgt 6 130.979 ± 0.155 us/op
DataOutputStreamTest.dataOutputStreamOverRawFileStream STRING 4096 avgt 6 6814.272 ± 52.770 us/op


// without writeChars optimization patch, (-XX:+UseBiasedLocking)
Benchmark (basicType) (size) Mode Cnt Score Error Units
DataOutputStreamTest.dataOutputStreamOverBufferedFileStream STRING 4096 avgt 6 130.367 ± 8.759 us/op
DataOutputStreamTest.dataOutputStreamOverByteArray STRING 4096 avgt 6 37.559 ± 0.059 us/op
DataOutputStreamTest.dataOutputStreamOverRawFileStream STRING 4096 avgt 6 12385.030 ± 376.560 us/op

// with writeChars optimization patch, (-XX:+UseBiasedLocking)
Benchmark (basicType) (size) Mode Cnt Score Error Units
DataOutputStreamTest.dataOutputStreamOverBufferedFileStream STRING 4096 avgt 6 45.494 ± 7.018 us/op
DataOutputStreamTest.dataOutputStreamOverByteArray STRING 4096 avgt 6 33.015 ± 0.349 us/op
DataOutputStreamTest.dataOutputStreamOverRawFileStream STRING 4096 avgt 6 6845.549 ± 38.712 us/op

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260273](https://bugs.openjdk.java.net/browse/JDK-8260273): DataOutputStream writeChars optimization


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2190/head:pull/2190`
`$ git checkout pull/2190`
