### PR TITLE
8260264: Move common os_<unix> inline methods to a common posix source file

### DIFF
--- a/src/hotspot/os/aix/os_aix.inline.hpp
+++ b/src/hotspot/os/aix/os_aix.inline.hpp
@@ -32,14 +32,6 @@
 // System includes
 
 #include <unistd.h>
-#include <sys/socket.h>
-#include <poll.h>
-#include <sys/ioctl.h>
-#include <netdb.h>
-
-inline bool os::uses_stack_guard_pages() {
-  return true;
-}
 
 // Whether or not calling code should/can commit/uncommit stack pages
 // before guarding them. Answer for AIX is definitly no, because memory
@@ -49,22 +41,6 @@ inline bool os::must_commit_stack_guard_pages() {
   return false;
 }
 
-// Bang the shadow pages if they need to be touched to be mapped.
-inline void os::map_stack_shadow_pages(address sp) {
-}
-
-inline void os::dll_unload(void *lib) {
-  ::dlclose(lib);
-}
-
-inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek64(fd, offset, whence);
-}
-
-inline int os::fsync(int fd) {
-  return ::fsync(fd);
-}
-
 inline int os::ftruncate(int fd, jlong length) {
   return ::ftruncate64(fd, length);
 }
@@ -72,43 +48,5 @@ inline int os::ftruncate(int fd, jlong length) {
 // We don't have NUMA support on Aix, but we need this for compilation.
 inline bool os::numa_has_static_binding()   { ShouldNotReachHere(); return true; }
 inline bool os::numa_has_group_homing()     { ShouldNotReachHere(); return false;  }
-
-inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
-  size_t res;
-  RESTARTABLE((size_t) ::write(fd, buf, (size_t) nBytes), res);
-  return res;
-}
-
-inline int os::socket_close(int fd) {
-  return ::close(fd);
-}
-
-inline int os::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
-}
-
-inline int os::recv(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::recv(fd, buf, nBytes, flags));
-}
-
-inline int os::send(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::send(fd, buf, nBytes, flags));
-}
-
-inline int os::raw_send(int fd, char *buf, size_t nBytes, uint flags) {
-  return os::send(fd, buf, nBytes, flags);
-}
-
-inline int os::connect(int fd, struct sockaddr *him, socklen_t len) {
-  RESTARTABLE_RETURN_INT(::connect(fd, him, len));
-}
-
-inline struct hostent* os::get_host_by_name(char* name) {
-  return ::gethostbyname(name);
-}
-
-inline void os::exit(int num) {
-  ::exit(num);
-}
 
 #endif // OS_AIX_OS_AIX_INLINE_HPP

--- a/src/hotspot/os/aix/os_aix.inline.hpp
+++ b/src/hotspot/os/aix/os_aix.inline.hpp
@@ -29,9 +29,9 @@
 #include "runtime/os.hpp"
 #include "os_posix.inline.hpp"
 
-// System includes
-
-#include <unistd.h>
+inline bool os::uses_stack_guard_pages() {
+  return true;
+}
 
 // Whether or not calling code should/can commit/uncommit stack pages
 // before guarding them. Answer for AIX is definitly no, because memory
@@ -41,12 +41,8 @@ inline bool os::must_commit_stack_guard_pages() {
   return false;
 }
 
