### PR TITLE
8260314: Replace border="1" on tables with CSS

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>AWT Desktop Properties</title>
-  <style type="text/css">
-    table  {border: outset 1px}
-    th, td {border:  inset 1px}
-  </style>
 </head>
 <!--
  Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -57,7 +53,7 @@ setting, they may not be available in environments that do
 not support them. In the event that a desktop property is
 unavailable for any reason, the implementation will return
 <code>null</code>.
-<table>
+<table class="striped">
 <caption>The following table summarizes the desktop properties documented
 here, and their value types.</caption>
 <thead>

--- a/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8"/>
   <title>AWT Desktop Properties</title>
+  <style type="text/css">
+    table  {border: outset 1px}
+    th, td {border:  inset 1px}
+  </style>
 </head>
 <!--
  Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -53,7 +57,7 @@ setting, they may not be available in environments that do
 not support them. In the event that a desktop property is
 unavailable for any reason, the implementation will return
 <code>null</code>.
-<table border=1>
+<table>
 <caption>The following table summarizes the desktop properties documented
 here, and their value types.</caption>
 <thead>

--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -6,8 +6,6 @@
   <style>
     td {text-align: center;}
     tr {text-align: center;}
-    table  {border: outset 1px}
-    th, td {border:  inset 1px}
   </style>
 </head>
 <!--
@@ -209,7 +207,7 @@
       Showing the toolkit-modal dialog: "M"<br>
       M remains unblocked.
 
-          <table>
+          <table class="striped">
 	        <caption>The Standard Blocking Matrix</caption>
             <tbody><tr>
               <th scope="col">current/shown</th>

--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -6,6 +6,8 @@
   <style>
     td {text-align: center;}
     tr {text-align: center;}
+    table  {border: outset 1px}
+    th, td {border:  inset 1px}
   </style>
 </head>
 <!--
@@ -207,7 +209,7 @@
       Showing the toolkit-modal dialog: "M"<br>
       M remains unblocked.
 
-          <table border="1">
+          <table>
 	        <caption>The Standard Blocking Matrix</caption>
             <tbody><tr>
               <th scope="col">current/shown</th>

--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -5,7 +5,6 @@
   <title>The AWT Modality</title>
   <style>
     td {text-align: center;}
-    tr {text-align: center;}
   </style>
 </head>
 <!--

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>GIF Metadata Format Specification</title>
-  <style type="text/css">
-    table  {border: outset 1px}
-    th, td {border:  inset 1px}
-  </style>
 </head>
 <!--
 Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -349,7 +345,7 @@ advanced only on user input.
 
 <p>
 <a id="mapping"></a>
-<table>
+<table class="striped">
 <caption><b>Mapping of Standard to GIF Native Stream Metadata</b></caption>
 <thead>
 <tr>
@@ -412,7 +408,7 @@ advanced only on user input.
 </tbody>
 </table>
 
-<table>
+<table class="striped">
 <caption><b>Mapping of Standard to GIF Native Image Metadata</b></caption>
 <thead>
 <tr>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/gif_metadata.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8"/>
   <title>GIF Metadata Format Specification</title>
+  <style type="text/css">
+    table  {border: outset 1px}
+    th, td {border:  inset 1px}
+  </style>
 </head>
 <!--
 Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -345,7 +349,7 @@ advanced only on user input.
 
 <p>
 <a id="mapping"></a>
-<table border=1>
+<table>
 <caption><b>Mapping of Standard to GIF Native Stream Metadata</b></caption>
 <thead>
 <tr>
@@ -408,7 +412,7 @@ advanced only on user input.
 </tbody>
 </table>
 
-<table border=1>
+<table>
 <caption><b>Mapping of Standard to GIF Native Image Metadata</b></caption>
 <thead>
 <tr>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="utf-8"/>
     <title>TIFF Metadata Format Specification and Usage Notes</title>
