### PR TITLE
8260674: ProblemList jdk/incubator/vector/VectorHash.java in Xcomp configs

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,3 +29,4 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8256368 generic-all
+jdk/incubator/vector/VectorHash.java 8259430 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList jdk/incubator/vector/VectorHash.java in Xcomp configs.
I'm trying to reduce the noise in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260674](https://bugs.openjdk.java.net/browse/JDK-8260674): ProblemList jdk/incubator/vector/VectorHash.java in Xcomp configs


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2321/head:pull/2321`
`$ git checkout pull/2321`
