### PR TITLE
8259905: Compiler treats 'sealed' keyword as 'var' keyword

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3338,13 +3338,15 @@ public class JavacParser implements Parser {
         if (elemType.hasTag(IDENT)) {
             Name typeName = ((JCIdent)elemType).name;
             if (restrictedTypeNameStartingAtSource(typeName, pos, !compound && localDecl) != null) {
-                if (type.hasTag(TYPEARRAY) && !compound) {
+                if (typeName != names.var) {
+                    reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedHere(typeName));
+                } else if (type.hasTag(TYPEARRAY) && !compound) {
                     //error - 'var' and arrays
-                    reportSyntaxError(pos, Errors.RestrictedTypeNotAllowedArray(typeName));
+                    reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedArray(typeName));
                 } else {
                     if(compound)
                         //error - 'var' in compound local var decl
-                        reportSyntaxError(pos, Errors.RestrictedTypeNotAllowedCompound(typeName));
+                        reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedCompound(typeName));
                     startPos = TreeInfo.getStartPos(mods);
                     if (startPos == Position.NOPOS)
                         startPos = TreeInfo.getStartPos(type);

--- a/test/langtools/tools/javac/lvti/ParserTest.out
+++ b/test/langtools/tools/javac/lvti/ParserTest.out
@@ -5,13 +5,13 @@ ParserTest.java:24:14: compiler.err.restricted.type.not.allowed: var, 10
 ParserTest.java:28:20: compiler.err.restricted.type.not.allowed: var, 10
 ParserTest.java:36:27: compiler.err.restricted.type.not.allowed: var, 10
 ParserTest.java:38:5: compiler.err.restricted.type.not.allowed.here: var
-ParserTest.java:41:15: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:42:13: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:43:17: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:44:13: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:45:15: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:46:13: compiler.err.restricted.type.not.allowed.array: var
-ParserTest.java:49:24: compiler.err.restricted.type.not.allowed.compound: var
+ParserTest.java:41:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:42:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:43:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:44:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:45:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:46:9: compiler.err.restricted.type.not.allowed.array: var
+ParserTest.java:49:9: compiler.err.restricted.type.not.allowed.compound: var
 ParserTest.java:54:5: compiler.err.restricted.type.not.allowed.here: var
 ParserTest.java:58:16: compiler.err.restricted.type.not.allowed.here: var
 ParserTest.java:59:14: compiler.err.restricted.type.not.allowed.here: var

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -258,30 +258,8 @@ public class SealedCompilationTests extends CompilationTestCase {
                 "class SealedTest { int sealed = 0; int non = 0; int ns = non-sealed; }",
                 "class SealedTest { void test(String sealed) { } }",
                 "class SealedTest { void sealed(String sealed) { } }",
-                "class SealedTest { void test() { String sealed = null; } }"
-        )) {
-            assertOK(s);
-        }
+                "class SealedTest { void test() { String sealed = null; } }",
 
-        for (String s : List.of(
-                "class sealed {}",
-                "enum sealed {}",
-                "record sealed() {}",
-                "interface sealed {}",
-                "@interface sealed {}"
-        )) {
-            assertFail("compiler.err.restricted.type.not.allowed", s);
-        }
-
-        for (String s : List.of(
-                "class Foo { sealed m() {} }",
-                "class Foo { sealed i; }",
-                "class Foo { void m(sealed i) {} }"
-                )) {
-            assertFail("compiler.err.restricted.type.not.allowed.here", s);
-        }
-
-        for (String s : List.of(
                 "class SealedTest { String permits; }",
                 "class SealedTest { int permits = 0; }",
                 "class SealedTest { void test(String permits) { } }",
@@ -292,6 +270,12 @@ public class SealedCompilationTests extends CompilationTestCase {
         }
 
         for (String s : List.of(
+                "class sealed {}",
+                "enum sealed {}",
+                "record sealed() {}",
+                "interface sealed {}",
+                "@interface sealed {}",
+
                 "class permits {}",
                 "enum permits {}",
                 "record permits() {}",
@@ -302,10 +286,16 @@ public class SealedCompilationTests extends CompilationTestCase {
         }
 
         for (String s : List.of(
+                "class Foo { sealed m() {} }",
+                "class Foo { sealed i; }",
+                "class Foo { void m() { sealed i; } }",
+                "class Foo { void m(sealed i) {} }",
+
                 "class Foo { permits m() {} }",
                 "class Foo { permits i; }",
+                "class Foo { void m() { permits i; } }",
                 "class Foo { void m(permits i) {} }"
-        )) {
+                )) {
             assertFail("compiler.err.restricted.type.not.allowed.here", s);
         }
 


### PR DESCRIPTION
Hi,

Please review this fix which is basically fixing an oversaw issue affecting new restricted keywords: `sealed` and `permits`. The fix per se is in lines: 3341-3343, but then I made some additional changes to the position where previous errors were reported at method JavacParser::variableDeclaratorRest. That was done for consistency with the new code. I could have done the other way but then users would have two error notifications for some code, one for the use of the restricted type per se and another one for the use of the variable or field so like:

```
void m() {
    sealed s1;
    ^
    compiler error here
           ^
                and before you go, compiler error here too
}
```
I guess it make sense for the already existing code to be positioned on the use of the restricted type and not on the variable declared afterwards. Doing that adjustment has implied some changes to the golden file associated to test ParserTest. Also I added another case and did some additional editing to test SealedCompilationTests.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259905](https://bugs.openjdk.java.net/browse/JDK-8259905): Compiler treats 'sealed' keyword as 'var' keyword


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2298/head:pull/2298`
`$ git checkout pull/2298`
