### PR TITLE
JDK-8222850: jshell tool: Misleading cascade compiler error in switch expression with undefined vars

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -736,7 +736,8 @@ public class Flow {
                 }
                 c.completesNormally = alive != Liveness.DEAD;
             }
-            if ((constants == null || !constants.isEmpty()) && !hasDefault) {
+            if ((constants == null || !constants.isEmpty()) && !hasDefault &&
+                !TreeInfo.isErrorEnumSwitch(tree.selector, tree.cases)) {
                 log.error(tree, Errors.NotExhaustive);
             }
             alive = prevAlive;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2629,6 +2629,15 @@ public class Resolve {
         }
     };
 
+    LogResolveHelper silentLogResolveHelper = new LogResolveHelper() {
+        public boolean resolveDiagnosticNeeded(Type site, List<Type> argtypes, List<Type> typeargtypes) {
+            return false;
+        }
+        public List<Type> getArgumentTypes(ResolveError errSym, Symbol accessedSym, Name name, List<Type> argtypes) {
+            return argtypes;
+        }
+    };
+
     LogResolveHelper methodLogResolveHelper = new LogResolveHelper() {
         public boolean resolveDiagnosticNeeded(Type site, List<Type> argtypes, List<Type> typeargtypes) {
             return !site.isErroneous() &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1324,4 +1324,9 @@ public class TreeInfo {
         return tree.sourcefile.isNameCompatible("package-info", JavaFileObject.Kind.SOURCE);
     }
 
+    public static boolean isErrorEnumSwitch(JCExpression selector, List<JCCase> cases) {
+        return selector.type.tsym.kind == Kinds.Kind.ERR &&
+               cases.stream().flatMap(c -> c.pats.stream())
+                             .allMatch(p -> p.hasTag(IDENT));
+    }
 }

--- a/test/langtools/tools/javac/recovery/SwitchUndefinedSelector.java
+++ b/test/langtools/tools/javac/recovery/SwitchUndefinedSelector.java
@@ -1,0 +1,26 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8222850
+ * @summary Check error recovery for switch over undefined variables.
+ * @compile/fail/ref=SwitchUndefinedSelector.out -XDrawDiagnostics --should-stop=at=FLOW SwitchUndefinedSelector.java
+ */
+
+public class SwitchUndefinedSelector {
+    private static final Object D = null;
+    public void switchTest() {
+        switch (undefined) {
+            case A -> {}
+            case B, C -> {}
+            case D -> {}
+        }
+        var v = switch (undefined) {
+            case A -> 0;
+            case B, C -> 0;
+            case D -> 0;
+        };
+        switch (undefined) {
+            case SwitchUndefinedSelector.D -> {}
+            case SwitchUndefinedSelector.UNDEF -> {}
+        }
+    }
+}

--- a/test/langtools/tools/javac/recovery/SwitchUndefinedSelector.out
+++ b/test/langtools/tools/javac/recovery/SwitchUndefinedSelector.out
@@ -1,0 +1,6 @@
+SwitchUndefinedSelector.java:11:17: compiler.err.cant.resolve.location: kindname.variable, undefined, , , (compiler.misc.location: kindname.class, SwitchUndefinedSelector, null)
+SwitchUndefinedSelector.java:16:25: compiler.err.cant.resolve.location: kindname.variable, undefined, , , (compiler.misc.location: kindname.class, SwitchUndefinedSelector, null)
+SwitchUndefinedSelector.java:21:17: compiler.err.cant.resolve.location: kindname.variable, undefined, , , (compiler.misc.location: kindname.class, SwitchUndefinedSelector, null)
+SwitchUndefinedSelector.java:22:41: compiler.err.string.const.req
+SwitchUndefinedSelector.java:23:41: compiler.err.cant.resolve.location: kindname.variable, UNDEF, , , (compiler.misc.location: kindname.class, SwitchUndefinedSelector, null)
+5 errors


### PR DESCRIPTION
Consider code like:
```
        switch (undefined) {
            case A -> {}
            case B, C -> {}
            case D -> {}
        }
```

javac will produce these errors for it:
```
$ javac Switch.java 
Switch.java:3: error: cannot find symbol
        switch (undefined) {
                ^
  symbol:   variable undefined
  location: class Switch
Switch.java:3: error: illegal parenthesized expression
        switch (undefined) {
               ^
Switch.java:4: error: cannot find symbol
            case A -> {}
                 ^
  symbol:   variable A
  location: class Switch
Switch.java:5: error: cannot find symbol
            case B, C -> {}
                 ^
  symbol:   variable B
  location: class Switch
Switch.java:5: error: cannot find symbol
            case B, C -> {}
                    ^
  symbol:   variable C
  location: class Switch
Switch.java:6: error: cannot find symbol
            case D -> {}
                 ^
  symbol:   variable D
  location: class Switch
6 errors
```

For jshell and switch expressions, there may be one more error reported at the end:
```
jshell> var v = switch (undefined) {case A -> 0;};
|  Error:
|  cannot find symbol
|    symbol:   variable undefined
|  var v = switch (undefined) {case A -> 0;};
|                  ^-------^
|  Error:
|  illegal parenthesized expression
|  var v = switch (undefined) {case A -> 0;};
|                 ^---------^
|  Error:
|  cannot find symbol
|    symbol:   variable A
|  var v = switch (undefined) {case A -> 0;};
|                                   ^
|  Error:
|  the switch expression does not cover all possible input values
|  var v = switch (undefined) {case A -> 0;};
|          ^-------------------------------^
```

We could prevent all the follow-up error reports, and keep only the first one, which is the real error in the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8222850](https://bugs.openjdk.java.net/browse/JDK-8222850): jshell tool: Misleading cascade compiler error in switch expression with undefined vars


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2336/head:pull/2336`
`$ git checkout pull/2336`
