### PR TITLE
8260401: StackOverflowError on open WindowsPreferences

### DIFF
--- a/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
+++ b/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,7 +432,7 @@ class WindowsPreferences extends AbstractPreferences {
         if (result[ERROR_CODE] != ERROR_SUCCESS) {
             logger().warning("Could not create windows registry node " +
                     byteArrayToString(windowsAbsolutePath()) +
-                    " at root 0x" + Long.toHexString(rootNativeHandle()) +
+                    " at root 0x" + Long.toHexString(parentNativeHandle) +
                     ". Windows RegCreateKeyEx(...) returned error code " +
                     result[ERROR_CODE] + ".");
             isBackingStoreAvailable = false;
@@ -458,7 +458,7 @@ class WindowsPreferences extends AbstractPreferences {
         if (result[ERROR_CODE] != ERROR_SUCCESS) {
             logger().warning("Could not open/create prefs root node " +
                     byteArrayToString(windowsAbsolutePath()) +
-                    " at root 0x" + Long.toHexString(rootNativeHandle()) +
+                    " at root 0x" + Long.toHexString(rootNativeHandle) +
                     ". Windows RegCreateKeyEx(...) returned error code " +
                     result[ERROR_CODE] + ".");
             isBackingStoreAvailable = false;


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue reported in https://bugs.openjdk.java.net/browse/JDK-8260401?

As noted in that issue, when the constructor of `java.util.prefs.WindowsPreferences` runs into an error while dealing with the Windows registry, it logs a warning message. The message construction calls `rootNativeHandle()` (on the same instance of `WindowsPreferences` that's being constructed) which then ultimately ends up calling the constructor of `WindowsPreferences` which then again runs into the Windows registry error and attempts to log a message and this whole cycle repeats indefinitely leading to that `StackOverFlowError`. 

Based on my limited knowledge of the code in that constructor and analyzing that code a bit, it's my understanding (and also the input provided by the reporter of the bug) that the log message should actually be using the `rootNativeHandle` parameter that is passed to this constructor instead of invoking the `rootNativeHandle()` method. The commit in this PR does this change to use the passed `rootNativeHandle` in the log message.

Furthermore, there's another constructor in this class which does a similar thing and potentially can run into the same error as this one. I've changed that constructor too, to avoid the call to `rootNativeHandle()` method in that log message. Reading the log message that's being generated there, it's my understanding that this change shouldn't cause any inaccuracy in what's being logged and in fact, I think it's now more precise about which handle returned the error code.

Finally, this log message creation, in both the constructors, also calls `windowsAbsolutePath()` and `byteArrayToString()` methods. The `byteArrayToString()` is a static method and a call to it doesn't lead back to the constructor again. The `windowsAbsolutePath()` is a instance method and although it does use a instance variable `absolutePath`, that instance variable is already initialized appropriately by the time this `windowsAbsolutePath()` gets called in the log message. Also, the `windowsAbsolutePath()` call doesn't lead back to the constructor of the `WindowsPreferences` so it doesn't pose the same issue as a call to `rootNativeHandle()`.

Given the nature of this issue, I haven't added any jtreg test for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260401](https://bugs.openjdk.java.net/browse/JDK-8260401): StackOverflowError on open WindowsPreferences


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2326/head:pull/2326`
`$ git checkout pull/2326`
