### PR TITLE
8260719: Input method character moves with caret

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -4786,6 +4786,9 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
         AttributedCharacterIterator text = e.getText();
         int composedTextIndex;
 
+        boolean isCaretMoved = false;
+        int caretPositionToRestore = 0;
+
         // old composed text deletion
         Document doc = getDocument();
         if (composedTextExists()) {
@@ -4793,6 +4796,15 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                 doc.remove(composedTextStart.getOffset(),
                            composedTextEnd.getOffset() -
                            composedTextStart.getOffset());
+                isCaretMoved = caret.getDot() != composedTextStart.getOffset();
+                if (isCaretMoved) {
+                    caretPositionToRestore = caret.getDot();
+                    // if caret set furter in the doc, we should add commitCount
+                    if (caretPositionToRestore > composedTextStart.getOffset()) {
+                        caretPositionToRestore += commitCount;
+                    }
+                    caret.setDot(composedTextStart.getOffset());
+                }
             } catch (BadLocationException ble) {}
             composedTextStart = composedTextEnd = null;
             composedTextAttribute = null;
@@ -4867,6 +4879,10 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                 latestCommittedTextStart =
                     latestCommittedTextEnd = null;
             }
+        }
+
+        if (isCaretMoved) {
+            caret.setDot(caretPositionToRestore);
         }
     }
 


### PR DESCRIPTION
I've fixed annoying behaviour of input methods in text components. 
Code checks caret position before submitting composed text.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260719](https://bugs.openjdk.java.net/browse/JDK-8260719): Input method character moves with caret


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2337/head:pull/2337`
`$ git checkout pull/2337`
