### PR TITLE
JDK-8260518: Change default -mmacosx-version-min to 10.12

### DIFF
--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -130,7 +130,7 @@ AC_DEFUN([FLAGS_SETUP_MACOSX_VERSION],
     # of the OS. It currently has a hard coded value. Setting this also limits
     # exposure to API changes in header files. Bumping this is likely to
     # require code changes to build.
-    MACOSX_VERSION_MIN=10.9.0
+    MACOSX_VERSION_MIN=10.12.0
     MACOSX_VERSION_MIN_NODOTS=${MACOSX_VERSION_MIN//\./}
 
     AC_SUBST(MACOSX_VERSION_MIN)

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -440,7 +440,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "pandoc"],
             configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
-                "--with-macosx-version-max=10.9.0",
+                "--with-macosx-version-max=10.12.00",
                 // Use system SetFile instead of the one in the devkit as the
                 // devkit one may not work on Catalina.
                 "SETFILE=/usr/bin/SetFile"),

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -794,7 +794,8 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
       DISABLED_WARNINGS_gcc := sign-compare type-limits unused-result \
           maybe-uninitialized shift-negative-value implicit-fallthrough \
           unused-function, \
-      DISABLED_WARNINGS_clang := incompatible-pointer-types sign-compare, \
+      DISABLED_WARNINGS_clang := incompatible-pointer-types sign-compare \
+          deprecated-declarations, \
       DISABLED_WARNINGS_microsoft := 4018 4244 4267, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \


### PR DESCRIPTION
To guarantee backwards compatible binaries on Macos, we use the option -mmacosx-version-min. This is currently set to 10.9, which is a really ancient version. I propose we bump this to 10.12, which is still a rather conservative old version (support ended in 2019).

The driving issue for bumping this now is the aarch64 port, where building for aarch64 requires the version min to be set to 11.0. Having a large gap between the target versions becomes problematic as we hit a lot of deprecation warnings in shared code. To be able to fix these deprecation warnings, we need a smaller version gap.

Just bumping us to 10.12 triggers warnings in libsplashscreen, so I will temporarily add "deprecated-declarations" to the list of disabled warnings there until they can be fixed in JDK-8260402.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260518](https://bugs.openjdk.java.net/browse/JDK-8260518): Change default -mmacosx-version-min to 10.12


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to 41d60207dbbb3ae60d678d56322a7e4a6afb135c
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 41d60207dbbb3ae60d678d56322a7e4a6afb135c
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 41d60207dbbb3ae60d678d56322a7e4a6afb135c
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2268/head:pull/2268`
`$ git checkout pull/2268`