+    <style type="text/css">
+        table  {border: outset 1px}
+        th, td {border:  inset 1px}
+    </style>
 </head>
 <!--
 Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -227,7 +231,7 @@ object returned by the TIFF reader using the
 <h4><a id="MapNativeStandard"></a>
 Mapping of TIFF Native Image Metadata to the Standard Metadata Format</h4>
 
-<table border="1">
+<table>
 <caption>The derivation of standard metadata format
 <a href="standard_metadata.html">javax_imageio_1.0</a>
 elements from <a href="#ImageMetadata">TIFF native image metadata</a> is given
@@ -511,7 +515,7 @@ the <code>ImageWriteParam</code> after setting the compression mode to
 <code>MODE_EXPLICIT</code>. The set of innately
 supported compression types is listed in the following table:
 
-<table border=1>
+<table>
 <caption><b>Supported Compression Types</b></caption>
 <thead>
 <tr>
@@ -757,7 +761,7 @@ writer.</p>
 Mapping of the Standard Metadata Format to TIFF Native Image Metadata</h4>
 
 
-<table border="1">
+<table>
 <caption>The derivation of <a href="#ImageMetadata">TIFF native image metadata</a>
 elements from the standard metadata format
 <a href="standard_metadata.html">javax_imageio_1.0</a> is

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -3,10 +3,6 @@
 <head>
     <meta charset="utf-8"/>
     <title>TIFF Metadata Format Specification and Usage Notes</title>
-    <style type="text/css">
-        table  {border: outset 1px}
-        th, td {border:  inset 1px}
-    </style>
 </head>
 <!--
 Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -231,7 +227,7 @@ object returned by the TIFF reader using the
 <h4><a id="MapNativeStandard"></a>
 Mapping of TIFF Native Image Metadata to the Standard Metadata Format</h4>
 
-<table>
+<table class="striped">
 <caption>The derivation of standard metadata format
 <a href="standard_metadata.html">javax_imageio_1.0</a>
 elements from <a href="#ImageMetadata">TIFF native image metadata</a> is given
@@ -515,7 +511,7 @@ the <code>ImageWriteParam</code> after setting the compression mode to
 <code>MODE_EXPLICIT</code>. The set of innately
 supported compression types is listed in the following table:
 
-<table>
+<table class="striped">
 <caption><b>Supported Compression Types</b></caption>
 <thead>
 <tr>
@@ -761,7 +757,7 @@ writer.</p>
 Mapping of the Standard Metadata Format to TIFF Native Image Metadata</h4>
 
 
-<table>
+<table class="striped">
 <caption>The derivation of <a href="#ImageMetadata">TIFF native image metadata</a>
 elements from the standard metadata format
 <a href="standard_metadata.html">javax_imageio_1.0</a> is

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
@@ -5,8 +5,6 @@
   <title>Component Specific Properties</title>
   <style type="text/css">
     tbody th {font-weight:normal;text-align:left}
-    table  {border: outset 1px}
-    th, td {border:  inset 1px}
   </style>
 </head>
 <!--
@@ -58,7 +56,7 @@ JComboBox, JScrollBar and JSplitPane (for the buttons on the divider).
 In       addition to the <a
  href="#buttonProperties">Button 	properties</a>, ArrowButton supports
 the following properties: </p>
-<table>
+<table class="striped">
 <caption>ArrowButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -80,7 +78,7 @@ the following properties: </p>
 <p> JButton paints text using the TEXT_FOREGROUND ColorType. In addition
 to the <a href="#buttonProperties">Button 	properties</a>, JButton
 supports the following property: </p>
-<table>
+<table class="striped">
 <caption>JButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -103,7 +101,7 @@ button that is 	    receiving focus. </td>
 <p> JCheckBox paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JCheckBox supports the following property: </p>
-<table>
+<table class="striped">
 <caption>JCheckBox Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -124,7 +122,7 @@ JCheckBox supports the following property: </p>
 <h2><a id="JComboBox">JComboBox</a></h2>
 <p> JComboBox is a composite component that consists of the following
 child Components: </p>
-<table>
+<table class="striped">
 <caption>JComboBox child components</caption>
   <thead><tr>
     <th scope="col">Name</th>
