### PR TITLE
8260368: [PPC64] GC interface needs enhancement to support GCs with load barriers

### DIFF
--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -108,7 +108,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
 }
 
 void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators, Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
-                                                 Register tmp1, Register tmp2, unsigned int preservation_level) {
+                                                 Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level) {
   bool not_null  = (decorators & IS_NOT_NULL) != 0,
        preloaded = obj == noreg;
   Register nv_save = noreg;
@@ -211,7 +211,7 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, Decorator
 }
 
 void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators, Register store_addr, Register new_val,
-                                                  Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level) {
+                                                  Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) {
   bool not_null = (decorators & IS_NOT_NULL) != 0;
 
   Label runtime, filtered;
@@ -287,7 +287,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, Decorato
 
 void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                        Register base, RegisterOrConstant ind_or_offs, Register val,
-                                       Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level) {
+                                       Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) {
   bool is_array = (decorators & IS_ARRAY) != 0;
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;
@@ -312,7 +312,7 @@ void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet deco
 void G1BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                     Register base, RegisterOrConstant ind_or_offs, Register dst,
                                     Register tmp1, Register tmp2,
-                                    unsigned int preservation_level, Label *L_handle_null) {
+                                    MacroAssembler::PreservationLevel preservation_level, Label *L_handle_null) {
   bool on_oop = is_reference_type(type);
   bool on_weak = (decorators & ON_WEAK_OOP_REF) != 0;
   bool on_phantom = (decorators & ON_PHANTOM_OOP_REF) != 0;
@@ -333,7 +333,7 @@ void G1BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorator
   __ bind(done);
 }
 
-void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2, unsigned int preservation_level) {
+void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level) {
   Label done, not_weak;
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -107,8 +107,10 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
   __ restore_LR_CR(R0);
 }
 
-void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators, Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
-                                                 Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level) {
+void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators,
+                                                 Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
+                                                 Register tmp1, Register tmp2,
+                                                 MacroAssembler::PreservationLevel preservation_level) {
   bool not_null  = (decorators & IS_NOT_NULL) != 0,
        preloaded = obj == noreg;
   Register nv_save = noreg;
@@ -210,8 +212,10 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, Decorator
   __ bind(filtered);
 }
 
-void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators, Register store_addr, Register new_val,
-                                                  Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) {
+void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators,
+                                                  Register store_addr, Register new_val,
+                                                  Register tmp1, Register tmp2, Register tmp3,
+                                                  MacroAssembler::PreservationLevel preservation_level) {
   bool not_null = (decorators & IS_NOT_NULL) != 0;
 
   Label runtime, filtered;
@@ -287,14 +291,21 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, Decorato
 
 void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                        Register base, RegisterOrConstant ind_or_offs, Register val,
-                                       Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) {
+                                       Register tmp1, Register tmp2, Register tmp3,
+                                       MacroAssembler::PreservationLevel preservation_level) {
   bool is_array = (decorators & IS_ARRAY) != 0;
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;
   // Load and record the previous value.
-  g1_write_barrier_pre(masm, decorators, base, ind_or_offs, tmp1, tmp2, tmp3, preservation_level);
+  g1_write_barrier_pre(masm, decorators,
+                       base, ind_or_offs,
+                       tmp1, tmp2, tmp3,
+                       preservation_level);
 
-  BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
+  BarrierSetAssembler::store_at(masm, decorators,
+                                type, base, ind_or_offs, val,
+                                tmp1, tmp2, tmp3,
+                                preservation_level);
 
   // No need for post barrier if storing NULL
   if (val != noreg) {
@@ -305,7 +316,10 @@ void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet deco
         __ add(base, ind_or_offs.as_register(), base);
       }
     }
-    g1_write_barrier_post(masm, decorators, base, val, tmp1, tmp2, tmp3, preservation_level);
+    g1_write_barrier_post(masm, decorators,
+                          base, val,
+                          tmp1, tmp2, tmp3,
+                          preservation_level);
   }
 }
 
@@ -320,20 +334,27 @@ void G1BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorator
   Label done;
   if (on_oop && on_reference && L_handle_null == NULL) { L_handle_null = &done; }
   // Load the value of the referent field.
-  ModRefBarrierSetAssembler::load_at(masm, decorators, type, base, ind_or_offs, dst, tmp1, tmp2, preservation_level, L_handle_null);
+  ModRefBarrierSetAssembler::load_at(masm, decorators, type,
+                                     base, ind_or_offs, dst,
+                                     tmp1, tmp2,
+                                     preservation_level, L_handle_null);
   if (on_oop && on_reference) {
     // Generate the G1 pre-barrier code to log the value of
     // the referent field in an SATB buffer. Note with
     // these parameters the pre-barrier does not generate
     // the load of the previous value
     // We only reach here if value is not null.
-    g1_write_barrier_pre(masm, decorators | IS_NOT_NULL, noreg /* obj */, (intptr_t)0, dst /* pre_val */,
-                         tmp1, tmp2, preservation_level);
+    g1_write_barrier_pre(masm, decorators | IS_NOT_NULL,
+                         noreg /* obj */, (intptr_t)0, dst /* pre_val */,
+                         tmp1, tmp2,
+                         preservation_level);
   }
   __ bind(done);
 }
 
-void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level) {
+void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
+                                            Register tmp1, Register tmp2,
+                                            MacroAssembler::PreservationLevel preservation_level) {
   Label done, not_weak;
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.
@@ -344,7 +365,10 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
 
   __ beq(CCR0, not_weak);     // Test for jweak tag.
   __ verify_oop(value, FILE_AND_LINE);
-  g1_write_barrier_pre(masm, IN_NATIVE | ON_PHANTOM_OOP_REF, noreg, noreg, value, tmp1, tmp2, preservation_level);
+  g1_write_barrier_pre(masm, IN_NATIVE | ON_PHANTOM_OOP_REF,
+                       noreg, noreg, value,
+                       tmp1, tmp2,
+                       preservation_level);
   __ bind(not_weak);
   __ verify_oop(value, FILE_AND_LINE);
   __ bind(done);

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
@@ -42,13 +42,13 @@ protected:
   virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register preserve);
 
   void g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators, Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
-                            Register tmp1, Register tmp2, unsigned int preservation_level);
+                            Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level);
   void g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators, Register store_addr, Register new_val,
-                             Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
+                             Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
+                            Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
 
 public:
 #ifdef COMPILER1
@@ -61,11 +61,11 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register base, RegisterOrConstant ind_or_offs, Register dst,
-                       Register tmp1, Register tmp2, unsigned int preservation_level,
+                       Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level,
                        Label *L_handle_null = NULL);
 
   virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
-                               unsigned int preservation_level);
+                               MacroAssembler::PreservationLevel preservation_level);
 };
 
 #endif // CPU_PPC_GC_G1_G1BARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,13 @@ protected:
   virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register preserve);
 
   void g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators, Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
-                            Register tmp1, Register tmp2, bool needs_frame);
+                            Register tmp1, Register tmp2, unsigned int preservation_level);
   void g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators, Register store_addr, Register new_val,
-                             Register tmp1, Register tmp2, Register tmp3);
+                             Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, bool needs_frame);
+                            Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
 
 public:
 #ifdef COMPILER1
