### PR TITLE
JDK-8260669: Missing quotes in fixpath.sh

### DIFF
--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -166,7 +166,7 @@ function import_path() {
           # unixpath is based on short name
         fi
         # Make it lower case
-        path="$(echo "$unixpath" | tr [:upper:] [:lower:])"
+        path="$(echo "$unixpath" | tr '[:upper:]' '[:lower:]')"
       fi
     else
       # On WSL1, PATHTOOL will fail for files in envroot. If the unix path


### PR DESCRIPTION
The build on Windows can fail if certain directory names are present in root directory of the workspace. In particular I've observed that the single letter 'p' is triggering this problem. This is caused by missing quotes around [:upper:] in a 'tr' call in fixpath.sh.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260669](https://bugs.openjdk.java.net/browse/JDK-8260669): Missing quotes in fixpath.sh


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2318/head:pull/2318`
`$ git checkout pull/2318`
