### PR TITLE
8260586: Shenandoah: simplify "Concurrent Weak References" logging

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -622,9 +622,8 @@ void ShenandoahConcurrentGC::op_weak_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_concurrent_weak_root_in_progress(), "Only during this phase");
   // Concurrent weak refs processing
-  ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_refs_work);
-  ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_refs_work);
-  heap->ref_processor()->process_references(ShenandoahPhaseTimings::conc_weak_refs_work, heap->workers(), true /* concurrent */);
+  ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_refs);
+  heap->ref_processor()->process_references(ShenandoahPhaseTimings::conc_weak_refs, heap->workers(), true /* concurrent */);
 }
 
 class ShenandoahEvacUpdateCleanupOopStorageRootsClosure : public BasicOopIterateClosure {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -115,7 +115,7 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
     case conc_mark_roots:
     case conc_thread_roots:
     case conc_weak_roots_work:
-    case conc_weak_refs_work:
+    case conc_weak_refs:
     case conc_strong_roots:
       return true;
     default:

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -77,8 +77,7 @@ class outputStream;
   f(conc_thread_roots_work,                           "  Threads")                     \
   SHENANDOAH_PAR_PHASE_DO(conc_thread_roots_work_,    "    CT: ", f)                   \
   f(conc_weak_refs,                                 "Concurrent Weak References")      \
-  f(conc_weak_refs_work,                            "  Process")                       \
-  SHENANDOAH_PAR_PHASE_DO(conc_weak_refs_work_,     "    CWRF: ", f)                   \
+  SHENANDOAH_PAR_PHASE_DO(conc_weak_refs_,          "  CWRF: ", f)                     \
   f(conc_weak_roots,                                "Concurrent Weak Roots")           \
   f(conc_weak_roots_work,                           "  Roots")                         \
   SHENANDOAH_PAR_PHASE_DO(conc_weak_roots_work_,    "    CWR: ", f)                    \


### PR DESCRIPTION
Concurrent Weak References always does parallel worker operation. Therefore "Process" counter is redundant, and we might as well make the root counter the per-worker one. This simplifies GC logging.

Old log:

```
[95.220s][info][gc,stats] Concurrent Weak References         1709 us
[95.220s][info][gc,stats]   Process                          1588 us, parallelism: 1.30x
[95.220s][info][gc,stats]     CWRF: <total>                  2056 us
[95.220s][info][gc,stats]     CWRF: Weak References          2056 us, workers (us): 454, 1450,   2, 145,   4,   1,   0,   0, 
```

New log:

```
[39.583s][info][gc,stats] Concurrent Weak References          651 us, parallelism: 1.52x
[39.583s][info][gc,stats]   CWRF: <total>                     986 us
[39.583s][info][gc,stats]   CWRF: Weak References             986 us, workers (us): 183,  29, 145, 627,   1,   0,   0,   0, 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260586](https://bugs.openjdk.java.net/browse/JDK-8260586): Shenandoah: simplify "Concurrent Weak References" logging


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to 8b9bf2e11886a18855a1b37f53ed830bfb7565da
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2288/head:pull/2288`
`$ git checkout pull/2288`
