### PR TITLE
8257705: vmTestbase/nsk/jdi/HiddenClass/events/events001.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/HiddenClass/events/events001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/HiddenClass/events/events001a.java
@@ -92,10 +92,11 @@ class events001a extends DebuggeeBase {
         Reference<? extends Class<?>> deletedObject = refQueue.poll();
         while(deletedObject == null) {
             WB.fullGC(); // force full GC with WB until hidden class unloaded
+            logMsg("Debuggee: Provoking class unload events");
             deletedObject = refQueue.poll();
         }
 
-        logMsg("Debuggee: finished provoking class unload events");
+        logMsg("Debuggee: class is unloaded");
 
         quitSyncWithDebugger();
     }


### PR DESCRIPTION
Test times out waiting for ClassUnloadRequest in the debugger. The debuggee waits for the quit command but this command is sent only after class is unloaded.

Another problem is that class unloading was finally triggered by jcmd command from the failure handler. (Which adds a lot of confusion.) 

The checking phantom reference in cycle allows several attempts and better logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257705](https://bugs.openjdk.java.net/browse/JDK-8257705): vmTestbase/nsk/jdi/HiddenClass/events/events001.java timed out


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2278/head:pull/2278`
`$ git checkout pull/2278`
