### PR TITLE
8260315: Typo "focul" instead of "focus" in FocusSpec.html

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/FocusSpec.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/FocusSpec.html
@@ -634,7 +634,7 @@ Assume the following:
    <li><b>A</b>, <b>B</b> and <b>C</b> are components in some window (a container)
    <li><b>R</b> is a container in the window and it is a parent of <b>B</b> and <b>C</b>.
        Besides, <b>R</b> is a focus cycle root.
-   <li><b>B</b> is the default component in the focul traversal cycle of <b>R</b>
+   <li><b>B</b> is the default component in the focus traversal cycle of <b>R</b>
    <li><b>R</b> is a traversable Container in the pic.1, and it is a non-traversable
        Container in the pic.2.
    <li>In such a case a forward traversal will look as follows:


### PR DESCRIPTION
A trivial fix for the typo in AWT Focus Spec, it replaces “focul” with “focus”.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260315](https://bugs.openjdk.java.net/browse/JDK-8260315): Typo "focul" instead of "focus" in FocusSpec.html


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2209/head:pull/2209`
`$ git checkout pull/2209`
