### PR TITLE
8242220: Capture JFR stack trace and thread other than the one the event is committed on

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -46,7 +46,9 @@
 #include "jfr/leakprofiler/leakProfiler.hpp"
 #include "jfr/support/jfrJdkJfrEvent.hpp"
 #include "jfr/support/jfrKlassUnloading.hpp"
+#include "jfr/support/jfrThreadId.hpp"
 #include "jfr/utilities/jfrJavaLog.hpp"
+#include "jfr/utilities/jfrThreadIterator.hpp"
 #include "jfr/utilities/jfrTimeConverter.hpp"
 #include "jfr/utilities/jfrTime.hpp"
 #include "jfr/writers/jfrJavaEventWriter.hpp"
@@ -252,6 +254,22 @@ JVM_END
 
 JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip))
   return JfrStackTraceRepository::record(thread, skip);
+JVM_END
+
+JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id_1(JNIEnv* env, jobject jvm, jlong tid, jint skip))
+
+  JfrJavaThreadIterator threads(true);
+  Thread* target_thread = NULL;
+  while (threads.has_next()) {
+    JavaThread* t = threads.next();
+    traceid ttid = JFR_THREAD_ID(t);
+    if (ttid == (traceid)tid) {
+      target_thread = t;
+      break;
+    }
+  }
+
+  return target_thread != NULL ? JfrStackTraceRepository::record_async(target_thread, skip) : 0;
 JVM_END
 
 JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message))

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -65,6 +65,8 @@ jstring JNICALL jfr_get_pid(JNIEnv* env, jobject jvm);
 
 jlong JNICALL jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip);
 
+jlong JNICALL jfr_stacktrace_id_1(JNIEnv* env, jobject jvm, jlong tid, jint skip);
+
 jlong JNICALL jfr_elapsed_frequency(JNIEnv* env, jobject jvm);
 
 void JNICALL jfr_subscribe_log_level(JNIEnv* env, jobject jvm, jobject log_tag, jint id);

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -47,6 +47,7 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"getClassIdNonIntrinsic", (char*)"(Ljava/lang/Class;)J", (void*)jfr_class_id,
       (char*)"getPid", (char*)"()Ljava/lang/String;", (void*)jfr_get_pid,
       (char*)"getStackTraceId", (char*)"(I)J", (void*)jfr_stacktrace_id,
+      (char*)"getStackTraceId", (char*)"(JI)J", (void*)jfr_stacktrace_id_1,
       (char*)"getThreadId", (char*)"(Ljava/lang/Thread;)J", (void*)jfr_id_for_thread,
       (char*)"getTicksFrequency", (char*)"()J", (void*)jfr_elapsed_frequency,
       (char*)"subscribeLogLevel", (char*)"(Ljdk/jfr/internal/LogTag;I)V", (void*)jfr_subscribe_log_level,

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -71,6 +71,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
 
  public:
   static traceid record(Thread* thread, int skip = 0);
+  static traceid record_async(Thread* thread, int skip = 0);
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACEREPOSITORY_HPP

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
@@ -135,11 +135,16 @@ final class ASMToolkit {
         return className.replace(".", "/");
     }
 
