### PR TITLE
8260579: PPC64 and S390 builds failures after JDK-8260467

### DIFF
--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -78,8 +78,8 @@ void MethodHandles::verify_klass(MacroAssembler* _masm,
                                  Register obj_reg, VMClassID klass_id,
                                  Register temp_reg, Register temp2_reg,
                                  const char* error_message) {
-  InstanceKlass** klass_addr = VMClassses::klass_addr_at(klass_id);
-  Klass* klass = VMClassses::klass_at(klass_id);
+  InstanceKlass** klass_addr = vmClasses::klass_addr_at(klass_id);
+  Klass* klass = vmClasses::klass_at(klass_id);
   Label L_ok, L_bad;
   BLOCK_COMMENT("verify_klass {");
   __ verify_oop(obj_reg, FILE_AND_LINE);

--- a/src/hotspot/cpu/s390/methodHandles_s390.cpp
+++ b/src/hotspot/cpu/s390/methodHandles_s390.cpp
@@ -80,8 +80,8 @@ void MethodHandles::verify_klass(MacroAssembler* _masm,
                                  Register temp_reg, Register temp2_reg,
                                  const char* error_message) {
 
-  InstanceKlass** klass_addr = VMClassses::klass_addr_at(klass_id);
-  Klass* klass = VMClassses::klass_at(klass_id);
+  InstanceKlass** klass_addr = vmClasses::klass_addr_at(klass_id);
+  Klass* klass = vmClasses::klass_at(klass_id);
 
   assert(temp_reg != Z_R0 && // Is used as base register!
          temp_reg != noreg && temp2_reg != noreg, "need valid registers!");


### PR DESCRIPTION
```
Creating support/modules_libs/java.base/server/libjvm.so from 889 file(s)
/home/shade/trunks/jdk/src/hotspot/cpu/s390/methodHandles_s390.cpp: In static member function 'static void MethodHandles::verify_klass(MacroAssembler*, Register, VMClassID, Register, Register, const char*)':
/home/shade/trunks/jdk/src/hotspot/cpu/s390/methodHandles_s390.cpp:83:32: error: 'VMClassses' has not been declared
   83 | InstanceKlass** klass_addr = VMClassses::klass_addr_at(klass_id);
      | ^~~~~~~~~~
/home/shade/trunks/jdk/src/hotspot/cpu/s390/methodHandles_s390.cpp:84:18: error: 'VMClassses' has not been declared
   84 | Klass* klass = VMClassses::klass_at(klass_id);
      | ^~~~~~~~~~
```
This is an obvious typo in "VMClassses", it should actually be "vmClasses".

This readily manifests in current GH Action runs. It would have been caught by #2246 PR, if GHA were enabled, @iklam.

Additional testing:
 - [x] Linux s390x hotspot cross-compile
 - [x] Linux ppc64le hotspot cross-compile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260579](https://bugs.openjdk.java.net/browse/JDK-8260579): PPC64 and S390 builds failures after JDK-8260467


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2282/head:pull/2282`
`$ git checkout pull/2282`
