### PR TITLE
8260581: IGV: enhance node search

### DIFF
--- a/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
@@ -274,6 +274,13 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
     public String[] getLines() {
         if (lines == null) {
             updateLines();
+            // Set the "label" property of each input node, so that by default
+            // search is done on the node label (without line breaks). See also
+            // class NodeQuickSearch in the View module.
+            for (InputNode n : getSource().getSourceNodes()) {
+                String label = resolveString(diagram.getNodeText(), n.getProperties());
+                n.getProperties().setProperty("label", label);
+            }
         }
         return lines;
     }

--- a/src/utils/IdealGraphVisualizer/View/nbproject/project.properties
+++ b/src/utils/IdealGraphVisualizer/View/nbproject/project.properties
@@ -1,2 +1,2 @@
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -114,7 +114,7 @@ public class NodeQuickSearch implements SearchProvider {
                 // digits (it is rare to select all nodes whose id contains a
                 // certain subsequence of digits).
                 if (matches.size() > 1 && !rawValue.matches("\\d+")) {
-                    response.addResult(new Runnable() {
+                    if (!response.addResult(new Runnable() {
                         @Override
                         public void run() {
                             final EditorTopComponent comp = EditorTopComponent.getActive();
@@ -128,7 +128,9 @@ public class NodeQuickSearch implements SearchProvider {
                         }
                     },
                             "All " + matches.size() + " matching nodes (" + name + "=" + value + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
-                    );
+                    )) {
+                        return;
+                    }
                 }
 
                 // Rank the matches.
@@ -139,7 +141,7 @@ public class NodeQuickSearch implements SearchProvider {
 
                 // Single matches
                 for (final InputNode n : matches) {
-                    response.addResult(new Runnable() {
+                    if (!response.addResult(new Runnable() {
                         @Override
                         public void run() {
                             final EditorTopComponent comp = EditorTopComponent.getActive();
@@ -155,7 +157,9 @@ public class NodeQuickSearch implements SearchProvider {
                         }
                     },
                             n.getProperties().get(name) + " (" + n.getId() + " " + n.getProperties().get("name") + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
-                    );
+                    )) {
+                        return;
+                    }
                 }
             }
         } else {

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -46,7 +46,7 @@ import org.openide.NotifyDescriptor.Message;
  */
 public class NodeQuickSearch implements SearchProvider {
 
-    private static final String DEFAULT_PROPERTY = "name";
+    private static final String DEFAULT_PROPERTY = "label";
 
     /**
      * Method is called by infrastructure when search operation was requested.

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -213,7 +213,6 @@ public class NodeQuickSearch implements SearchProvider {
                 return component.length() - query.length() + 2;
             }
         }
-        System.out.println(Integer.MAX_VALUE);
         return Integer.MAX_VALUE;
     }
 }

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -108,21 +108,27 @@ public class NodeQuickSearch implements SearchProvider {
             if (matches != null) {
                 final Set<InputNode> set = new HashSet<>(matches);
                 final InputGraph theGraph = p.getGraph() != matchGraph ? matchGraph : null;
-                response.addResult(new Runnable() {
-                    @Override
-                    public void run() {
-                        final EditorTopComponent comp = EditorTopComponent.getActive();
-                        if (comp != null) {
-                            if (theGraph != null) {
-                                comp.getDiagramModel().selectGraph(theGraph);
+                // Show "All N matching nodes" entry only if 1) there are
+                // multiple matches and 2) the query does not only contain
+                // digits (it is rare to select all nodes whose id contains a
+                // certain subsequence of digits).
+                if (matches.size() > 1 && !rawValue.matches("\\d+")) {
+                    response.addResult(new Runnable() {
+                        @Override
+                        public void run() {
+                            final EditorTopComponent comp = EditorTopComponent.getActive();
+                            if (comp != null) {
+                                if (theGraph != null) {
+                                    comp.getDiagramModel().selectGraph(theGraph);
+                                }
+                                comp.setSelectedNodes(set);
+                                comp.requestActive();
                             }
-                            comp.setSelectedNodes(set);
-                            comp.requestActive();
                         }
-                    }
-                },
-                        "All " + matches.size() + " matching nodes (" + name + "=" + value + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
-                );
+                    },
+                            "All " + matches.size() + " matching nodes (" + name + "=" + value + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
+                    );
+                }
 
                 // Single matches
                 for (final InputNode n : matches) {

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -66,18 +66,17 @@ public class NodeQuickSearch implements SearchProvider {
         final String[] parts = query.split("=", 2);
 
         String name;
+        String rawValue;
         String value;
 
         if (parts.length == 1) {
             name = DEFAULT_PROPERTY;
-            value = ".*" + Pattern.quote(parts[0]) + ".*";
+            rawValue = parts[0];
+            value = ".*" + Pattern.quote(rawValue) + ".*";
         } else {
             name = parts[0];
-            value = parts[1];
-        }
-
-        if (value.isEmpty()) {
-            value = ".*";
+            rawValue = parts[1];
+            value = (rawValue.isEmpty() ? "" : Pattern.quote(rawValue)) + ".*";
         }
 
         final InputGraphProvider p = LookupHistory.getLast(InputGraphProvider.class);

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -136,8 +136,9 @@ public class NodeQuickSearch implements SearchProvider {
                 // Rank the matches.
                 Collections.sort(matches,
                                  (InputNode a, InputNode b) ->
-                                 Integer.compare(rankMatch(rawValue, a.getProperties().get(name)),
-                                                 rankMatch(rawValue, b.getProperties().get(name))));
+                                 compareByRankThenNumVal(rawValue,
+                                                         a.getProperties().get(name),
+                                                         b.getProperties().get(name)));
 
                 // Single matches
                 for (final InputNode n : matches) {
@@ -188,6 +189,27 @@ public class NodeQuickSearch implements SearchProvider {
             );
         }
         return null;
+    }
+
+    /**
+     * Compare two matches for a given query, first by rank (see rankMatch()
+     * below) and then by numeric value, if applicable.
+     */
+    private int compareByRankThenNumVal(String qry, String prop1, String prop2) {
+        int key1 = rankMatch(qry, prop1);
+        int key2 = rankMatch(qry, prop2);
+        if (key1 == key2) {
+            // If the matches have the same rank, compare the numeric values of
+            // their first words, if applicable.
+            try {
+                key1 = Integer.parseInt(prop1.split("\\W+")[0]);
+                key2 = Integer.parseInt(prop2.split("\\W+")[0]);
+            } catch (Exception e) {
+                // Not applicable, return equality value.
+                return 0;
+            }
+        }
+        return Integer.compare(key1, key2);
     }
 
     /**

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -136,8 +136,8 @@ public class NodeQuickSearch implements SearchProvider {
                 // Rank the matches.
                 Collections.sort(matches,
                                  (InputNode a, InputNode b) ->
-                                 Integer.valueOf(rankMatch(rawValue, a.getProperties().get(name)))
-                                 .compareTo(rankMatch(rawValue, b.getProperties().get(name))));
+                                 Integer.compare(rankMatch(rawValue, a.getProperties().get(name)),
+                                                 rankMatch(rawValue, b.getProperties().get(name))));
 
                 // Single matches
                 for (final InputNode n : matches) {

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/layer.xml
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/layer.xml
@@ -75,15 +75,9 @@
         <file name="GoToType_hidden"/>
         <file name="Help_hidden"/>
         <file name="Hudson_hidden"/>
-        <folder name="Recent_hidden">
-        </folder>
-        <folder name="Recent Searches">
-            <attr name="position" intvalue="1"/>
-            <file name="org-netbeans-modules-quicksearch-recent.RecentProvider.instance"/>
-        </folder>
         <folder name="Nodes">
             <attr name="command" stringvalue="n"/>
-            <attr name="position" intvalue="2"/>
+            <attr name="position" intvalue="0"/>
             <file name="com-sun-hotspot-igv-view-NodeQuickSearch.instance"/>
         </folder>
         <file name="Projects_hidden"/>

--- a/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/layer.xml
+++ b/src/utils/IdealGraphVisualizer/View/src/com/sun/hotspot/igv/view/layer.xml
@@ -75,9 +75,15 @@
         <file name="GoToType_hidden"/>
         <file name="Help_hidden"/>
         <file name="Hudson_hidden"/>
+        <folder name="Recent_hidden">
+        </folder>
+        <folder name="Recent Searches">
+            <attr name="position" intvalue="1"/>
+            <file name="org-netbeans-modules-quicksearch-recent.RecentProvider.instance"/>
+        </folder>
         <folder name="Nodes">
             <attr name="command" stringvalue="n"/>
-            <attr name="position" intvalue="0"/>
+            <attr name="position" intvalue="2"/>
             <file name="com-sun-hotspot-igv-view-NodeQuickSearch.instance"/>
         </folder>
         <file name="Projects_hidden"/>


### PR DESCRIPTION
Apply several enhancements to the quick node search functionality: 

- Allow users to search by node id or name by default (i.e. when no property is specified) instead of name only.
- Show partial matches when searching for a specific property (e.g. so that searching "type=con" lists all "control"-type nodes).
- Avoid showing the "All _N_ matching nodes" entry if there is a single match, or the user is searching a numeric value.
- Rank matches so that full matches are listed first, followed by matches at the beginning of the partially matched value, followed by the rest of matches in increasing size of the partially matched value. Numeric matches with the same rank are sorted increasingly. For example, searching "5" on a set of nodes with labels {"5 AddI", "25 AddL", "253 AddL", "554 MulI"} should list the matches as follows:
    1. **5** AddI
    2. **5**54 MulI
    3. 2**5** AddL
    4. 2**5**3 AddL

As an illustration of some of these enhancements, this screenshot shows the behavior of the quick node search functionality before the changes:

![search-before](https://user-images.githubusercontent.com/8792647/106283438-374ba500-6242-11eb-8ef4-d18117eabcbb.png)

and after:

![search-after](https://user-images.githubusercontent.com/8792647/106282880-7e856600-6241-11eb-8cb5-48fae5582cc2.png)


Tested manually on small and large (~10000 nodes) graphs. Thanks to Christian Hagedorn for feedback on several iterations of the enhancements.

As part of the review, please evaluate not just the code changes but also the usability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260581](https://bugs.openjdk.java.net/browse/JDK-8260581): IGV: enhance node search


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 73d0ed022294a160eb208648ea585d8d824f87b4
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role)


### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2285/head:pull/2285`
`$ git checkout pull/2285`
