### PR TITLE
8260460: GitHub actions still fail on Linux x86_32 with "Could not configure libc6:i386"

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -632,14 +632,14 @@ jobs:
 
       # Roll in the multilib environment and its dependencies.
       # Some multilib libraries do not have proper inter-dependencies, so we have to
-      # install their dependencies manually. Additionally, installing libc6 libraries
-      # ahead of the bulk of other packages solves potential circularity problems.
+      # install their dependencies manually. Additionally, upgrading apt solves
+      # the libc6 installation bugs until base image catches up, see JDK-8260460.
       - name: Install dependencies
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install gcc-10-multilib g++-10-multilib libc6:i386 libc6-dev:i386
-          sudo apt-get install libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo apt-get install --only-upgrade apt
+          sudo apt-get install gcc-10-multilib g++-10-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure


### PR DESCRIPTION
See for example:
 https://github.com/shipilev/jdk/runs/1771453139?check_suite_focus=true

```
E: Could not configure 'libc6:i386'.
E: Could not perform immediate configuration on 'libgcc-s1:i386'. Please see man 5 apt.conf under APT::Immediate-Configure for details. (2)
```

It seems JDK-8259924 helped only for a while.

There is a [bugfix](https://salsa.debian.org/apt-team/apt/-/commit/998a17d7e6f834c341f198ca5b6df2f27e18df38) in Apt 2.0.4 that prints these warnings and then allows the whole thing to continue. It was [released](https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268) in Ubuntu a week ago, but it is not in base image yet. So, if we upgrade apt before installing other packages, apt updates from 2.0.2 to 2.0.4 and the whole thing starts to work.

This also reverts changes added by previous attempt in [JDK-8259924](https://github.com/openjdk/jdk/commit/a9519c83).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260460](https://bugs.openjdk.java.net/browse/JDK-8260460): GitHub actions still fail on Linux x86_32 with "Could not configure libc6:i386"


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2243/head:pull/2243`
`$ git checkout pull/2243`
