### PR TITLE
8231436: Fix the applicability of a no-@Target annotation type

### DIFF
--- a/src/java.base/share/classes/java/lang/annotation/Target.java
+++ b/src/java.base/share/classes/java/lang/annotation/Target.java
@@ -32,8 +32,8 @@ package java.lang.annotation;
  * enum constants of {@link ElementType java.lang.annotation.ElementType}.
  *
  * <p>If an {@code @Target} meta-annotation is not present on an annotation
- * interface {@code T}, then an annotation of type {@code T} may be written as
- * a modifier for any declaration except a type parameter declaration.
+ * interface {@code T}, then an annotation of type {@code T} is applicable
+ * in all declaration contexts and all type contexts.
  *
  * <p>If an {@code @Target} meta-annotation is present, the compiler will enforce
  * the usage restrictions indicated by {@code ElementType}

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg/AnnotationType.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg/AnnotationType.java
@@ -28,6 +28,16 @@ import java.lang.annotation.*;
 /**
  * This is just a test annotation type.
  */
+@Target({
+    ElementType.TYPE,
+    ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.CONSTRUCTOR,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.PACKAGE,
+})
 @Documented public @interface AnnotationType {
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg/AnnotationTypeUndocumented.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg/AnnotationTypeUndocumented.java
@@ -29,6 +29,16 @@ import java.lang.annotation.*;
  * This is just a test annotation type this is not documented because it
  * is missing the @Documented tag.
  */
+@Target({
+    ElementType.TYPE,
+    ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.CONSTRUCTOR,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.PACKAGE,
+})
 public @interface AnnotationTypeUndocumented {
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -423,6 +423,9 @@ public class TestRecordTypes extends JavadocTester {
                     set.add(types[b]);
                 }
             }
+            if (set.isEmpty()) {
+                continue;
+            }
             testAnnotations(base, set);
         }
     }

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/8029017/TypeUseTargetNeg.out
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/8029017/TypeUseTargetNeg.out
@@ -3,5 +3,4 @@ TypeUseTargetNeg.java:36:1: compiler.err.invalid.repeatable.annotation.incompati
 TypeUseTargetNeg.java:54:1: compiler.err.invalid.repeatable.annotation.incompatible.target: BazContainer, Baz
 TypeUseTargetNeg.java:71:1: compiler.err.invalid.repeatable.annotation.incompatible.target: QuxContainer, Qux
 TypeUseTargetNeg.java:81:1: compiler.err.invalid.repeatable.annotation.incompatible.target: QuuxContainer, Quux
-TypeUseTargetNeg.java:92:1: compiler.err.invalid.repeatable.annotation.incompatible.target: QuuuxContainer, Quuux
-6 errors
+5 errors

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeParameter.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeParameter.java
@@ -2,8 +2,8 @@ import java.lang.annotation.*;
 
 /**
  * @test /nodynamiccopyright/
- * @bug 8006547
- * @compile/fail/ref=DefaultTargetTypeParameter.out -XDrawDiagnostics DefaultTargetTypeParameter.java
+ * @bug 8006547 8231436
+ * @compile DefaultTargetTypeParameter.java
  */
 
 @Target({

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeParameter.out
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeParameter.out
@@ -1,2 +1,0 @@
-DefaultTargetTypeParameter.java:16:1: compiler.err.invalid.repeatable.annotation.incompatible.target: Container, DefaultTargetTypeParameter
-1 error

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeUse.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeUse.java
@@ -2,8 +2,8 @@ import java.lang.annotation.*;
 
 /**
  * @test /nodynamiccopyright/
- * @bug 8006547
- * @compile/fail/ref=DefaultTargetTypeUse.out -XDrawDiagnostics DefaultTargetTypeUse.java
+ * @bug 8006547 8231436
+ * @compile DefaultTargetTypeUse.java
  */
 
 @Target({

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeUse.out
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/DefaultTargetTypeUse.out
@@ -1,2 +1,0 @@
-DefaultTargetTypeUse.java:16:1: compiler.err.invalid.repeatable.annotation.incompatible.target: Container, DefaultTargetTypeUse
-1 error

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
 
 /**
  * @test
- * @bug 8006547
+ * @bug 8006547 8261088
  * @compile --enable-preview -source ${jdk.version} NoTargetOnContainer.java
  */
 
@@ -42,7 +42,10 @@ import java.lang.annotation.*;
     ElementType.PACKAGE,
     ElementType.ANNOTATION_TYPE,
     ElementType.FIELD,
-    ElementType.RECORD_COMPONENT
+    ElementType.RECORD_COMPONENT,
+    ElementType.MODULE,
+    ElementType.TYPE_USE,
+    ElementType.TYPE_PARAMETER,
 })
 @Repeatable(FooContainer.class)
 @interface Foo {}

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer2.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer2.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
 
 /**
  * @test
- * @bug 8006547
+ * @bug 8006547 8261088
  * @compile --enable-preview -source ${jdk.version} NoTargetOnContainer2.java
  */
 
@@ -44,7 +44,8 @@ import java.lang.annotation.*;
     ElementType.FIELD,
     ElementType.TYPE_USE,
     ElementType.TYPE_PARAMETER,
-    ElementType.RECORD_COMPONENT
+    ElementType.RECORD_COMPONENT,
+    ElementType.MODULE,
 })
 @Repeatable(FooContainer.class)
 @interface Foo {}

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/combo/TargetAnnoCombo.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/combo/TargetAnnoCombo.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      7151010 8006547 8007766 8029017 8246774
+ * @bug      7151010 8006547 8007766 8029017 8246774 8231436
  * @summary  Default test cases for running combinations for Target values
  * @modules jdk.compiler
  * @build    Helper