-inline int os::ftruncate(int fd, jlong length) {
-  return ::ftruncate64(fd, length);
+// Bang the shadow pages if they need to be touched to be mapped.
+inline void os::map_stack_shadow_pages(address sp) {
 }
-
-// We don't have NUMA support on Aix, but we need this for compilation.
-inline bool os::numa_has_static_binding()   { ShouldNotReachHere(); return true; }
-inline bool os::numa_has_group_homing()     { ShouldNotReachHere(); return false;  }
 
 #endif // OS_AIX_OS_AIX_INLINE_HPP

--- a/src/hotspot/os/bsd/os_bsd.inline.hpp
+++ b/src/hotspot/os/bsd/os_bsd.inline.hpp
@@ -28,9 +28,9 @@
 #include "runtime/os.hpp"
 #include "os_posix.inline.hpp"
 
-// System includes
-
-#include <unistd.h>
+inline bool os::uses_stack_guard_pages() {
+  return true;
+}
 
 inline bool os::must_commit_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
@@ -45,11 +45,8 @@ inline bool os::must_commit_stack_guard_pages() {
 #endif
 }
 
-inline int os::ftruncate(int fd, jlong length) {
-  return ::ftruncate(fd, length);
+// Bang the shadow pages if they need to be touched to be mapped.
+inline void os::map_stack_shadow_pages(address sp) {
 }
-
-inline bool os::numa_has_static_binding()   { return true; }
-inline bool os::numa_has_group_homing()     { return false;  }
 
 #endif // OS_BSD_OS_BSD_INLINE_HPP

--- a/src/hotspot/os/bsd/os_bsd.inline.hpp
+++ b/src/hotspot/os/bsd/os_bsd.inline.hpp
@@ -31,13 +31,6 @@
 // System includes
 
 #include <unistd.h>
-#include <sys/socket.h>
-#include <poll.h>
-#include <netdb.h>
-
-inline bool os::uses_stack_guard_pages() {
-  return true;
-}
 
 inline bool os::must_commit_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
@@ -52,65 +45,11 @@ inline bool os::must_commit_stack_guard_pages() {
 #endif
 }
 
-// Bang the shadow pages if they need to be touched to be mapped.
-inline void os::map_stack_shadow_pages(address sp) {
-}
-
-inline void os::dll_unload(void *lib) {
-  ::dlclose(lib);
-}
-
-inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek(fd, offset, whence);
-}
-
-inline int os::fsync(int fd) {
-  return ::fsync(fd);
-}
-
 inline int os::ftruncate(int fd, jlong length) {
   return ::ftruncate(fd, length);
 }
 
 inline bool os::numa_has_static_binding()   { return true; }
 inline bool os::numa_has_group_homing()     { return false;  }
-
-inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
-  size_t res;
-  RESTARTABLE((size_t) ::write(fd, buf, (size_t) nBytes), res);
-  return res;
-}
-
-inline int os::socket_close(int fd) {
-  return ::close(fd);
-}
-
-inline int os::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
-}
-
-inline int os::recv(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::recv(fd, buf, nBytes, flags));
-}
-
-inline int os::send(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::send(fd, buf, nBytes, flags));
-}
-
-inline int os::raw_send(int fd, char* buf, size_t nBytes, uint flags) {
-  return os::send(fd, buf, nBytes, flags);
-}
-
-inline int os::connect(int fd, struct sockaddr* him, socklen_t len) {
-  RESTARTABLE_RETURN_INT(::connect(fd, him, len));
-}
-
-inline struct hostent* os::get_host_by_name(char* name) {
-  return ::gethostbyname(name);
-}
-
-inline void os::exit(int num) {
-  ::exit(num);
-}
 
 #endif // OS_BSD_OS_BSD_INLINE_HPP

--- a/src/hotspot/os/linux/os_linux.inline.hpp
+++ b/src/hotspot/os/linux/os_linux.inline.hpp
@@ -28,20 +28,17 @@
 #include "runtime/os.hpp"
 #include "os_posix.inline.hpp"
 
-// System includes
-
-#include <unistd.h>
+inline bool os::uses_stack_guard_pages() {
+  return true;
+}
 
 inline bool os::must_commit_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
   return true;
 }
 
-inline int os::ftruncate(int fd, jlong length) {
-  return ::ftruncate64(fd, length);
+// Bang the shadow pages if they need to be touched to be mapped.
+inline void os::map_stack_shadow_pages(address sp) {
 }
-
-inline bool os::numa_has_static_binding()   { return true; }
-inline bool os::numa_has_group_homing()     { return false;  }
 
 #endif // OS_LINUX_OS_LINUX_INLINE_HPP

--- a/src/hotspot/os/linux/os_linux.inline.hpp
+++ b/src/hotspot/os/linux/os_linux.inline.hpp
@@ -31,33 +31,10 @@
 // System includes
 
 #include <unistd.h>
-#include <sys/socket.h>
-#include <poll.h>
-#include <netdb.h>
-
-inline bool os::uses_stack_guard_pages() {
-  return true;
-}
 
 inline bool os::must_commit_stack_guard_pages() {
   assert(uses_stack_guard_pages(), "sanity check");
   return true;
-}
-
-// Bang the shadow pages if they need to be touched to be mapped.
-inline void os::map_stack_shadow_pages(address sp) {
-}
-
-inline void os::dll_unload(void *lib) {
-  ::dlclose(lib);
-}
-
-inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek64(fd, offset, whence);
-}
-
-inline int os::fsync(int fd) {
-  return ::fsync(fd);
 }
 
 inline int os::ftruncate(int fd, jlong length) {
@@ -66,43 +43,5 @@ inline int os::ftruncate(int fd, jlong length) {
 
 inline bool os::numa_has_static_binding()   { return true; }
 inline bool os::numa_has_group_homing()     { return false;  }
-
-inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
-  size_t res;
-  RESTARTABLE((size_t) ::write(fd, buf, (size_t) nBytes), res);
-  return res;
-}
-
-inline int os::socket_close(int fd) {
-  return ::close(fd);
-}
-
-inline int os::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
-}
-
-inline int os::recv(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::recv(fd, buf, nBytes, flags));
-}
-
-inline int os::send(int fd, char* buf, size_t nBytes, uint flags) {
-  RESTARTABLE_RETURN_INT(::send(fd, buf, nBytes, flags));
-}
-
-inline int os::raw_send(int fd, char* buf, size_t nBytes, uint flags) {
-  return os::send(fd, buf, nBytes, flags);
-}
-
-inline int os::connect(int fd, struct sockaddr* him, socklen_t len) {
-  RESTARTABLE_RETURN_INT(::connect(fd, him, len));
-}
-
-inline struct hostent* os::get_host_by_name(char* name) {
-  return ::gethostbyname(name);
-}
-
-inline void os::exit(int num) {
-  ::exit(num);
-}
 
 #endif // OS_LINUX_OS_LINUX_INLINE_HPP