@@ -61,9 +61,11 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register base, RegisterOrConstant ind_or_offs, Register dst,
-                       Register tmp1, Register tmp2, bool needs_frame, Label *L_handle_null = NULL);
+                       Register tmp1, Register tmp2, unsigned int preservation_level,
+                       Label *L_handle_null = NULL);
 
-  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2, bool needs_frame);
+  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
+                               unsigned int preservation_level);
 };
 
 #endif // CPU_PPC_GC_G1_G1BARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.hpp
@@ -37,18 +37,26 @@ class G1PostBarrierStub;
 
 class G1BarrierSetAssembler: public ModRefBarrierSetAssembler {
 protected:
-  virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators, Register from, Register to, Register count,
+  virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators,
+                                               Register from, Register to, Register count,
                                                Register preserve1, Register preserve2);
-  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register preserve);
+  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
+                                                Register addr, Register count,
+                                                Register preserve);
 
-  void g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators, Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
-                            Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level);
-  void g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators, Register store_addr, Register new_val,
-                             Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
+  void g1_write_barrier_pre(MacroAssembler* masm, DecoratorSet decorators,
+                            Register obj, RegisterOrConstant ind_or_offs, Register pre_val,
+                            Register tmp1, Register tmp2,
+                            MacroAssembler::PreservationLevel preservation_level);
+  void g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators,
+                             Register store_addr, Register new_val,
+                             Register tmp1, Register tmp2, Register tmp3,
+                             MacroAssembler::PreservationLevel preservation_level);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
+                            Register tmp1, Register tmp2, Register tmp3,
+                            MacroAssembler::PreservationLevel preservation_level);
 
 public:
 #ifdef COMPILER1
@@ -61,10 +69,12 @@ public:
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register base, RegisterOrConstant ind_or_offs, Register dst,
-                       Register tmp1, Register tmp2, MacroAssembler::PreservationLevel preservation_level,
+                       Register tmp1, Register tmp2,
+                       MacroAssembler::PreservationLevel preservation_level,
                        Label *L_handle_null = NULL);
 
-  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
+  virtual void resolve_jobject(MacroAssembler* masm, Register value,
+                               Register tmp1, Register tmp2,
                                MacroAssembler::PreservationLevel preservation_level);
 };
 

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -35,7 +35,7 @@
 void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                    Register base, RegisterOrConstant ind_or_offs, Register val,
                                    Register tmp1, Register tmp2, Register tmp3,
-                                   unsigned int preservation_level) {
+                                   MacroAssembler::PreservationLevel preservation_level) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool not_null = (decorators & IS_NOT_NULL) != 0;
@@ -69,7 +69,7 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
 void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                   Register base, RegisterOrConstant ind_or_offs, Register dst,
                                   Register tmp1, Register tmp2,
-                                  unsigned int preservation_level, Label *L_handle_null) {
+                                  MacroAssembler::PreservationLevel preservation_level, Label *L_handle_null) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool not_null = (decorators & IS_NOT_NULL) != 0;
@@ -108,7 +108,7 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
 
 void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
                                           Register tmp1, Register tmp2,
-                                          unsigned int preservation_level) {
+                                          MacroAssembler::PreservationLevel preservation_level) {
   Label done;
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,8 @@
 
 void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                    Register base, RegisterOrConstant ind_or_offs, Register val,
-                                   Register tmp1, Register tmp2, Register tmp3, bool needs_frame) {
+                                   Register tmp1, Register tmp2, Register tmp3,
+                                   unsigned int preservation_level) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool not_null = (decorators & IS_NOT_NULL) != 0;
@@ -67,7 +68,8 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
 
 void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                   Register base, RegisterOrConstant ind_or_offs, Register dst,
-                                  Register tmp1, Register tmp2, bool needs_frame, Label *L_handle_null) {
+                                  Register tmp1, Register tmp2,
+                                  unsigned int preservation_level, Label *L_handle_null) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool not_null = (decorators & IS_NOT_NULL) != 0;
@@ -105,7 +107,8 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
 }
 
 void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
-                                          Register tmp1, Register tmp2, bool needs_frame) {
+                                          Register tmp1, Register tmp2,
+                                          unsigned int preservation_level) {
   Label done;
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -42,15 +42,15 @@ public:
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Register base, RegisterOrConstant ind_or_offs, Register val,
                         Register tmp1, Register tmp2, Register tmp3,
-                        unsigned int preservation_level);
+                        MacroAssembler::PreservationLevel preservation_level);
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register base, RegisterOrConstant ind_or_offs, Register dst,
                        Register tmp1, Register tmp2,
-                       unsigned int preservation_level, Label *L_handle_null = NULL);
+                       MacroAssembler::PreservationLevel preservation_level, Label *L_handle_null = NULL);
 
   virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
-                               unsigned int preservation_level);
+                               MacroAssembler::PreservationLevel preservation_level);
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -49,7 +49,8 @@ public:
                        Register tmp1, Register tmp2,
                        MacroAssembler::PreservationLevel preservation_level, Label *L_handle_null = NULL);
 
-  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
+  virtual void resolve_jobject(MacroAssembler* masm, Register value,
+                               Register tmp1, Register tmp2,
                                MacroAssembler::PreservationLevel preservation_level);
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,13 +41,16 @@ public:
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Register base, RegisterOrConstant ind_or_offs, Register val,
-                        Register tmp1, Register tmp2, Register tmp3, bool needs_frame);
+                        Register tmp1, Register tmp2, Register tmp3,
+                        unsigned int preservation_level);
 
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register base, RegisterOrConstant ind_or_offs, Register dst,
-                       Register tmp1, Register tmp2, bool needs_frame, Label *L_handle_null = NULL);
+                       Register tmp1, Register tmp2,
+                       unsigned int preservation_level, Label *L_handle_null = NULL);
 
-  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2, bool needs_frame);
+  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2,
+                               unsigned int preservation_level);
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
@@ -97,7 +97,10 @@ void CardTableBarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorS
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;
 
-  BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
+  BarrierSetAssembler::store_at(masm, decorators, type,
+                                base, ind_or_offs, val,
+                                tmp1, tmp2, tmp3,
+                                preservation_level);
 
   // No need for post barrier if storing NULL
   if (val != noreg) {

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
@@ -92,7 +92,7 @@ void CardTableBarrierSetAssembler::card_write_barrier_post(MacroAssembler* masm,
 void CardTableBarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                                 Register base, RegisterOrConstant ind_or_offs, Register val,
                                                 Register tmp1, Register tmp2, Register tmp3,
-                                                unsigned int preservation_level) {
+                                                MacroAssembler::PreservationLevel preservation_level) {
   bool is_array = (decorators & IS_ARRAY) != 0;
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,12 +91,13 @@ void CardTableBarrierSetAssembler::card_write_barrier_post(MacroAssembler* masm,
 
 void CardTableBarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                                 Register base, RegisterOrConstant ind_or_offs, Register val,
-                                                Register tmp1, Register tmp2, Register tmp3, bool needs_frame) {
+                                                Register tmp1, Register tmp2, Register tmp3,
+                                                unsigned int preservation_level) {
   bool is_array = (decorators & IS_ARRAY) != 0;
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;
 
-  BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, needs_frame);
+  BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
 
   // No need for post barrier if storing NULL
   if (val != noreg) {

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.hpp
@@ -41,7 +41,7 @@ protected:
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
                             Register tmp1, Register tmp2, Register tmp3,
-                            unsigned int preservation_level);
+                            MacroAssembler::PreservationLevel preservation_level);
 };
 
 #endif // CPU_PPC_GC_SHARED_CARDTABLEBARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ protected:
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, bool needs_frame);
+                            Register tmp1, Register tmp2, Register tmp3,
+                            unsigned int preservation_level);
 };
 
 #endif // CPU_PPC_GC_SHARED_CARDTABLEBARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -59,7 +59,7 @@ void ModRefBarrierSetAssembler::arraycopy_epilogue(MacroAssembler* masm, Decorat
 void ModRefBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                          Register base, RegisterOrConstant ind_or_offs, Register val,
                                          Register tmp1, Register tmp2, Register tmp3,
