### PR TITLE
8260413: x86_32 debug build fails after JDK-8259894

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "jvm_io.h"
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "ci/ciReplay.hpp"


### PR DESCRIPTION
```
$ CONF=linux-x86-server-slowdebug make clean all
...
* For target buildjdk_hotspot_variant-server_libjvm_objs_compile.o:
/home/shade/trunks/jdk/src/hotspot/share/opto/compile.cpp: In member function 'void Compile::print_method(CompilerPhaseType, int, int)':
/home/shade/trunks/jdk/src/hotspot/share/opto/compile.cpp:4673:5: error: 'jio_snprintf' was not declared in this scope; did you mean 'vsnprintf'?
 4673 | jio_snprintf(output, sizeof(output), "%s:%d", CompilerPhaseTypeHelper::to_string(cpt), idx);
      | ^~~~~~~~~~~~
      | vsnprintf
/home/shade/trunks/jdk/src/hotspot/share/opto/compile.cpp:4675:5: error: 'jio_snprintf' was not declared in this scope; did you mean 'vsnprintf'?
 4675 | jio_snprintf(output, sizeof(output), "%s", CompilerPhaseTypeHelper::to_string(cpt));
      | ^~~~~~~~~~~~
      | vsnprintf
```

It is somewhat weird it only manifests on x86_32.

Additional testing:
 - [x] Linux x86_32 slowdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260413](https://bugs.openjdk.java.net/browse/JDK-8260413): x86_32 debug build fails after JDK-8259894


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2237/head:pull/2237`
`$ git checkout pull/2237`
