### PR TITLE
8257497: Update keytool to create AKID from the SKID of the issuing certificate as specified by RFC 5280

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1481,7 +1481,7 @@ public final class Main {
         PublicKey issuerPubKey = signerCert.getPublicKey();
 
         KeyIdentifier signerSubjectKeyId;
-        if (subjectPubKey.equals(issuerPubKey)) {
+        if (Arrays.equals(subjectPubKey.getEncoded(), issuerPubKey.getEncoded())) {
             // No AKID for self-signed cert
             signerSubjectKeyId = null;
         } else {

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4265,6 +4265,26 @@ public final class Main {
             }
         }
         try {
+            // always non-critical
+            setExt(result, new SubjectKeyIdentifierExtension(
+                    new KeyIdentifier(pkey).getIdentifier()));
+            if (akey != null && !pkey.equals(akey)) {
+                if (aSubjectKeyIdExt == null) {
+                    setExt(result, new AuthorityKeyIdentifierExtension(
+                            new KeyIdentifier(akey), null, null));
+                } else {
+                    // To enforce compliance with RFC 5280 section 4.2.1.1: "Where a key
+                    // identifier has been previously established, the CA SHOULD use the
+                    // previously established identifier."
+                    // SubjectKeyIdentifierExtension in X509Certificate encapsulates its
+                    // value with two levels of OCTET_STRING wrapper.
+                    byte[] subjectKeyId1 = new DerValue(aSubjectKeyIdExt).getOctetString();
+                    byte[] subjectKeyId2 = new DerValue(subjectKeyId1).getOctetString();
+                    setExt(result, new AuthorityKeyIdentifierExtension(
+                            new KeyIdentifier(subjectKeyId2), null, null));
+                }
+            }
+
             // name{:critical}{=value}
             // Honoring requested extensions
             if (requestedEx != null) {
@@ -4585,25 +4605,6 @@ public final class Main {
                     default:
                         throw new Exception(rb.getString(
                                 "Unknown.extension.type.") + extstr);
-                }
-            }
-            // always non-critical
-            setExt(result, new SubjectKeyIdentifierExtension(
-                    new KeyIdentifier(pkey).getIdentifier()));
-            if (akey != null && !pkey.equals(akey)) {
-                if (aSubjectKeyIdExt == null) {
-                    setExt(result, new AuthorityKeyIdentifierExtension(
-                            new KeyIdentifier(akey), null, null));
-                } else {
-                    // To enforce compliance with RFC 5280 section 4.2.1.1: "Where a key
-                    // identifier has been previously established, the CA SHOULD use the
-                    // previously established identifier."
-                    // SubjectKeyIdentifierExtension in X509Certificate encapsulates its
-                    // value with two levels of OCTET_STRING wrapper.
-                    byte[] subjectKeyId1 = new DerValue(aSubjectKeyIdExt).getOctetString();
-                    byte[] subjectKeyId2 = new DerValue(subjectKeyId1).getOctetString();
-                    setExt(result, new AuthorityKeyIdentifierExtension(
-                            new KeyIdentifier(subjectKeyId2), null, null));
                 }
             }
         } catch(IOException e) {

--- a/test/jdk/sun/security/tools/keytool/CheckCertAKID.java
+++ b/test/jdk/sun/security/tools/keytool/CheckCertAKID.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257497
+ * @summary Check if issuer's SKID is used to establish the AKID for the subject cert
+ * @library /test/lib
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class CheckCertAKID {
+
+    static OutputAnalyzer kt(String cmd, String ks) throws Exception {
+        return SecurityTools.keytool("-storepass changeit " + cmd +
+                " -keystore " + ks);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("Generating a root cert with SubjectKeyIdentifier extension");
+        kt("-genkeypair -keyalg rsa -alias ca -dname CN=CA -ext bc:c " +
+                "-ext 2.5.29.14=04:14:00:01:02:03:04:05:06:07:08:09:10:11:12:13:14:15:16:17:18:19",
+                "ks");
+
+        kt("-exportcert -alias ca -rfc -file root.cert", "ks");
+
+        SecurityTools.keytool("-keystore ks -storepass changeit " +
+                "-printcert -file root.cert")
+                .shouldNotContain("AuthorityKeyIdentifier")
+                .shouldContain("SubjectKeyIdentifier")
+                .shouldContain("0000: 00 01 02 03 04 05 06 07   08 09 10 11 12 13 14 15")
+                .shouldContain("0010: 16 17 18 19")
+                .shouldHaveExitValue(0);
+
+        System.out.println("Generating an end entity cert using issuer CA's SKID as its AKID");
+        kt("-genkeypair -keyalg rsa -alias e1 -dname CN=E1", "ks");
+        kt("-certreq -alias e1 -file tmp.req", "ks");
+        kt("-gencert -alias ca -ext san=dns:e1 -infile tmp.req -outfile tmp.cert ",
+                "ks");
+
+        SecurityTools.keytool("-keystore ks -storepass changeit " +
+                "-printcert -file tmp.cert")
+                .shouldContain("AuthorityKeyIdentifier")
+                .shouldContain("0000: 00 01 02 03 04 05 06 07   08 09 10 11 12 13 14 15")
+                .shouldContain("0010: 16 17 18 19")
+                .shouldHaveExitValue(0);
+
+    }
+}

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -155,7 +155,6 @@ public class ExtOptionCamelCase {
                 CertificateExtensions.class,
                 List.class,
                 PublicKey.class,
-                PublicKey.class,
                 KeyIdentifier.class);
         createV3Extensions.setAccessible(true);
         ctor = Main.class.getDeclaredConstructor();
@@ -199,7 +198,7 @@ public class ExtOptionCamelCase {
         try {
             CertificateExtensions exts = (CertificateExtensions)
                     createV3Extensions.invoke(ctor.newInstance(),
-                            null, null, List.of(option), pk, null, null);
+                            null, null, List.of(option), pk, null);
 
             // ATTENTION: the extensions created above might contain raw
             // extensions (not of a subtype) and we need to store and reload

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -38,6 +38,7 @@ import sun.security.util.DerValue;
 import sun.security.x509.BasicConstraintsExtension;
 import sun.security.x509.CertificateExtensions;
 import sun.security.x509.Extension;
+import sun.security.x509.KeyIdentifier;
 import sun.security.x509.KeyUsageExtension;
 
 import java.io.ByteArrayOutputStream;
@@ -155,7 +156,7 @@ public class ExtOptionCamelCase {
                 List.class,
                 PublicKey.class,
                 PublicKey.class,
-                byte[].class);
+                KeyIdentifier.class);
         createV3Extensions.setAccessible(true);
         ctor = Main.class.getDeclaredConstructor();
         ctor.setAccessible(true);

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8231950
+ * @bug 8231950 8257497
  * @summary keytool -ext camel-case shorthand not working
  * @modules java.base/sun.security.tools.keytool
  *          java.base/sun.security.tools.keytool:open
@@ -154,7 +154,8 @@ public class ExtOptionCamelCase {
                 CertificateExtensions.class,
                 List.class,
                 PublicKey.class,
-                PublicKey.class);
+                PublicKey.class,
+                byte[].class);
         createV3Extensions.setAccessible(true);
         ctor = Main.class.getDeclaredConstructor();
         ctor.setAccessible(true);
@@ -197,7 +198,7 @@ public class ExtOptionCamelCase {
         try {
             CertificateExtensions exts = (CertificateExtensions)
                     createV3Extensions.invoke(ctor.newInstance(),
-                            null, null, List.of(option), pk, null);
+                            null, null, List.of(option), pk, null, null);
 
             // ATTENTION: the extensions created above might contain raw
             // extensions (not of a subtype) and we need to store and reload


### PR DESCRIPTION
This change is made for compliance with RFC 5280 section 4.2.1.1 for Authority Key Identifier extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257497](https://bugs.openjdk.java.net/browse/JDK-8257497): Update keytool to create AKID from the SKID of the issuing certificate as specified by RFC 5280


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**) ⚠️ Review applies to 88cae5cc538bf8a25eb8b162b9c67a32b54e5457
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 4bd7e45c34804ad00cb43895e5dfa66bc797ab63


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2343/head:pull/2343`
`$ git checkout pull/2343`
