### PR TITLE
8260685: ProblemList 2 compiler/jvmci/compilerToVM tests in Xcomp configs

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -28,3 +28,5 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
+compiler/jvmci/compilerToVM/IsMatureTest.java 8219555 generic-all
+compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java 8219555 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList two tests in Xcomp configs:

compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java
compiler/jvmci/compilerToVM/IsMatureTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260685](https://bugs.openjdk.java.net/browse/JDK-8260685): ProblemList 2 compiler/jvmci/compilerToVM tests in Xcomp configs


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2327/head:pull/2327`
`$ git checkout pull/2327`
