### PR TITLE
8260584: Shenandoah: simplify "Concurrent Thread Roots" logging

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -73,9 +73,8 @@ class outputStream;
   f(init_evac,                                      "  Initial Evacuation")            \
   SHENANDOAH_PAR_PHASE_DO(evac_,                    "    E: ", f)                      \
                                                                                        \
-  f(conc_thread_roots,                              "Concurrent Stack Processing")     \
-  f(conc_thread_roots_work,                           "  Threads")                     \
-  SHENANDOAH_PAR_PHASE_DO(conc_thread_roots_work_,    "    CT: ", f)                   \
+  f(conc_thread_roots,                              "Concurrent Thread Roots")         \
+  SHENANDOAH_PAR_PHASE_DO(conc_thread_roots_,       "  CTR: ", f)                      \
   f(conc_weak_refs,                                 "Concurrent Weak References")      \
   f(conc_weak_refs_work,                            "  Process")                       \
   SHENANDOAH_PAR_PHASE_DO(conc_weak_refs_work_,     "    CWRF: ", f)                   \


### PR DESCRIPTION
There are two separate counters now:

```
 f(conc_thread_roots, "Concurrent Stack Processing") \
 f(conc_thread_roots_work, " Threads") \
  SHENANDOAH_PAR_PHASE_DO(conc_thread_roots_work_, " CT: ", f) \
```
...and `_work` counter is unused, and `conc_thread_roots` is used to report worker stats. So the log says `<total>`, where `Thread Roots` should have been mentioned:

```
[34.169s][info][gc,stats] Concurrent Stack Processing       11341 us, parallelism: 7.93x
[34.169s][info][gc,stats]   Threads                         89908 us
[34.169s][info][gc,stats]     CT: <total>                   89908 us, workers (us): 11231, 11270, 11251, 11252, 11237, 11230, 11214, 11223, 
```

Fixed log says:

```
[99.797s][info][gc,stats] Concurrent Thread Roots            3929 us, parallelism: 7.45x
[99.797s][info][gc,stats]   CTR: <total>                    29273 us
[99.797s][info][gc,stats]   CTR: Thread Roots               29273 us, workers (us): 3652, 3643, 3622, 3623, 3623, 3676, 3606, 3829, 
```

Also, I believe it should be called "Concurrent Thread Roots", in symmetry with "Concurrent Update Thread Roots" later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260584](https://bugs.openjdk.java.net/browse/JDK-8260584): Shenandoah: simplify "Concurrent Thread Roots" logging


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2287/head:pull/2287`
`$ git checkout pull/2287`