-                                         unsigned int preservation_level) {
+                                         MacroAssembler::PreservationLevel preservation_level) {
   if (is_reference_type(type)) {
     oop_store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
   } else {

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -32,7 +32,9 @@
 void ModRefBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                                    Register src, Register dst, Register count, Register preserve1, Register preserve2) {
   if (type == T_OBJECT) {
-    gen_write_ref_array_pre_barrier(masm, decorators, src, dst, count, preserve1, preserve2);
+    gen_write_ref_array_pre_barrier(masm, decorators,
+                                    src, dst, count,
+                                    preserve1, preserve2);
 
     bool checkcast = (decorators & ARRAYCOPY_CHECKCAST) != 0;
     if (!checkcast) {
@@ -61,8 +63,14 @@ void ModRefBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet deco
                                          Register tmp1, Register tmp2, Register tmp3,
                                          MacroAssembler::PreservationLevel preservation_level) {
   if (is_reference_type(type)) {
-    oop_store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
+    oop_store_at(masm, decorators, type,
+                 base, ind_or_offs, val,
+                 tmp1, tmp2, tmp3,
+                 preservation_level);
   } else {
-    BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
+    BarrierSetAssembler::store_at(masm, decorators, type,
+                                  base, ind_or_offs, val,
+                                  tmp1, tmp2, tmp3,
+                                  preservation_level);
   }
 }

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,10 +58,11 @@ void ModRefBarrierSetAssembler::arraycopy_epilogue(MacroAssembler* masm, Decorat
 
 void ModRefBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                          Register base, RegisterOrConstant ind_or_offs, Register val,
-                                         Register tmp1, Register tmp2, Register tmp3, bool needs_frame) {
+                                         Register tmp1, Register tmp2, Register tmp3,
+                                         unsigned int preservation_level) {
   if (is_reference_type(type)) {
-    oop_store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, needs_frame);
+    oop_store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
   } else {
-    BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, needs_frame);
+    BarrierSetAssembler::store_at(masm, decorators, type, base, ind_or_offs, val, tmp1, tmp2, tmp3, preservation_level);
   }
 }

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
@@ -35,22 +35,28 @@
 
 class ModRefBarrierSetAssembler: public BarrierSetAssembler {
 protected:
-  virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators, Register from, Register to, Register count,
+  virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators,
+                                               Register from, Register to, Register count,
                                                Register preserve1, Register preserve2) {}
-  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register preserve) {}
+  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
+                                                Register addr, Register count, Register preserve) {}
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) = 0;
+                            Register tmp1, Register tmp2, Register tmp3,
+                            MacroAssembler::PreservationLevel preservation_level) = 0;
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                  Register src, Register dst, Register count, Register preserve1, Register preserve2);
+                                  Register src, Register dst, Register count,
+                                  Register preserve1, Register preserve2);
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                  Register dst, Register count, Register preserve);
+                                  Register dst, Register count,
+                                  Register preserve);
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Register base, RegisterOrConstant ind_or_offs, Register val,
-                        Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
+                        Register tmp1, Register tmp2, Register tmp3,
+                        MacroAssembler::PreservationLevel preservation_level);
 };
 
 #endif // CPU_PPC_GC_SHARED_MODREFBARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
@@ -41,7 +41,7 @@ protected:
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level) = 0;
+                            Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level) = 0;
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                   Register src, Register dst, Register count, Register preserve1, Register preserve2);
@@ -50,7 +50,7 @@ public:
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Register base, RegisterOrConstant ind_or_offs, Register val,
-                        Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
+                        Register tmp1, Register tmp2, Register tmp3, MacroAssembler::PreservationLevel preservation_level);
 };
 
 #endif // CPU_PPC_GC_SHARED_MODREFBARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ protected:
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                            Register tmp1, Register tmp2, Register tmp3, bool needs_frame) = 0;
+                            Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level) = 0;
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                                   Register src, Register dst, Register count, Register preserve1, Register preserve2);
@@ -50,7 +50,7 @@ public:
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Register base, RegisterOrConstant ind_or_offs, Register val,
-                        Register tmp1, Register tmp2, Register tmp3, bool needs_frame);
+                        Register tmp1, Register tmp2, Register tmp3, unsigned int preservation_level);
 };
 
 #endif // CPU_PPC_GC_SHARED_MODREFBARRIERSETASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2017 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
                          Register tmp1, Register tmp2, Register tmp3, Label &ok_is_subtype);
 
   // Load object from cpool->resolved_references(index).
-  void load_resolved_reference_at_index(Register result, Register index, Label *L_handle_null = NULL);
+  void load_resolved_reference_at_index(Register result, Register index, Register tmp1, Label *L_handle_null = NULL);
 
   // load cpool->resolved_klass_at(index)
   void load_resolved_klass_at_offset(Register Rcpool, Register Roffset, Register Rklass);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -475,14 +475,15 @@ void InterpreterMacroAssembler::get_u4(Register Rdst, Register Rsrc, int offset,
 }
 
 // Load object from cpool->resolved_references(index).
-void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result, Register index, Label *L_handle_null) {
+void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result, Register index, Register tmp1,
+                                                                 Label *L_handle_null) {
   assert_different_registers(result, index);
   get_constant_pool(result);
 
   // Convert from field index to resolved_references() index and from
   // word index to byte offset. Since this is a java object, it can be compressed.
-  Register tmp = index;  // reuse
-  sldi(tmp, index, LogBytesPerHeapOop);
+  Register tmp2 = index;  // reuse
+  sldi(tmp1, index, LogBytesPerHeapOop);
   // Load pointer for resolved_references[] objArray.
   ld(result, ConstantPool::cache_offset_in_bytes(), result);
   ld(result, ConstantPoolCache::resolved_references_offset_in_bytes(), result);
@@ -491,14 +492,16 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result
   Label index_ok;
   lwa(R0, arrayOopDesc::length_offset_in_bytes(), result);
   sldi(R0, R0, LogBytesPerHeapOop);
-  cmpd(CCR0, tmp, R0);
+  cmpd(CCR0, tmp1, R0);
   blt(CCR0, index_ok);
   stop("resolved reference index out of bounds");
   bind(index_ok);
 #endif
   // Add in the index.
-  add(result, tmp, result);
-  load_heap_oop(result, arrayOopDesc::base_offset_in_bytes(T_OBJECT), result, tmp, R0, false, 0, L_handle_null);
+  add(result, tmp1, result);
+  load_heap_oop(result, arrayOopDesc::base_offset_in_bytes(T_OBJECT), result, tmp1, tmp2,
+                MacroAssembler::PRESERVATION_FRAME_LR,
+                0, L_handle_null);
 }
 
 // load cpool->resolved_klass_at(index)

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -475,6 +475,8 @@ void InterpreterMacroAssembler::get_u4(Register Rdst, Register Rsrc, int offset,
 }
 
 // Load object from cpool->resolved_references(index).
