### PR TITLE
8260718: Reconsider SymbolTable shared/dynamic switch optimization

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -307,8 +307,10 @@ Symbol* SymbolTable::lookup_common(const char* name,
   if (_lookup_shared_first) {
     sym = lookup_shared(name, len, hash);
     if (sym == NULL) {
-      _lookup_shared_first = false;
       sym = lookup_dynamic(name, len, hash);
+      if (sym != NULL) {
+        _lookup_shared_first = false;
+      }
     }
   } else {
     sym = lookup_dynamic(name, len, hash);


### PR DESCRIPTION
Look here:

```
Symbol* SymbolTable::lookup_common(const char* name,
                            int len, unsigned int hash) {
  Symbol* sym;
  if (_lookup_shared_first) {
    sym = lookup_shared(name, len, hash);
    if (sym == NULL) {
      _lookup_shared_first = false; // <--- switches here
      sym = lookup_dynamic(name, len, hash);
    }
  } else {
    sym = lookup_dynamic(name, len, hash);
    if (sym == NULL) {
      sym = lookup_shared(name, len, hash);
      if (sym != NULL) {
        _lookup_shared_first = true;
      }
    }
  }
  return sym;
}
```

It would seem that the switch to dynamic table is too eager: it switches to dynamic table even if the lookup from there would be `NULL`. Plus, the field is `static`, so it might contend when accessed from multiple threads (with enough motivation we can come up with a case where it completely trashes). Changing it to a more symmetric thing and providing hysteresis for switching seems to marginally improve the Hello World time.

```
 Performance counter stats for 'taskset -c 13 build/baseline/bin/java -Xms128m -Xmx128m -Xint Hello' (5000 runs):

             23.58 msec task-clock                #    0.938 CPUs utilized            ( +-  0.01% )
        86,746,905      cycles                    #    3.679 GHz                      ( +-  0.01% )
        79,974,251      instructions              #    0.92  insn per cycle           ( +-  0.00% )

        0.02513794 +- 0.00000309 seconds time elapsed  ( +-  0.01% )

 Performance counter stats for 'taskset -c 13 build/linux-x86_64-server-release/images/jdk/bin/java -Xms128m -Xmx128m -Xint Hello' (5000 runs):

             23.32 msec task-clock                #    0.939 CPUs utilized            ( +-  0.01% )
        86,083,668      cycles                    #    3.691 GHz                      ( +-  0.01% )
        80,200,509      instructions              #    0.93  insn per cycle           ( +-  0.00% )

        0.02482835 +- 0.00000282 seconds time elapsed  ( +-  0.01% )
```

It would be interesting to consider a more hysteresis-based approach for this switching.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260718](https://bugs.openjdk.java.net/browse/JDK-8260718): Reconsider SymbolTable shared/dynamic switch optimization


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2335/head:pull/2335`
`$ git checkout pull/2335`
