### PR TITLE
JDK-8260694: (fc) Clarify FileChannel.transferFrom to better describe "no bytes available" case

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -642,8 +642,8 @@ public abstract class FileChannel
      * number of bytes will be transferred if the source channel has fewer than
      * {@code count} bytes remaining, or if the source channel is non-blocking
      * and has fewer than {@code count} bytes immediately available in its
-     * input buffer. No bytes are transferred if the source channel has reached
-     * the end-of-stream in which case zero will be returned.
+     * input buffer. No bytes are transferred, and zero is returned, if the
+     * source has reached end-of-stream.
      *
      * <p> This method does not modify this channel's position.  If the given
      * position is greater than the file's current size then no bytes are

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -588,10 +588,6 @@ public abstract class FileChannel
      * operating systems can transfer bytes directly from the filesystem cache
      * to the target channel without actually copying them.  </p>
      *
-     * @apiNote
-     * This method only returns the number of bytes that were actually
-     * transferred, it will not return -1.
-     *
      * @param  position
      *         The position within the file at which the transfer is to begin;
      *         must be non-negative
@@ -646,7 +642,8 @@ public abstract class FileChannel
      * number of bytes will be transferred if the source channel has fewer than
      * {@code count} bytes remaining, or if the source channel is non-blocking
      * and has fewer than {@code count} bytes immediately available in its
-     * input buffer.
+     * input buffer. No bytes are transferred if the source channel has reached
+     * end-of-stream.
      *
      * <p> This method does not modify this channel's position.  If the given
      * position is greater than the file's current size then no bytes are
@@ -661,7 +658,7 @@ public abstract class FileChannel
      *
      * @apiNote
      * This method only returns the number of bytes that were actually
-     * transferred, it will not return -1, e.g. in case of EOF of the
+     * transferred, it will not return -1, e.g. in case of end-of-stream of the
      * {@code src} parameter.
      *
      * @param  src

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -643,7 +643,7 @@ public abstract class FileChannel
      * {@code count} bytes remaining, or if the source channel is non-blocking
      * and has fewer than {@code count} bytes immediately available in its
      * input buffer. No bytes are transferred if the source channel has reached
-     * end-of-stream.
+     * the end-of-stream in which case zero will be returned.
      *
      * <p> This method does not modify this channel's position.  If the given
      * position is greater than the file's current size then no bytes are
@@ -655,11 +655,6 @@ public abstract class FileChannel
      * that reads from the source channel and writes to this channel.  Many
      * operating systems can transfer bytes directly from the source channel
      * into the filesystem cache without actually copying them.  </p>
-     *
-     * @apiNote
-     * This method only returns the number of bytes that were actually
-     * transferred, it will not return -1, e.g. in case of end-of-stream of the
-     * {@code src} parameter.
      *
      * @param  src
      *         The source channel

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -588,6 +588,10 @@ public abstract class FileChannel
      * operating systems can transfer bytes directly from the filesystem cache
      * to the target channel without actually copying them.  </p>
      *
+     * @apiNote
+     * This method only returns the number of bytes that were actually
+     * transferred, it will not return -1.
+     *
      * @param  position
      *         The position within the file at which the transfer is to begin;
      *         must be non-negative
@@ -654,6 +658,11 @@ public abstract class FileChannel
      * that reads from the source channel and writes to this channel.  Many
      * operating systems can transfer bytes directly from the source channel
      * into the filesystem cache without actually copying them.  </p>
+     *
+     * @apiNote
+     * This method only returns the number of bytes that were actually
+     * transferred, it will not return -1, e.g. in case of EOF of the
+     * {@code src} parameter.
      *
      * @param  src
      *         The source channel


### PR DESCRIPTION
We'd better put more detailed messages in FileChannel.transferFrom/transferTo that it will not return -1, as we met several cases where developers of framework/program assume that it will return -1 on some error conditions, e.g. EOF of src Channel of transferFrom.

please check more details in JDK-8260486, and discussion in https://mail.openjdk.java.net/pipermail/nio-dev/2021-January/008094.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260694](https://bugs.openjdk.java.net/browse/JDK-8260694): (fc) Clarify FileChannel.transferFrom to better describe "no bytes available" case


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2329/head:pull/2329`
`$ git checkout pull/2329`
