### PR TITLE
8260561: [doc] HexFormat has incorrect @since tag

### DIFF
--- a/src/java.base/share/classes/java/util/HexFormat.java
+++ b/src/java.base/share/classes/java/util/HexFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,7 @@ import java.nio.charset.StandardCharsets;
  * Unless otherwise noted, passing a null argument to any method will cause a
  * {@link java.lang.NullPointerException NullPointerException} to be thrown.
  *
- * @since 16
+ * @since 17
  */
 
 


### PR DESCRIPTION
A doc-only change to correct the @ since tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260561](https://bugs.openjdk.java.net/browse/JDK-8260561): [doc] HexFormat has incorrect @since tag


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2270/head:pull/2270`
`$ git checkout pull/2270`
