### PR TITLE
8260304: (se) EPollSelectorImpl wakeup mechanism broken on Linux 32-bit

### DIFF
--- a/src/java.base/linux/native/libnio/ch/EventFD.c
+++ b/src/java.base/linux/native/libnio/ch/EventFD.c
@@ -48,7 +48,7 @@ Java_sun_nio_ch_EventFD_eventfd0(JNIEnv *env, jclass klazz)
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_EventFD_set0(JNIEnv *env, jclass klazz, jint efd)
 {
-    long one = 1L;
-    return convertReturnVal(env, write(efd, (void*)&one, sizeof(long)),
+    uint64_t one = 1L;
+    return convertReturnVal(env, write(efd, (void*)&one, sizeof(uint64_t)),
         JNI_FALSE);
 }

--- a/src/java.base/linux/native/libnio/ch/EventFD.c
+++ b/src/java.base/linux/native/libnio/ch/EventFD.c
@@ -48,7 +48,7 @@ Java_sun_nio_ch_EventFD_eventfd0(JNIEnv *env, jclass klazz)
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_EventFD_set0(JNIEnv *env, jclass klazz, jint efd)
 {
-    uint64_t one = 1L;
+    uint64_t one = 1ULL;
     return convertReturnVal(env, write(efd, (void*)&one, sizeof(uint64_t)),
         JNI_FALSE);
 }


### PR DESCRIPTION
This readily manifests in GH Actions testing, for example:
 https://github.com/shipilev/jdk/runs/1748754939

Reproducible locally with:

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=sun/misc/JarIndex/metaInfFilenames/Basic.java
...
Caused by: java.io.IOException: Invalid argument
at java.base/sun.nio.ch.EventFD.set0(Native Method)
at java.base/sun.nio.ch.EventFD.set(EventFD.java:48)
at java.base/sun.nio.ch.EPollSelectorImpl.wakeup(EPollSelectorImpl.java:251)
```

The failure is obvious when you look at the code: `long` should be `uint64_t`.

Additional testing:
 - [x] Failing test on Linux x86_32 (now passes)
 - [x] Failing test on Linux x86_64 (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260304](https://bugs.openjdk.java.net/browse/JDK-8260304): (se) EPollSelectorImpl wakeup mechanism broken on Linux 32-bit


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 51f324ae1d1a26c1a9d37138efa30b135ff4edbf
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 51f324ae1d1a26c1a9d37138efa30b135ff4edbf


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2196/head:pull/2196`
`$ git checkout pull/2196`
