### PR TITLE
8260308: Update LogCompilation junit to 4.13.1

### DIFF
--- a/src/utils/LogCompilation/pom.xml
+++ b/src/utils/LogCompilation/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Build and tested on Centos8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260308](https://bugs.openjdk.java.net/browse/JDK-8260308): Update LogCompilation junit to 4.13.1


### Reviewers
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2199/head:pull/2199`
`$ git checkout pull/2199`
