### PR TITLE
8260864: ProblemList two security/krb5 tests on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -698,6 +698,8 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
+sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java          8258855 linux-all
+sun/security/krb5/auto/ReplayCacheTestProc.java                 8258855 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList these two tests on Linux:

sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
sun/security/krb5/auto/ReplayCacheTestProc.java

We're rolling machines over to Linux 8.3 and these two tests are starting
to fail in the CI in Tier2 (so far). So we need to reduce the noise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260864](https://bugs.openjdk.java.net/browse/JDK-8260864): ProblemList two security/krb5 tests on Linux


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2342/head:pull/2342`
`$ git checkout pull/2342`
