### PR TITLE
8129776: The optimized Stream returned from Files.lines should unmap the mapped byte buffer (if created) when closed

### DIFF
--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.Objects;
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.misc.ScopedMemoryAccess;
+import jdk.internal.misc.Unsafe;
 
 
 /**
@@ -132,7 +133,7 @@ public abstract class MappedByteBuffer
 
                     @Override
                     public void unmap() {
-                        throw new UnsupportedOperationException();
+                        Unsafe.getUnsafe().invokeCleaner(MappedByteBuffer.this);
                     }
                 } : null;
     }

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -94,13 +94,14 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
     // non-null to null, either when traversing begins or if the spliterator is
     // closed before traversal.  If the count is zero after decrementing, then
     // the buffer is unmapped.
-    private AtomicInteger bufRefCount;
+    private final AtomicInteger bufRefCount;
 
     FileChannelLinesSpliterator(FileChannel fc, Charset cs, int index, int fence) {
         this.fc = fc;
         this.cs = cs;
         this.index = index;
         this.fence = fence;
+        this.bufRefCount = new AtomicInteger();
     }
 
     private FileChannelLinesSpliterator(FileChannel fc, Charset cs, int index,
@@ -209,7 +210,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         ByteBuffer b;
         if ((b = buffer) == null) {
             b = buffer = getMappedByteBuffer();
-            bufRefCount = new AtomicInteger(1);
+            bufRefCount.set(1);
         }
 
         final int hi = fence, lo = index;

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,11 @@ import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.JavaNioAccess;
 
 /**
  * A file-based lines spliterator, leveraging a shared mapped byte buffer and
@@ -84,6 +88,14 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
     // Non-null when traversing
     private BufferedReader reader;
 
+    // Number of references to the shared mapped buffer.  Initialized to unity
+    // when the buffer is created by the root spliterator.  Incremented in the
+    // sub-spliterator constructor.  Decremented when 'buffer' transitions from
+    // non-null to null, either when traversing begins or if the spliterator is
+    // closed before traversal.  If the count is zero after decrementing, then
+    // the buffer is unmapped.
+    private AtomicInteger bufRefCount;
+
     FileChannelLinesSpliterator(FileChannel fc, Charset cs, int index, int fence) {
         this.fc = fc;
         this.cs = cs;
@@ -91,12 +103,15 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         this.fence = fence;
     }
 
-    private FileChannelLinesSpliterator(FileChannel fc, Charset cs, int index, int fence, ByteBuffer buffer) {
+    private FileChannelLinesSpliterator(FileChannel fc, Charset cs, int index,
+        int fence, ByteBuffer buffer, AtomicInteger bufRefCount) {
         this.fc = fc;
-        this.buffer = buffer;
         this.cs = cs;
         this.index = index;
         this.fence = fence;
+        this.buffer = buffer;
+        this.bufRefCount = bufRefCount;
+        this.bufRefCount.incrementAndGet();
     }
 
     @Override
@@ -167,7 +182,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
     private String readLine() {
         if (reader == null) {
             reader = getBufferedReader();
-            buffer = null;
+            unmap();
         }
 
         try {
@@ -178,13 +193,6 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
     }
 
     private ByteBuffer getMappedByteBuffer() {
-        // TODO can the mapped byte buffer be explicitly unmapped?
-        // It's possible, via a shared-secret mechanism, when either
-        // 1) the spliterator starts traversing, although traversal can
-        //    happen concurrently for mulitple spliterators, so care is
-        //    needed in this case; or
-        // 2) when the stream is closed using some shared holder to pass
-        //    the mapped byte buffer when it is created.
         try {
             return fc.map(FileChannel.MapMode.READ_ONLY, 0, fence);
         } catch (IOException e) {
@@ -201,6 +209,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         ByteBuffer b;
         if ((b = buffer) == null) {
             b = buffer = getMappedByteBuffer();
+            bufRefCount = new AtomicInteger(1);
         }
 
         final int hi = fence, lo = index;
@@ -246,7 +255,8 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
 
         // The left spliterator will have the line-separator at the end
         return (mid > lo && mid < hi)
-               ? new FileChannelLinesSpliterator(fc, cs, lo, index = mid, b)
+               ? new FileChannelLinesSpliterator(fc, cs, lo, index = mid,
+                                                 b, bufRefCount)
                : null;
     }
 
@@ -266,5 +276,23 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
     @Override
     public int characteristics() {
         return Spliterator.ORDERED | Spliterator.NONNULL;
+    }
+
+    private void unmap() {
+        if (buffer != null) {
+            ByteBuffer b = buffer;
+            buffer = null;
+            if (bufRefCount.decrementAndGet() == 0) {
+                JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
+                try {
+                    nioAccess.unmapper(b).unmap();
+                } catch (UnsupportedOperationException ignored) {
+                }
+            }
+        }
+    }
+
+    void close() {
+        unmap();
     }
 }

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -4125,7 +4125,7 @@ public final class Files {
                     new FileChannelLinesSpliterator(fc, cs, 0, (int) length);
                 return StreamSupport.stream(fcls, false)
                         .onClose(Files.asUncheckedRunnable(fc))
-                        .onClose(() -> { fcls.close(); });
+                        .onClose(() -> fcls.close());
             }
         } catch (Error|RuntimeException|IOException e) {
             try {

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4121,9 +4121,11 @@ public final class Files {
             // FileChannel.size() may in certain circumstances return zero
             // for a non-zero length file so disallow this case.
             if (length > 0 && length <= Integer.MAX_VALUE) {
-                Spliterator<String> s = new FileChannelLinesSpliterator(fc, cs, 0, (int) length);
-                return StreamSupport.stream(s, false)
-                        .onClose(Files.asUncheckedRunnable(fc));
+                FileChannelLinesSpliterator fcls =
+                    new FileChannelLinesSpliterator(fc, cs, 0, (int) length);
+                return StreamSupport.stream(fcls, false)
+                        .onClose(Files.asUncheckedRunnable(fc))
+                        .onClose(() -> { fcls.close(); });
             }
         } catch (Error|RuntimeException|IOException e) {
             try {


### PR DESCRIPTION
Please review this proposed change to unmap the mapped buffer shared between the root and sub-spliterators used in the optimized `Stream` implementation returned by `Files.lines()`. A reference counter is added to track the total number of spliterators sharing the buffer. It is set to 1 when the shared buffer is created, and incremented each time a sub-spliterator is created. It is decremented when traversing begins or when the spliterator is closed. If the counter is zero after it is decremented then the shared buffer is unmapped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8129776](https://bugs.openjdk.java.net/browse/JDK-8129776): The optimized Stream returned from Files.lines should unmap the mapped byte buffer (if created) when closed 


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 378214104421e11da5ddbf2cf8aed5c78771f529
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to e2b0219f3b566ada58d2fa35c8dfcab6f0dcb5f3
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to e2b0219f3b566ada58d2fa35c8dfcab6f0dcb5f3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2229/head:pull/2229`
`$ git checkout pull/2229`