+// Kills:
+//   - index
 void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result, Register index, Register tmp1,
                                                                  Label *L_handle_null) {
   assert_different_registers(result, index);
@@ -499,7 +501,8 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result
 #endif
   // Add in the index.
   add(result, tmp1, result);
-  load_heap_oop(result, arrayOopDesc::base_offset_in_bytes(T_OBJECT), result, tmp1, tmp2,
+  load_heap_oop(result, arrayOopDesc::base_offset_in_bytes(T_OBJECT), result,
+                tmp1, tmp2,
                 MacroAssembler::PRESERVATION_FRAME_LR,
                 0, L_handle_null);
 }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -726,8 +726,8 @@ void MacroAssembler::clobber_carg_stack_slots(Register tmp) {
   const int magic_number = 0x43;
 
   li(tmp, magic_number);
-  for (int m = 1; m <= 8; m++) {
-    std(tmp, 40 + m * 8, R1_SP);
+  for (int m = 0; m <= 7; m++) {
+    std(tmp, frame::abi_minframe_size + m * 8, R1_SP);
   }
 }
 

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -3064,7 +3064,8 @@ void MacroAssembler::safepoint_poll(Label& slow_path, Register temp_reg) {
   bne(CCR0, slow_path);
 }
 
-void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2, unsigned int preservation_level) {
+void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2,
+                                     MacroAssembler::PreservationLevel preservation_level) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->resolve_jobject(this, value, tmp1, tmp2, preservation_level);
 }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -723,7 +723,7 @@ void MacroAssembler::clobber_volatile_gprs(Register excluded_register) {
 }
 
 void MacroAssembler::clobber_carg_stack_slots(Register tmp) {
-  const int magic_number = 0x42;
+  const int magic_number = 0x43;
 
   li(tmp, magic_number);
   for (int m = 1; m <= 8; m++) {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -707,6 +707,30 @@ address MacroAssembler::get_dest_of_bxx64_patchable_at(address instruction_addr,
   }
 }
 
+void MacroAssembler::clobber_volatile_gprs(Register excluded_register) {
+  const int magic_number = 0x42;
+
+  // Preserve stack pointer register (R1_SP) and system thread id register (R13);
+  // although they're technically volatile
+  for (int i = 2; i < 13; i++) {
+    Register reg = as_Register(i);
+    if (reg == excluded_register) {
+      continue;
+    }
+
+    li(reg, magic_number);
+  }
+}
+
+void MacroAssembler::clobber_carg_stack_slots(Register tmp) {
+  const int magic_number = 0x42;
+
+  li(tmp, magic_number);
+  for (int m = 1; m <= 8; m++) {
+    std(tmp, 40 + m * 8, R1_SP);
+  }
+}
+
 // Uses ordering which corresponds to ABI:
 //    _savegpr0_14:  std  r14,-144(r1)
 //    _savegpr0_15:  std  r15,-136(r1)
@@ -797,9 +821,11 @@ void MacroAssembler::restore_nonvolatile_gprs(Register src, int offset) {
 }
 
 // For verify_oops.
-void MacroAssembler::save_volatile_gprs(Register dst, int offset) {
+void MacroAssembler::save_volatile_gprs(Register dst, int offset, bool include_fp_regs, bool include_R3_RET_reg) {
   std(R2,  offset, dst);   offset += 8;
-  std(R3,  offset, dst);   offset += 8;
+  if (include_R3_RET_reg) {
+    std(R3, offset, dst);  offset += 8;
+  }
   std(R4,  offset, dst);   offset += 8;
   std(R5,  offset, dst);   offset += 8;
   std(R6,  offset, dst);   offset += 8;
@@ -810,26 +836,30 @@ void MacroAssembler::save_volatile_gprs(Register dst, int offset) {
   std(R11, offset, dst);   offset += 8;
   std(R12, offset, dst);   offset += 8;
 
-  stfd(F0, offset, dst);   offset += 8;
-  stfd(F1, offset, dst);   offset += 8;
-  stfd(F2, offset, dst);   offset += 8;
-  stfd(F3, offset, dst);   offset += 8;
-  stfd(F4, offset, dst);   offset += 8;
-  stfd(F5, offset, dst);   offset += 8;
-  stfd(F6, offset, dst);   offset += 8;
-  stfd(F7, offset, dst);   offset += 8;
-  stfd(F8, offset, dst);   offset += 8;
-  stfd(F9, offset, dst);   offset += 8;
-  stfd(F10, offset, dst);  offset += 8;
-  stfd(F11, offset, dst);  offset += 8;
-  stfd(F12, offset, dst);  offset += 8;
-  stfd(F13, offset, dst);
+  if (include_fp_regs) {
+    stfd(F0, offset, dst);   offset += 8;
+    stfd(F1, offset, dst);   offset += 8;
+    stfd(F2, offset, dst);   offset += 8;
+    stfd(F3, offset, dst);   offset += 8;
+    stfd(F4, offset, dst);   offset += 8;
+    stfd(F5, offset, dst);   offset += 8;
+    stfd(F6, offset, dst);   offset += 8;
+    stfd(F7, offset, dst);   offset += 8;
+    stfd(F8, offset, dst);   offset += 8;
+    stfd(F9, offset, dst);   offset += 8;
+    stfd(F10, offset, dst);  offset += 8;
+    stfd(F11, offset, dst);  offset += 8;
+    stfd(F12, offset, dst);  offset += 8;
+    stfd(F13, offset, dst);
+  }
 }
 
 // For verify_oops.
-void MacroAssembler::restore_volatile_gprs(Register src, int offset) {
+void MacroAssembler::restore_volatile_gprs(Register src, int offset, bool include_fp_regs, bool include_R3_RET_reg) {
   ld(R2,  offset, src);   offset += 8;
-  ld(R3,  offset, src);   offset += 8;
+  if (include_R3_RET_reg) {
+    ld(R3,  offset, src);   offset += 8;
+  }
   ld(R4,  offset, src);   offset += 8;
   ld(R5,  offset, src);   offset += 8;
   ld(R6,  offset, src);   offset += 8;
@@ -840,20 +870,22 @@ void MacroAssembler::restore_volatile_gprs(Register src, int offset) {
   ld(R11, offset, src);   offset += 8;
   ld(R12, offset, src);   offset += 8;
 
-  lfd(F0, offset, src);   offset += 8;
-  lfd(F1, offset, src);   offset += 8;
-  lfd(F2, offset, src);   offset += 8;
-  lfd(F3, offset, src);   offset += 8;
-  lfd(F4, offset, src);   offset += 8;
-  lfd(F5, offset, src);   offset += 8;
-  lfd(F6, offset, src);   offset += 8;
-  lfd(F7, offset, src);   offset += 8;
-  lfd(F8, offset, src);   offset += 8;
-  lfd(F9, offset, src);   offset += 8;
-  lfd(F10, offset, src);  offset += 8;
-  lfd(F11, offset, src);  offset += 8;
-  lfd(F12, offset, src);  offset += 8;
-  lfd(F13, offset, src);
+  if (include_fp_regs) {
+    lfd(F0, offset, src);   offset += 8;
+    lfd(F1, offset, src);   offset += 8;
+    lfd(F2, offset, src);   offset += 8;
+    lfd(F3, offset, src);   offset += 8;
+    lfd(F4, offset, src);   offset += 8;
+    lfd(F5, offset, src);   offset += 8;
+    lfd(F6, offset, src);   offset += 8;
+    lfd(F7, offset, src);   offset += 8;
+    lfd(F8, offset, src);   offset += 8;
+    lfd(F9, offset, src);   offset += 8;
+    lfd(F10, offset, src);  offset += 8;
+    lfd(F11, offset, src);  offset += 8;
+    lfd(F12, offset, src);  offset += 8;
+    lfd(F13, offset, src);
+  }
 }
 
 void MacroAssembler::save_LR_CR(Register tmp) {
@@ -3032,9 +3064,9 @@ void MacroAssembler::safepoint_poll(Label& slow_path, Register temp_reg) {
   bne(CCR0, slow_path);
 }
 
-void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2, bool needs_frame) {
+void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2, unsigned int preservation_level) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->resolve_jobject(this, value, tmp1, tmp2, needs_frame);
+  bs->resolve_jobject(this, value, tmp1, tmp2, preservation_level);
 }
 
 // Values for last_Java_pc, and last_Java_sp must comply to the rules

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -39,8 +39,7 @@ class MacroAssembler: public Assembler {
  public:
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
 
-  // Workaround (enum class is new in C++11; thus unavailable in previous versions)
-  enum RuntimeInvocationPreservationLevel {
+  enum PreservationLevel {
     PRESERVATION_NONE,
     PRESERVATION_FRAME_LR,
     PRESERVATION_FRAME_LR_GP_REGS,
@@ -668,7 +667,8 @@ class MacroAssembler: public Assembler {
   // Check if safepoint requested and if so branch
   void safepoint_poll(Label& slow_path, Register temp_reg);
 
-  void resolve_jobject(Register value, Register tmp1, Register tmp2, unsigned int preservation_level);
+  void resolve_jobject(Register value, Register tmp1, Register tmp2,
+                       MacroAssembler::PreservationLevel preservation_level);
 
   // Support for managing the JavaThread pointer (i.e.; the reference to
   // thread-local information).
@@ -710,22 +710,23 @@ class MacroAssembler: public Assembler {
   inline void access_store_at(BasicType type, DecoratorSet decorators,
                               Register base, RegisterOrConstant ind_or_offs, Register val,
                               Register tmp1, Register tmp2, Register tmp3,
-                              unsigned int preservation_level);
+                              MacroAssembler::PreservationLevel preservation_level);
   inline void access_load_at(BasicType type, DecoratorSet decorators,
                              Register base, RegisterOrConstant ind_or_offs, Register dst,
                              Register tmp1, Register tmp2,
-                             unsigned int preservation_level, Label *L_handle_null = NULL);
+                             MacroAssembler::PreservationLevel preservation_level, Label *L_handle_null = NULL);
 
  public:
   // Specify tmp1 for better code in certain compressed oops cases. Specify Label to bail out on null oop.
   // tmp1, tmp2 and needs_frame are used with decorators ON_PHANTOM_OOP_REF or ON_WEAK_OOP_REF.
   inline void load_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                             Register tmp1, Register tmp2,
-                            unsigned int preservation_level, DecoratorSet decorators = 0, Label *L_handle_null = NULL);
+                            MacroAssembler::PreservationLevel preservation_level,
+                            DecoratorSet decorators = 0, Label *L_handle_null = NULL);
 
   inline void store_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                              Register tmp1, Register tmp2, Register tmp3,
-                             unsigned int preservation_level, DecoratorSet decorators = 0);
+                             MacroAssembler::PreservationLevel preservation_level, DecoratorSet decorators = 0);
 
   // Encode/decode heap oop. Oop may not be null, else en/decoding goes wrong.
   // src == d allowed.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,14 @@ class ciTypeArray;
 class MacroAssembler: public Assembler {
  public:
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
+
+  // Workaround (enum class is new in C++11; thus unavailable in previous versions)
+  enum RuntimeInvocationPreservationLevel {
+    PRESERVATION_NONE,
+    PRESERVATION_FRAME_LR,
+    PRESERVATION_FRAME_LR_GP_REGS,
+    PRESERVATION_FRAME_LR_GP_FP_REGS
+  };
 
   //
   // Optimized instruction emitters
@@ -260,11 +268,26 @@ class MacroAssembler: public Assembler {
   //
 
   // some ABI-related functions
+
+  // Clobbers all volatile, (non-floating-point) general-purpose registers for debugging purposes.
+  // This is especially useful for making calls to the JRT in places in which this haven't been done before;
+  // e.g. with the introduction of LRBs (load reference barriers) for concurrent garbage collection.
+  void clobber_volatile_gprs(Register excluded_register = noreg);
+  void clobber_carg_stack_slots(Register tmp);
+
   void save_nonvolatile_gprs(   Register dst_base, int offset);
   void restore_nonvolatile_gprs(Register src_base, int offset);
-  enum { num_volatile_regs = 11 + 14 }; // GPR + FPR
-  void save_volatile_gprs(   Register dst_base, int offset);
-  void restore_volatile_gprs(Register src_base, int offset);
+
+  enum {
+    num_volatile_gp_regs = 11,
+    num_volatile_fp_regs = 14,
+    num_volatile_regs = num_volatile_gp_regs + num_volatile_fp_regs
+  };
+
+  void save_volatile_gprs(   Register dst_base, int offset,
+                             bool include_fp_regs = true, bool include_R3_RET_reg = true);
+  void restore_volatile_gprs(Register src_base, int offset,
+                             bool include_fp_regs = true, bool include_R3_RET_reg = true);
   void save_LR_CR(   Register tmp);     // tmp contains LR on return.
   void restore_LR_CR(Register tmp);
 
@@ -645,7 +668,7 @@ class MacroAssembler: public Assembler {
   // Check if safepoint requested and if so branch
   void safepoint_poll(Label& slow_path, Register temp_reg);
 
-  void resolve_jobject(Register value, Register tmp1, Register tmp2, bool needs_frame);
+  void resolve_jobject(Register value, Register tmp1, Register tmp2, unsigned int preservation_level);
 
   // Support for managing the JavaThread pointer (i.e.; the reference to
   // thread-local information).
@@ -686,21 +709,23 @@ class MacroAssembler: public Assembler {
  private:
   inline void access_store_at(BasicType type, DecoratorSet decorators,
                               Register base, RegisterOrConstant ind_or_offs, Register val,
-                              Register tmp1, Register tmp2, Register tmp3, bool needs_frame);
+                              Register tmp1, Register tmp2, Register tmp3,
+                              unsigned int preservation_level);
   inline void access_load_at(BasicType type, DecoratorSet decorators,
                              Register base, RegisterOrConstant ind_or_offs, Register dst,
-                             Register tmp1, Register tmp2, bool needs_frame, Label *L_handle_null = NULL);
+                             Register tmp1, Register tmp2,
+                             unsigned int preservation_level, Label *L_handle_null = NULL);
 
  public:
   // Specify tmp1 for better code in certain compressed oops cases. Specify Label to bail out on null oop.
   // tmp1, tmp2 and needs_frame are used with decorators ON_PHANTOM_OOP_REF or ON_WEAK_OOP_REF.
   inline void load_heap_oop(Register d, RegisterOrConstant offs, Register s1,
-                            Register tmp1, Register tmp2, bool needs_frame,
-                            DecoratorSet decorators = 0, Label *L_handle_null = NULL);
+                            Register tmp1, Register tmp2,
+                            unsigned int preservation_level, DecoratorSet decorators = 0, Label *L_handle_null = NULL);
 
   inline void store_heap_oop(Register d, RegisterOrConstant offs, Register s1,
-                             Register tmp1, Register tmp2, Register tmp3, bool needs_frame,
-                             DecoratorSet decorators = 0);
+                             Register tmp1, Register tmp2, Register tmp3,
+                             unsigned int preservation_level, DecoratorSet decorators = 0);
 
   // Encode/decode heap oop. Oop may not be null, else en/decoding goes wrong.
   // src == d allowed.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -39,6 +39,7 @@ class MacroAssembler: public Assembler {
  public:
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
 
+  // Indicates whether and, if so, which registers must be preserved when calling runtime code.
   enum PreservationLevel {
     PRESERVATION_NONE,
     PRESERVATION_FRAME_LR,
@@ -269,7 +270,7 @@ class MacroAssembler: public Assembler {
   // some ABI-related functions
 
   // Clobbers all volatile, (non-floating-point) general-purpose registers for debugging purposes.
-  // This is especially useful for making calls to the JRT in places in which this haven't been done before;
+  // This is especially useful for making calls to the JRT in places in which this hasn't been done before;
   // e.g. with the introduction of LRBs (load reference barriers) for concurrent garbage collection.
   void clobber_volatile_gprs(Register excluded_register = noreg);
   void clobber_carg_stack_slots(Register tmp);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,7 +350,8 @@ inline void MacroAssembler::null_check(Register a, int offset, Label *Lis_null) 
 
 inline void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorators,
                                             Register base, RegisterOrConstant ind_or_offs, Register val,
-                                            Register tmp1, Register tmp2, Register tmp3, bool needs_frame) {
+                                            Register tmp1, Register tmp2, Register tmp3,
+                                            unsigned int preservation_level) {
   assert((decorators & ~(AS_RAW | IN_HEAP | IN_NATIVE | IS_ARRAY | IS_NOT_NULL |
                          ON_UNKNOWN_OOP_REF)) == 0, "unsupported decorator");
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -359,17 +360,18 @@ inline void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorat
   if (as_raw) {
     bs->BarrierSetAssembler::store_at(this, decorators, type,
                                       base, ind_or_offs, val,
-                                      tmp1, tmp2, tmp3, needs_frame);
+                                      tmp1, tmp2, tmp3, preservation_level);
   } else {
     bs->store_at(this, decorators, type,
                  base, ind_or_offs, val,
-                 tmp1, tmp2, tmp3, needs_frame);
+                 tmp1, tmp2, tmp3, preservation_level);
   }
 }
 
 inline void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorators,
                                            Register base, RegisterOrConstant ind_or_offs, Register dst,
-                                           Register tmp1, Register tmp2, bool needs_frame, Label *L_handle_null) {
+                                           Register tmp1, Register tmp2,
+                                           unsigned int preservation_level, Label *L_handle_null) {
   assert((decorators & ~(AS_RAW | IN_HEAP | IN_NATIVE | IS_ARRAY | IS_NOT_NULL |
                          ON_PHANTOM_OOP_REF | ON_WEAK_OOP_REF)) == 0, "unsupported decorator");
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -378,24 +380,27 @@ inline void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorato
   if (as_raw) {
     bs->BarrierSetAssembler::load_at(this, decorators, type,
                                      base, ind_or_offs, dst,
-                                     tmp1, tmp2, needs_frame, L_handle_null);
+                                     tmp1, tmp2, preservation_level, L_handle_null);
   } else {
     bs->load_at(this, decorators, type,
                 base, ind_or_offs, dst,
-                tmp1, tmp2, needs_frame, L_handle_null);
+                tmp1, tmp2, preservation_level, L_handle_null);
   }
 }
 
 inline void MacroAssembler::load_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                                           Register tmp1, Register tmp2,