@@ -172,7 +170,7 @@ the renderer is a UIResource. 	</td>
 </table>
 
 <p>&nbsp;</p>
-<table>
+<table class="striped">
 <caption>JComboBox Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -192,7 +190,7 @@ with the keyboard. </td>
 </table>
 <br>
 <h2>JFileChooser</h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JFileChooser Specific Properties</caption>
   <thead>
     <tr>
@@ -352,7 +350,7 @@ of the file chooser.<br>
 </table>
 <br>
 <h2><a id="JInternalFrame"></a>JInternalFrame</h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JInternalFrame Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -384,7 +382,7 @@ the system menu will be shown.<br>
 <p>JInternalFrameTitlePane is the control bar located at the top of the
 internal frame similar to that found in a frame.<br>
 </p>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JInternalFrameTitlePane Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -482,7 +480,7 @@ abililty to close the internal frame.
 <h2><a id="JList">JList</a></h2>
 <p> JList's sets the name of the renderer to List.renderer.       JList
 supports the following properties: </p>
-<table>
+<table class="striped">
 <caption>JList Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -526,7 +524,7 @@ specific to the       component and Region.MENU_ITEM_ACCELERATOR.
 MENU_ITEM_ACCELERATOR is used for painting the accelerator. Both Regions
 paint text using the TEXT_FOREGROUND ColorType. The following set of
 properties are supported: </p>
-<table>
+<table class="striped">
 <caption>Menu classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -581,7 +579,7 @@ this is used. </td>
 <p> <code>Prefix</code> is one of: CheckBoxMenuItem, Menu, MenuItem, or
 RadioButtonMenuItem. </p>
 <p> JMenu also supports the following properties: </p>
-<table>
+<table class="striped">
 <caption>JMenu specific properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -610,7 +608,7 @@ RadioButtonMenuItem. </p>
 components, they are: OptionPane.button, OptionPane.label,
 OptionPane.comboBox, OptionPane.scrollPane, OptionPane.list,
 OptionPane.textField, OptionPane.iconLabel. </p>
-<table>
+<table class="striped">
 <caption>JOptionPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -723,7 +721,7 @@ it follows the other buttons. 	</td>
 <br>
 <h2><a id="JProgressBar"></a>JProgressBar<br>
 </h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JProgressBar Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>
@@ -763,7 +761,7 @@ the bouncing box per frame when the progress bar is indeterminate.<br>
 <p> JRadioButton paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JRadioButton supports the following property: </p>
-<table>
+<table class="striped">
 <caption>JRadioButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -784,7 +782,7 @@ JRadioButton supports the following property: </p>
 <h2><a id="JScrollBar">JScrollBar</a></h2>
 <p> JScrollBar is a composite component that consists of the following
 child Components: </p>
-<table>
+<table class="striped">
 <caption>JScrollBar child components</caption>
   <thead><tr>
     <th scope="col">Name</th>
@@ -801,7 +799,7 @@ child Components: </p>
 </table>
 
 <p>&nbsp;</p>
-<table>
+<table class="striped">
 <caption>JScrollBar Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -856,7 +854,7 @@ will be made equal. 	</td>
 <h2><a id="Separator">Separators</a></h2>
 <p> All of the separator classes, JSeparator, JPopupMenu.Separator and
 JToolBar.Separator use the same property: </p>
-<table>
+<table class="striped">
 <caption>Separator classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -876,7 +874,7 @@ preferred size will include the Insets. </td>
   </tbody>
 </table>
 <p> JToolBar.Separator also supports the following property: </p>
-<table>
+<table class="striped">
 <caption>JToolBar.Separator specific properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -910,7 +908,7 @@ preferred size will include the Insets. </td>
       <code>paintViewportBorder</code> is called to paint the
       <code>Viewport</code>s border.
  </p>
-<table>
+<table class="striped">
 <caption>JScrollPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -934,7 +932,7 @@ potentially two buttons, if setOneTouchExpandable(true) has been
 invoked. The two buttons will be named:
 SplitPaneDivider.leftOneTouchButton and
 SplitPaneDivider.rightOneTouchButton. </p>
