### PR TITLE
8164484: Unity, JTable cell editor, javax/swing/JComboBox/6559152/bug6559152.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -730,7 +730,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradien
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 8013450 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
-javax/swing/JComboBox/6559152/bug6559152.java 8164484 linux-x64
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -92,16 +92,17 @@ public class bug6559152 {
         frame.add(cb);
 
         frame.pack();
-        frame.setVisible(true);
         frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
 
     private static void test() throws Exception {
         robot.mouseMove(p.x, p.y);
+        robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        testImpl();
         robot.waitForIdle();
+        testImpl();
         checkResult();
     }
 
@@ -114,6 +115,7 @@ public class bug6559152 {
         robot.waitForIdle();
         robot.keyPress(KeyEvent.VK_ENTER);
         robot.keyRelease(KeyEvent.VK_ENTER);
+        robot.waitForIdle();
     }
 
     private static void checkResult() {


### PR DESCRIPTION
This test was problemlisted for linux as it fails only on ubuntu18.04 in mach5 nightly testing. It was infact passing on ubuntu19.10, 20.04 and 20.10 so it was test specific issue. Made appropriate stability fix by adding waitForIdle() at appropriate location.
Mach5 job running specifically on ubuntu18.04 and all other platforms is ok. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8164484](https://bugs.openjdk.java.net/browse/JDK-8164484): Unity, JTable cell editor, javax/swing/JComboBox/6559152/bug6559152.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2192/head:pull/2192`
`$ git checkout pull/2192`
