### PR TITLE
8259584: SuperWord::fix_commutative_inputs checks in_bb(fin1) instead of in_bb(fin2)

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -4705,7 +4705,7 @@ bool SuperWord::fix_commutative_inputs(Node* gold, Node* fix) {
   Node* fin2 = fix->in(2);
   bool swapped = false;
 
-  if (in_bb(gin1) && in_bb(gin2) && in_bb(fin1) && in_bb(fin1)) {
+  if (in_bb(gin1) && in_bb(gin2) && in_bb(fin1) && in_bb(fin2)) {
     if (same_origin_idx(gin1, fin1) &&
         same_origin_idx(gin2, fin2)) {
       return true; // nothing to fix


### PR DESCRIPTION
Fix typo. Note, this change does not affect product because this code is not executed after JDK-8251994 fix: 
https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/superword.cpp#L519

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259584](https://bugs.openjdk.java.net/browse/JDK-8259584): SuperWord::fix_commutative_inputs checks in_bb(fin1) instead of in_bb(fin2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2299/head:pull/2299`
`$ git checkout pull/2299`