-    public static Method makeWriteMethod(List<FieldInfo> fields) {
+    public static Method makeWriteMethod(List<FieldInfo> fields, boolean overridable) {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
+        if (overridable) {
+            // make the first argument to take the custom thread
+            sb.append("Ljava/lang/Thread;");
+            sb.append("[Ljava/lang/StackTraceElement;");
+        }
         for (FieldInfo v : fields) {
-            if (!v.fieldName.equals(EventInstrumentation.FIELD_EVENT_THREAD) && !v.fieldName.equals(EventInstrumentation.FIELD_STACK_TRACE)) {
+            if ((!v.fieldName.equals(EventInstrumentation.FIELD_EVENT_THREAD)) && !v.fieldName.equals(EventInstrumentation.FIELD_STACK_TRACE)) {
                 sb.append(v.fieldDescriptor);
             }
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -154,6 +154,15 @@ public final class EventWriter {
         putLong(threadID);
     }
 
+    public void putEventThread(Thread athread) {
+        if (athread == null) {
+            putLong(threadID);
+        } else {
+            long tid = jvm.getThreadId(athread);
+            putLong(tid);
+        }
+    }
+
     public void putThread(Thread athread) {
         if (athread == null) {
             putLong(0L);
@@ -173,6 +182,19 @@ public final class EventWriter {
     public void putStackTrace() {
         if (eventType.getStackTraceEnabled()) {
             putLong(jvm.getStackTraceId(eventType.getStackTraceOffset()));
+        } else {
+            putLong(0L);
+        }
+    }
+
+    public void putStackTrace(Thread athread, StackTraceElement[] stackTrace) {
+        if (eventType.getStackTraceEnabled()) {
+            System.out.println("===> thread: " + athread + ", etype: " + eventType + ", offset: " + eventType.getStackTraceOffset());
+            if (athread != null) {
+                putLong(jvm.getStackTraceId(jvm.getThreadId(athread), 0)); // do not skip any frames
+            } else {
+                putLong(jvm.getStackTraceId(eventType.getStackTraceOffset()));
+            }
         } else {
             putLong(0L);
         }
@@ -294,6 +316,7 @@ public final class EventWriter {
     }
 
     private EventWriter(long startPos, long maxPos, long startPosAddress, long threadID, boolean valid) {
+        try {
         startPosition = currentPosition = startPos;
         maxPosition = maxPos;
         startPositionAddress = startPosAddress;
@@ -302,6 +325,10 @@ public final class EventWriter {
         flushOnEnd = false;
         this.valid = valid;
         notified = false;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
+        }
     }
 
     private static int makePaddedInt(int v) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
@@ -44,7 +44,8 @@ public enum EventWriterMethod {
     PUT_CLASS("(Ljava/lang/Class;)V", Type.CLASS.getName(), "putClass"),
     PUT_STRING("(Ljava/lang/String;Ljdk/jfr/internal/StringPool;)V", Type.STRING.getName(), "putString"),
     PUT_EVENT_THREAD("()V", Type.THREAD.getName(), "putEventThread"),
-    PUT_STACK_TRACE("()V", Type.TYPES_PREFIX + "StackTrace", "putStackTrace");
+    PUT_EVENT_THREAD_1("(Ljava/lang/Thread;)V", Type.THREAD.getName(), "putEventThread"),
+    PUT_STACK_TRACE("(Ljava/lang/Thread;[Ljava/lang/StackTraceElement;)V", Type.TYPES_PREFIX + "StackTrace", "putStackTrace");
 
     private final Method asmMethod;
     private final String typeDescriptor;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -163,6 +163,17 @@ public final class JVM {
     public native long getStackTraceId(int skipCount);
 
     /**
+     * Return unique identifier for stack trace obtained from the given thread.
+     *
+     * Requires that JFR has been started with {@link #createNativeJFR()}
+     *
+     * @param tid id of a thread to get the stacktrace from
+     * @param skipCount number of frames to skip
+     * @return a unique stack trace identifier
+     */
+    public native long getStackTraceId(long tid, int skipCount);
+
+    /**
      * Return identifier for thread
      *
      * @param t thread

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
@@ -67,6 +67,7 @@ final class JVMUpcalls {
             }
             return JDKEvents.retransformCallback(clazz, oldBytes);
         } catch (Throwable t) {
+            t.printStackTrace();
             Logger.log(LogTag.JFR_SYSTEM, LogLevel.WARN, "Unexpected error when adding instrumentation to event class " + clazz.getName());
         }
         return oldBytes;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Overridden.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Overridden.java
@@ -1,0 +1,27 @@
+package jdk.jfr.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Inherited
+public @interface Overridden {
+    enum Target {
+        EVENT_THREAD(Thread.class), STACKTRACE(StackTraceElement[].class);
+
+        private final Class<?> targetType;
+        Target(Class<?> targetType) {
+            this.targetType = targetType;
+        }
+
+        public Class<?> getTargetType() {
+            return targetType;
+        }
+    }
+
+    Target value();
+}

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -100,10 +100,10 @@ public final class PlatformEventType extends Type {
     private static int stackTraceOffset(String name, boolean isJDK) {
         if (isJDK) {
             if (isExceptionEvent(name)) {
-                return 4;
+                return 5;
             }
             if (isUsingHandler(name)) {
-                return 3;
+                return 4;
             }
         }
         return 4;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/handlers/EventHandler.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/handlers/EventHandler.java
@@ -115,27 +115,51 @@ public abstract class EventHandler {
        return platformEventType.setRegistered(registered);
     }
 
-    public void write(long start, long duration, String host, String address, int port, long timeout, long bytesRead, boolean endOfSTream) {
+    public void write(long start, long duration, String host, String address, int port, long timeout, long bytesRead, boolean endOfStream) {
+        write(null, null, start, duration, host, address, port, timeout, bytesRead, endOfStream);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String host, String address, int port, long timeout, long bytesRead, boolean endOfStream) {
         throwError("SocketReadEvent");
     }
 
     public void write(long start, long duration, String host, String address, int port, long bytesWritten) {
+        write(null, null, start, duration, host, address, port, bytesWritten);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String host, String address, int port, long bytesWritten) {
         throwError("SocketWriteEvent");
     }
 
     public void write(long start, long duration, String path, boolean metadata) {
+        write(null, null, start, duration, path, metadata);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String path, boolean metadata) {
         throwError("FileForceEvent");
     }
 
     public void write(long start, long duration, String path, long bytesRead, boolean endOfFile) {
+        write(null, null, start, duration, path, bytesRead, endOfFile);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String path, long bytesRead, boolean endOfFile) {
         throwError("FileReadEvent");
     }
 
     public void write(long start, long duration, String path, long bytesWritten) {
+        write(null, null, start, duration, path, bytesWritten);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String path, long bytesWritten) {
         throwError("FileWriteEvent");
     }
 
     public void write(long start, long duration, String path, Class<?> exceptionClass)  {
+        write(null, null, start, duration, path, exceptionClass);
+    }
+
+    public void write(Thread thrd, StackTraceElement[] stactkrace, long start, long duration, String path, Class<?> exceptionClass)  {
         throwError("ExceptionThrownEvent or ErrorThrownEvent");
     }
 

--- a/test/jdk/jdk/jfr/event/runtime/TestExceptionEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestExceptionEvents.java
@@ -99,6 +99,7 @@ public class TestExceptionEvents {
             List<RecordedEvent> events = Events.fromRecording(r);
             Events.hasEvents(events);
             for (RecordedEvent e : events) {
+                System.out.println(e);
                 RecordedStackTrace rs = e.getStackTrace();
                 RecordedClass rc = e.getValue("thrownClass");
                 List<RecordedFrame> frames = rs.getFrames();

--- a/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
+++ b/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.LockSupport;
+
+import jdk.jfr.AnnotationElement;
+import jdk.jfr.Event;
+import jdk.jfr.EventType;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Recording;
+import jdk.jfr.ValueDescriptor;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import jdk.jfr.internal.Overridden;
+import jdk.jfr.internal.Overridden.Target;
+import jdk.test.lib.Utils;
+
+/**
+ * @test TextCustomThreadJavaEvent
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main/othervm jdk.jfr.jvm.TestCustomThreadJavaEvent
+ */
+public class TestCustomThreadJavaEvent {
+
+    private static final int EVENTS_PER_THREAD = 50;
+    private static final int THREAD_COUNT = 100;
+
+    public static class MyEvent extends Event {
+        @Overridden(Target.EVENT_THREAD)
+        public Thread customThread;
+    }
+
+    public static void main(String... args) throws IOException, InterruptedException {
+        Recording r = new Recording();
+        // for (Method m : MyEvent.class.getMethods()) {
+        //     System.err.println("===> " + m);
+        // }
+        r.enable(MyEvent.class).withThreshold(Duration.ofNanos(0)).withStackTrace();
+        r.enable("jdk.SafepointBegin").withStackTrace();
+        r.start();
+
+        LongAdder adder = new LongAdder();
+        Thread worker = new Thread(()-> {
+            while (!Thread.currentThread().isInterrupted()) {
+                adder.add(call1());
+                LockSupport.parkNanos(10_000_000L); // 10ms pause
+            }
+        }, "Worker Thread");
+        worker.setDaemon(true);
+        worker.start();
+
+        ThreadGroup rootGroup = getRootGroup();
+        for (int i = 0; i < 5000; i++) {
+            processThreadGroup(rootGroup);
+            Thread.sleep(1);
+        }
+
+        r.stop();
+        System.out.println("Worker result: " + adder.sum());
+        prettyPrint();
+        File file = Utils.createTempFile("test", ".jfr").toFile();
+        r.dump(file.toPath());
+        System.err.println("===> Dumped to: " + file);
+        int eventCount = 0;
+        for (RecordedEvent e : RecordingFile.readAllEvents(file.toPath())) {
+            if (e.getEventType().getName().equals(MyEvent.class.getName())) {
+                eventCount++;
+            }
+            if (e.getThread() != null && e.getThread().getJavaName() != null && e.getThread().getJavaName().contains("Worker Thread")) {
+                System.out.println(e);
+            }
+        }
+        System.out.println("Event count was " + eventCount + ", expected " + THREAD_COUNT * EVENTS_PER_THREAD);
+        r.close();
+    }
+
+    private static ThreadGroup getRootGroup() {
+        ThreadGroup currentTG = Thread.currentThread().getThreadGroup();
+        ThreadGroup parentTG = currentTG.getParent();
+        while (parentTG != null) {
+            currentTG = parentTG;
+            parentTG = currentTG.getParent();
+        }
+        return currentTG;
+    }
+
+    private static void processThreadGroup(ThreadGroup group) {
+        ThreadGroup[] groups = new ThreadGroup[group.activeGroupCount()];
+        Thread[] threads = new Thread[group.activeCount()];
+        group.enumerate(groups);
+        group.enumerate(threads);
+        for (Thread t : threads) {
+            if (t.isAlive()) {
+                MyEvent event = new MyEvent();
+                if (event.shouldCommit()) {
+                    event.customThread = t;
+                    event.commit();
+                }
+            }
+        }
+        for (ThreadGroup subgroup : groups) {
+            processThreadGroup(subgroup);
+        }
+    }
+
+    static void prettyPrint() {
+        for (EventType type : FlightRecorder.getFlightRecorder().getEventTypes()) {
+            for (AnnotationElement a : type.getAnnotationElements()) {
+                printAnnotation("", a);
+            }
+            System.out.print("class " + removePackage(type.getName()));
+            System.out.print(" extends Event");
+
+            System.out.println(" {");
+            List<ValueDescriptor> values = type.getFields();
+            for (int i = 0; i < values.size(); i++) {
+                ValueDescriptor v = values.get(i);
+                for (AnnotationElement a : v.getAnnotationElements()) {
+                    printAnnotation("  ", a);
+                }
+                System.out.println("  " + removePackage(v.getTypeName() + brackets(v.isArray())) + " " + v.getName());
+                if (i != values.size() - 1) {
+                    System.out.println();
+                }
+            }
+            System.out.println("}");
+            System.out.println();
+        }
+    }
+
+    private static String brackets(boolean isArray) {
+        return isArray ? "[]" : "";
+    }
+
+    private static String removePackage(String s) {
+
+        int index = s.lastIndexOf(".");
+        return s.substring(index + 1);
+    }
+
+    private static void printAnnotation(String indent, AnnotationElement a) {
+        String name = removePackage(a.getTypeName());
+        if (a.getValues().isEmpty()) {
+            System.out.println(indent + "@" + name);
+            return;
+        }
+        System.out.print(indent + "@" + name + "(");
+        for (Object o : a.getValues()) {
+            printAnnotationValue(o);
+        }
+        System.out.println(")");
+    }
+
+    private static void printAnnotationValue(Object o) {
+        if (o instanceof String) {
+            System.out.print("\"" + o + "\"");
+        } else {
+            System.out.print(String.valueOf(o));
+        }
+    }
+
+    private static int call1() {
+        LockSupport.parkNanos(1_000L); // 1us pause
+        return call2() + 17;
+    }
+
+    private static int call2() {
+        LockSupport.parkNanos(1_000_000L); // 1ms pause
+        return call3() % 872451;
+    }
+
+    private static int call3() {
+        int num = ThreadLocalRandom.current().nextInt();
+        int add = ThreadLocalRandom.current().nextInt();
+        for (int i = 0; i < add; i++) {
+            num += i;
+        }
+        return num;
+    }
+
+}


### PR DESCRIPTION
This is an early prototype of a mechanism to allow committing a JFR event on a custom java thread. This would open door, for example, to having a scheduled 'sampling' thread generating events and filling them up with shared aggregation data and then committing them on behalf of a 'sampled' thread.

TBD

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8242220](https://bugs.openjdk.java.net/browse/JDK-8242220): Capture JFR stack trace and thread other than the one the event is committed on


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2238/head:pull/2238` \
`$ git checkout pull/2238`

Update a local copy of the PR: \
`$ git checkout pull/2238` \
`$ git pull https://git.openjdk.java.net/jdk pull/2238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2238`

View PR using the GUI difftool: \
`$ git pr show -t 2238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2238.diff">https://git.openjdk.java.net/jdk/pull/2238.diff</a>

</details>