--- a/src/hotspot/os/posix/os_posix.inline.hpp
+++ b/src/hotspot/os/posix/os_posix.inline.hpp
@@ -44,14 +44,6 @@
 } while(false)
 
 
-inline bool os::uses_stack_guard_pages() {
-  return true;
-}
-
-// Bang the shadow pages if they need to be touched to be mapped.
-inline void os::map_stack_shadow_pages(address sp) {
-}
-
 inline void os::dll_unload(void *lib) {
   ::dlclose(lib);
 }
@@ -63,6 +55,14 @@ inline jlong os::lseek(int fd, jlong offset, int whence) {
 inline int os::fsync(int fd) {
   return ::fsync(fd);
 }
+
+inline int os::ftruncate(int fd, jlong length) {
+   return BSD_ONLY(::ftruncate) NOT_BSD(::ftruncate64)(fd, length);
+}
+
+// Aix does not have NUMA support but need these for compilation.
+inline bool os::numa_has_static_binding()   { AIX_ONLY(ShouldNotReachHere();) return true; }
+inline bool os::numa_has_group_homing()     { AIX_ONLY(ShouldNotReachHere();) return false;  }
 
 inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
   size_t res;

--- a/src/hotspot/os/posix/os_posix.inline.hpp
+++ b/src/hotspot/os/posix/os_posix.inline.hpp
@@ -28,6 +28,8 @@
 #include "runtime/os.hpp"
 
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netdb.h>
 
 // macros for restartable system calls
 
@@ -42,8 +44,66 @@
 } while(false)
 
 
+inline bool os::uses_stack_guard_pages() {
+  return true;
+}
+
+// Bang the shadow pages if they need to be touched to be mapped.
+inline void os::map_stack_shadow_pages(address sp) {
+}
+
+inline void os::dll_unload(void *lib) {
+  ::dlclose(lib);
+}
+
+inline jlong os::lseek(int fd, jlong offset, int whence) {
+  return (jlong) ::lseek(fd, offset, whence);
+}
+
+inline int os::fsync(int fd) {
+  return ::fsync(fd);
+}
+
+inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
+  size_t res;
+  RESTARTABLE((size_t) ::write(fd, buf, (size_t) nBytes), res);
+  return res;
+}
+
 inline int os::close(int fd) {
   return ::close(fd);
+}
+
+inline int os::socket_close(int fd) {
+  return ::close(fd);
+}
+
+inline int os::socket(int domain, int type, int protocol) {
+  return ::socket(domain, type, protocol);
+}
+
+inline int os::recv(int fd, char* buf, size_t nBytes, uint flags) {
+  RESTARTABLE_RETURN_INT(::recv(fd, buf, nBytes, flags));
+}
+
+inline int os::send(int fd, char* buf, size_t nBytes, uint flags) {
+  RESTARTABLE_RETURN_INT(::send(fd, buf, nBytes, flags));
+}
+
+inline int os::raw_send(int fd, char* buf, size_t nBytes, uint flags) {
+  return os::send(fd, buf, nBytes, flags);
+}
+
+inline int os::connect(int fd, struct sockaddr* him, socklen_t len) {
+  RESTARTABLE_RETURN_INT(::connect(fd, him, len));
+}
+
+inline struct hostent* os::get_host_by_name(char* name) {
+  return ::gethostbyname(name);
+}
+
+inline void os::exit(int num) {
+  ::exit(num);
 }
 
 // Platform Mutex/Monitor implementation

--- a/src/hotspot/os/posix/os_posix.inline.hpp
+++ b/src/hotspot/os/posix/os_posix.inline.hpp
@@ -49,7 +49,7 @@ inline void os::dll_unload(void *lib) {
 }
 
 inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek(fd, offset, whence);
+  return (jlong) BSD_ONLY(::lseek) NOT_BSD(::lseek64)(fd, offset, whence);
 }
 
 inline int os::fsync(int fd) {


### PR DESCRIPTION
Please review this fix for JDK-8260264 to move common functions from os_<unix>.inline.hpp files to os_posix.inline.hpp.  Functions ftruncate() and the two numa* functions could also be moved to os_posix.inline.hpp but would require BSD_ONLY and AIX_ONLY macros because of minor differences.

The change was tested by running Mach5 tiers 1,2 on Linux, Mac OS, and Windows, and tiers 3-5 on Linux x64.  Additionally, builds were done on Linux-s390x, Linux-ppc, Linux-arm32, and linux-x86.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260264](https://bugs.openjdk.java.net/browse/JDK-8260264): Move common os_<unix> inline methods to a common posix source file


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to d9597254f92fc87ca3dc9c9570b6bb3da12be8db
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to d9597254f92fc87ca3dc9c9570b6bb3da12be8db
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2267/head:pull/2267`
`$ git checkout pull/2267`
