### PR TITLE
8260878: com/sun/jdi/JdbOptions.java fails without jfr

### DIFF
--- a/test/jdk/com/sun/jdi/JdbOptions.java
+++ b/test/jdk/com/sun/jdi/JdbOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,6 +96,7 @@ public class JdbOptions {
         // 'options' contains commas - values are quoted (double quotes)
         test("-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options=\"-client\" \"-XX:+PrintVMOptions\""
+                + " -XX:+IgnoreUnrecognizedVMOptions"
                 + " \"-XX:StartFlightRecording=dumponexit=true,maxsize=500M\" \"-XX:FlightRecorderOptions=repository=jfrrep\""
                 + ",main=" + targ)
             .expectedArg("-XX:StartFlightRecording=dumponexit=true,maxsize=500M")
@@ -104,6 +105,7 @@ public class JdbOptions {
         // 'options' contains commas - values are quoted (single quotes)
         test("-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options='-client' '-XX:+PrintVMOptions'"
+                        + " -XX:+IgnoreUnrecognizedVMOptions"
                         + " '-XX:StartFlightRecording=dumponexit=true,maxsize=500M' '-XX:FlightRecorderOptions=repository=jfrrep'"
                         + ",main=" + targ)
             .expectedArg("-XX:StartFlightRecording=dumponexit=true,maxsize=500M")
@@ -115,6 +117,7 @@ public class JdbOptions {
                 "-Dprop2=val 2",
                 "-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options=-Dprop3=val3 '-Dprop4=val 4'"
+                        + " -XX:+IgnoreUnrecognizedVMOptions"
                         + " \"-XX:StartFlightRecording=dumponexit=true,maxsize=500M\""
                         + " '-XX:FlightRecorderOptions=repository=jfrrep'"
                         + ",main=" + targ + " prop1 prop2 prop3 prop4")


### PR DESCRIPTION
Hi all,

com/sun/jdi/JdbOptions.java fails in our ci/cd when jfr is disabled.
It would be better to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260878](https://bugs.openjdk.java.net/browse/JDK-8260878): com/sun/jdi/JdbOptions.java fails without jfr


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2346/head:pull/2346`
`$ git checkout pull/2346`
