### PR TITLE
8260466: Test TestHeapDumpOnOutOfMemoryError.java needs multiple @test sections

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -24,9 +24,14 @@
 /*
  * @test TestHeapDumpOnOutOfMemoryError
  * @summary Test verifies that -XX:HeapDumpOnOutOfMemoryError dumps heap when OutOfMemory is thrown in heap
- *          and when OutOfMemory is thrown in metaspace.
  * @library /test/lib
  * @run driver TestHeapDumpOnOutOfMemoryError run heap
+ */
+
+/*
+ * @test TestHeapDumpOnOutOfMemoryError
+ * @summary Test verifies that -XX:HeapDumpOnOutOfMemoryError dumps heap when OutOfMemory is thrown in metaspace.
+ * @library /test/lib
  * @run driver/timeout=240 TestHeapDumpOnOutOfMemoryError run metaspace
  */
 


### PR DESCRIPTION
Please review this change to fix JDK-8260466.  The fix adds separate @test sections for the two tests in TestHeapDumpOnOutOfMemorty.java.  The change was tested by using Mach5 to run the test on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260466](https://bugs.openjdk.java.net/browse/JDK-8260466):  Test TestHeapDumpOnOutOfMemoryError.java needs multiple @test sections


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2264/head:pull/2264`
`$ git checkout pull/2264`
