### PR TITLE
8257988: Remove JNF dependency from libsaproc/MacosxDebuggerLocal.m

### DIFF
--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -69,7 +69,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSA, \
     LIBS := $(LIBCXX), \
     LIBS_unix := -ljava, \
     LIBS_linux := $(LIBDL), \
-    LIBS_macosx := -framework Foundation -framework JavaNativeFoundation \
+    LIBS_macosx := -framework Foundation \
         -framework JavaRuntimeSupport -framework Security -framework CoreFoundation, \
     LIBS_windows := dbgeng.lib $(WIN_JAVA_LIB), \
 ))

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -831,7 +831,7 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__I(
 {
   print_debug("attach0 called for jpid=%d\n", (int)jpid);
 
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; 
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   @try {
 
   kern_return_t result;
@@ -1045,7 +1045,7 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_detach0(
      return;
   }
 
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; 
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   @try {
 
   task_t gTask = getTask(env, this_obj);


### PR DESCRIPTION
This removes the JNF dependency from the jdk.hotspot.agent module.
The macro expansions are the same as already used in the Java desktop module - which actually uses a macro
still but there there are hundreds of uses.
The function of this macro code is to prevent NSExceptions escaping to Java and also to drain the auto-release pool.
What test group would be good for verifying this change ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257988](https://bugs.openjdk.java.net/browse/JDK-8257988): Remove JNF dependency from libsaproc/MacosxDebuggerLocal.m


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 9919a02ccefacea6ab3769b4da3fdf37f18b1d93
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2304/head:pull/2304`
`$ git checkout pull/2304`
