### PR TITLE
8260337: Optimize ImageReader lookup, used by Class.getResource

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3048,15 +3048,19 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     /**
-     * Add a package name prefix if the name is not absolute Remove leading "/"
+     * Add a package name prefix if the name is not absolute. Remove leading "/"
      * if name is absolute
      */
     private String resolveName(String name) {
         if (!name.startsWith("/")) {
-            Class<?> c = isArray() ? elementType() : this;
-            String baseName = c.getPackageName();
+            String baseName = getPackageName();
             if (baseName != null && !baseName.isEmpty()) {
-                name = baseName.replace('.', '/') + "/" + name;
+                int len = baseName.length() + 1 + name.length();
+                StringBuilder sb = new StringBuilder(len);
+                name = sb.append(baseName.replace('.', '/'))
+                    .append('/')
+                    .append(name)
+                    .toString();
             }
         } else {
             name = name.substring(1);

--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -329,9 +329,7 @@ public class BasicImageReader implements AutoCloseable {
         if (offset < 0 || offset >= strings.limit()) {
             throw new IndexOutOfBoundsException("offset");
         }
-
-        ByteBuffer buffer = slice(strings, offset, strings.limit() - offset);
-        return ImageStringsReader.stringFromByteBuffer(buffer);
+        return ImageStringsReader.stringFromByteBuffer(strings, offset);
     }
 
     private byte[] getBufferBytes(ByteBuffer buffer) {

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
@@ -137,10 +137,10 @@ public class ImageLocation {
         Objects.requireNonNull(module);
         Objects.requireNonNull(name);
         int index = 0;
-        int moduleOffset = -1;
-        int parentOffset = -1;
-        int baseOffset = -1;
-        int extOffset = -1;
+        int moduleOffset = 0;
+        int parentOffset = 0;
+        int baseOffset = 0;
+        int extOffset = 0;
 
         int limit = locations.limit();
         while (locationOffset < limit) {
@@ -170,10 +170,6 @@ public class ImageLocation {
                     break;
             }
             locationOffset += length;
-        }
-
-        if (moduleOffset == -1 || parentOffset == -1 || baseOffset == -1 || extOffset == -1) {
-            return false;
         }
 
         if (moduleOffset != 0) {

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java
@@ -136,9 +136,7 @@ public class ImageLocation {
     }
 
     static boolean verify(String module, String name, ByteBuffer locations,
-                                  int locationOffset, ImageStrings strings) {
-        Objects.requireNonNull(module);
-        Objects.requireNonNull(name);
+                          int locationOffset, ImageStrings strings) {
         int moduleOffset = 0;
         int parentOffset = 0;
         int baseOffset = 0;

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -148,6 +148,11 @@ public final class ImageReader implements AutoCloseable {
         return reader.findLocation(mn, rn);
     }
 
+    public boolean verifyLocation(String mn, String rn) {
+        requireOpen();
+        return reader.verifyLocation(mn, rn);
+    }
+
     public ImageLocation findLocation(String name) {
         requireOpen();
         return reader.findLocation(name);
@@ -740,7 +745,7 @@ public final class ImageReader implements AutoCloseable {
 
         public void walk(Consumer<? super Node> consumer) {
             consumer.accept(this);
-            for ( Node child : children ) {
+            for (Node child : children) {
                 if (child.isDirectory()) {
                     ((Directory)child).walk(consumer);
                 } else {

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStrings.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStrings.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStrings.java
@@ -33,7 +33,17 @@ package jdk.internal.jimage;
  * to the jimage file provided by the shipped JDK by tools running on JDK 8.
  */
 public interface ImageStrings {
-    public String get(int offset);
+    String get(int offset);
 
-    public int add(final String string);
+    int add(final String string);
+
+    /**
+     * If there's a string at {@code offset} matching in full a substring of
+     * {@code string} starting at {@code stringOffset}, return the length
+     * of that string. Otherwise returns -1. Optional operation.
+     */
+    default int match(int offset, String string, int stringOffset) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
@@ -263,7 +263,7 @@ public class ImageStringsReader implements ImageStrings {
             }
             return new String(asciiBytes, StandardCharsets.US_ASCII);
         }
-        char[] chars = new char[length];
+        char[] chars = new char[-length];
         charsFromByteBuffer(chars, buffer, offset);
         return new String(chars);
     }

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -432,11 +432,27 @@ public final class SystemModuleFinders {
             }
         }
 
+        /**
+         * Verifies the existence of the given resource, {@code false}
+         * if not found.
+         */
+        private boolean containsLocation(String name) throws IOException {
+            Objects.requireNonNull(name);
+            if (closed)
+                throw new IOException("ModuleReader is closed");
+            ImageReader imageReader = SystemImage.reader();
+            if (imageReader != null) {
+                return imageReader.verifyLocation(module, name);
+            } else {
+                // not an images build
+                return false;
+            }
+        }
+
         @Override
         public Optional<URI> find(String name) throws IOException {
-            ImageLocation location = findImageLocation(name);
-            if (location != null) {
-                URI u = URI.create("jrt:/" + module + "/" + name);
+            if (containsLocation(name)) {
+                URI u = JNUA.create("jrt", "/" + module + "/" + name);
                 return Optional.of(u);
             } else {
                 return Optional.empty();

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,10 +433,10 @@ public final class SystemModuleFinders {
         }
 
         /**
-         * Verifies the existence of the given resource, {@code false}
+         * Returns {@code true} if the given resource exists, {@code false}
          * if not found.
          */
-        private boolean containsLocation(String name) throws IOException {
+        private boolean containsImageLocation(String name) throws IOException {
             Objects.requireNonNull(name);
             if (closed)
                 throw new IOException("ModuleReader is closed");
@@ -451,7 +451,7 @@ public final class SystemModuleFinders {
 
         @Override
         public Optional<URI> find(String name) throws IOException {
-            if (containsLocation(name)) {
+            if (containsImageLocation(name)) {
                 URI u = JNUA.create("jrt", "/" + module + "/" + name);
                 return Optional.of(u);
             } else {

--- a/test/micro/org/openjdk/bench/java/lang/ClassGetResource.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassGetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/ClassGetResource.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassGetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.java.nio.file;
+package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.nio.file.FileSystems;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -41,9 +41,11 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 3)
 @State(Scope.Thread)
-public class JrtFileSystemBench {
+public class ClassGetResource {
+
+    /** Calls Class.getResource with the same name */
     @Benchmark
-    public FileSystem createJrtFileSystem() throws Exception {
-        return FileSystems.getFileSystem(URI.create("jrt://"));
+    public URL stringClass() throws ClassNotFoundException {
+        return String.class.getResource("String.class");
     }
 }

--- a/test/micro/org/openjdk/bench/java/nio/file/JrtFileSystemBench.java
+++ b/test/micro/org/openjdk/bench/java/nio/file/JrtFileSystemBench.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.nio.file;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.file.FileSystems;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgs = "-Xmx1g")
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Thread)
+public class JrtFileSystemBench {
+    @Benchmark
+    public FileSystem createJrtFileSystem() throws Exception {
+        return FileSystems.getFileSystem(URI.create("jrt://"));
+    }
+}


### PR DESCRIPTION
This patch optimizes the code paths exercised by `String.class.getResource("String.class")` by:

- Adding an ASCII fast-path to methods verifying strings in the jimage, which can then be done allocation-free
- Avoiding the allocation of the `long[8]` attributes when verifying only for the purpose of verifying a path exists
- Using the `JNUA.create` fast-path in `SystemModuleReader` (which should be OK since we just verified the given name is a JRT path)
- Remove a redundant check in `Class::resolveName` and fitting the `StringBuilder` to size

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260337](https://bugs.openjdk.java.net/browse/JDK-8260337): Optimize ImageReader lookup, used by Class.getResource


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2212/head:pull/2212`
`$ git checkout pull/2212`
