### PR TITLE
8260860: ProblemList tools/jlink/plugins/CompressorPluginTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -776,6 +776,7 @@ sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 
 tools/jlink/JLinkReproducibleTest.java                          8217166 windows-all,linux-aarch64
 tools/jlink/JLinkReproducible3Test.java                         8253688 linux-aarch64
+tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to put tools/jlink/plugins/CompressorPluginTest.java back on the
ProblemList. It was removed in error (see the bug for the details).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260860](https://bugs.openjdk.java.net/browse/JDK-8260860): ProblemList tools/jlink/plugins/CompressorPluginTest.java


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2341/head:pull/2341`
`$ git checkout pull/2341`
