### PR TITLE
8260449: Remove stale declaration of SATBMarkQueue::apply_closure_and_empty()

### DIFF
--- a/src/hotspot/share/gc/shared/satbMarkQueue.hpp
+++ b/src/hotspot/share/gc/shared/satbMarkQueue.hpp
@@ -60,10 +60,6 @@ public:
   bool is_active() const { return _active; }
   void set_active(bool value) { _active = value; }
 
-  // Apply cl to the active part of the buffer.
-  // Prerequisite: Must be at a safepoint.
-  void apply_closure_and_empty(SATBBufferClosure* cl);
-
 #ifndef PRODUCT
   // Helpful for debugging
   void print(const char* name);


### PR DESCRIPTION
JDK-8258742 removed apply_closure_and_empty(), but curiously JDK-8260263 reintroduced its declaration (but no definition).

Testing:
 - [x] build fastdebug/release on Linux/x86_64
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260449](https://bugs.openjdk.java.net/browse/JDK-8260449): Remove stale declaration of SATBMarkQueue::apply_closure_and_empty()


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2242/head:pull/2242`
`$ git checkout pull/2242`
