### PR TITLE
8260520: Avoid getting permissions in JarFileFactory when no SecurityManager installed

### DIFF
--- a/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -123,10 +123,10 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
 
         /* if the JAR file is cached, the permission will always be there */
         if (result != null) {
-            Permission perm = getPermission(result);
-            if (perm != null) {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
+            SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                Permission perm = getPermission(result);
+                if (perm != null) {
                     try {
                         sm.checkPermission(perm);
                     } catch (SecurityException se) {

--- a/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -133,10 +133,10 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
 
         /* if the JAR file is cached, the permission will always be there */
         if (result != null) {
-            Permission perm = getPermission(result);
-            if (perm != null) {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
+            SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                Permission perm = getPermission(result);
+                if (perm != null) {
                     try {
                         sm.checkPermission(perm);
                     } catch (SecurityException se) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260520](https://bugs.openjdk.java.net/browse/JDK-8260520): Avoid getting permissions in JarFileFactory when no SecurityManager installed


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 09e4ff9e2f93283498e8ee502f6549986a42f5e5
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to 09e4ff9e2f93283498e8ee502f6549986a42f5e5
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2263/head:pull/2263`
`$ git checkout pull/2263`
