### PR TITLE
8260522: Clean up warnings in hotspot JTReg runtime tests

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestJcmdOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,8 @@ public class TestJcmdOutput {
     public static class runJcmd {
 
         public static void main(String[] args) throws Exception {
-            int minHeapFreeRatio = new Integer((new DynamicVMOption("MinHeapFreeRatio")).getValue());
-            int maxHeapFreeRatio = new Integer((new DynamicVMOption("MaxHeapFreeRatio")).getValue());
+            int minHeapFreeRatio = Integer.valueOf((new DynamicVMOption("MinHeapFreeRatio")).getValue());
+            int maxHeapFreeRatio = Integer.valueOf((new DynamicVMOption("MaxHeapFreeRatio")).getValue());
             PidJcmdExecutor executor = new PidJcmdExecutor();
 
             Asserts.assertGT(minHeapFreeRatio, 0, "MinHeapFreeRatio must be greater than 0");

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/DoubleJVMOption.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/DoubleJVMOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class DoubleJVMOption extends JVMOption {
      */
     @Override
     void setMin(String min) {
-        this.min = new Double(min);
+        this.min = Double.valueOf(min);
     }
 
     /**
@@ -96,7 +96,7 @@ public class DoubleJVMOption extends JVMOption {
      */
     @Override
     void setMax(String max) {
-        this.max = new Double(max);
+        this.max = Double.valueOf(max);
     }
 
     /**

--- a/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.nio.file.FileStore;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.spi.ToolProvider;
 import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -46,6 +47,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class LongBCP {
 
     private static final int MAX_PATH = 260;
+
+    private static final ToolProvider JAR = ToolProvider.findFirst("jar")
+        .orElseThrow(() -> new RuntimeException("ToolProvider for jar not found"));
 
     public static void main(String args[]) throws Exception {
         Path sourceDir = Paths.get(System.getProperty("test.src"), "test-classes");
@@ -85,11 +89,9 @@ public class LongBCP {
               .shouldHaveExitValue(0);
 
         // create a hello.jar
-        sun.tools.jar.Main jarTool = new sun.tools.jar.Main(System.out, System.err, "jar");
         String helloJar = destDir.toString() + File.separator + "hello.jar";
-        if (!jarTool.run(new String[]
-            {"-cf", helloJar, "-C", destDir.toString(), "Hello.class"})) {
-            throw new RuntimeException("Could not write the Hello jar file");
+        if (JAR.run(System.out, System.err, "-cf", helloJar, "-C", destDir.toString(), "Hello.class") != 0) {
+            throw new RuntimeException("jar operation for hello.jar failed");
         }
 
         // run with long bootclasspath to hello.jar

--- a/test/hotspot/jtreg/runtime/LoadClass/TriggerResize.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/TriggerResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class TriggerResize extends ClassLoader
   {
     int count = 0;
     if (args.length >= 1) {
-      Integer i = new Integer(args[0]);
+      Integer i = Integer.parseInt(args[0]);
       count = i.intValue();
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,6 @@ public class CommandLineFlagCombo {
     // shared base address test table
     private static final String[] testTable = {
         "-XX:+UseG1GC", "-XX:+UseSerialGC", "-XX:+UseParallelGC",
-        "-XX:+FlightRecorder",
         "-XX:+UseLargePages", // may only take effect on machines with large-pages
         "-XX:+UseCompressedClassPointers",
         "-XX:+UseCompressedOops",
@@ -122,7 +121,7 @@ public class CommandLineFlagCombo {
             }
         }
 
-        if (!WhiteBox.getWhiteBox().isJFRIncludedInVmBuild() && testEntry.equals("-XX:+FlightRecorder"))
+        if (!WhiteBox.getWhiteBox().isJFRIncludedInVmBuild())
         {
             System.out.println("JFR does not exist");
             return true;

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestWithProfiler.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestWithProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public class TestWithProfiler {
         output = TestCommon.exec(appJar,
             "-XX:+UnlockDiagnosticVMOptions",
             "-Xint",
-            "-XX:+FlightRecorder",
             "-XX:StartFlightRecording=duration=15s,filename=myrecording.jfr,settings=profile,dumponexit=true",
             "TestWithProfilerHelper");
         TestCommon.checkExec(output);

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class MirrorWithReferenceFieldsApp {
 
     public MirrorWithReferenceFieldsApp() {
         non_archived_field_1 = new Object();
-        non_archived_field_2 = new Integer(1);
+        non_archived_field_2 = Integer.valueOf(1);
     }
 
     public static void main(String args[]) throws Exception {

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/BasicJarBuilder.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/BasicJarBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,15 @@
 
 import java.io.File;
 import java.util.ArrayList;
-import sun.tools.jar.Main;
+import java.util.spi.ToolProvider;
 
 // Using JarBuilder requires that all to-be-jarred classes should be placed
 // in the current working directory, aka "."
 public class BasicJarBuilder {
     private static final String classDir = System.getProperty("test.classes");
+
+    private static final ToolProvider JAR = ToolProvider.findFirst("jar")
+        .orElseThrow(() -> new RuntimeException("ToolProvider for jar not found"));
 
     public static void build(boolean classesInWorkDir, String jarName,
         String ...classNames) throws Exception {
@@ -73,8 +76,7 @@ public class BasicJarBuilder {
     }
 
     private static void createJar(ArrayList<String> args) {
-        Main jarTool = new Main(System.out, System.err, "jar");
-        if (!jarTool.run(args.toArray(new String[1]))) {
+        if (JAR.run(System.out, System.err, args.toArray(new String[1])) != 0) {
             throw new RuntimeException("jar operation failed");
         }
     }

--- a/test/hotspot/jtreg/runtime/reflect/ArrayGetIntException.java
+++ b/test/hotspot/jtreg/runtime/reflect/ArrayGetIntException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.lang.reflect.Array;
 
 public class ArrayGetIntException {
     public static void main(String[] args) throws Exception {
-        Object[] objArray = {new Integer(Integer.MAX_VALUE)};
+        Object[] objArray = {Integer.valueOf(Integer.MAX_VALUE)};
 
         // this access is legal
         try {

--- a/test/hotspot/jtreg/runtime/verifier/defaultMethods/DefaultMethodRegressionTests.java
+++ b/test/hotspot/jtreg/runtime/verifier/defaultMethods/DefaultMethodRegressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,10 +71,10 @@ public class DefaultMethodRegressionTests {
     }
     void testLostOverloadedMethod() {
         C c = new C();
-        assertEquals(c.bbb(new Integer(1)), 22);
-        assertEquals(c.bbb(new Float(1.1)), 33);
-        assertEquals(c.bbb(new Long(1L)), 44);
-        assertEquals(c.bbb(new Double(0.01)), 55);
+        assertEquals(c.bbb(Integer.valueOf(1)), 22);
+        assertEquals(c.bbb(Float.valueOf(1.1F)), 33);
+        assertEquals(c.bbb(Long.valueOf(1L)), 44);
+        assertEquals(c.bbb(Double.valueOf(0.01)), 55);
         assertEquals(c.bbb(new String("")), 66);
     }
     // Test to ensure that the inference verifier accepts older classfiles

--- a/test/hotspot/jtreg/testlibrary/jvmti/TransformerAgent.java
+++ b/test/hotspot/jtreg/testlibrary/jvmti/TransformerAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,9 +98,9 @@ public class TransformerAgent {
     static Integer incrCounter(String className) {
         Integer i = counterMap.get(className);
         if (i == null) {
-            i = new Integer(1);
+            i = Integer.valueOf(1);
         } else {
-            i = new Integer(i.intValue() + 1);
+            i = Integer.valueOf(i.intValue() + 1);
         }
         counterMap.put(className, i);
         return i;

--- a/test/lib/jdk/test/lib/classloader/GeneratingClassLoader.java
+++ b/test/lib/jdk/test/lib/classloader/GeneratingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public class GeneratingClassLoader extends ClassLoader {
                     if (i == bytecode.length) {
                         break;
                     }
-                    offsets.add(new Integer(i));
+                    offsets.add(i);
                     i++;
                 }
             } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Please review this fix to clean up some of the warnings generated when running hotspot/jtreg/runtime tests.  This fix cleans up warnings such as:
    warning: [removal] Integer(int) in Integer has been deprecated and marked for removal
    warning: Main is internal proprietary API and may be removed in a future release
    warning: Option FlightRecorder was deprecated in version 13.0 ...

The fix does not clean up warnings such as the following. They should probably best be cleaned up when the deprecated items are actually removed:
    warning: [removal] suspend() in Thread has been deprecated and marked for removal
    warning: [removal] resume() in Thread has been deprecated and marked for removal
    warning: [removal] defineAnonymousClass(Class<?>,byte[],Object[]) in Unsafe has been deprecated ...
    warning: the use of signal() and sigset() for signal chaining was deprecated in version 16.0

The fix was tested by running Mach5 hs-tiers 1-3 and by running tests locally and then looking for warnings in the resulting .jtr files.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260522](https://bugs.openjdk.java.net/browse/JDK-8260522): Clean up warnings in hotspot JTReg runtime tests


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2293/head:pull/2293`
`$ git checkout pull/2293`