@@ -66,7 +66,7 @@ public class TargetAnnoCombo {
     final static Set<ElementType> empty = EnumSet.noneOf(ElementType.class);
 
     // [TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE, ANNOTATION_TYPE,
-    // PACKAGE, TYPE_PARAMETER, TYPE_USE, RECORD_COMPONENT]
+    // PACKAGE, TYPE_PARAMETER, TYPE_USE, MODULE, RECORD_COMPONENT]
     final static Set<ElementType> allTargets = EnumSet.allOf(ElementType.class);
 
     // [TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE, ANNOTATION_TYPE,
@@ -144,11 +144,7 @@ public class TargetAnnoCombo {
              * In both cases, the set will be a valid set with no @Target for base annotation
              */
             if (baseAnnotations == null) {
-                if (containerAnnotations == null) {
-                    return true;
-                }
-                return !(containerAnnotations.contains(TYPE_USE) ||
-                         containerAnnotations.contains(TYPE_PARAMETER));
+                return true;
             }
 
             Set<ElementType> tempBaseSet = EnumSet.noneOf(ElementType.class);
@@ -169,7 +165,11 @@ public class TargetAnnoCombo {
             // If containerAnno has no @Target, only valid case if baseAnnoTarget has
             // all targets defined else invalid set.
             if (containerAnnotations == null) {
-                return tempBaseSet.containsAll(jdk7);
+                if (source8.equals(options)) {
+                    return tempBaseSet.containsAll(jdk7) && tempBaseSet.containsAll(jdk8);
+                } else {
+                    return tempBaseSet.containsAll(allTargets);
+                }
             }
 
             // At this point, neither conAnnoTarget or baseAnnoTarget are null.
@@ -384,9 +384,7 @@ public class TargetAnnoCombo {
         // then all 8 ElementType enum constants are applicable as targets for
         // container annotation.
         if (shouldCompile && conAnnoTarget == null) {
-            Set<ElementType> copySet = EnumSet.noneOf(ElementType.class);
-            copySet.addAll(jdk7);
-            conAnnoTarget = copySet;
+            conAnnoTarget = EnumSet.copyOf(allTargets);
         }
 
         if (shouldCompile) {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/NoTargetAnnotations.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/NoTargetAnnotations.java
@@ -31,8 +31,9 @@ import com.sun.tools.classfile.*;
 
 /*
  * @test NoTargetAnnotations
+ * @bug 8231436
  * @summary test that annotations with no Target meta type is emitted
- *          only once as declaration annotation
+ *          as both a declaration and type annotation
  * @modules jdk.jdeps/com.sun.tools.classfile
  */
 public class NoTargetAnnotations {
@@ -191,7 +192,7 @@ public class NoTargetAnnotations {
 
     /*********************** Test class *************************/
     static int expected_invisibles = 0;
-    static int expected_visibles = 0;
+    static int expected_visibles = 1;
     static int expected_decl = 1;
 
     static class Test {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.java
@@ -5,8 +5,11 @@
  * @compile/fail/ref=AnnotatedMethodSelectorTest.out -XDrawDiagnostics AnnotatedMethodSelectorTest.java
  */
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 class AnnotatedMethodSelectorTest {
+    @Target(ElementType.METHOD)
     @interface A {}
     static public void main(String... args) {
         java.util.@A Arrays.stream(args);

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest.out
@@ -1,2 +1,2 @@
-AnnotatedMethodSelectorTest.java:12:19: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest.A
+AnnotatedMethodSelectorTest.java:15:19: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest.A
 1 error

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest2.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest2.java
@@ -5,7 +5,11 @@
  * @compile/fail/ref=AnnotatedMethodSelectorTest2.out -XDrawDiagnostics AnnotatedMethodSelectorTest2.java
  */
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
 class AnnotatedMethodSelectorTest2<T> {
+    @Target(ElementType.METHOD)
     @interface A {}
     class Inner {}
     static public void main(String... args) {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest2.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest2.out
@@ -1,3 +1,3 @@
-AnnotatedMethodSelectorTest2.java:12:42: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest2.A
-AnnotatedMethodSelectorTest2.java:13:23: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest2.A
+AnnotatedMethodSelectorTest2.java:16:42: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest2.A
+AnnotatedMethodSelectorTest2.java:17:23: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest2.A
 2 errors

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest3.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest3.java
@@ -5,8 +5,11 @@
  * @compile/fail/ref=AnnotatedMethodSelectorTest3.out -XDrawDiagnostics AnnotatedMethodSelectorTest3.java
  */
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 class AnnotatedMethodSelectorTest3 {
+    @Target(ElementType.METHOD)
     @interface A {}
     static <T> AnnotatedMethodSelectorTest3 id() {
         return null;

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest3.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotatedMethodSelectorTest3.out
@@ -1,2 +1,2 @@
-AnnotatedMethodSelectorTest3.java:15:39: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest3.A
+AnnotatedMethodSelectorTest3.java:18:39: compiler.err.annotation.type.not.applicable.to.type: AnnotatedMethodSelectorTest3.A
 1 error

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.java
@@ -6,6 +6,10 @@
  * @author Werner Dietl
  * @compile/fail/ref=DeclarationAnnotation.out -XDrawDiagnostics DeclarationAnnotation.java
  */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
 class DeclarationAnnotation {
     Object e1 = new @DA int[5];
     Object e2 = new @DA String[42];
@@ -13,4 +17,5 @@ class DeclarationAnnotation {
     Object e4 = new @DA Object() { };
 }
 
+@Target(ElementType.METHOD)
 @interface DA { }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.out
@@ -1,5 +1,5 @@
-DeclarationAnnotation.java:13:21: compiler.err.annotation.type.not.applicable.to.type: DA
-DeclarationAnnotation.java:10:21: compiler.err.annotation.type.not.applicable.to.type: DA
-DeclarationAnnotation.java:11:21: compiler.err.annotation.type.not.applicable.to.type: DA
-DeclarationAnnotation.java:12:21: compiler.err.annotation.type.not.applicable.to.type: DA
+DeclarationAnnotation.java:17:21: compiler.err.annotation.type.not.applicable.to.type: DA
+DeclarationAnnotation.java:14:21: compiler.err.annotation.type.not.applicable.to.type: DA
+DeclarationAnnotation.java:15:21: compiler.err.annotation.type.not.applicable.to.type: DA
+DeclarationAnnotation.java:16:21: compiler.err.annotation.type.not.applicable.to.type: DA
 4 errors

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/parambounds/BrokenAnnotation.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/parambounds/BrokenAnnotation.out
@@ -1,5 +1,4 @@
 BrokenAnnotation.java:16:6: compiler.err.cant.resolve.location: kindname.class, Target, , , (compiler.misc.location: kindname.class, BrokenAnnotation<T>, null)
 BrokenAnnotation.java:16:14: compiler.err.cant.resolve.location: kindname.variable, ElementType, , , (compiler.misc.location: kindname.class, BrokenAnnotation<T>, null)
 BrokenAnnotation.java:16:36: compiler.err.cant.resolve.location: kindname.variable, ElementType, , , (compiler.misc.location: kindname.class, BrokenAnnotation<T>, null)
-BrokenAnnotation.java:15:34: compiler.err.annotation.type.not.applicable.to.type: BrokenAnnotation.A
-4 errors
+3 errors

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.java
@@ -1,6 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 8013852
+ * @ignore 8261197
  * @summary ensure that declaration annotations are not allowed on
  *   method receiver types
  * @author Werner Dietl
@@ -15,6 +16,7 @@ class DeclarationAnnotation {
     void good(@TA DeclarationAnnotation this) {}
 }
 
+@Target(ElementType.PARAMETER)
 @interface DA { }
 
 @Target(ElementType.TYPE_USE)

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/receiver/DeclarationAnnotation.out
@@ -1,2 +1,2 @@
-DeclarationAnnotation.java:14:14: compiler.err.annotation.type.not.applicable.to.type: DA
+DeclarationAnnotation.java:14:14: compiler.err.annotation.type.not.applicable: DA
 1 error

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/wildcards/DeclarationAnnotation.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/wildcards/DeclarationAnnotation.java
@@ -16,6 +16,7 @@ class DeclarationAnnotation {
     List<@TA ? extends Object> good;
 }
 
+@Target(ElementType.METHOD)
 @interface DA { }
 
 @Target(ElementType.TYPE_USE)

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
@@ -77,7 +77,7 @@ public class Fields {
         return "@Decl String test;";
     }
 
-    @TADescriptions({})
+    @TADescription(annotation = "A", type = FIELD)
     public String fieldWithNoTargetAnno() {
         return "@A String test;";
     }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/MethodParameters.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/MethodParameters.java
@@ -129,7 +129,7 @@ public class MethodParameters {
         return "void test(@Decl String a) { }";
     }
 
-    @TADescriptions({})
+    @TADescription(annotation = "A", type = METHOD_FORMAL_PARAMETER, paramIndex = 0)
     public String methodWithNoTargetAnno() {
         return "void test(@A String a) { }";
     }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/MethodReturns.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/MethodReturns.java
@@ -78,7 +78,7 @@ public class MethodReturns {
         return "@Decl String test() { return null; }";
     }
 
-    @TADescriptions({})
+    @TADescription(annotation = "A", type = METHOD_RETURN)
     public String methodWithNoTargetAnno() {
         return "@A String test() { return null; }";
     }

--- a/test/langtools/tools/javac/api/TestGetScopeResult.java
+++ b/test/langtools/tools/javac/api/TestGetScopeResult.java
@@ -617,7 +617,7 @@ public class TestGetScopeResult {
                             @interface Annotation {}
                             """,
                             List.of(
-                                List.of("i:int", "super:java.lang.Record", "this:Test"),
+                                List.of("i:@Annotation int", "super:java.lang.Record", "this:Test"),
                                 List.of("super:java.lang.Record", "this:Test")
                             ))
             };

--- a/test/langtools/tools/javac/diags/examples/TypeAnnoNotApplicableInTypeContext.java
+++ b/test/langtools/tools/javac/diags/examples/TypeAnnoNotApplicableInTypeContext.java
@@ -23,7 +23,11 @@
 
 // key: compiler.err.annotation.type.not.applicable.to.type
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
 class TypeAnnoNotApplicableInTypeContext<T> {
+    @Target(ElementType.METHOD)
     @interface A { }
     TypeAnnoNotApplicableInTypeContext<@A String> m;
 }

--- a/test/langtools/tools/javac/lvti/harness/InferredType.java
+++ b/test/langtools/tools/javac/lvti/harness/InferredType.java
@@ -21,6 +21,11 @@
  * questions.
  */
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.LOCAL_VARIABLE)
+
 public @interface InferredType {
     String value();
 }

--- a/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
+++ b/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
@@ -218,12 +218,16 @@ public class CreateSymbolsTestImpl {
         doPrintElementTest("package t;" +
                            "import java.lang.annotation.*;" +
                            "public @Visible @Invisible class T { public void extra() { } }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.RUNTIME) @interface Visible { }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.CLASS) @interface Invisible { }",
                            "package t;" +
                            "import java.lang.annotation.*;" +
                            "public @Visible @Invisible class T { }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.RUNTIME) @interface Visible { }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.CLASS) @interface Invisible { }",
                            "t.T",
                            "package t;\n\n" +
@@ -235,6 +239,7 @@ public class CreateSymbolsTestImpl {
                            "}\n",
                            "t.Visible",
                            "package t;\n\n" +
+                           "@java.lang.annotation.Target({TYPE, PARAMETER})\n" +
                            "@java.lang.annotation.Retention(RUNTIME)\n" +
                            "@interface Visible {\n" +
                            "}\n");
@@ -244,7 +249,9 @@ public class CreateSymbolsTestImpl {
                            "public class T {" +
                            "    public void test(int h, @Invisible int i, @Visible List<String> j, int k) { }" +
                            "}" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.RUNTIME) @interface Visible { }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.CLASS) @interface Invisible { }",
                            "package t;" +
                            "import java.lang.annotation.*;" +
@@ -253,7 +260,9 @@ public class CreateSymbolsTestImpl {
                            "    public void test(int h, @Invisible int i, @Visible List<String> j, int k) { }" +
                            "    public void extra() { }" +
                            "}" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.RUNTIME) @interface Visible { }" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.CLASS) @interface Invisible { }",
                            "t.T",
                            "package t;\n\n" +
@@ -266,6 +275,7 @@ public class CreateSymbolsTestImpl {
                            "}\n",
                            "t.Visible",
                            "package t;\n\n" +
+                           "@java.lang.annotation.Target({TYPE, PARAMETER})\n" +
                            "@java.lang.annotation.Retention(RUNTIME)\n" +
                            "@interface Visible {\n" +
                            "}\n");
@@ -274,6 +284,7 @@ public class CreateSymbolsTestImpl {
                            "public class T {" +
                            "    public void test(@Ann(v=\"url\", dv=\"\\\"\\\"\") String str) { }" +
                            "}" +
+                           "@Target({ElementType.TYPE, ElementType.PARAMETER}) " +
                            "@Retention(RetentionPolicy.RUNTIME) @interface Ann {" +
                            "    public String v();" +
                            "    public String dv();" +
@@ -486,8 +497,11 @@ public class CreateSymbolsTestImpl {
                            "    public record R(int i, java.util.List<String> l) { }" +
                            "}",
                            "package t;" +
+                           "import java.lang.annotation.*; " +
                            "public class T {" +
                            "    public record R(@Ann int i, long j, java.util.List<String> l) { }" +
+                           "    @Target({ElementType.RECORD_COMPONENT, ElementType.PARAMETER, " +
+                           "             ElementType.METHOD}) " +
                            "    public @interface Ann {} " +
                            "}",
                            "t.T$R",

--- a/test/langtools/tools/javac/processing/model/element/RecordNotPreservingNestedTypeAnnotationsTest.java
+++ b/test/langtools/tools/javac/processing/model/element/RecordNotPreservingNestedTypeAnnotationsTest.java
@@ -69,5 +69,6 @@ public record RecordNotPreservingNestedTypeAnnotationsTest(@RegularAnnotation @T
     @interface TypeAnnotation {}
 
     @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.RECORD_COMPONENT})
     @interface RegularAnnotation {}
 }

--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -381,6 +381,7 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
     }
 
     /** Annotation to identify test cases. */
+    @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
     @Repeatable(Tests.class)
     @interface Test {
         /** Where to look for the annotation, expressed as a scan index. */
@@ -391,6 +392,7 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
         String expect();
     }
 
+    @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
     @interface Tests {
         Test[] value();
     }


### PR DESCRIPTION
Please review this fix to add `ElementType.MODULE` to the default list of annotation targets, to allow annotations without an explicit `@Target` to be used on module declarations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8231436](https://bugs.openjdk.java.net/browse/JDK-8231436): Fix the applicability of a no-@Target annotation type


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2303/head:pull/2303`
`$ git checkout pull/2303`