-<table>
+<table class="striped">
 <caption>JSplitPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -978,7 +976,7 @@ setOneTouchExpandable. 	</td>
 </table>
 <br>
 <h2><a id="JSlider"></a>JSlider</h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JSlider Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -1037,7 +1035,7 @@ of the slider.<br>
 </table>
 <br>
 <h2><a id="JTabbedPane"></a>JTabbedPane</h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>JTabbedPane Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>
@@ -1100,7 +1098,7 @@ selected tab.<br>
 <h2><a id="JTable">JTable</a></h2>
 <p> JTable sets the name of the renderer to Table.cellRenderer.
 JTable supports the following properties: </p>
-<table>
+<table class="striped">
 <caption>JTable Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1145,7 +1143,7 @@ renderer will only succeed if it is a Synth Border. 	</td>
 <h2><a id="JTree">JTree</a></h2>
 <p> JTree sets the name of the renderer to Tree.renderer, the name of
 the editor is Tree.cellEditor.</p>
-<table>
+<table class="striped">
 <caption>JTree Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1229,7 +1227,7 @@ and <a href="synthFileFormat.html#e.graphicsUtils">binding it</a> to the tree.</
 <p> JToggleButton paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JToggleButton supports the following property: </p>
-<table>
+<table class="striped">
 <caption>JToggleButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1251,7 +1249,7 @@ JToggleButton supports the following property: </p>
 <p> Each of the Button classes (JButton, JCheckBox, JRadioButton,
 JToggleButton and SynthArrowButton) support a similar set of properties.
 These properties are: </p>
-<table>
+<table class="striped">
 <caption>Button classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1303,7 +1301,7 @@ JToggleButton.<br>
 </p>
 <h2><a id="textProperties"></a>Text Properties<br>
 </h2>
-<table style="text-align: left; width: 100%;">
+<table class="striped" style="text-align: left; width: 100%;">
 <caption>Text classes common properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
@@ -3,9 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <title>Component Specific Properties</title>
-  <style type="text/css">
-    tbody th {font-weight:normal;text-align:left}
-  </style>
+  <style type="text/css">tbody th {font-weight:normal;text-align:left}</style>
 </head>
 <!--
 Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/componentProperties.html
@@ -3,7 +3,11 @@
 <head>
   <meta charset="utf-8"/>
   <title>Component Specific Properties</title>
-  <style type="text/css">tbody th {font-weight:normal;text-align:left}</style>
+  <style type="text/css">
+    tbody th {font-weight:normal;text-align:left}
+    table  {border: outset 1px}
+    th, td {border:  inset 1px}
+  </style>
 </head>
 <!--
 Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
@@ -54,7 +58,7 @@ JComboBox, JScrollBar and JSplitPane (for the buttons on the divider).
 In       addition to the <a
  href="#buttonProperties">Button 	properties</a>, ArrowButton supports
 the following properties: </p>
-<table border="1">
+<table>
 <caption>ArrowButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -76,7 +80,7 @@ the following properties: </p>
 <p> JButton paints text using the TEXT_FOREGROUND ColorType. In addition
 to the <a href="#buttonProperties">Button 	properties</a>, JButton
 supports the following property: </p>
-<table border="1">
+<table>
 <caption>JButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -99,7 +103,7 @@ button that is 	    receiving focus. </td>
 <p> JCheckBox paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JCheckBox supports the following property: </p>
-<table border="1">
+<table>
 <caption>JCheckBox Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -120,7 +124,7 @@ JCheckBox supports the following property: </p>
 <h2><a id="JComboBox">JComboBox</a></h2>
 <p> JComboBox is a composite component that consists of the following
 child Components: </p>
-<table border="1">
+<table>
 <caption>JComboBox child components</caption>
   <thead><tr>
     <th scope="col">Name</th>
@@ -168,7 +172,7 @@ the renderer is a UIResource. 	</td>
 </table>
 
 <p>&nbsp;</p>
