### PR TITLE
8259816: Typo in java.util.stream package description

### DIFF
--- a/src/java.base/share/classes/java/util/stream/package-info.java
+++ b/src/java.base/share/classes/java/util/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -346,7 +346,7 @@
  * <pre>{@code
  *     List<String> results =
  *         stream.filter(s -> pattern.matcher(s).matches())
- *               .collect(Collectors.toList());  // No side-effects!
+ *               .toList();  // No side-effects!
  * }</pre>
  *
  * <h3><a id="Ordering">Ordering</a></h3>
@@ -436,7 +436,7 @@
  * can operate on subsets of the data in parallel, and then combine the
  * intermediate results to get the final correct answer.  (Even if the language
  * had a "parallel for-each" construct, the mutative accumulation approach would
- * still required the developer to provide
+ * still require the developer to provide
  * thread-safe updates to the shared accumulating variable {@code sum}, and
  * the required synchronization would then likely eliminate any performance gain from
  * parallelism.)  Using {@code reduce()} instead removes all of the


### PR DESCRIPTION
Fix a typo, and change an example to use Stream.toList().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259816](https://bugs.openjdk.java.net/browse/JDK-8259816): Typo in java.util.stream package description


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2249/head:pull/2249`
`$ git checkout pull/2249`
