### PR TITLE
8240247: No longer need to wrap files with contentContainer

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -5,7 +5,7 @@
   <title>AWT Threading Issues</title>
 </head>
 <!--
- Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>AWT Threading Issues</h1>
 
 <a id="ListenersThreads"></a>
@@ -193,7 +192,6 @@ non-daemon thread that blocks forever.
 <cite>The Java Virtual Machine Specification</cite>
  guarantees
 that the JVM doesn't exit until this thread terminates.
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
@@ -5,7 +5,7 @@
   <title>AWT Desktop Properties</title>
 </head>
 <!--
- Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>AWT Desktop Properties</h1>
 
 The following refers to standard AWT desktop properties that
@@ -274,7 +273,6 @@ only: {@code NOBUTTON}, {@code BUTTON1}, {@code BUTTON2} and
 This property should be used when there is no need in listening mouse events fired as a result of
 activity with extra mouse button.
 By default this property is set to {@code true}.
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/java/awt/doc-files/FocusSpec.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/FocusSpec.html
@@ -5,7 +5,7 @@
   <title>The AWT Focus Subsystem</title>
 </head>
 <!--
- Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
     <body>
     <main role="main">
-    <div class="contentContainer">
       <h1>The AWT Focus Subsystem</h1>
 
     <p>
@@ -1363,7 +1362,6 @@ and VetoableChangeListener</a>.
           change requests in all cases. Previously, requests were granted
           for heavyweights, but denied for lightweights.
     </ol>
-  </div>
   </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -9,7 +9,7 @@
   </style>
 </head>
 <!--
- Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@
 
 <body>
 <main role="main">
-<div class="contentContainer">
     <h1>The AWT Modality</h1>
 
     <p>
@@ -441,6 +440,5 @@
         <img src="modal-example4.gif" alt="Example 4">
     </p>
     <br style="clear:both;">
-</div>
 </main>
 </body></html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/bmp_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/bmp_metadata.html
@@ -5,7 +5,7 @@
   <title>BMP Metadata Format Specification</title>
 </head>
 <!--
-Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>BMP Metadata Format Specification</h1>
 
 The XML schema for the native image metadata format is as follows:
@@ -162,6 +161,5 @@ The XML schema for the native image metadata format is as follows:
 </pre>
 
 @since 1.5
-</div>
 </main>
 </body>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
@@ -5,7 +5,7 @@
   <title>GIF Metadata Format Specification</title>
 </head>
 <!--
-Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>GIF Metadata Format Specification</h1>
 <a id="gif_stream_metadata_format"></a>
 <h2>GIF Stream Metadata Format Specification</h2>
@@ -463,7 +462,6 @@ advanced only on user input.
 </tr>
 </tbody>
 </table>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/jpeg_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/jpeg_metadata.html
@@ -5,7 +5,7 @@
   <title>JPEG Metadata Format Specification and Usage Notes</title>
 </head>
 <!--
-Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>JPEG Metadata Format Specification and Usage Notes</h1>
 
 <p>
@@ -1160,7 +1159,6 @@ format, performs a <code>reset</code> followed by a merge of the new tree.
   &lt;!-- All elements are as defined above for image metadata --&gt;
 ]&gt;
 </pre>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/png_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/png_metadata.html
@@ -5,7 +5,7 @@
   <title>PNG Metadata Format Specification</title>
 </head>
 <!--
-Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>PNG Metadata Format Specification</h1>
 
 <p>
@@ -562,7 +561,6 @@ written, or to determine the order of the chunks in a file being read.
           &lt;!-- Data type: String --&gt;
 ]&gt;
 </pre>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/standard_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/standard_metadata.html
@@ -5,7 +5,7 @@
   <title>Standard Metadata Format Specification</title>
 </head>
 <!--
-Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>Standard (Plug-in Neutral) Metadata Format Specification</h1>
 
 <p> The plug-in neutral "javax_imageio_1.0" format consists
@@ -395,7 +394,6 @@ following DTD:
             &lt;!-- Data type: Integer --&gt;
 ]&gt;
 </pre>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -5,7 +5,7 @@
     <title>TIFF Metadata Format Specification and Usage Notes</title>
 </head>
 <!--
-Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>TIFF Metadata Format Specification and Usage Notes</h1>
 
 <a href="#Reading">Reading Images</a>
@@ -1234,7 +1233,6 @@ The DTD for the TIFF native image metadata format is as follows:
 </pre>
 
 @since 9
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/wbmp_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/wbmp_metadata.html
@@ -5,7 +5,7 @@
   <title>WBMP Metadata Format Specification</title>
 </head>
 <!--
-Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>WBMP Metadata Format Specification</h1>
 
 The XML schema for the native image metadata format is as follows:
@@ -64,6 +63,5 @@ The XML schema for the native image metadata format is as follows:
 </pre>
 
 @since 1.5
-</div>
 </main>
 </body>

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
@@ -5,7 +5,7 @@
   <title>Using the Multiplexing Look and Feel</title>
 </head>
 <!--
- Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>Using the Multiplexing Look and Feel</h1>
 
 <blockquote>
@@ -496,7 +495,6 @@ if you use this kind of statement, be careful, because the suppliers
 of auxiliary look and feels will most likely have developed and
 tested against our Multiplexing look and feel.
 </p>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/doc-files/properties.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/doc-files/properties.html
@@ -5,7 +5,7 @@
   <title>Colors Used in Nimbus Look and Feel</title>
 </head>
 <!--
- Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>Colors Used in Nimbus Look and Feel</h1>
 <h2 id="primaryColors">Primary Colors</h2>
 <table>
@@ -247,7 +246,6 @@
 </tr>
 </tbody>
 </table>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
@@ -6,7 +6,7 @@
   <style type="text/css">tbody th {font-weight:normal;text-align:left}</style>
 </head>
 <!--
-Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ questions.
 
 <body>
 <main role="main">
-<div class="contentContainer">
 <h1>Component Specific Properties</h1>
 <p> The look, and to some degree the feel of Synth
   can be customized by way of component specific properties.
@@ -1347,7 +1346,6 @@ the blink rate fo the caret.<br>
 <p><code>Prefix</code> is one of: EditorPane, FormattedTextField,
 PasswordField, TextArea, TextField or TextPane.<br>
 </p>
-</div>
 </main>
 </body>
 </html>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"/>
   <title>Synth File Format</title>
 <!--
- Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ div.example {
 
   <body>
   <main role="main">
-  <div class="contentContainer">
     <h1><a id="file">File Format</a></h1>
     <p>
       Synth's file format (<a href="synth.dtd">dtd</a>)
@@ -1031,7 +1030,6 @@ div.example {
 &lt;/synth>
       </pre>
     </div>
-  </div>
   </main>
   </body>
 </html>


### PR DESCRIPTION
[JDK-8231144](https://bugs.openjdk.java.net/browse/JDK-8231144) wrapped the contents of plain HTML documents into `<div class="contentContainer">` to apply the styles and add the margins around the content for a consistent look.

This is no longer necessary after [JDK-8239817](https://bugs.openjdk.java.net/browse/JDK-8239817) was fixed.

These documents looks fine without being wrapped. So this fix basically undoes changes under JDK-8231144 and removes the redundant `<div>` wrapper element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240247](https://bugs.openjdk.java.net/browse/JDK-8240247): No longer need to wrap files with contentContainer


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2203/head:pull/2203`
`$ git checkout pull/2203`
