### PR TITLE
8257746: Regression introduced with JDK-8250984 - memory might be null in some machines

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -444,14 +444,14 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     public long getMemoryAndSwapFailCount() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryFailCount();
         }
         return getLongValue(memory, "memory.memsw.failcnt");
     }
 
     public long getMemoryAndSwapLimit() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryLimit();
         }
         long retval = getLongValue(memory, "memory.memsw.limit_in_bytes");
@@ -469,14 +469,14 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     public long getMemoryAndSwapMaxUsage() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryMaxUsage();
         }
         return getLongValue(memory, "memory.memsw.max_usage_in_bytes");
     }
 
     public long getMemoryAndSwapUsage() {
-        if (!memory.isSwapEnabled()) {
+        if (memory != null && !memory.isSwapEnabled()) {
             return getMemoryUsage();
         }
         return getLongValue(memory, "memory.memsw.usage_in_bytes");


### PR DESCRIPTION
Please review this simple change that adds null checks for memory in CgroupV1Subsystem.java.

Problem: After the backport of JDK-8250984,  there are places where memory.isSwapEnabled() is called. For example:

    public long getMemoryAndSwapFailCount() {
        if (!memory.isSwapEnabled()) {
            return getMemoryFailCount();
        }
        return SubSystem.getLongValue(memory, "memory.memsw.failcnt");
    }
 
But memory could be Null on some machines that have cgroup entries for CPU but not for memory. This would cause a NullPointerException when memory is accessed.

Fix: Add null checks for memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257746](https://bugs.openjdk.java.net/browse/JDK-8257746): Regression introduced with JDK-8250984 - memory might be null in some machines


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2269/head:pull/2269`
`$ git checkout pull/2269`
