### PR TITLE
8259886 : Improve SSL session cache performance and scalability

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -84,6 +84,7 @@ $(eval $(call SetupJavaCompilation, BUILD_INDIFY, \
 #### Compile Targets
 
 # Building microbenchmark requires the jdk.unsupported and java.management modules.
+# sun.security.util is required to compile Cache benchmark
 
 # Build microbenchmark suite for the current JDK
 $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
@@ -93,6 +94,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     DISABLED_WARNINGS := processing rawtypes cast serial, \
     SRC := $(MICROBENCHMARK_SRC), \
     BIN := $(MICROBENCHMARK_CLASSES), \
+    JAVAC_FLAGS := $(JAVAC_FLAGS) --add-exports java.base/sun.security.util=ALL-UNNAMED, \
     JAVA_FLAGS := --add-modules jdk.unsupported --limit-modules java.management, \
 ))
 

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -94,7 +94,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     DISABLED_WARNINGS := processing rawtypes cast serial, \
     SRC := $(MICROBENCHMARK_SRC), \
     BIN := $(MICROBENCHMARK_CLASSES), \
-    JAVAC_FLAGS := $(JAVAC_FLAGS) --add-exports java.base/sun.security.util=ALL-UNNAMED, \
+    JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED, \
     JAVA_FLAGS := --add-modules jdk.unsupported --limit-modules java.management, \
 ))
 

