### PR TITLE
8260327: Shenandoah: Shenandoah may fail with -XX:UseSSE=0 on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -44,6 +44,23 @@
 #define __ masm->
 
 static void save_xmm_registers(MacroAssembler* masm) {
+#ifndef _LP64
+    if (UseSSE < 1) {
+        // Don't need to save the xmm state.
+        return;
+    } else if (UseSSE == 1) {
+        __ subptr(rsp, 32);
+        __ movflt(Address(rsp, 0), xmm0);
+        __ movflt(Address(rsp, 4), xmm1);
+        __ movflt(Address(rsp, 8), xmm2);
+        __ movflt(Address(rsp, 12), xmm3);
+        __ movflt(Address(rsp, 16), xmm4);
+        __ movflt(Address(rsp, 20), xmm5);
+        __ movflt(Address(rsp, 24), xmm6);
+        __ movflt(Address(rsp, 28), xmm7);
+        return;
+    }
+#endif
     __ subptr(rsp, 64);
     __ movdbl(Address(rsp, 0), xmm0);
     __ movdbl(Address(rsp, 8), xmm1);
@@ -56,6 +73,23 @@ static void save_xmm_registers(MacroAssembler* masm) {
 }
 
 static void restore_xmm_registers(MacroAssembler* masm) {
+#ifndef _LP64
+    if (UseSSE < 1) {
+        // Don't need to restore the xmm state.
+        return;
+    } else if (UseSSE == 1) {
+        __ movflt(xmm0, Address(rsp, 0));
+        __ movflt(xmm1, Address(rsp, 4));
+        __ movflt(xmm2, Address(rsp, 8));
+        __ movflt(xmm3, Address(rsp, 12));
+        __ movflt(xmm4, Address(rsp, 16));
+        __ movflt(xmm5, Address(rsp, 20));
+        __ movflt(xmm6, Address(rsp, 24));
+        __ movflt(xmm7, Address(rsp, 28));
+        __ addptr(rsp, 32);
+        return;
+    }
+#endif
     __ movdbl(xmm0, Address(rsp, 0));
     __ movdbl(xmm1, Address(rsp, 8));
     __ movdbl(xmm2, Address(rsp, 16));

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -3672,13 +3672,23 @@ class StubGenerator: public StubCodeGenerator {
     const int xmm_size = wordSize * 4;
     const int xmm_spill_size = xmm_size * 2;
     __ subptr(rsp, xmm_spill_size);
-    __ movdqu(Address(rsp, xmm_size * 1), xmm1);
-    __ movdqu(Address(rsp, xmm_size * 0), xmm0);
+    if (UseSSE == 1) {
+        __ movflt(Address(rsp, xmm_size * 1), xmm1);
+        __ movflt(Address(rsp, xmm_size * 0), xmm0);
+    } else if (UseSSE >= 2) {
+        __ movdqu(Address(rsp, xmm_size * 1), xmm1);
+        __ movdqu(Address(rsp, xmm_size * 0), xmm0);
+    }
 
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(address*)>(BarrierSetNMethod::nmethod_stub_entry_barrier)), rbx);
 
-    __ movdqu(xmm0, Address(rsp, xmm_size * 0));
-    __ movdqu(xmm1, Address(rsp, xmm_size * 1));
+    if (UseSSE == 1) {
+        __ movflt(xmm0, Address(rsp, xmm_size * 0));
+        __ movflt(xmm1, Address(rsp, xmm_size * 1));
+    } else if (UseSSE >= 2) {
+        __ movdqu(xmm0, Address(rsp, xmm_size * 0));
+        __ movdqu(xmm1, Address(rsp, xmm_size * 1));
+    }
     __ addptr(rsp, xmm_spill_size);
 
     __ cmpl(rax, 1); // 1 means deoptimize


### PR DESCRIPTION
Hi all,

I'd like to fix this bug although UseSSE=0 won't be used in product environments.
However, it will be benefit for our testing of OpenJDK.

The fix just following the style of RegisterSaver::save_live_registers [1].

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp#L205