### PR TITLE
8260420: C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1430,6 +1430,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
         // control, then the cloning of n is a pointless exercise, because
         // GVN will ensure that we end up where we started.
         if (!n->is_Load() || late_load_ctrl != n_ctrl) {
+          Node* outer_loop_clone = NULL;
           for (DUIterator_Last jmin, j = n->last_outs(jmin); j >= jmin; ) {
             Node *u = n->last_out(j); // Clone private computation per use
             _igvn.rehash_node_delayed(u);
@@ -1467,7 +1468,9 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
               //
               // Because we are setting the actual control input, factor in
               // the result from get_late_ctrl() so we respect any
-              // anti-dependences. (6233005).
+              // anti-dependences. (6233005). Re-compute late ctrl now that
+              // the load has been cloned and is less restricted by its users.
+              late_load_ctrl = get_late_ctrl(x, n_ctrl);
               x_ctrl = dom_lca(late_load_ctrl, x_ctrl);
 
               // Don't allow the control input to be a CFG splitting node.
@@ -1477,16 +1480,25 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
 
               IdealLoopTree* x_loop = get_loop(x_ctrl);
               Node* x_head = x_loop->_head;
-              if (x_head->is_Loop() && (x_head->is_OuterStripMinedLoop() || x_head->as_Loop()->is_strip_mined()) && is_dominator(n_ctrl, x_head)) {
-                // Anti dependence analysis is sometimes too
-                // conservative: a store in the outer strip mined loop
-                // can prevent a load from floating out of the outer
-                // strip mined loop but the load may not be referenced
-                // from the safepoint: loop strip mining verification
-                // code reports a problem in that case. Make sure the
-                // load is not moved in the outer strip mined loop in
-                // that case.
-                x_ctrl = x_head->as_Loop()->skip_strip_mined()->in(LoopNode::EntryControl);
+              if (x_head->is_Loop() && (x_head->is_OuterStripMinedLoop() || x_head->as_Loop()->is_strip_mined())) {
+                if (is_dominator(n_ctrl, x_head)) {
+                  // Anti dependence analysis is sometimes too
+                  // conservative: a store in the outer strip mined loop
+                  // can prevent a load from floating out of the outer
+                  // strip mined loop but the load may not be referenced
+                  // from the safepoint: loop strip mining verification
+                  // code reports a problem in that case. Make sure the
+                  // load is not moved in the outer strip mined loop in
+                  // that case.
+                  x_ctrl = x_head->as_Loop()->skip_strip_mined()->in(LoopNode::EntryControl);
+                } else if (x_head->is_OuterStripMinedLoop()) {
+                  // Do not add duplicate LoadNodes to the outer strip mined loop
+                  if (outer_loop_clone != NULL) {
+                    _igvn.replace_node(x, outer_loop_clone);
+                    continue;
+                  }
+                  outer_loop_clone = x;
+                }
               }
               assert(dom_depth(n_ctrl) <= dom_depth(x_ctrl), "n is later than its clone");
 
@@ -1503,8 +1515,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
             // to fold a StoreP and an AddP together (as part of an
             // address expression) and the AddP and StoreP have
             // different controls.
-            BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-            if (!x->is_Load() && !x->is_DecodeNarrowPtr() && !x->is_AddP() && !bs->is_gc_barrier_node(x)) {
+            if (!x->is_Load() && !x->is_DecodeNarrowPtr()) {
               _igvn._worklist.yank(x);
             }
           }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1468,9 +1468,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
               //
               // Because we are setting the actual control input, factor in
               // the result from get_late_ctrl() so we respect any
-              // anti-dependences. (6233005). Re-compute late ctrl now that
-              // the load has been cloned and is less restricted by its users.
-              late_load_ctrl = get_late_ctrl(x, n_ctrl);
+              // anti-dependences. (6233005).
               x_ctrl = dom_lca(late_load_ctrl, x_ctrl);
 
               // Don't allow the control input to be a CFG splitting node.


### PR DESCRIPTION
Loop strip mining verification fails because a `LoadNode` with no safepoint use ends up in the `OuterStripMinedLoop`. The root cause is very similar to [JDK-8249607](https://bugs.openjdk.java.net/browse/JDK-8249607): A `LoadNode` with two uses (a field store and a return, see `test2`) is cloned by `PhaseIdealLoop::split_if_with_blocks_post()` for each use, to allow it to flow out of the loop. Both clones end up in the `OuterStripMinedLoop`, the clone for the field store because the store has a safepoint use and the clone for the return because `late_load_ctrl` is too conservative by taking all initial uses into account.

Now the load without a safepoint use is always detected by loop strip mining verification but without verification (for example, in a product build), we still hit several different issues depending on the exact use of the load (compare `test2/3/4`). The main issue is that loads without a safepoint use are not correctly wired when creating pre/main/post loops. Christian described this well in his RFR for [JDK-8249607](https://bugs.openjdk.java.net/browse/JDK-8249607): https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-August/039638.html

Therefore, relaxing loop strip mining verification is not an option.

The problem with the fix for [JDK-8249607](https://bugs.openjdk.java.net/browse/JDK-8249607) is that it relies on IGVN being executed before pre/main/post loops are created, merging the two clones such that the remaining one has a safepoint use and is therefore correctly handled. However, this is not guaranteed. In fact, if `major_progress` is not set, pre/main/post loops could be created in the same round of loop opts without IGVN in-between (`IdealLoopTree::iteration_split` is executed right after `PhaseIdealLoop::split_if_with_blocks`).

I think we have the following options:
1) Bail out if the loop is strip mined. I think that would be too conservative.

2) Simply set `major_progress` when pinning a `LoadNode` to the `OuterStripMinedLoop` to make sure IGVN is executed and duplicate `LoadNodes` are merged. That seems quite invasive though.

3) Allow the cloned load without a safepoint use (and therefore no usages in the `OuterStripMinedLoop`) to completely flow out of the loop. Currently, this is blocked by `late_load_ctrl` being computed on the initial `LoadNode` instead of the clone and therefore also taking into account the store that is referenced by the safepoint. We could simply re-compute the late ctrl for the cloned load, allowing it to flow out of the `OuterStripMinedLoop`. However, that only works if there is no anti-dependency in the `OuterStripMinedLoop`.

4) Detect duplicate loads in the `OuterStripMinedLoop` on creation in `PhaseIdealLoop::split_if_with_blocks` and merge them right away.

I've decided to go with 4) and also reverted the fix for JDK-8249607 which is no longer required.

As Roland and Christian already noticed, there are various other issues with that code that hopefully will be addressed at some point by [JDK-8252372](https://bugs.openjdk.java.net/browse/JDK-8252372).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260420](https://bugs.openjdk.java.net/browse/JDK-8260420): C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2315/head:pull/2315`
`$ git checkout pull/2315`
