### PR TITLE
8260407: cmp != __null && cmp->Opcode() == Op_CmpL failure with -XX:StressLongCountedLoop=200000000 in lucene

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1151,7 +1151,7 @@ Node *PhaseIdealLoop::place_near_use(Node *useblock) const {
 
 
 bool PhaseIdealLoop::identical_backtoback_ifs(Node *n) {
-  if (!n->is_If() || n->is_CountedLoopEnd()) {
+  if (!n->is_If() || n->is_BaseCountedLoopEnd()) {
     return false;
   }
   if (!n->in(0)->is_Region()) {

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestLongCountedLoopSplitIf.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestLongCountedLoopSplitIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestLongCountedLoopSplitIf.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestLongCountedLoopSplitIf.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260407
+ * @summary cmp != __null && cmp->Opcode() == Op_CmpL failure with -XX:StressLongCountedLoop=200000000 in lucene
+ *
+ * @run main/othervm -XX:-BackgroundCompilation TestLongCountedLoopSplitIf
+ *
+ */
+
+public class TestLongCountedLoopSplitIf {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(0, 100);
+            test_helper(100, 0, 0);
+        }
+    }
+
+    private static float test(long start, long stop) {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+            }
+        }
+        float res = 1;
+
+        long l = start;
+
+        for (; ; ) {
+            res = test_helper(l, stop, res);
+            if (shouldStop(l, stop)) {
+                break;
+            }
+            l++;
+        }
+        return res;
+    }
+
+    private static boolean shouldStop(long l, long stop) {
+        return l >= stop;
+    }
+
+    private static float test_helper(long l, long stop, float res) {
+        if (l < stop) {
+            res += l;
+        } else {
+            res *= l;
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
Long counted loops are transformed in 3 steps:

1- LongCountedLoopNode/LongCountedLoopEndNode are created (similar to
int counted loops)

2- a loop nest is built from the
LongCountedLoopNode/LongCountedLoopEndNode with an inner loop with a
int iv

3- the inner loop is transformed to a CountedLoop

Between 1- and 2-, the LongCountedLoopEndNode is transformed by split
if because a dominated if uses the same condition. Fix simplys applies
existing check for CountedLoopEndNode to LongCountedLoopEndNode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260407](https://bugs.openjdk.java.net/browse/JDK-8260407): cmp != __null && cmp->Opcode() == Op_CmpL failure with -XX:StressLongCountedLoop=200000000 in lucene


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 8b3312aa7341f57f827f5ca5869e8e1c5d1c4e05
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 8b3312aa7341f57f827f5ca5869e8e1c5d1c4e05


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2240/head:pull/2240`
`$ git checkout pull/2240`
