### PR TITLE
JDK-8260426: awt debug_mem.c DMem_AllocateBlock might leak memory

### DIFF
--- a/src/java.desktop/share/native/common/awt/debug/debug_mem.c
+++ b/src/java.desktop/share/native/common/awt/debug/debug_mem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,6 +218,7 @@ void * DMem_AllocateBlock(size_t size, const char * filename, int linenumber) {
     /* add block to list of allocated memory */
     header->listEnter = DMem_TrackBlock(header);
     if ( header->listEnter == NULL ) {
+        DMem_ClientFree(header);
         goto Exit;
     }
 


### PR DESCRIPTION
It seems that the function DMem_AllocateBlock (debug_mem.c) has an early return that might lead to memory leaks.
See also the sonar issue Potential leak of memory pointed to by 'header' :
https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=c&open=AXck8B7zBBG2CXpcngZM&resolved=false&severities=BLOCKER&types=BUG

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260426](https://bugs.openjdk.java.net/browse/JDK-8260426): awt debug_mem.c DMem_AllocateBlock might leak memory


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2252/head:pull/2252`
`$ git checkout pull/2252`
