### PR TITLE
8260289: Unable to customize module lists after change JDK-8258411

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@
 ifndef _MODULES_GMK
 _MODULES_GMK := 1
 
-# Hook to include the corresponding custom file, if present.
-$(eval $(call IncludeCustomExtension, common/Modules.gmk))
-
 ################################################################################
 # Setup module sets for classloaders
 
@@ -47,6 +44,11 @@ include $(TOPDIR)/make/conf/docs-modules.conf
 # Setup module sets needed by the build system
 
 include $(TOPDIR)/make/conf/build-module-sets.conf
+
+################################################################################
+# Hook to include the corresponding custom file, if present.
+# Allowing MODULE list extensions setup above.
+$(eval $(call IncludeCustomExtension, common/Modules.gmk))
 
 ################################################################################
 # Depending on the configuration, we might need to filter out some modules that


### PR DESCRIPTION
A problem was found downstream with Eclipse OpenJ9 builds whereby since JDK-8258411 they were unable to extend the module lists.
This PR adds a IncludeCustomExtension to the conf/module-loader-map.conf, to enable the module list extension again.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260289](https://bugs.openjdk.java.net/browse/JDK-8260289): Unable to customize module lists after change JDK-8258411


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2219/head:pull/2219`
`$ git checkout pull/2219`
