### PR TITLE
8260591: Shenandoah: improve parallelism for concurrent thread root scans

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -596,9 +596,9 @@ private:
   ShenandoahJavaThreadsIterator _java_threads;
 
 public:
-  ShenandoahConcurrentEvacUpdateThreadTask() :
+  ShenandoahConcurrentEvacUpdateThreadTask(uint n_workers) :
     AbstractGangTask("Shenandoah Evacuate/Update Concurrent Thread Roots"),
-    _java_threads(ShenandoahPhaseTimings::conc_thread_roots) {
+    _java_threads(ShenandoahPhaseTimings::conc_thread_roots, n_workers) {
   }
 
   void work(uint worker_id) {
@@ -614,7 +614,7 @@ void ShenandoahConcurrentGC::op_thread_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_evacuation_in_progress(), "Checked by caller");
   ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_thread_roots);
-  ShenandoahConcurrentEvacUpdateThreadTask task;
+  ShenandoahConcurrentEvacUpdateThreadTask task(heap->workers()->active_workers());
   heap->workers()->run_task(&task);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -38,20 +38,24 @@
 #include "runtime/stackWatermarkSet.inline.hpp"
 #include "runtime/thread.hpp"
 
-ShenandoahJavaThreadsIterator::ShenandoahJavaThreadsIterator(ShenandoahPhaseTimings::Phase phase) :
+ShenandoahJavaThreadsIterator::ShenandoahJavaThreadsIterator(ShenandoahPhaseTimings::Phase phase, uint n_workers) :
   _threads(),
+  _length(_threads.length()),
+  _stride(MAX2(1u, _length / n_workers / _chunks_per_worker)),
   _claimed(0),
   _phase(phase) {
 }
 
 uint ShenandoahJavaThreadsIterator::claim() {
-  return Atomic::fetch_and_add(&_claimed, 1u);
+  return Atomic::fetch_and_add(&_claimed, _stride);
 }
 
 void ShenandoahJavaThreadsIterator::threads_do(ThreadClosure* cl, uint worker_id) {
   ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::ThreadRoots, worker_id);
-  for (uint i = claim(); i < _threads.length(); i = claim()) {
-    cl->do_thread(_threads.thread_at(i));
+  for (uint i = claim(); i < _length; i = claim()) {
+    for (uint t = i; t < MIN2(_length, i + _stride); t++) {
+      cl->do_thread(thread_at(t));
+    }
   }
 }
 
