### PR TITLE
8260378: [TESTBUG] DcmdMBeanTestCheckJni.java reports false positive

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -27,4 +27,3 @@
 #
 #############################################################################
 
-com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java 8260378 windows-all

--- a/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java
+++ b/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java
@@ -48,7 +48,8 @@ public class DcmdMBeanTestCheckJni {
         OutputAnalyzer out = ProcessTools.executeTestJvm(
             "-Xcheck:jni",
             DcmdMBeanRunner.class.getName());
-        out.shouldNotMatch("WARNING: JNI local refs: \\d+, exceeds capacity: \\d+")
+        out.shouldNotMatch("WARNING: JNI local refs: \\d+, exceeds capacity: \\d+\\s+" +
+                           "at com.sun.management.internal.DiagnosticCommandImpl.getDiagnosticCommandInfo")
            .shouldContain("DcmdMBeanRunner COMPLETE")
            .shouldHaveExitValue(0);
     }


### PR DESCRIPTION
I propose to add additional context to the string which must not match after [JDK-8258836](https://bugs.openjdk.java.net/browse/JDK-8258836). This then passes the test for a fixed JDK (including JDKs with JDK-8187450 *not* fixed).

Testing:
- [x] Reverted the fix from product code of JDK-8258836, ran the test. Failed as expected.
- [x] Ran the updated test on current head. Passed.
- [x] Ran the updated test with [1] included. Passed even though the processes' stdout contained [2].

[1] Explicitly add a call to NetworkInterface.getNetworkInterfaces()
```
diff --git a/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java b/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java
index 73e53da63f1..4f32af3f463 100644
--- a/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java
+++ b/test/jdk/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.java
@@ -62,6 +62,7 @@ class DcmdMBeanRunner {
         "com.sun.management:type=DiagnosticCommand";
 
     public static void main(String[] args) throws Exception {
+        java.net.NetworkInterface.getNetworkInterfaces();
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         JMXServiceURL url = new JMXServiceURL("rmi", null, 0);
         JMXConnectorServer cs = null;
```
[2]
```
--- ProcessLog ---
cmd: /disk/openjdk/upstream-sources/git/jdk-jdk/./build/linux-x86_64-server-release/images/jdk/bin/java -cp /disk/openjdk/upstream-sources/git/jdk-jdk/JTwork/classes/com/sun/management/DiagnosticCommandMBean/DcmdMBeanTestCheckJni.d:/disk/openjdk/upstream-sources/git/jdk-jdk/test/jdk/com/sun/management/DiagnosticCommandMBean:/disk/openjdk/upstream-sources/git/jdk-jdk/JTwork/classes/test/lib:/disk/openjdk/upstream-sources/git/jdk-jdk/test/lib:/disk/openjdk/upstream-sources/jtreg-5.1-b01/lib/javatest.jar:/disk/openjdk/upstream-sources/jtreg-5.1-b01/lib/jtreg.jar -Xcheck:jni DcmdMBeanRunner
exitvalue: 0
stderr:
stdout: WARNING: JNI local refs: 33, exceeds capacity: 32
        at java.net.NetworkInterface.getAll(java.base@17-internal/Native Method)
        at java.net.NetworkInterface.getNetworkInterfaces(java.base@17-internal/NetworkInterface.java:351)
        at DcmdMBeanRunner.main(DcmdMBeanTestCheckJni.java:65)
DiagnosticCommand MBean: com.sun.management:type=DiagnosticCommand
DcmdMBeanRunner COMPLETE
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260378](https://bugs.openjdk.java.net/browse/JDK-8260378): [TESTBUG] DcmdMBeanTestCheckJni.java reports false positive


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2234/head:pull/2234`
`$ git checkout pull/2234`
