### PR TITLE
8260502: [s390] NativeMovRegMem::verify() fails because it's too strict

### DIFF
--- a/src/hotspot/cpu/s390/nativeInst_s390.cpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.cpp
@@ -601,37 +601,10 @@ void NativeMovConstReg::set_pcrel_data(intptr_t newData, CompiledMethod *passed_
 
 void NativeMovRegMem::verify() {
   address l1 = addr_at(0);
-  address l2 = addr_at(MacroAssembler::load_const_size());
 
   if (!MacroAssembler::is_load_const(l1)) {
     tty->cr();
     tty->print_cr("NativeMovRegMem::verify(): verifying addr " PTR_FORMAT, p2i(l1));
-    tty->cr();
-    ((NativeMovRegMem*)l1)->dump(64, "NativeMovConstReg::verify()");
-    fatal("this is not a `NativeMovRegMem' site");
-  }
-
-  unsigned long inst1;
-  Assembler::get_instruction(l2, &inst1);
-
-  if (!Assembler::is_z_lb(inst1)   &&
-      !Assembler::is_z_llgh(inst1) &&
-      !Assembler::is_z_lh(inst1)   &&
-      !Assembler::is_z_l(inst1)    &&
-      !Assembler::is_z_llgf(inst1) &&
-      !Assembler::is_z_lg(inst1)   &&
-      !Assembler::is_z_le(inst1)   &&
-      !Assembler::is_z_ld(inst1)   &&
-      !Assembler::is_z_stc(inst1)  &&
-      !Assembler::is_z_sth(inst1)  &&
-      !Assembler::is_z_st(inst1)   &&
-      !UseCompressedOops           &&
-      !Assembler::is_z_stg(inst1)  &&
-      !Assembler::is_z_ste(inst1)  &&
-      !Assembler::is_z_std(inst1)) {
-    tty->cr();
-    tty->print_cr("NativeMovRegMem::verify(): verifying addr " PTR_FORMAT
-                  ": wrong or missing load or store at " PTR_FORMAT, p2i(l1), p2i(l2));
     tty->cr();
     ((NativeMovRegMem*)l1)->dump(64, "NativeMovConstReg::verify()");
     fatal("this is not a `NativeMovRegMem' site");

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -516,7 +516,7 @@ class NativeMovConstReg: public NativeInstruction {
 // The instruction sequence looks like this:
 //   iihf        %r1,$bits1              ; load offset for mem access
 //   iilf        %r1,$bits2
-//   [compress oop]                      ; optional, load only
+//   [compress oop]                      ; optional, store only
 //   load/store  %r2,0(%r1,%r2)          ; memory access
 
 class NativeMovRegMem;


### PR DESCRIPTION
"fatal error: this is not a `NativeMovRegMem' site" was observed while testing the debug build without CompressedOops.
NativeMovRegMem::verify() tries to verify instructions beyond the load_const at a place at which we don't have valid instructions. See bug for details.
I suggest to remove the wrong part of the verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260502](https://bugs.openjdk.java.net/browse/JDK-8260502): [s390] NativeMovRegMem::verify() fails because it's too strict


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to 54fa039c826cf7face6291dde83237194a808757
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2258/head:pull/2258`
`$ git checkout pull/2258`
