### PR TITLE
8260421: Shenandoah: Fix conc_mark_roots timing name and indentations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -56,8 +56,8 @@ class outputStream;
   f(scan_roots,                                     "  Scan Roots")                    \
   SHENANDOAH_PAR_PHASE_DO(scan_,                    "    S: ", f)                      \
                                                                                        \
-  f(conc_mark_roots,                                "  Roots ")                        \
-  SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "    CM: ", f)                     \
+  f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
+  SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \


### PR DESCRIPTION
Please review this trivial patch that renames conc_mark_roots timing name and fixes indentations

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260421](https://bugs.openjdk.java.net/browse/JDK-8260421): Shenandoah: Fix conc_mark_roots timing name and indentations


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2241/head:pull/2241`
`$ git checkout pull/2241`
