### PR TITLE
8260408: Shenandoah: adjust inline hints after JDK-8255019

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -37,9 +37,8 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
   BUILD_LIBJVM_cardTableBarrierSetAssembler_x86.cpp_CXXFLAGS := -Wno-maybe-uninitialized
   BUILD_LIBJVM_interp_masm_x86.cpp_CXXFLAGS := -Wno-uninitialized
   ifeq ($(DEBUG_LEVEL), release)
-    # Need extra inlining to collapse all marking code into the hot marking loop
-    BUILD_LIBJVM_shenandoahConcurrentMark.cpp_CXXFLAGS := --param inline-unit-growth=1000
-    BUILD_LIBJVM_shenandoahTraversalGC.cpp_CXXFLAGS := --param inline-unit-growth=1000
+    # Need extra inlining to collapse shared marking code into the hot marking loop
+    BUILD_LIBJVM_shenandoahMark.cpp_CXXFLAGS := --param inline-unit-growth=1000
   endif
 endif
 


### PR DESCRIPTION
I was following up on performance testing results for some ongoing work, and realized that there are `ShenandoahMarkContext::mark_strong` calls from `mark_work_loop`. Those callees were supposed to be inlined. I believe it is a simple omission after JDK-8255019 moved `mark_work_loop` code to `shenandoahMark.cpp`.

On a typical workload:

```
# Before
[44.500s][info][gc,stats] Concurrent Marking  =    0.395 s (a =    11278 us) 
   (n =    35) (lvls, us =     6426,     9473,    11133,    12891,    16476)

# After
[44.405s][info][gc,stats] Concurrent Marking  =    0.337 s (a =     9636 us) 
   (n =    35) (lvls, us =     3770,     7383,     9785,    11328,    16776)
```

Additional testing:
 - [x] Eyeballing GC hot paths
 - [x] Ad-hoc performance tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260408](https://bugs.openjdk.java.net/browse/JDK-8260408): Shenandoah: adjust inline hints after JDK-8255019


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2235/head:pull/2235`
`$ git checkout pull/2235`