-<table border="1">
+<table>
 <caption>JComboBox Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -188,7 +192,7 @@ with the keyboard. </td>
 </table>
 <br>
 <h2>JFileChooser</h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JFileChooser Specific Properties</caption>
   <thead>
     <tr>
@@ -348,7 +352,7 @@ of the file chooser.<br>
 </table>
 <br>
 <h2><a id="JInternalFrame"></a>JInternalFrame</h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JInternalFrame Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -380,7 +384,7 @@ the system menu will be shown.<br>
 <p>JInternalFrameTitlePane is the control bar located at the top of the
 internal frame similar to that found in a frame.<br>
 </p>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JInternalFrameTitlePane Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -478,7 +482,7 @@ abililty to close the internal frame.
 <h2><a id="JList">JList</a></h2>
 <p> JList's sets the name of the renderer to List.renderer.       JList
 supports the following properties: </p>
-<table border="1">
+<table>
 <caption>JList Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -522,7 +526,7 @@ specific to the       component and Region.MENU_ITEM_ACCELERATOR.
 MENU_ITEM_ACCELERATOR is used for painting the accelerator. Both Regions
 paint text using the TEXT_FOREGROUND ColorType. The following set of
 properties are supported: </p>
-<table border="1">
+<table>
 <caption>Menu classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -577,7 +581,7 @@ this is used. </td>
 <p> <code>Prefix</code> is one of: CheckBoxMenuItem, Menu, MenuItem, or
 RadioButtonMenuItem. </p>
 <p> JMenu also supports the following properties: </p>
-<table border="1">
+<table>
 <caption>JMenu specific properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -606,7 +610,7 @@ RadioButtonMenuItem. </p>
 components, they are: OptionPane.button, OptionPane.label,
 OptionPane.comboBox, OptionPane.scrollPane, OptionPane.list,
 OptionPane.textField, OptionPane.iconLabel. </p>
-<table border="1">
+<table>
 <caption>JOptionPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -719,7 +723,7 @@ it follows the other buttons. 	</td>
 <br>
 <h2><a id="JProgressBar"></a>JProgressBar<br>
 </h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JProgressBar Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>
@@ -759,7 +763,7 @@ the bouncing box per frame when the progress bar is indeterminate.<br>
 <p> JRadioButton paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JRadioButton supports the following property: </p>
-<table border="1">
+<table>
 <caption>JRadioButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -780,7 +784,7 @@ JRadioButton supports the following property: </p>
 <h2><a id="JScrollBar">JScrollBar</a></h2>
 <p> JScrollBar is a composite component that consists of the following
 child Components: </p>
-<table border="1">
+<table>
 <caption>JScrollBar child components</caption>
   <thead><tr>
     <th scope="col">Name</th>
@@ -797,7 +801,7 @@ child Components: </p>
 </table>
 
 <p>&nbsp;</p>
-<table border="1">
+<table>
 <caption>JScrollBar Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -852,7 +856,7 @@ will be made equal. 	</td>
 <h2><a id="Separator">Separators</a></h2>
 <p> All of the separator classes, JSeparator, JPopupMenu.Separator and
 JToolBar.Separator use the same property: </p>
-<table border="1">
+<table>
 <caption>Separator classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -872,7 +876,7 @@ preferred size will include the Insets. </td>
   </tbody>
 </table>
 <p> JToolBar.Separator also supports the following property: </p>
-<table border="1">
+<table>
 <caption>JToolBar.Separator specific properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -906,7 +910,7 @@ preferred size will include the Insets. </td>
       <code>paintViewportBorder</code> is called to paint the
       <code>Viewport</code>s border.
  </p>
-<table border="1">
+<table>
 <caption>JScrollPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -930,7 +934,7 @@ potentially two buttons, if setOneTouchExpandable(true) has been
 invoked. The two buttons will be named:
 SplitPaneDivider.leftOneTouchButton and
 SplitPaneDivider.rightOneTouchButton. </p>
