### PR TITLE
JDK-8260432: allocateSpaceForGP in freetypeScaler.c might leak memory

### DIFF
--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -1265,8 +1265,6 @@ static int allocateSpaceForGP(GPData* gpdata, int npoints, int ncontours) {
              malloc(gpdata->lenTypes*sizeof(jbyte));
         gpdata->pointCoords = (jfloat*)
              malloc(gpdata->lenCoords*sizeof(jfloat));
-        if (gpdata->pointTypes == NULL && gpdata->pointCoords != NULL) free(gpdata->pointCoords);
-        if (gpdata->pointTypes != NULL && gpdata->pointCoords == NULL) free(gpdata->pointTypes);
         gpdata->numTypes = 0;
         gpdata->numCoords = 0;
         gpdata->wr = WIND_NON_ZERO; /* By default, outlines are filled
@@ -1287,10 +1285,12 @@ static int allocateSpaceForGP(GPData* gpdata, int npoints, int ncontours) {
     }
 
     /* failure if any of mallocs failed */
-    if (gpdata->pointTypes == NULL || gpdata->pointCoords == NULL)
+    if (gpdata->pointTypes == NULL || gpdata->pointCoords == NULL) {
+        if (gpdata->pointTypes != NULL)  { free(gpdata->pointTypes); gpdata->pointTypes = NULL; }
+        if (gpdata->pointCoords != NULL) { free(gpdata->pointCoords); gpdata->pointCoords = NULL; }
         return 0;
-    else
-        return 1;
+    }
+    return 1;
 }
 
 static void addSeg(GPData *gp, jbyte type) {

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -1286,8 +1286,14 @@ static int allocateSpaceForGP(GPData* gpdata, int npoints, int ncontours) {
 
     /* failure if any of mallocs failed */
     if (gpdata->pointTypes == NULL || gpdata->pointCoords == NULL) {
-        if (gpdata->pointTypes != NULL)  { free(gpdata->pointTypes); gpdata->pointTypes = NULL; }
-        if (gpdata->pointCoords != NULL) { free(gpdata->pointCoords); gpdata->pointCoords = NULL; }
+        if (gpdata->pointTypes != NULL)  {
+            free(gpdata->pointTypes);
+            gpdata->pointTypes = NULL;
+        }
+        if (gpdata->pointCoords != NULL) {
+            free(gpdata->pointCoords);
+            gpdata->pointCoords = NULL;
+        }
         return 0;
     }
     return 1;

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1265,6 +1265,8 @@ static int allocateSpaceForGP(GPData* gpdata, int npoints, int ncontours) {
              malloc(gpdata->lenTypes*sizeof(jbyte));
         gpdata->pointCoords = (jfloat*)
              malloc(gpdata->lenCoords*sizeof(jfloat));
+        if (gpdata->pointTypes == NULL && gpdata->pointCoords != NULL) free(gpdata->pointCoords);
+        if (gpdata->pointTypes != NULL && gpdata->pointCoords == NULL) free(gpdata->pointTypes);
         gpdata->numTypes = 0;
         gpdata->numCoords = 0;
         gpdata->wr = WIND_NON_ZERO; /* By default, outlines are filled
@@ -1285,7 +1287,7 @@ static int allocateSpaceForGP(GPData* gpdata, int npoints, int ncontours) {
     }
 
     /* failure if any of mallocs failed */
-    if (gpdata->pointTypes == NULL ||  gpdata->pointCoords == NULL)
+    if (gpdata->pointTypes == NULL || gpdata->pointCoords == NULL)
         return 0;
     else
         return 1;


### PR DESCRIPTION
The function  AllocateSpaceForGP in freetypeScaler.c calls potentially 2 times malloc ; however the memory is not always freed correctly in case of errors.
See also the related  sonar issue :
https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=c&open=AXck8B_SBBG2CXpcngxr&resolved=false&severities=BLOCKER&types=BUG

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260432](https://bugs.openjdk.java.net/browse/JDK-8260432): allocateSpaceForGP in freetypeScaler.c might leak memory


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to afda19e5002e82b12be74400c65d791ac50dd1e2
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2250/head:pull/2250`
`$ git checkout pull/2250`
