### PR TITLE
JDK-8260707: java/lang/instrument/PremainClass/InheritAgent0100.java times out

### DIFF
--- a/test/jdk/java/lang/instrument/NegativeAgentRunner.java
+++ b/test/jdk/java/lang/instrument/NegativeAgentRunner.java
@@ -36,7 +36,7 @@ public class NegativeAgentRunner {
         String agentClassName = argv[0];
         String excepClassName = argv[1];
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                "-javaagent:" + agentClassName + ".jar",
+                "-javaagent:" + agentClassName + ".jar", "-Xmx128m", "-XX:-CreateCoredumpOnCrash",
                 agentClassName);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain(excepClassName);

--- a/test/jdk/java/lang/instrument/PremainClass/NoPremainAgent.java
+++ b/test/jdk/java/lang/instrument/PremainClass/NoPremainAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @build jdk.java.lang.instrument.PremainClass.NoPremainAgent
  * @run driver jdk.test.lib.util.JavaAgentBuilder
  *             NoPremainAgent NoPremainAgent.jar
- * @run main/othervm -XX:-CreateCoredumpOnCrash jdk.java.lang.instrument.NegativeAgentRunner NoPremainAgent NoSuchMethodException
+ * @run main/othervm jdk.java.lang.instrument.NegativeAgentRunner NoPremainAgent NoSuchMethodException
  */
 
 public class NoPremainAgent {

--- a/test/jdk/java/lang/instrument/PremainClass/ZeroArgPremainAgent.java
+++ b/test/jdk/java/lang/instrument/PremainClass/ZeroArgPremainAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @build jdk.java.lang.instrument.PremainClass.ZeroArgPremainAgent
  * @run driver jdk.test.lib.util.JavaAgentBuilder
  *             ZeroArgPremainAgent ZeroArgPremainAgent.jar
- * @run main/othervm -XX:-CreateCoredumpOnCrash jdk.java.lang.instrument.NegativeAgentRunner ZeroArgPremainAgent NoSuchMethodException
+ * @run main/othervm jdk.java.lang.instrument.NegativeAgentRunner ZeroArgPremainAgent NoSuchMethodException
  */
 
 public class ZeroArgPremainAgent {


### PR DESCRIPTION
Hi,

may I please have reviews for this trivial fix.

We see timeouts with this test on slow large (memory wise) AIX machines, as well as large core files.

This test is a negative test which tests that the VM corectly recognizes an error condition and aborts. Code goes through jni_FatalError()->os::abort(), writes a core and aborts the process.

No parameters are given for that VM invocation, so heap size depends on machine size. On my Linux box, the generated core takes about 500m. On AIX we see cores of 16G and more.

The difference between AIX and other platforms is that AIX does not have the notion of "committing" memory (we have no MAP_NORESERVE flag), so all mmapped memory counts toward the commit charge from the moment it is mapped. That makes core files on AIX annoyingly large. I'd expect a similar behavior on other platforms with overcommit disabled.

The fix is to run the test without CreateCoredumpOnCrash. For good measure, I also reduced the heap size to 128m.

Thanks to @ArnoZeller for figuring that one out.

/contributor add @ArnoZeller

-----
Tests: manual jtreg tests, verifying that no cores are written.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260707](https://bugs.openjdk.java.net/browse/JDK-8260707): java/lang/instrument/PremainClass/InheritAgent0100.java times out


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 746972071bd7fab1359e670c0c60be54268250e9
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Contributors
 * Arno Zeller `<azeller@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2332/head:pull/2332`
`$ git checkout pull/2332`
