### PR TITLE
8259487: Remove unused StarTask

### DIFF
--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -513,36 +513,6 @@ uint GenericTaskQueueSet<T, F>::tasks() const {
 class TerminatorTerminator: public CHeapObj<mtInternal> {
 public:
   virtual bool should_exit_termination() = 0;
-};
-
-// This is a container class for either an oop* or a narrowOop*.
-// Both are pushed onto a task queue and the consumer will test is_narrow()
-// to determine which should be processed.
-class StarTask {
-  void*  _holder;        // either union oop* or narrowOop*
-
-  enum { COMPRESSED_OOP_MASK = 1 };
-
- public:
-  StarTask(narrowOop* p) {
-    assert(((uintptr_t)p & COMPRESSED_OOP_MASK) == 0, "Information loss!");
-    _holder = (void *)((uintptr_t)p | COMPRESSED_OOP_MASK);
-  }
-  StarTask(oop* p)       {
-    assert(((uintptr_t)p & COMPRESSED_OOP_MASK) == 0, "Information loss!");
-    _holder = (void*)p;
-  }
-  StarTask()             { _holder = NULL; }
-  // Trivially copyable, for use in GenericTaskQueue.
-
-  operator oop*()        { return (oop*)_holder; }
-  operator narrowOop*()  {
-    return (narrowOop*)((uintptr_t)_holder & ~COMPRESSED_OOP_MASK);
-  }
-
-  bool is_narrow() const {
-    return (((uintptr_t)_holder & COMPRESSED_OOP_MASK) != 0);
-  }
 };
 
 class ObjArrayTask


### PR DESCRIPTION
Please review this change which removes the StarTask class.  It was
superseded by ScannerTask in JDK-8244684 and JDK-8245022, and is no longer
used.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259487](https://bugs.openjdk.java.net/browse/JDK-8259487): Remove unused StarTask


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2277/head:pull/2277`
`$ git checkout pull/2277`
