### PR TITLE
JDK-8260571: Add PrintMetaspaceStatistics to print metaspace statistics upon VM exit

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1484,6 +1484,9 @@ const intx ObjectAlignmentInBytes = 8;
   product(ccstr, MetaspaceReclaimPolicy, "balanced",                        \
           "options: balanced, aggressive, none")                            \
                                                                             \
+  product(bool, PrintMetaspaceStatistics, false, DIAGNOSTIC,                \
+          "Print metaspace statistics upon VM exit.")                       \
+                                                                            \
   product(bool, MetaspaceGuardAllocations, false, DIAGNOSTIC,               \
           "Metapace allocations are guarded.")                              \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1484,7 +1484,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(ccstr, MetaspaceReclaimPolicy, "balanced",                        \
           "options: balanced, aggressive, none")                            \
                                                                             \
-  product(bool, PrintMetaspaceStatistics, false, DIAGNOSTIC,                \
+  product(bool, PrintMetaspaceStatisticsAtExit, false, DIAGNOSTIC,          \
           "Print metaspace statistics upon VM exit.")                       \
                                                                             \
   product(bool, MetaspaceGuardAllocations, false, DIAGNOSTIC,               \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -328,7 +328,7 @@ void print_statistics() {
     MemTracker::final_report(tty);
   }
 
-  if (PrintMetaspaceStatistics) {
+  if (PrintMetaspaceStatisticsAtExit) {
     MetaspaceUtils::print_basic_report(tty, 0);
   }
 
@@ -374,7 +374,7 @@ void print_statistics() {
     MemTracker::final_report(tty);
   }
 
-  if (PrintMetaspaceStatistics) {
+  if (PrintMetaspaceStatisticsAtExit) {
     MetaspaceUtils::print_basic_report(tty, 0);
   }
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -328,6 +328,10 @@ void print_statistics() {
     MemTracker::final_report(tty);
   }
 
+  if (PrintMetaspaceStatistics) {
+    MetaspaceUtils::print_basic_report(tty, 0);
+  }
+
   ThreadsSMRSupport::log_statistics();
 }
 
@@ -368,6 +372,10 @@ void print_statistics() {
   // Native memory tracking data
   if (PrintNMTStatistics) {
     MemTracker::final_report(tty);
+  }
+
+  if (PrintMetaspaceStatistics) {
+    MetaspaceUtils::print_basic_report(tty, 0);
   }
 
   if (LogTouchedMethods && PrintTouchedMethodsAtExit) {


### PR DESCRIPTION
This patch adds a new diagnostic boolean switch `PrintMetaspaceStatistics`. When set, it will cause the VM to print a brief report about metaspace occupancy when exiting. It follows the same logic as `PrintNMTStatistics` and similar switches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260571](https://bugs.openjdk.java.net/browse/JDK-8260571): Add PrintMetaspaceStatistics to print metaspace statistics upon VM exit


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 9959026778c52cbd4c3d9627781d9b88914b5ab8


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2283/head:pull/2283`
`$ git checkout pull/2283`
