### PR TITLE
8260566: Pattern type X is a subtype of expression type Y message is incorrect

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3956,7 +3956,7 @@ public class Attr extends JCTree.Visitor {
             clazztype = tree.pattern.type;
             if (types.isSubtype(exprtype, clazztype) &&
                 !exprtype.isErroneous() && !clazztype.isErroneous()) {
-                log.error(tree.pos(), Errors.InstanceofPatternNoSubtype(clazztype, exprtype));
+                log.error(tree.pos(), Errors.InstanceofPatternNoSubtype(exprtype, clazztype));
             }
             JCBindingPattern pattern = (JCBindingPattern) tree.pattern;
             typeTree = pattern.var.vartype;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1413,7 +1413,7 @@ compiler.err.instanceof.reifiable.not.safe=\
 
 # 0: type, 1: type
 compiler.err.instanceof.pattern.no.subtype=\
-    pattern type {0} is a subtype of expression type {1}
+    expression type {0} is a subtype of pattern type {1}
 
 # 0: symbol
 compiler.misc.varargs.trustme.on.non.varargs.meth=\

--- a/test/langtools/tools/javac/patterns/NoSubtypeCheck.out
+++ b/test/langtools/tools/javac/patterns/NoSubtypeCheck.out
@@ -1,5 +1,5 @@
 NoSubtypeCheck.java:10:24: compiler.err.instanceof.pattern.no.subtype: java.lang.Object, java.lang.Object
-NoSubtypeCheck.java:12:24: compiler.err.instanceof.pattern.no.subtype: java.lang.Object, java.lang.String
+NoSubtypeCheck.java:12:24: compiler.err.instanceof.pattern.no.subtype: java.lang.String, java.lang.Object
 NoSubtypeCheck.java:13:24: compiler.err.instanceof.pattern.no.subtype: java.lang.String, java.lang.String
 NoSubtypeCheck.java:14:24: compiler.err.instanceof.pattern.no.subtype: NoSubtypeCheck.List<java.lang.String>, NoSubtypeCheck.List<java.lang.String>
 NoSubtypeCheck.java:16:22: compiler.err.cant.resolve.location: kindname.variable, undef, , , (compiler.misc.location: kindname.class, NoSubtypeCheck, null)

--- a/test/langtools/tools/javac/patterns/NullsInPatterns.out
+++ b/test/langtools/tools/javac/patterns/NullsInPatterns.out
@@ -1,3 +1,3 @@
-NullsInPatterns.java:12:18: compiler.err.instanceof.pattern.no.subtype: java.util.List, compiler.misc.type.null
-NullsInPatterns.java:23:18: compiler.err.instanceof.pattern.no.subtype: java.util.List<?>, compiler.misc.type.null
+NullsInPatterns.java:12:18: compiler.err.instanceof.pattern.no.subtype: compiler.misc.type.null, java.util.List
+NullsInPatterns.java:23:18: compiler.err.instanceof.pattern.no.subtype: compiler.misc.type.null, java.util.List<?>
 2 errors


### PR DESCRIPTION
Hi all,

The order of the arguments is wrong when using method `Errors.InstanceofPatternNoSubtype`.

This patch fixes it and revises the corresponding tests.
Thank you for taking the time to review.
And it may be good to fix JDK16 as well.

Best Regards.
-- xiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260566](https://bugs.openjdk.java.net/browse/JDK-8260566): Pattern type X is a subtype of expression type Y message is incorrect


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Tagir F. Valeev](https://openjdk.java.net/census#tvaleev) (@amaembo - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2311/head:pull/2311`
`$ git checkout pull/2311`
