### PR TITLE
8260169: LogCompilation: Unexpected method mismatch

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1000,10 +1000,13 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
             }
             methods.put(id, m);
         } else if (qname.equals("call")) {
-          if (scopes.peek() == null) {
-              Phase p = phaseStack.peek();
-              assert p != null && p.getName().equals("optimizer") : "should not be in parse here";
-          } else {
+            Phase p = phaseStack.peek();
+            if (scopes.peek() == null && p != null) {
+                // Do not process other phases when scopes is null
+                if (p.getName().equals("parse")) {
+                  reportInternalError( "should not be in parse here:" + p.getName());
+                }
+            } else {
               if (methodHandleSite != null) {
                   methodHandleSite = null;
               }
@@ -1054,9 +1057,12 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
         } else if (qname.equals("replace_string_concat")) {
             expectStringConcatTrap = true;
         } else if (qname.equals("inline_fail")) {
-            if (scopes.peek() == null) {
-                Phase p = phaseStack.peek();
-                assert p != null && p.getName().equals("optimizer") : "should not be in parse here";
+            Phase p = phaseStack.peek();
+            if (scopes.peek() == null && p != null) {
+                // Do not process other phases when scopes is null
+                if (p.getName().equals("parse")) {
+                  reportInternalError( "should not be in parse here:" + p.getName());
+                }
             } else {
                 if (methodHandleSite != null) {
                     scopes.peek().add(methodHandleSite);

--- a/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
+++ b/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package com.sun.hotspot.tools.compiler;
 
 import java.util.Arrays;
 import java.util.Collection;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -125,13 +126,29 @@ public class TestLogCompilation {
         this.logFile = logFile;
     }
 
+    void doItOrFail(String[] args) {
+        try {
+            LogCompilation.main(args);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        String[] args = {
+            logFile
+        };
+        doItOrFail(args);
+    }
+
     @Test
     public void testDashi() throws Exception {
         String[] args = {"-i",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -140,17 +157,7 @@ public class TestLogCompilation {
             "-t",
             logFile
         };
-
-        LogCompilation.main(args);
-    }
-
-    @Test
-    public void testDefault() throws Exception {
-        String[] args = {
-            logFile
-        };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -158,8 +165,7 @@ public class TestLogCompilation {
         String[] args = {"-S",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -167,8 +173,7 @@ public class TestLogCompilation {
         String[] args = {"-U",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -176,8 +181,7 @@ public class TestLogCompilation {
         String[] args = {"-e",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -185,8 +189,7 @@ public class TestLogCompilation {
         String[] args = {"-n",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 
     @Test
@@ -194,7 +197,6 @@ public class TestLogCompilation {
         String[] args = {"-z",
             logFile
         };
-
-        LogCompilation.main(args);
+        doItOrFail(args);
     }
 }


### PR DESCRIPTION
This change checks the phase and scopes so the call stack model is preserved correctly as we process the compilation log. Tested with various JDK 8 and 17, +/-TieredCompilation, with Renaissance, jvm2008, dacapo etc logs as inputs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260169](https://bugs.openjdk.java.net/browse/JDK-8260169): LogCompilation: Unexpected method mismatch


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2205/head:pull/2205`
`$ git checkout pull/2205`
