### PR TITLE
8259050: Error recovery in lexer could be improved

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -205,7 +205,9 @@ public class JavaTokenizer extends UnicodeReader {
      */
     protected void lexError(DiagnosticFlag flags, int pos, JCDiagnostic.Error key) {
         log.error(flags, pos, key);
-        tk = TokenKind.ERROR;
+        if (flags != DiagnosticFlag.SOURCE_LEVEL) {
+            tk = TokenKind.ERROR;
+        }
         errPos = pos;
     }
 

--- a/test/langtools/tools/javac/lexer/JavaLexerTest.java
+++ b/test/langtools/tools/javac/lexer/JavaLexerTest.java
@@ -94,11 +94,12 @@ public class JavaLexerTest {
             new TestTuple(DOUBLELITERAL, "0x8pd", "0x8pd"),
             new TestTuple(INTLITERAL,    "0xpd", "0x"),
 
-            new TestTuple(ERROR,         "\"\\u20\""),
-            new TestTuple(ERROR,         "\"\\u\""),
-            new TestTuple(ERROR,         "\"\\uG000\""),
-            new TestTuple(ERROR,         "\"\\u \""),
+            new TestTuple(STRINGLITERAL, "\"\\u20\""),
+            new TestTuple(STRINGLITERAL, "\"\\u\""),
+            new TestTuple(STRINGLITERAL, "\"\\uG000\""),
+            new TestTuple(STRINGLITERAL, "\"\\u \""),
             new TestTuple(ERROR,         "\"\\q\""),
+            new TestTuple(EOF,           "\\u", ""),
 
             new TestTuple(ERROR,         "\'\'"),
             new TestTuple(ERROR,         "\'\\q\'", "\'\\"),


### PR DESCRIPTION
Consider code like:
```
public class BrokenEscape {
    private String s = "\uaaa";
}
```
(note the broken escape). This produces:
```
$ javac BrokenEscape.java 
BrokenEscape.java:2: error: illegal unicode escape
    private String s = "\uaaa";
                        ^
BrokenEscape.java:2: error: unclosed string literal
    private String s = "\uaaa";
                       ^
2 errors
```

After this patch, it produces:
```
$ javac BrokenEscape.java 
BrokenEscape.java:2: error: illegal unicode escape
    private String s = "\uaaa";
                             ^
1 error
```
which is the error message that used to be produced in the past.

The patch also improves the AST for source levels where text blocks are not supported, but are in fact present in the source code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259050](https://bugs.openjdk.java.net/browse/JDK-8259050): Error recovery in lexer could be improved


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2239/head:pull/2239`
`$ git checkout pull/2239`
