### PR TITLE
JDK-8260625: Rename MetaspaceExpand_lock

### DIFF
--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ char Metachunk::get_state_char() const {
 
 #ifdef ASSERT
 void Metachunk::assert_have_expand_lock() {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 }
 #endif
 
@@ -91,7 +91,7 @@ bool Metachunk::commit_up_to(size_t new_committed_words) {
 #endif
 
   // We should hold the expand lock at this point.
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   const size_t commit_from = _committed_words;
   const size_t commit_to =   MIN2(align_up(new_committed_words, Settings::commit_granule_words()), word_size());
@@ -117,7 +117,7 @@ bool Metachunk::commit_up_to(size_t new_committed_words) {
 bool Metachunk::ensure_committed(size_t new_committed_words) {
   bool rc = true;
   if (new_committed_words > committed_words()) {
-    MutexLocker cl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker cl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
     rc = commit_up_to(new_committed_words);
   }
   return rc;
@@ -125,7 +125,7 @@ bool Metachunk::ensure_committed(size_t new_committed_words) {
 
 bool Metachunk::ensure_committed_locked(size_t new_committed_words) {
   // the .._locked() variant should be called if we own the lock already.
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   bool rc = true;
   if (new_committed_words > committed_words()) {
     rc = commit_up_to(new_committed_words);
@@ -137,13 +137,13 @@ bool Metachunk::ensure_committed_locked(size_t new_committed_words) {
 // commit granule size (in other words, we cannot uncommit chunks smaller than
 // a commit granule size).
 void Metachunk::uncommit() {
-  MutexLocker cl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker cl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
   uncommit_locked();
 }
 
 void Metachunk::uncommit_locked() {
   // Only uncommit chunks which are free, have no used words set (extra precaution) and are equal or larger in size than a single commit granule.
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert(_state == State::Free && _used_words == 0 && word_size() >= Settings::commit_granule_words(),
          "Only free chunks equal or larger than commit granule size can be uncommitted "
          "(chunk " METACHUNK_FULL_FORMAT ").", METACHUNK_FULL_FORMAT_ARGS(this));
@@ -184,7 +184,7 @@ void Metachunk::zap_header(uint8_t c) {
 // Verifies linking with neighbors in virtual space.
 // Can only be done under expand lock protection.
 void Metachunk::verify_neighborhood() const {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert(!is_dead(), "Do not call on dead chunks.");
   if (is_root_chunk()) {
     // Root chunks are all alone in the world.

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,7 @@ bool RootChunkArea::is_free() const {
   }
 
 void RootChunkArea::verify() const {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert_is_aligned(_base, chunklevel::MAX_CHUNK_BYTE_SIZE);
 
   // Iterate thru all chunks in this area. They must be ordered correctly,
@@ -415,7 +415,7 @@ void RootChunkArea::verify() const {
 }
 
 void RootChunkArea::verify_area_is_ideally_merged() const {
-  SOMETIMES(assert_lock_strong(MetaspaceExpand_lock);)
+  SOMETIMES(assert_lock_strong(Metaspace_lock);)
   int num_chunk = 0;
   for (const Metachunk* c = _first_chunk; c != NULL; c = c->next_in_vs()) {
     if (!c->is_root_chunk() && c->is_free()) {

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
 
 MetaspaceTestContext::~MetaspaceTestContext() {
   DEBUG_ONLY(verify();)
-  MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
   delete _context;
   if (_rs.is_reserved()) {
     _rs.release();

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ VirtualSpaceList::VirtualSpaceList(const char* name, ReservedSpace rs, CommitLim
 }
 
 VirtualSpaceList::~VirtualSpaceList() {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   // Note: normally, there is no reason ever to delete a vslist since they are
   // global objects, but for gtests it makes sense to allow this.
   VirtualSpaceNode* vsn = _first_node;
@@ -90,7 +90,7 @@ VirtualSpaceList::~VirtualSpaceList() {
 // List must be expandable for this to work.
 void VirtualSpaceList::create_new_node() {
   assert(_can_expand, "List is not expandable");
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   VirtualSpaceNode* vsn = VirtualSpaceNode::create_node(Settings::virtual_space_node_default_word_size(),
                                                         _commit_limiter,
@@ -105,7 +105,7 @@ void VirtualSpaceList::create_new_node() {
 // Hence, before using this chunk, it must be committed.
 // Also, no limits are checked, since no committing takes place.
 Metachunk*  VirtualSpaceList::allocate_root_chunk() {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   if (_first_node == NULL ||
       _first_node->free_words() < chunklevel::MAX_CHUNK_WORD_SIZE) {
@@ -138,7 +138,7 @@ Metachunk*  VirtualSpaceList::allocate_root_chunk() {
 // The free chunks are removed from the freelists before the nodes are deleted.
 // Return number of purged nodes.
 int VirtualSpaceList::purge(FreeChunkListVector* freelists) {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   UL(debug, "purging.");
 
   VirtualSpaceNode* vsn = _first_node;
@@ -173,7 +173,7 @@ int VirtualSpaceList::purge(FreeChunkListVector* freelists) {
 
 // Print all nodes in this space list.
 void VirtualSpaceList::print_on(outputStream* st) const {
-  MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
 
   st->print_cr("vsl %s:", _name);
   const VirtualSpaceNode* vsn = _first_node;
@@ -190,7 +190,7 @@ void VirtualSpaceList::print_on(outputStream* st) const {
 
 #ifdef ASSERT
 void VirtualSpaceList::verify_locked() const {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert(_name != NULL, "Sanity");
 
   int n = 0;
@@ -216,7 +216,7 @@ void VirtualSpaceList::verify_locked() const {
 }
 
 void VirtualSpaceList::verify() const {
-  MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
   verify_locked();
 }
 #endif

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ void check_word_size_is_aligned_to_commit_granule(size_t word_size) {
 bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   DEBUG_ONLY(check_pointer_is_aligned_to_commit_granule(p);)
   DEBUG_ONLY(check_word_size_is_aligned_to_commit_granule(word_size);)
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   // First calculate how large the committed regions in this range are
   const size_t committed_words_in_range = _commit_mask.get_committed_size_in_range(p, word_size);
@@ -157,7 +157,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
 //
 // Returns true if success, false if it did hit a commit limit.
 bool VirtualSpaceNode::ensure_range_is_committed(MetaWord* p, size_t word_size) {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert(p != NULL && word_size > 0, "Sanity");
   MetaWord* p_start = align_down(p, Settings::commit_granule_bytes());
   MetaWord* p_end = align_up(p + word_size, Settings::commit_granule_bytes());
@@ -170,7 +170,7 @@ bool VirtualSpaceNode::ensure_range_is_committed(MetaWord* p, size_t word_size) 
 void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   DEBUG_ONLY(check_pointer_is_aligned_to_commit_granule(p);)
   DEBUG_ONLY(check_word_size_is_aligned_to_commit_granule(word_size);)
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   // First calculate how large the committed regions in this range are
   const size_t committed_words_in_range = _commit_mask.get_committed_size_in_range(p, word_size);
@@ -291,7 +291,7 @@ VirtualSpaceNode::~VirtualSpaceNode() {
 // Note that this just returns reserved memory; caller must take care of committing this
 //  chunk before using it.
 Metachunk* VirtualSpaceNode::allocate_root_chunk() {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert_is_aligned(free_words(), chunklevel::MAX_CHUNK_WORD_SIZE);
 
   if (free_words() >= chunklevel::MAX_CHUNK_WORD_SIZE) {
@@ -318,7 +318,7 @@ Metachunk* VirtualSpaceNode::allocate_root_chunk() {
 // The resulting target chunk resides at the same address as the original chunk.
 // The resulting splinters are added to freelists.
 void VirtualSpaceNode::split(chunklevel_t target_level, Metachunk* c, FreeChunkListVector* freelists) {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   // Get the area associated with this chunk and let it handle the splitting
   RootChunkArea* rca = _root_chunk_area_lut.get_area_by_address(c->base());
   DEBUG_ONLY(rca->verify_area_is_ideally_merged();)
@@ -336,7 +336,7 @@ void VirtualSpaceNode::split(chunklevel_t target_level, Metachunk* c, FreeChunkL
 // original chunk will be invalid and should not be accessed anymore! !!!
 Metachunk* VirtualSpaceNode::merge(Metachunk* c, FreeChunkListVector* freelists) {
   assert(c != NULL && c->is_free(), "Sanity");
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   // Get the rca associated with this chunk and let it handle the merging
   RootChunkArea* rca = _root_chunk_area_lut.get_area_by_address(c->base());
@@ -356,7 +356,7 @@ Metachunk* VirtualSpaceNode::merge(Metachunk* c, FreeChunkListVector* freelists)
 // On success, true is returned, false otherwise.
 bool VirtualSpaceNode::attempt_enlarge_chunk(Metachunk* c, FreeChunkListVector* freelists) {
   assert(c != NULL && c->is_in_use() && !c->is_root_chunk(), "Sanity");
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   // Get the rca associated with this chunk and let it handle the merging
   RootChunkArea* rca = _root_chunk_area_lut.get_area_by_address(c->base());
@@ -378,7 +378,7 @@ bool VirtualSpaceNode::attempt_enlarge_chunk(Metachunk* c, FreeChunkListVector* 
 // Returns true if the node has been deleted, false if not.
 // !! If this returns true, do not access the node from this point on. !!
 bool VirtualSpaceNode::attempt_purge(FreeChunkListVector* freelists) {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
 
   if (!_owns_rs) {
     // We do not allow purging of nodes if we do not own the
@@ -436,7 +436,7 @@ size_t VirtualSpaceNode::committed_words() const {
 
 #ifdef ASSERT
 void VirtualSpaceNode::verify() const {
-  MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
   verify_locked();
 }
 
@@ -444,7 +444,7 @@ volatile int test_access = 0;
 
 // Verify counters and basic structure. Slow mode: verify all chunks in depth
 void VirtualSpaceNode::verify_locked() const {
-  assert_lock_strong(MetaspaceExpand_lock);
+  assert_lock_strong(Metaspace_lock);
   assert(base() != NULL, "Invalid base");
   assert(base() == (MetaWord*)_rs.base() &&
          word_size() == _rs.size() / BytesPerWord,

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -139,7 +139,7 @@ Mutex*   UnsafeJlong_lock             = NULL;
 #endif
 Mutex*   CodeHeapStateAnalytics_lock  = NULL;
 
-Mutex*   MetaspaceExpand_lock         = NULL;
+Mutex*   Metaspace_lock               = NULL;
 Mutex*   ClassLoaderDataGraph_lock    = NULL;
 Monitor* ThreadsSMRDelete_lock        = NULL;
 Mutex*   ThreadIdTableCreate_lock     = NULL;
@@ -244,7 +244,7 @@ void mutex_init() {
   def(RawMonitor_lock              , PaddedMutex  , special,     true,  _safepoint_check_never);
   def(OopMapCacheAlloc_lock        , PaddedMutex  , leaf,        true,  _safepoint_check_always); // used for oop_map_cache allocation.
 
-  def(MetaspaceExpand_lock         , PaddedMutex  , leaf-1,      true,  _safepoint_check_never);
+  def(Metaspace_lock               , PaddedMutex  , leaf-1,      true,  _safepoint_check_never);
   def(ClassLoaderDataGraph_lock    , PaddedMutex  , nonleaf,     false, _safepoint_check_always);
 
   def(Patching_lock                , PaddedMutex  , special,     true,  _safepoint_check_never);      // used for safepointing and code patching.

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -147,7 +147,7 @@ extern Monitor* JfrThreadSampler_lock;           // used to suspend/resume JFR t
 extern Mutex*   UnsafeJlong_lock;                // provides Unsafe atomic updates to jlongs on platforms that don't support cx8
 #endif
 
-extern Mutex*   MetaspaceExpand_lock;            // protects Metaspace virtualspace and chunk expansions
+extern Mutex*   Metaspace_lock;            // protects Metaspace virtualspace and chunk expansions
 extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed for concurrent unloading
 
 

--- a/test/hotspot/gtest/metaspace/test_metachunk.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunk.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ TEST_VM(metaspace, chunk_buddy_stuff) {
     // buddies are adjacent in memory
     // (next/prev_in_vs needs lock)
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       EXPECT_EQ(c1->next_in_vs(), c2);
       EXPECT_EQ(c1->end(), c2->base());
       EXPECT_NULL(c1->prev_in_vs()); // since we know this is the first in the area
@@ -316,7 +316,7 @@ TEST_VM(metaspace, chunk_split_and_merge) {
       // Splitting/Merging chunks is usually done by the chunkmanager, and no explicit
       // outside API exists. So we split/merge chunks via the underlying vs node, directly.
       // This means that we have to go through some extra hoops to not trigger any asserts.
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       c->reset_used_words();
       c->set_free();
       c->vsnode()->split(target_lvl, c, &splinters);
@@ -350,7 +350,7 @@ TEST_VM(metaspace, chunk_split_and_merge) {
     // Revert the split by using merge. This should result in all splinters coalescing
     // to one chunk.
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       Metachunk* merged = c->vsnode()->merge(c, &splinters);
 
       // the merged chunk should occupy the same address as the splinter

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ class VirtualSpaceNodeTest {
 
   void lock_and_verify_node() {
 #ifdef ASSERT
-    MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
     _node->verify_locked();
 #endif
   }
@@ -92,7 +92,7 @@ class VirtualSpaceNodeTest {
     const bool node_is_full = _node->used_words() == _node->word_size();
     Metachunk* c = NULL;
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       c = _node->allocate_root_chunk();
     }
 
@@ -218,7 +218,7 @@ class VirtualSpaceNodeTest {
 
     // Split...
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       _node->split(target_level, c, freelist);
     }
 
@@ -259,7 +259,7 @@ class VirtualSpaceNodeTest {
 
     Metachunk* result = NULL;
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       result = _node->merge(c, freelist);
     }
     EXPECT_NOT_NULL(result);
@@ -297,7 +297,7 @@ public:
     _commit_limit(commit_limit)
   {
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       _node = VirtualSpaceNode::create_node(vs_word_size, &_commit_limiter,
                                             &_counter_reserved_words, &_counter_committed_words);
       EXPECT_EQ(_node->word_size(), vs_word_size);
@@ -308,7 +308,7 @@ public:
 
   ~VirtualSpaceNodeTest() {
     {
-      MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       delete _node;
     }
     // After the node is deleted, counters should be back to zero
@@ -373,7 +373,7 @@ public:
 
         bool rc = false;
         {
-          MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+          MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
           rc = _node->ensure_range_is_committed(c->base() + r.start(), r.size());
         }
 
@@ -390,7 +390,7 @@ public:
         //LOG("u " SIZE_FORMAT "," SIZE_FORMAT, r.start(), r.end());
 
         {
-          MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+          MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
           _node->uncommit_range(c->base() + r.start(), r.size());
         }
 
@@ -491,7 +491,7 @@ public:
 
 TEST_VM(metaspace, virtual_space_node_test_basics) {
 
-  MutexLocker fcl(MetaspaceExpand_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
 
   const size_t word_size = metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 10;
 


### PR DESCRIPTION
Hi, may I have reviews please for this trivial change:

MetaspaceExpand_lock is a potentially confusing misnomer for the casual code reader, since it does not only guard metaspace expansion but guards access to all central metaspace structures for expansion, reclamation, access to freelist etc. 

With this patch it is renamed to the more generic "Metaspace_lock".

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260625](https://bugs.openjdk.java.net/browse/JDK-8260625): Rename MetaspaceExpand_lock


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2308/head:pull/2308`
`$ git checkout pull/2308`