@@ -207,7 +211,7 @@ void ShenandoahConcurrentMarkThreadClosure::do_thread(Thread* thread) {
 ShenandoahConcurrentRootScanner::ShenandoahConcurrentRootScanner(uint n_workers,
                                                                  ShenandoahPhaseTimings::Phase phase) :
    ShenandoahRootProcessor(phase),
-   _java_threads(phase),
+   _java_threads(phase, n_workers),
   _vm_roots(phase),
   _cld_roots(phase, n_workers),
   _codecache_snapshot(NULL),
@@ -231,19 +235,24 @@ void ShenandoahConcurrentRootScanner::roots_do(OopClosure* oops, uint worker_id)
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   CLDToOopClosure clds_cl(oops, ClassLoaderData::_claim_strong);
 
-  ShenandoahConcurrentMarkThreadClosure thr_cl(oops);
-  _java_threads.threads_do(&thr_cl, worker_id);
-
+  // Process light-weight/limited parallel roots then
   _vm_roots.oops_do(oops, worker_id);
 
-  if (!heap->unload_classes()) {
-    _cld_roots.cld_do(&clds_cl, worker_id);
-    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
-    CodeBlobToOopClosure blobs(oops, !CodeBlobToOopClosure::FixRelocations);
-    _codecache_snapshot->parallel_blobs_do(&blobs);
-  } else {
+  if (heap->unload_classes()) {
     _cld_roots.always_strong_cld_do(&clds_cl, worker_id);
+  } else {
+    _cld_roots.cld_do(&clds_cl, worker_id);
+
+    {
+      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
+      CodeBlobToOopClosure blobs(oops, !CodeBlobToOopClosure::FixRelocations);
+      _codecache_snapshot->parallel_blobs_do(&blobs);
+    }
   }
+
+  // Process heavy-weight/fully parallel roots the last
+  ShenandoahConcurrentMarkThreadClosure thr_cl(oops);
+  _java_threads.threads_do(&thr_cl, worker_id);
 }
 
 void ShenandoahConcurrentRootScanner::update_tlab_stats() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -67,16 +67,20 @@ public:
 
 class ShenandoahJavaThreadsIterator {
 private:
+  static const uint _chunks_per_worker = 16; // educated guess
+
   ThreadsListHandle             _threads;
+  uint const                    _length;
+  uint const                    _stride;
   volatile uint                 _claimed;
   ShenandoahPhaseTimings::Phase _phase;
 
   uint claim();
 public:
-  ShenandoahJavaThreadsIterator(ShenandoahPhaseTimings::Phase phase);
+  ShenandoahJavaThreadsIterator(ShenandoahPhaseTimings::Phase phase, uint n_workers);
   void threads_do(ThreadClosure* cl, uint worker_id);
 
-  uint length() const { return _threads.length(); }
+  uint length() const { return _length; }
   Thread* thread_at(uint index) const { return _threads.thread_at(index); }
 };
 


### PR DESCRIPTION
Following JDK-8256298, there are a few minor performance issues with the implementation.

First, in the spirit of JDK-8246100, we should be scanning the Java threads the last, as they have the most parallelism. Less parallel, or lightweight roots should be scanned before them to improve overall parallelism.

Second, claiming each thread dominates the per-thread processing cost. We should really be doing chunked processing.

Motivating example is SPECjvm2008 serial, which has very fast concurrent cycles, and thread root scan speed is important.

Before:
```
# Baseline
[56.176s][info][gc,stats] Concurrent Mark Roots          =    0.308 s (a =     1452 us) (n =   212) (lvls, us =      305,      398,      457,      719,    11216)
[56.176s][info][gc,stats]   CMR: <total>                 =    1.236 s (a =     5832 us) (n =   212) (lvls, us =     2676,     3535,     4199,     5391,    54522)
[56.176s][info][gc,stats]   CMR: Thread Roots            =    1.179 s (a =     5563 us) (n =   212) (lvls, us =     2441,     3242,     3945,     5156,    54288)
[56.176s][info][gc,stats]   CMR: VM Strong Roots         =    0.005 s (a =       23 us) (n =   212) (lvls, us =       12,       19,       21,       23,      204)
[56.176s][info][gc,stats]   CMR: CLDG Roots              =    0.052 s (a =      247 us) (n =   212) (lvls, us =       73,      203,      252,      293,      562)

...
[56.176s][info][gc,stats] Concurrent Stack Processing    =    0.124 s (a =     5149 us) (n =    24) (lvls, us =      535,      607,      885,     6387,    27177)
[56.176s][info][gc,stats]   Threads                      =    0.632 s (a =    26345 us) (n =    24) (lvls, us =     6465,     8086,    10742,    39453,   145679)
[56.176s][info][gc,stats]     CT: <total>                =    0.632 s (a =    26345 us) (n =    24) (lvls, us =     6465,     8086,    10742,    39453,   145679)
```

After:
```
[56.010s][info][gc,stats] Concurrent Mark Roots          =    0.116 s (a =      587 us) (n =   198) (lvls, us =      312,      371,      400,      502,     4316)
[56.010s][info][gc,stats]   CMR: <total>                 =    0.931 s (a =     4703 us) (n =   198) (lvls, us =     2402,     3438,     3770,     4453,    62629)
[56.010s][info][gc,stats]   CMR: Thread Roots            =    0.864 s (a =     4366 us) (n =   198) (lvls, us =     1914,     3125,     3477,     4199,    54075)
[56.010s][info][gc,stats]   CMR: VM Strong Roots         =    0.015 s (a =       76 us) (n =   198) (lvls, us =       20,       31,       35,       38,     4693)
[56.010s][info][gc,stats]   CMR: CLDG Roots              =    0.052 s (a =      261 us) (n =   198) (lvls, us =       61,      172,      256,      299,     3861)
...
[56.010s][info][gc,stats] Concurrent Stack Processing    =    0.081 s (a =     3671 us) (n =    22) (lvls, us =      457,      537,      770,     3359,    24003)
[56.010s][info][gc,stats]   Threads                      =    0.469 s (a =    21309 us) (n =    22) (lvls, us =     6016,     6855,     8711,    18945,   103939)
[56.010s][info][gc,stats]     CT: <total>                =    0.469 s (a =    21309 us) (n =    22) (lvls, us =     6016,     6855,     8711,    18945,   103939)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260591](https://bugs.openjdk.java.net/browse/JDK-8260591): Shenandoah: improve parallelism for concurrent thread root scans 


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2290/head:pull/2290`
`$ git checkout pull/2290`