-                                          bool needs_frame, DecoratorSet decorators, Label *L_handle_null) {
-  access_load_at(T_OBJECT, IN_HEAP | decorators, s1, offs, d, tmp1, tmp2, needs_frame, L_handle_null);
+                                          unsigned int preservation_level,
+                                          DecoratorSet decorators, Label *L_handle_null) {
+  access_load_at(T_OBJECT, decorators | IN_HEAP, s1, offs, d, tmp1, tmp2,
+                 preservation_level, L_handle_null);
 }
 
 inline void MacroAssembler::store_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                                            Register tmp1, Register tmp2, Register tmp3,
-                                           bool needs_frame, DecoratorSet decorators) {
-  access_store_at(T_OBJECT, IN_HEAP | decorators, s1, offs, d, tmp1, tmp2, tmp3, needs_frame);
+                                           unsigned int preservation_level,
+                                           DecoratorSet decorators) {
+  access_store_at(T_OBJECT, decorators | IN_HEAP, s1, offs, d, tmp1, tmp2, tmp3, preservation_level);
 }
 
 inline Register MacroAssembler::encode_heap_oop_not_null(Register d, Register src) {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
@@ -351,7 +351,7 @@ inline void MacroAssembler::null_check(Register a, int offset, Label *Lis_null) 
 inline void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorators,
                                             Register base, RegisterOrConstant ind_or_offs, Register val,
                                             Register tmp1, Register tmp2, Register tmp3,
-                                            unsigned int preservation_level) {
+                                            MacroAssembler::PreservationLevel preservation_level) {
   assert((decorators & ~(AS_RAW | IN_HEAP | IN_NATIVE | IS_ARRAY | IS_NOT_NULL |
                          ON_UNKNOWN_OOP_REF)) == 0, "unsupported decorator");
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -371,7 +371,8 @@ inline void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorat
 inline void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorators,
                                            Register base, RegisterOrConstant ind_or_offs, Register dst,
                                            Register tmp1, Register tmp2,
-                                           unsigned int preservation_level, Label *L_handle_null) {
+                                           MacroAssembler::PreservationLevel preservation_level,
+                                           Label *L_handle_null) {
   assert((decorators & ~(AS_RAW | IN_HEAP | IN_NATIVE | IS_ARRAY | IS_NOT_NULL |
                          ON_PHANTOM_OOP_REF | ON_WEAK_OOP_REF)) == 0, "unsupported decorator");
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -390,7 +391,7 @@ inline void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorato
 
 inline void MacroAssembler::load_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                                           Register tmp1, Register tmp2,
-                                          unsigned int preservation_level,
+                                          MacroAssembler::PreservationLevel preservation_level,
                                           DecoratorSet decorators, Label *L_handle_null) {
   access_load_at(T_OBJECT, decorators | IN_HEAP, s1, offs, d, tmp1, tmp2,
                  preservation_level, L_handle_null);
@@ -398,7 +399,7 @@ inline void MacroAssembler::load_heap_oop(Register d, RegisterOrConstant offs, R
 
 inline void MacroAssembler::store_heap_oop(Register d, RegisterOrConstant offs, Register s1,
                                            Register tmp1, Register tmp2, Register tmp3,
-                                           unsigned int preservation_level,
+                                           MacroAssembler::PreservationLevel preservation_level,
                                            DecoratorSet decorators) {
   access_store_at(T_OBJECT, decorators | IN_HEAP, s1, offs, d, tmp1, tmp2, tmp3, preservation_level);
 }

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -179,7 +179,7 @@ void MethodHandles::jump_to_lambda_form(MacroAssembler* _masm,
   // Load the invoker, as MH -> MH.form -> LF.vmentry
   __ verify_oop(recv, FILE_AND_LINE);
 
-  const unsigned int preservation_level = for_compiler_entry
+  const MacroAssembler::PreservationLevel preservation_level = for_compiler_entry
     ? MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS
     : MacroAssembler::PRESERVATION_FRAME_LR;
 
@@ -320,7 +320,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
   if (receiver_reg != noreg)  assert_different_registers(temp1, temp2, temp3, temp4, receiver_reg);
   if (member_reg   != noreg)  assert_different_registers(temp1, temp2, temp3, temp4, member_reg);
 
-  const unsigned int preservation_level = for_compiler_entry
+  const MacroAssembler::PreservationLevel preservation_level = for_compiler_entry
     ? MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS
     : MacroAssembler::PRESERVATION_FRAME_LR;
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2430,7 +2430,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   // --------------------------------------------------------------------------
 
   if (is_reference_type(ret_type)) {
-    __ resolve_jobject(R3_RET, r_temp_1, r_temp_2, /* needs_frame */ false);
+    __ resolve_jobject(R3_RET, r_temp_1, r_temp_2, MacroAssembler::PRESERVATION_NONE);
   }
 
   if (CheckJNICalls) {

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2226,12 +2226,10 @@ class StubGenerator: public StubCodeGenerator {
 
     // ======== loop entry is here ========
     __ bind(load_element);
-    {
-      Register tmp1 = R12_tmp, tmp2 = R11_klass;
-      __ load_heap_oop(R10_oop, R8_offset, R3_from, tmp1, tmp2,
-                       MacroAssembler::PRESERVATION_FRAME_LR_GP_REGS,
-                       AS_RAW, &store_null);
-    }
+    __ load_heap_oop(R10_oop, R8_offset, R3_from,
+                     R11_scratch1, R12_tmp,
+                     MacroAssembler::PRESERVATION_FRAME_LR_GP_REGS,
+                     AS_RAW, &store_null);
 
     __ load_klass(R11_klass, R10_oop); // Query the object klass.
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2226,7 +2226,12 @@ class StubGenerator: public StubCodeGenerator {
 
     // ======== loop entry is here ========
     __ bind(load_element);
-    __ load_heap_oop(R10_oop, R8_offset, R3_from, R12_tmp, noreg, false, AS_RAW, &store_null);
+    {
+      Register tmp1 = R12_tmp, tmp2 = R11_klass;
+      __ load_heap_oop(R10_oop, R8_offset, R3_from, tmp1, tmp2,
+                       MacroAssembler::PRESERVATION_FRAME_LR_GP_REGS,
+                       AS_RAW, &store_null);
+    }
 
     __ load_klass(R11_klass, R10_oop); // Query the object klass.
 

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -525,7 +525,8 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   __ cmpdi(CCR0, R3_RET, 0);
   __ beq(CCR0, slow_path);
 
-  __ load_heap_oop(R3_RET, referent_offset, R3_RET, /* non-volatile temp */ R31, R11_scratch1,
+  __ load_heap_oop(R3_RET, referent_offset, R3_RET,
+                   /* non-volatile temp */ R31, R11_scratch1,
                    MacroAssembler::PRESERVATION_FRAME_LR,
                    ON_WEAK_OOP_REF);
 

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -405,7 +405,7 @@ address TemplateInterpreterGenerator::generate_result_handler_for(BasicType type
      break;
   case T_OBJECT:
     // JNIHandles::resolve result.
-    __ resolve_jobject(R3_RET, R11_scratch1, R31, /* needs_frame */ true); // kills R31
+    __ resolve_jobject(R3_RET, R11_scratch1, R31, MacroAssembler::PRESERVATION_FRAME_LR); // kills R31
     break;
   case T_FLOAT:
      break;
@@ -525,8 +525,9 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   __ cmpdi(CCR0, R3_RET, 0);
   __ beq(CCR0, slow_path);
 
-  __ load_heap_oop(R3_RET, referent_offset, R3_RET,
-                   /* non-volatile temp */ R31, R11_scratch1, true, ON_WEAK_OOP_REF);
+  __ load_heap_oop(R3_RET, referent_offset, R3_RET, /* non-volatile temp */ R31, R11_scratch1,
+                   MacroAssembler::PRESERVATION_FRAME_LR,
+                   ON_WEAK_OOP_REF);
 
   // Generate the G1 pre-barrier code to log the value of
   // the referent field in an SATB buffer. Note with

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -305,20 +305,18 @@ void TemplateTable::fast_aldc(bool wide) {
   transition(vtos, atos);
 
   int index_size = wide ? sizeof(u2) : sizeof(u1);
-  const Register tmp1 = R11_scratch1,
-                 tmp2 = R12_scratch2;
   Label is_null;
 
   // We are resolved if the resolved reference cache entry contains a
   // non-null object (CallSite, etc.)
-  __ get_cache_index_at_bcp(tmp1, 1, index_size);  // Load index.
-  __ load_resolved_reference_at_index(R17_tos, tmp1, tmp2, &is_null);
+  __ get_cache_index_at_bcp(R11_scratch1, 1, index_size);  // Load index.
+  __ load_resolved_reference_at_index(R17_tos, R11_scratch1, R12_scratch2, &is_null);
 
   // Convert null sentinel to NULL
-  int simm16_rest = __ load_const_optimized(tmp1, Universe::the_null_sentinel_addr(), R0, true);
-  __ ld(tmp1, simm16_rest, tmp1);
-  __ resolve_oop_handle(tmp1);
-  __ cmpld(CCR0, R17_tos, tmp1);
+  int simm16_rest = __ load_const_optimized(R11_scratch1, Universe::the_null_sentinel_addr(), R0, true);
+  __ ld(R11_scratch1, simm16_rest, R11_scratch1);
+  __ resolve_oop_handle(R11_scratch1);
+  __ cmpld(CCR0, R17_tos, R11_scratch1);
   if (VM_Version::has_isel()) {
     __ isel_0(R17_tos, CCR0, Assembler::equal);
   } else {

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2013, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ static void do_oop_store(InterpreterMacroAssembler* _masm,
                          Register           tmp3,
                          DecoratorSet       decorators) {
   assert_different_registers(tmp1, tmp2, tmp3, val, base);
-  __ store_heap_oop(val, offset, base, tmp1, tmp2, tmp3, false, decorators);
+  __ store_heap_oop(val, offset, base, tmp1, tmp2, tmp3, MacroAssembler::PRESERVATION_NONE, decorators);
 }
 
 static void do_oop_load(InterpreterMacroAssembler* _masm,
@@ -80,7 +80,7 @@ static void do_oop_load(InterpreterMacroAssembler* _masm,
                         DecoratorSet decorators) {
   assert_different_registers(base, tmp1, tmp2);
   assert_different_registers(dst, tmp1, tmp2);
-  __ load_heap_oop(dst, offset, base, tmp1, tmp2, false, decorators);
+  __ load_heap_oop(dst, offset, base, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE, decorators);
 }
 
 Address TemplateTable::at_bcp(int offset) {
@@ -305,19 +305,20 @@ void TemplateTable::fast_aldc(bool wide) {
   transition(vtos, atos);
 
   int index_size = wide ? sizeof(u2) : sizeof(u1);
-  const Register Rscratch = R11_scratch1;
+  const Register tmp1 = R11_scratch1,
+                 tmp2 = R12_scratch2;
   Label is_null;
 
   // We are resolved if the resolved reference cache entry contains a
   // non-null object (CallSite, etc.)
-  __ get_cache_index_at_bcp(Rscratch, 1, index_size);  // Load index.
-  __ load_resolved_reference_at_index(R17_tos, Rscratch, &is_null);
+  __ get_cache_index_at_bcp(tmp1, 1, index_size);  // Load index.
+  __ load_resolved_reference_at_index(R17_tos, tmp1, tmp2, &is_null);
 
   // Convert null sentinel to NULL
-  int simm16_rest = __ load_const_optimized(Rscratch, Universe::the_null_sentinel_addr(), R0, true);
-  __ ld(Rscratch, simm16_rest, Rscratch);
-  __ resolve_oop_handle(Rscratch);
-  __ cmpld(CCR0, R17_tos, Rscratch);
+  int simm16_rest = __ load_const_optimized(tmp1, Universe::the_null_sentinel_addr(), R0, true);
+  __ ld(tmp1, simm16_rest, tmp1);
+  __ resolve_oop_handle(tmp1);
+  __ cmpld(CCR0, R17_tos, tmp1);
   if (VM_Version::has_isel()) {
     __ isel_0(R17_tos, CCR0, Assembler::equal);
   } else {
@@ -2427,7 +2428,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
                  Roffset       = R23_tmp3,
                  Rflags        = R31,
                  Rbtable       = R5_ARG3,
-                 Rbc           = R6_ARG4,
+                 Rbc           = R30,
                  Rscratch      = R12_scratch2;
 
   static address field_branch_table[number_of_states],
@@ -2462,7 +2463,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
   // Load from branch table and dispatch (volatile case: one instruction ahead).
   __ sldi(Rflags, Rflags, LogBytesPerWord);
-  __ cmpwi(CCR6, Rscratch, 1); // Volatile?
+  __ cmpwi(CCR2, Rscratch, 1); // Volatile?
   if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
     __ sldi(Rscratch, Rscratch, exact_log2(BytesPerInstWord)); // Volatile ? size of 1 instruction : 0.
   }
@@ -2513,7 +2514,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   }
   {
     Label acquire_double;
-    __ beq(CCR6, acquire_double); // Volatile?
+    __ beq(CCR2, acquire_double); // Volatile?
     __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
     __ bind(acquire_double);
@@ -2534,7 +2535,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   }
   {
     Label acquire_float;
-    __ beq(CCR6, acquire_float); // Volatile?
+    __ beq(CCR2, acquire_float); // Volatile?
     __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
     __ bind(acquire_float);
@@ -2553,7 +2554,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_igetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2566,7 +2567,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_lgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2580,7 +2581,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_bgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2594,7 +2595,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
     // use btos rewriting, no truncating to t/f bit is needed for getfield.
     patch_bytecode(Bytecodes::_fast_bgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2607,7 +2608,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_cgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2620,7 +2621,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_sgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2635,7 +2636,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_agetfield, Rbc, Rscratch);
   }
-  __ beq(CCR6, Lacquire); // Volatile?
+  __ beq(CCR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 12);
@@ -3332,7 +3333,8 @@ void TemplateTable::prepare_invoke(int byte_no,
 
   assert_different_registers(Rmethod, Rindex, Rflags, Rscratch);
   assert_different_registers(Rmethod, Rrecv, Rflags, Rscratch);
-  assert_different_registers(Rret_addr, Rscratch);
+  // Rret_addr and Rindex have to be distinct as Rret_addr is used as a second temp register
+  assert_different_registers(Rret_addr, Rindex, Rscratch);
 
   load_invoke_cp_cache_entry(byte_no, Rmethod, Rindex, Rflags, is_invokevirtual, false, is_invokedynamic);
 
@@ -3341,14 +3343,16 @@ void TemplateTable::prepare_invoke(int byte_no,
   // Maybe push "appendix" to arguments.
   if (is_invokedynamic || is_invokehandle) {
     Label Ldone;
+    Register reference = Rret_addr; // safe to use here; first use comes later
+
     __ rldicl_(R0, Rflags, 64-ConstantPoolCacheEntry::has_appendix_shift, 63);
     __ beq(CCR0, Ldone);
     // Push "appendix" (MethodType, CallSite, etc.).
     // This must be done before we get the receiver,
     // since the parameter_size includes it.
-    __ load_resolved_reference_at_index(Rscratch, Rindex);
-    __ verify_oop(Rscratch);
-    __ push_ptr(Rscratch);
+    __ load_resolved_reference_at_index(reference, Rindex, Rscratch);
+    __ verify_oop(reference);
+    __ push_ptr(reference);
     __ bind(Ldone);
   }
 
@@ -3649,7 +3653,7 @@ void TemplateTable::invokedynamic(int byte_no) {
   transition(vtos, vtos);
 
   const Register Rret_addr = R3_ARG1,
-                 Rflags    = R4_ARG2,
+                 Rflags    = R31,
                  Rmethod   = R22_tmp2,
                  Rscratch1 = R11_scratch1,
                  Rscratch2 = R12_scratch2;
@@ -3673,7 +3677,7 @@ void TemplateTable::invokehandle(int byte_no) {
   transition(vtos, vtos);
 
   const Register Rret_addr = R3_ARG1,
-                 Rflags    = R4_ARG2,
+                 Rflags    = R31,
                  Rrecv     = R5_ARG3,
                  Rmethod   = R22_tmp2,
                  Rscratch1 = R11_scratch1,


### PR DESCRIPTION
At present, the `needs_frame` flag is used on the ppc platform to determine whether gc barriers must emit a new stack frame (and save the link register, for that matter) or not. With the introduction of load reference barriers, however, this mechansim is no longer sufficient. This holds especially true for compiler stubs as those make heavy use of volatile registers.

To mitigate this, this patch replaces the `needs_frame` flag with a simple enumeration. As the enumerators are incremental, handling the different "register preservation needs" in the actual gc barrier implementations is comparatively (pun intended) easy. 

_This is a preparational change for the ShenandoahGC port to ppc. As such, it may provide some functionality this version doesn't make use of, but that is required for the upcoming change. This way, the scope of the upcoming change is limited to GC-specific functionality; making its review a little easier._

_For the same reason, this patch also introduces patching support for `LIR_Assembler::leal`._

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260368](https://bugs.openjdk.java.net/browse/JDK-8260368): [PPC64] GC interface needs enhancement to support GCs with load barriers


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to 46bfce1693224e014a7c46edc982e6c0541c0f3a
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2302/head:pull/2302`
`$ git checkout pull/2302`
