### PR TITLE
8247918: Clarify Reader.skip behavior for end of stream

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -397,14 +397,7 @@ public class BufferedReader extends Reader {
     }
 
     /**
-     * Skips characters.
-     *
-     * @param  n  The number of characters to skip
-     *
-     * @return    The number of characters actually skipped
-     *
-     * @throws     IllegalArgumentException  If {@code n} is negative.
-     * @throws     IOException  If an I/O error occurs
+     * {@inheritDoc}
      */
     public long skip(long n) throws IOException {
         if (n < 0L) {

--- a/src/java.base/share/classes/java/io/CharArrayReader.java
+++ b/src/java.base/share/classes/java/io/CharArrayReader.java
@@ -146,11 +146,19 @@ public class CharArrayReader extends Reader {
     }
 
     /**
-     * {@inheritDoc}
+     * Skips characters. If the stream is already at its end before this method
+     * is invoked, then no characters are skipped and zero is returned.
+     *
      * <p>The {@code n} parameter may be negative, even though the
      * {@code skip} method of the {@link Reader} superclass throws
      * an exception in this case. If {@code n} is negative, then
      * this method does nothing and returns {@code 0}.
+     *
+     * @param n {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     *
+     * @throws IOException {@inheritDoc}
      */
     public long skip(long n) throws IOException {
         synchronized (lock) {

--- a/src/java.base/share/classes/java/io/CharArrayReader.java
+++ b/src/java.base/share/classes/java/io/CharArrayReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,16 +146,11 @@ public class CharArrayReader extends Reader {
     }
 
     /**
-     * Skips characters.  Returns the number of characters that were skipped.
-     *
+     * {@inheritDoc}
      * <p>The {@code n} parameter may be negative, even though the
      * {@code skip} method of the {@link Reader} superclass throws
      * an exception in this case. If {@code n} is negative, then
      * this method does nothing and returns {@code 0}.
-     *
-     * @param      n The number of characters to skip
-     * @return     The number of characters actually skipped
-     * @throws     IOException If the stream is closed, or an I/O error occurs
      */
     public long skip(long n) throws IOException {
         synchronized (lock) {

--- a/src/java.base/share/classes/java/io/FilterReader.java
+++ b/src/java.base/share/classes/java/io/FilterReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,9 +76,11 @@ public abstract class FilterReader extends Reader {
     }
 
     /**
-     * Skips characters.
+     * {@inheritDoc}
      *
-     * @throws     IOException  If an I/O error occurs
+     * @throws     IllegalArgumentException  If {@code n} is negative and the
+     *             contained {@code Reader}'s {@code skip} method throws an
+     *             IllegalArgumentException for a negative parameter
      */
     public long skip(long n) throws IOException {
         return in.skip(n);

--- a/src/java.base/share/classes/java/io/LineNumberReader.java
+++ b/src/java.base/share/classes/java/io/LineNumberReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,18 +267,7 @@ public class LineNumberReader extends BufferedReader {
     private char skipBuffer[] = null;
 
     /**
-     * Skip characters.
-     *
-     * @param  n
-     *         The number of characters to skip
-     *
-     * @return  The number of characters actually skipped
-     *
-     * @throws  IOException
-     *          If an I/O error occurs
-     *
-     * @throws  IllegalArgumentException
-     *          If {@code n} is negative
+     * {@inheritDoc}
      */
     public long skip(long n) throws IOException {
         if (n < 0)

--- a/src/java.base/share/classes/java/io/PushbackReader.java
+++ b/src/java.base/share/classes/java/io/PushbackReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -254,15 +254,7 @@ public class PushbackReader extends FilterReader {
     }
 
     /**
-     * Skips characters.  This method will block until some characters are
-     * available, an I/O error occurs, or the end of the stream is reached.
-     *
-     * @param     n  The number of characters to skip
-     *
-     * @return    The number of characters actually skipped
-     *
-     * @throws    IllegalArgumentException  If {@code n} is negative.
-     * @throws    IOException  If an I/O error occurs
+     * {@inheritDoc}
      */
     public long skip(long n) throws IOException {
         if (n < 0L)

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -269,6 +269,8 @@ public abstract class Reader implements Readable, Closeable {
     /**
      * Skips characters.  This method will block until some characters are
      * available, an I/O error occurs, or the end of the stream is reached.
+     * If the stream is already at its end before this method is invoked,
+     * then no characters are skipped and zero is returned.
      *
      * @param  n  The number of characters to skip
      *

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -105,7 +105,8 @@ public class StringReader extends Reader {
     }
 
     /**
-     * {@inheritDoc}
+     * Skips characters. If the stream is already at its end before this method
+     * is invoked, then no characters are skipped and zero is returned.
      *
      * <p>The {@code n} parameter may be negative, even though the
      * {@code skip} method of the {@link Reader} superclass throws
@@ -116,6 +117,12 @@ public class StringReader extends Reader {
      *
      * <p>If the entire string has been read or skipped, then this method has
      * no effect and always returns {@code 0}.
+     *
+     * @param n {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     *
+     * @throws IOException {@inheritDoc}
      */
     public long skip(long n) throws IOException {
         synchronized (lock) {

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -107,9 +107,9 @@ public class StringReader extends Reader {
     /**
      * {@inheritDoc}
      *
-     * <p>The {@code ns} parameter may be negative, even though the
+     * <p>The {@code n} parameter may be negative, even though the
      * {@code skip} method of the {@link Reader} superclass throws
-     * an exception in this case. Negative values of {@code ns} cause the
+     * an exception in this case. Negative values of {@code n} cause the
      * stream to skip backwards. Negative return values indicate a skip
      * backwards. It is not possible to skip backwards past the beginning of
      * the string.

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,8 +105,7 @@ public class StringReader extends Reader {
     }
 
     /**
-     * Skips the specified number of characters in the stream. Returns
-     * the number of characters that were skipped.
+     * {@inheritDoc}
      *
      * <p>The {@code ns} parameter may be negative, even though the
      * {@code skip} method of the {@link Reader} superclass throws
@@ -116,20 +115,18 @@ public class StringReader extends Reader {
      * the string.
      *
      * <p>If the entire string has been read or skipped, then this method has
-     * no effect and always returns 0.
-     *
-     * @throws     IOException  If an I/O error occurs
+     * no effect and always returns {@code 0}.
      */
-    public long skip(long ns) throws IOException {
+    public long skip(long n) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if (next >= length)
                 return 0;
             // Bound skip by beginning and end of the source
-            long n = Math.min(length - next, ns);
-            n = Math.max(-next, n);
-            next += n;
-            return n;
+            long r = Math.min(length - next, n);
+            r = Math.max(-next, r);
+            next += r;
+            return r;
         }
     }
 

--- a/test/jdk/java/io/Reader/Skip.java
+++ b/test/jdk/java/io/Reader/Skip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,29 +22,83 @@
  */
 
 /* @test
-   @bug 4134311
-   @summary Test if skip works correctly
+ * @bug 4134311 8247918
+ * @summary Test if skip works correctly
+ * @run testng Skip
 */
 
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.PushbackReader;
+import java.io.RandomAccessFile;
+import java.io.Reader;
+import java.io.StringReader;
 
-
-import java.io.*;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 public class Skip {
-    public static void main(String argv[]) throws Exception {
-        File f = new File(System.getProperty("test.src", "."),
-                          "SkipInput.txt");
-        FileReader fr = new FileReader(f);
-        try {
+    private static String FILENAME =
+        System.getProperty("test.src", ".") + File.separator + "SkipInput.txt";
+    private static File file = new File(FILENAME);
+
+    @Test
+    public void skip() throws IOException {
+        try (FileReader fr = new FileReader(file)) {
             long nchars = 8200;
             long actual = fr.skip(nchars);
 
-            if (actual > nchars) {
-                throw new Exception
-                    ("Should skip " + nchars + ", but skipped " +actual+" chars");
-            }
-        } finally {
-            fr.close();
+            Assert.assertFalse(actual > nchars,
+                "Should skip " + nchars + ", but skipped " +actual+" chars");
         }
+    }
+
+    @DataProvider(name = "readers")
+    public Object[][] getReaders() throws IOException {
+        return new Object[][] {
+            {new LineNumberReader(new FileReader(file))},
+            {new CharArrayReader(new char[] {27})},
+            {new PushbackReader(new FileReader(file))},
+            {new FileReader(file)},
+            {new StringReader(new String(new byte[] {(byte)42}))}
+        };
+    }
+
+    @Test(dataProvider = "readers")
+    public void eof(Reader r) throws IOException {
+         r.skip(Long.MAX_VALUE);
+         Assert.assertEquals(r.skip(1), 0);
+         Assert.assertEquals(r.read(), -1);
+    }
+
+    @DataProvider(name = "skipIAE")
+    public Object[][] getSkipIAEs() throws IOException {
+        return new Object[][] {
+            {new LineNumberReader(new FileReader(file))},
+            {new PushbackReader(new FileReader(file))},
+            {new FileReader(file)}
+        };
+    }
+
+    @Test(dataProvider = "skipIAE", expectedExceptions = IllegalArgumentException.class)
+    public void testThrowsIAE(Reader r) throws IOException {
+        r.skip(-1);
+    }
+
+    @DataProvider(name = "skipNoIAE")
+    public Object[][] getSkipNoIAEs() throws IOException {
+        return new Object[][] {
+            {new CharArrayReader(new char[] {27})},
+            {new StringReader(new String(new byte[] {(byte)42}))}
+        };
+    }
+
+    @Test(dataProvider = "skipNoIAE")
+    public void testNoIAE(Reader r) throws IOException {
+        r.skip(-1);
     }
 }


### PR DESCRIPTION
Please review this clarification of the specification of the method `skip(long)` in `java.io.Reader` and its subclasses. Specifically, the behavior of the method is made clear for the case when the `Reader` is already at the end of its stream when the method is invoked. A corresponding CSR will be filed. Also, the change includes an update to an existing test in order to verify that the specification change reflects actual behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247918](https://bugs.openjdk.java.net/browse/JDK-8247918): Clarify Reader.skip behavior for end of stream


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2274/head:pull/2274`
`$ git checkout pull/2274`