--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -248,6 +248,7 @@ class MemoryCache<K,V> extends Cache<K,V> {
     private final Map<K, CacheEntry<K,V>> cacheMap;
     private int maxSize;
     private long lifetime;
+    private long nextExpirationTime = Long.MAX_VALUE;
 
     // ReferenceQueue is of type V instead of Cache<K,V>
     // to allow SoftCacheEntry to extend SoftReference<V>
@@ -317,12 +318,18 @@ class MemoryCache<K,V> extends Cache<K,V> {
         }
         int cnt = 0;
         long time = System.currentTimeMillis();
+        if (nextExpirationTime > time) {
+            return;
+        }
+        nextExpirationTime = Long.MAX_VALUE;
         for (Iterator<CacheEntry<K,V>> t = cacheMap.values().iterator();
                 t.hasNext(); ) {
             CacheEntry<K,V> entry = t.next();
             if (entry.isValid(time) == false) {
                 t.remove();
                 cnt++;
+            } else if (nextExpirationTime > entry.getExpirationTime()) {
+                nextExpirationTime = entry.getExpirationTime();
             }
         }
         if (DEBUG) {
@@ -356,6 +363,9 @@ class MemoryCache<K,V> extends Cache<K,V> {
         emptyQueue();
         long expirationTime = (lifetime == 0) ? 0 :
                                         System.currentTimeMillis() + lifetime;
+        if (expirationTime < nextExpirationTime) {
+            nextExpirationTime = expirationTime;
+        }
         CacheEntry<K,V> newEntry = newEntry(key, value, expirationTime, queue);
         CacheEntry<K,V> oldEntry = cacheMap.put(key, newEntry);
         if (oldEntry != null) {
@@ -470,6 +480,7 @@ class MemoryCache<K,V> extends Cache<K,V> {
 
         V getValue();
 
+        long getExpirationTime();
     }
 
     private static class HardCacheEntry<K,V> implements CacheEntry<K,V> {
@@ -490,6 +501,10 @@ class MemoryCache<K,V> extends Cache<K,V> {
 
         public V getValue() {
             return value;
+        }
+
+        public long getExpirationTime() {
+            return expirationTime;
         }
 
         public boolean isValid(long currentTime) {
@@ -527,6 +542,10 @@ class MemoryCache<K,V> extends Cache<K,V> {
 
         public V getValue() {
             return get();
+        }
+
+        public long getExpirationTime() {
+            return expirationTime;
         }
 
         public boolean isValid(long currentTime) {

--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -356,7 +356,7 @@ class MemoryCache<K,V> extends Cache<K,V> {
     }
 
     public synchronized void put(K key, V value) {
-        emptyQueue();
+        expungeExpiredEntries(false);
         long expirationTime = (lifetime == 0) ? 0 :
                                         System.currentTimeMillis() + lifetime;
         CacheEntry<K,V> newEntry = newEntry(key, value, expirationTime, queue);
@@ -366,17 +366,14 @@ class MemoryCache<K,V> extends Cache<K,V> {
             return;
         }
         if (maxSize > 0 && cacheMap.size() > maxSize) {
-            expungeExpiredEntries(false);
-            if (cacheMap.size() > maxSize) { // still too large?
-                Iterator<CacheEntry<K,V>> t = cacheMap.values().iterator();
-                CacheEntry<K,V> lruEntry = t.next();
-                if (DEBUG) {
-                    System.out.println("** Overflow removal "
-                        + lruEntry.getKey() + " | " + lruEntry.getValue());
-                }
-                t.remove();
-                lruEntry.invalidate();
+            Iterator<CacheEntry<K,V>> t = cacheMap.values().iterator();
+            CacheEntry<K,V> lruEntry = t.next();
+            if (DEBUG) {
+                System.out.println("** Overflow removal "
+                    + lruEntry.getKey() + " | " + lruEntry.getValue());
             }
+            t.remove();
+            lruEntry.invalidate();
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Dynatrace LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import sun.security.util.Cache;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+public class CacheBench {
+    private Integer[] arrayToAdd;
+    private Cache<Integer, Integer> cache;
+    private int index;
+
+    @Param({"20480", "204800"})
+    private int size;
+
+    @Param({"86400", "0"})
+    private int timeout;
+
+    @Setup
+    public void setup() {
+        cache = Cache.newSoftMemoryCache(size, timeout);
+        arrayToAdd = IntStream.range(0, size + 1).boxed().toArray(Integer[]::new);
+        index = 0;
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() {
+        index++;
+        if (index >= arrayToAdd.length) {
+            index = 0;
+        }
+    }
+
+    @Benchmark
+    public void put() {
+        Integer i = arrayToAdd[index];
+        cache.put(i, i);
+    }
+}


### PR DESCRIPTION
Under certain load, MemoryCache operations take a substantial fraction of the time needed to complete SSL handshakes. This series of patches improves performance characteristics of MemoryCache, at the cost of a functional change: expired entries are no longer guaranteed to be removed before live ones. Unused entries are still removed before used ones, and cache performance no longer depends on its capacity.

First patch in the series contains a benchmark that can be run with `make test TEST="micro:CacheBench"`.
Baseline results before any MemoryCache changes:
```
Benchmark       (size)  (timeout)  Mode  Cnt     Score    Error  Units
CacheBench.put   20480      86400  avgt   25    83.653 ?  6.269  us/op
CacheBench.put   20480          0  avgt   25     0.107 ?  0.001  us/op
CacheBench.put  204800      86400  avgt   25  2057.781 ? 35.942  us/op
CacheBench.put  204800          0  avgt   25     0.108 ?  0.001  us/op
```
there's a nonlinear performance drop between 20480 and 204800 entries, probably attributable to CPU cache thrashing. Beyond 204800 entries the cache scales more linearly.

Benchmark results after the 2nd and 3rd patches are pretty similar, so I'll only copy one:
```
Benchmark       (size)  (timeout)  Mode  Cnt  Score   Error  Units
CacheBench.put   20480      86400  avgt   25  0.146 ? 0.002  us/op
CacheBench.put   20480          0  avgt   25  0.108 ? 0.002  us/op
CacheBench.put  204800      86400  avgt   25  0.150 ? 0.001  us/op
CacheBench.put  204800          0  avgt   25  0.106 ? 0.001  us/op
```
The third patch improves worst-case times on a mostly idle cache by scattering removal of expired entries over multiple `put` calls. It does not affect performance of an overloaded cache.

The 4th patch removes all code that clears cached values before handing them over to the GC. [This comment](https://github.com/openjdk/jdk/commit/5859a0320334bfb6b46b62eb16b4c387641f4a2a#diff-c6bd583a97fbc4f471621fee7eab37c63718cdb6932ce357fa403cfda4b32b6fL346) stated that clearing values was supposed to be a GC performance optimization. It wasn't. Benchmark results after that commit:
```
Benchmark       (size)  (timeout)  Mode  Cnt  Score   Error  Units
CacheBench.put   20480      86400  avgt   25  0.113 ? 0.001  us/op
CacheBench.put   20480          0  avgt   25  0.075 ? 0.002  us/op
CacheBench.put  204800      86400  avgt   25  0.116 ? 0.001  us/op
CacheBench.put  204800          0  avgt   25  0.072 ? 0.001  us/op
```
I wasn't expecting that much of an improvement, and don't know how to explain it.

The 40ns difference between cache with and without a timeout can be attributed to 2 `System.currentTimeMillis()` calls; they were pretty slow on my VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259886](https://bugs.openjdk.java.net/browse/JDK-8259886): Improve SSL session cache performance and scalability


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 34949970eb168facef79bd6e4cd14f8752508428
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to f9bc386abaf1818663d67768b843fe843c95d384


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2255/head:pull/2255`
`$ git checkout pull/2255`
