### PR TITLE
8260462: Missing <thead> in Modality.html

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -208,14 +208,14 @@
 
           <table class="striped">
 	        <caption>The Standard Blocking Matrix</caption>
-            <tbody><tr>
+            <thead><tr>
               <th scope="col">current/shown</th>
               <th scope="col">frame &amp; modeless</th>
               <th scope="col">document</th>
               <th scope="col">application</th>
               <th scope="col">toolkit</th>
-            </tr>
-            <tr>
+            </tr></thead>
+            <tbody><tr>
               <th scope="row">-</th>
               <td>-</td>
               <td>-</td>


### PR DESCRIPTION
The first row in The Standard Blocking Matrix table in The AWT Modality (`Modality.html`) is a header row and it should be inside `<thead>` element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260462](https://bugs.openjdk.java.net/browse/JDK-8260462): Missing <thead> in Modality.html


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2314/head:pull/2314`
`$ git checkout pull/2314`
