### PR TITLE
8260643: Remove parallel version handling in CardTableRS::younger_refs_in_space_iterate()

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -98,5 +98,5 @@ void SerialHeap::young_process_roots(OopIterateClosure* root_closure,
                 cld_closure, cld_closure, &mark_code_closure);
 
   rem_set()->at_younger_refs_iterate();
-  old_gen()->younger_refs_iterate(old_gen_closure, 0);
+  old_gen()->younger_refs_iterate(old_gen_closure);
 }

--- a/src/hotspot/share/gc/shared/cardGeneration.cpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.cpp
@@ -307,7 +307,7 @@ void CardGeneration::space_iterate(SpaceClosure* blk,
   blk->do_space(space());
 }
 
-void CardGeneration::younger_refs_iterate(OopIterateClosure* blk, uint n_threads) {
+void CardGeneration::younger_refs_iterate(OopIterateClosure* blk) {
   // Apply "cl->do_oop" to (the address of) (exactly) all the ref fields in
   // "sp" that point into younger generations.
   // The iteration is only over objects allocated at the start of the
@@ -315,5 +315,5 @@ void CardGeneration::younger_refs_iterate(OopIterateClosure* blk, uint n_threads
   // not included.
 
   HeapWord* gen_boundary = reserved().start();
-  _rs->younger_refs_in_space_iterate(space(), gen_boundary, blk, n_threads);
+  _rs->younger_refs_in_space_iterate(space(), gen_boundary, blk);
 }

--- a/src/hotspot/share/gc/shared/cardGeneration.hpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.hpp
@@ -89,7 +89,7 @@ class CardGeneration: public Generation {
 
   void space_iterate(SpaceClosure* blk, bool usedOnly = false);
 
-  void younger_refs_iterate(OopIterateClosure* blk, uint n_threads);
+  void younger_refs_iterate(OopIterateClosure* blk);
 
   bool is_in(const void* p) const;
 

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -88,7 +88,7 @@ public:
   CardTableRS(MemRegion whole_heap, bool scanned_concurrently);
   ~CardTableRS();
 
-  void younger_refs_in_space_iterate(Space* sp, HeapWord* gen_boundary, OopIterateClosure* cl, uint n_threads);
+  void younger_refs_in_space_iterate(Space* sp, HeapWord* gen_boundary, OopIterateClosure* cl);
 
   virtual void verify_used_region_at_save_marks(Space* sp) const NOT_DEBUG_RETURN;
 
@@ -147,15 +147,11 @@ public:
   // Iterate over the portion of the card-table which covers the given
   // region mr in the given space and apply cl to any dirty sub-regions
   // of mr. Clears the dirty cards as they are processed.
-  void non_clean_card_iterate_possibly_parallel(Space* sp, HeapWord* gen_boundary,
-                                                MemRegion mr, OopIterateClosure* cl,
-                                                CardTableRS* ct, uint n_threads);
-
-  // Work method used to implement non_clean_card_iterate_possibly_parallel()
-  // above in the parallel case.
-  virtual void non_clean_card_iterate_parallel_work(Space* sp, MemRegion mr,
-                                                    OopIterateClosure* cl, CardTableRS* ct,
-                                                    uint n_threads);
+  void non_clean_card_iterate(Space* sp,
+                              HeapWord* gen_boundary,
+                              MemRegion mr,
+                              OopIterateClosure* cl,
+                              CardTableRS* ct);
 
   // This is an array, one element per covered region of the card table.
   // Each entry is itself an array, with one element per chunk in the
@@ -175,7 +171,6 @@ public:
 class ClearNoncleanCardWrapper: public MemRegionClosure {
   DirtyCardToOopClosure* _dirty_card_closure;
   CardTableRS* _ct;
-  bool _is_par;
 
 public:
 
@@ -191,7 +186,7 @@ private:
   bool is_word_aligned(CardValue* entry);
 
 public:
-  ClearNoncleanCardWrapper(DirtyCardToOopClosure* dirty_card_closure, CardTableRS* ct, bool is_par);
+  ClearNoncleanCardWrapper(DirtyCardToOopClosure* dirty_card_closure, CardTableRS* ct);
   void do_MemRegion(MemRegion mr);
 };
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -163,8 +163,7 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
 
 DirtyCardToOopClosure* Space::new_dcto_cl(OopIterateClosure* cl,
                                           CardTable::PrecisionStyle precision,
-                                          HeapWord* boundary,
-                                          bool parallel) {
+                                          HeapWord* boundary) {
   return new DirtyCardToOopClosure(this, cl, precision, boundary);
 }
 
@@ -243,8 +242,7 @@ ContiguousSpaceDCTOC__walk_mem_region_with_cl_DEFN(FilteringClosure)
 DirtyCardToOopClosure*
 ContiguousSpace::new_dcto_cl(OopIterateClosure* cl,
                              CardTable::PrecisionStyle precision,
-                             HeapWord* boundary,
-                             bool parallel) {
+                             HeapWord* boundary) {
   return new ContiguousSpaceDCTOC(this, cl, precision, boundary);
 }
 

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -173,8 +173,7 @@ class Space: public CHeapObj<mtGC> {
   // operate. ResourceArea allocated.
   virtual DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
                                              CardTable::PrecisionStyle precision,
-                                             HeapWord* boundary,
-                                             bool parallel);
+                                             HeapWord* boundary);
 
   // If "p" is in the space, returns the address of the start of the
   // "block" that contains "p".  We say "block" instead of "object" since
@@ -588,8 +587,7 @@ class ContiguousSpace: public CompactibleSpace {
   // Override.
   DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
                                      CardTable::PrecisionStyle precision,
-                                     HeapWord* boundary,
-                                     bool parallel);
+                                     HeapWord* boundary);
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
   // starting with the _saved_mark_word, which was noted during a generation's


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes parallel handling in `CardTableRS::younger_refs_in_space_iterate` as it is always called with n_threads <= 1, making the parallel code handling there obsolete. 

A larger cleanup of `CardTableRS` will follow in JDK-8234534.

Testing:
tier1,2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260643](https://bugs.openjdk.java.net/browse/JDK-8260643): Remove parallel version handling in CardTableRS::younger_refs_in_space_iterate()


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2333/head:pull/2333`
`$ git checkout pull/2333`
