### PR TITLE
8260592: jpackage tests fail when Desktop is not supported

### DIFF
--- a/test/jdk/tools/jpackage/apps/image/Hello.java
+++ b/test/jdk/tools/jpackage/apps/image/Hello.java
@@ -151,11 +151,14 @@ public class Hello implements OpenFilesHandler {
         if (GraphicsEnvironment.isHeadless()) {
             return null;
         }
+
+        trace("Environment supports a display");
+
         if (!Desktop.isDesktopSupported()) {
             return null;
         }
 
-        trace("Environment supports a display");
+        trace("Environment supports a desktop");
 
         try {
             // Disable JAB.

--- a/test/jdk/tools/jpackage/apps/image/Hello.java
+++ b/test/jdk/tools/jpackage/apps/image/Hello.java
@@ -151,6 +151,9 @@ public class Hello implements OpenFilesHandler {
         if (GraphicsEnvironment.isHeadless()) {
             return null;
         }
+        if (!Desktop.isDesktopSupported()) {
+            return null;
+        }
 
         trace("Environment supports a display");
 
@@ -162,12 +165,6 @@ public class Hello implements OpenFilesHandler {
         } catch (SecurityException ex) {
             ex.printStackTrace();
         }
-
-        if (!Desktop.isDesktopSupported()) {
-            return null;
-        }
-
-        trace("Environment supports a desktop");
 
         try {
             var desktop = Desktop.getDesktop();

--- a/test/jdk/tools/jpackage/apps/image/Hello.java
+++ b/test/jdk/tools/jpackage/apps/image/Hello.java
@@ -163,6 +163,12 @@ public class Hello implements OpenFilesHandler {
             ex.printStackTrace();
         }
 
+        if (!Desktop.isDesktopSupported()) {
+            return null;
+        }
+
+        trace("Environment supports a desktop");
+
         try {
             var desktop = Desktop.getDesktop();
             if (desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {


### PR DESCRIPTION
If you run x86 configuration (cross-compiled on x86_64), then many tests would fail with:

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=tools/jpackage
...
can not load libgnomevfs-2.so
Exception in thread "main" java.lang.ExceptionInInitializerError
Caused by: java.lang.UnsupportedOperationException: Desktop API is not supported on the current platform
at java.desktop/java.awt.Desktop.getDesktop(Unknown Source)
at com.that/com.that.main.Florence.createInstance(Unknown Source)
at com.that/com.that.main.Florence.<clinit>(Unknown Source)
Failed to launch JVM
java.lang.AssertionError: Expected [0]. Actual [1]: Check command [/home/shade/trunks/jdk/build/linux-x86-server-fastdebug/test-support/jtreg_test_jdk_tools_jpackage/scratch/10/./testMainLauncherIsModular.ed4f638d/output/MainLauncherIsModularAddLauncherTest/bin/ModularAppLauncher](1) exited with 0 code
```

The tests probably need to check `Desktop.isDesktopSupported()`, similarly how they check `GraphicsEnvironment.isHeadless()`.

Additional testing:
 - [x] Linux x86_32 `tools/jpackage` (now pass)
 - [x] Linux x86_64 `tools/jpackage` (still pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260592](https://bugs.openjdk.java.net/browse/JDK-8260592): jpackage tests fail when Desktop is not supported


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to c0975ae319b0b19a3f90a6337ddd23320bcbe334


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2291/head:pull/2291`
`$ git checkout pull/2291`
