### PR TITLE
8242456: PreviewFeature.Feature enum removal of TEXT_BLOCKS

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -54,13 +54,6 @@ public @interface PreviewFeature {
     public boolean reflective() default false;
 
     public enum Feature {
-        // 8242284:
-        // The TEXT_BLOCKS enum constant is not used in the JDK 15 codebase, but
-        // exists to support the bootcycle build of JDK 15. The bootcycle build
-        // of JDK 15 is performed with JDK 14 and the PreviewFeature type from
-        // JDK 15. Since the JDK 14 codebase uses the enum constant, it is
-        // necessary for PreviewFeature in JDK 15 to declare the enum constant.
-        TEXT_BLOCKS,
         // The RECORDS enum constant is not used in the JDK 16 codebase, but
         // exists to support the bootcycle build of JDK 16. The bootcycle build
         // of JDK 16 is performed with JDK 15 and the PreviewFeature type from


### PR DESCRIPTION
The enum constant is unused, and can be removed. The class is not an API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242456](https://bugs.openjdk.java.net/browse/JDK-8242456): PreviewFeature.Feature enum removal of TEXT_BLOCKS 


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2218/head:pull/2218`
`$ git checkout pull/2218`
