### PR TITLE
8253420: Refactor HeapRegionManager::find_highest_free

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -537,8 +537,7 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   // Loop downwards from the highest region index, looking for an
   // entry which is either free or not yet committed.  If not yet
   // committed, expand at that index.
-  for (uint i = 0; i < reserved_length(); ++i) {
-    uint curr = reserved_length() - 1 - i;
+  for (uint curr = reserved_length(); curr-- > 0;) {
     HeapRegion *hr = _regions.get_by_index(curr);
     if (hr == NULL || !is_available(curr)) {
       // Found uncommitted and free region, expand to make it available for use.

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -537,8 +537,8 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   // Loop downwards from the highest region index, looking for an
   // entry which is either free or not yet committed.  If not yet
   // committed, expand at that index.
-  uint curr = reserved_length() - 1;
-  while (true) {
+  for (uint i = 0; i < reserved_length(); ++i) {
+    uint curr = reserved_length() - 1 - i;
     HeapRegion *hr = _regions.get_by_index(curr);
     if (hr == NULL || !is_available(curr)) {
       // Found uncommitted and free region, expand to make it available for use.
@@ -547,17 +547,13 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
 
       *expanded = true;
       return curr;
-    } else {
-      if (hr->is_free()) {
-        *expanded = false;
-        return curr;
-      }
     }
-    if (curr == 0) {
-      return G1_NO_HRM_INDEX;
+    if (hr->is_free()) {
+      *expanded = false;
+      return curr;
     }
-    curr--;
   }
+  return G1_NO_HRM_INDEX;
 }
 
 bool HeapRegionManager::allocate_containing_regions(MemRegion range, size_t* commit_count, WorkGang* pretouch_workers) {


### PR DESCRIPTION
Using for-loop to make the number of iterations more explicit. Direct backward iteration, `for (uint curr = reserved_length() - 1; curr >= 0; curr--)` doesn't work due to underflow of `uint` type. Therefore, I went for current approach.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253420](https://bugs.openjdk.java.net/browse/JDK-8253420): Refactor HeapRegionManager::find_highest_free


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2193/head:pull/2193`
`$ git checkout pull/2193`