-<table border="1">
+<table>
 <caption>JSplitPane Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -974,7 +978,7 @@ setOneTouchExpandable. 	</td>
 </table>
 <br>
 <h2><a id="JSlider"></a>JSlider</h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JSlider Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property<br>
@@ -1033,7 +1037,7 @@ of the slider.<br>
 </table>
 <br>
 <h2><a id="JTabbedPane"></a>JTabbedPane</h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>JTabbedPane Specific Properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>
@@ -1096,7 +1100,7 @@ selected tab.<br>
 <h2><a id="JTable">JTable</a></h2>
 <p> JTable sets the name of the renderer to Table.cellRenderer.
 JTable supports the following properties: </p>
-<table border="1">
+<table>
 <caption>JTable Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1141,7 +1145,7 @@ renderer will only succeed if it is a Synth Border. 	</td>
 <h2><a id="JTree">JTree</a></h2>
 <p> JTree sets the name of the renderer to Tree.renderer, the name of
 the editor is Tree.cellEditor.</p>
-<table border="1">
+<table>
 <caption>JTree Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1225,7 +1229,7 @@ and <a href="synthFileFormat.html#e.graphicsUtils">binding it</a> to the tree.</
 <p> JToggleButton paints text using the TEXT_FOREGROUND ColorType. In
 addition to the <a href="#buttonProperties">Button 	properties</a>,
 JToggleButton supports the following property: </p>
-<table border="1">
+<table>
 <caption>JToggleButton Specific Properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1247,7 +1251,7 @@ JToggleButton supports the following property: </p>
 <p> Each of the Button classes (JButton, JCheckBox, JRadioButton,
 JToggleButton and SynthArrowButton) support a similar set of properties.
 These properties are: </p>
-<table border="1">
+<table>
 <caption>Button classes common properties</caption>
   <thead><tr>
     <th scope="col">Property</th>
@@ -1299,7 +1303,7 @@ JToggleButton.<br>
 </p>
 <h2><a id="textProperties"></a>Text Properties<br>
 </h2>
-<table border="1" style="text-align: left; width: 100%;">
+<table style="text-align: left; width: 100%;">
 <caption>Text classes common properties</caption>
   <thead><tr>
       <th scope="col" style="vertical-align: top; text-align: center;">Property</th>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -41,13 +41,6 @@ div.example {
     width: 100%;
     color: maroon;
 }
-
-table {
-    border: outset 1px
-}
-th, td {
-    border:  inset 1px
-}
   </style>
   </head>
 
@@ -783,7 +776,7 @@ th, td {
       The following outlines which painter will be used for what
       SynthPainter method:
     </p>
-    <table>
+    <table class="striped">
      <caption>Painters for SynthPainter methods</caption>
       <thead>
       <tr>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8"/>
   <title>Synth File Format</title>
+  <style type="text/css">
+    table  {border: outset 1px}
+    th, td {border:  inset 1px}
+  </style>
 <!--
  Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -776,7 +780,7 @@ div.example {
       The following outlines which painter will be used for what
       SynthPainter method:
     </p>
-    <table border=1>
+    <table>
      <caption>Painters for SynthPainter methods</caption>
       <thead>
       <tr>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>Synth File Format</title>
-  <style type="text/css">
-    table  {border: outset 1px}
-    th, td {border:  inset 1px}
-  </style>
 <!--
  Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -44,6 +40,13 @@ pre.dtd-fragment {
 div.example {
     width: 100%;
     color: maroon;
+}
+
+table {
+    border: outset 1px
+}
+th, td {
+    border:  inset 1px
 }
   </style>
   </head>


### PR DESCRIPTION
Replace presentational attribute `border="1"` on `<table>` element with CSS styles:
```
table {border: outset 1px}
th, td {border: inset 1px} 
```

These declarations produce the same rendering as the default one in Firefox and Edge. 

Another option is to use `solid` in both cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260314](https://bugs.openjdk.java.net/browse/JDK-8260314): Replace border="1" on tables with CSS


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2210/head:pull/2210`
`$ git checkout pull/2210`
