### PR TITLE
JDK-8260902: CDS mapping errors should not lead to unconditional output

### DIFF
--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -1667,12 +1667,12 @@ char* FileMapInfo::map_bitmap_region() {
   char* bitmap_base = os::map_memory(_fd, _full_path, si->file_offset(),
                                      requested_addr, si->used_aligned(), read_only, allow_exec, mtClassShared);
   if (bitmap_base == NULL) {
-    log_error(cds)("failed to map relocation bitmap");
+    log_info(cds)("failed to map relocation bitmap");
     return NULL;
   }
 
   if (VerifySharedSpaces && !region_crc_check(bitmap_base, si->used_aligned(), si->crc())) {
-    log_error(cds)("relocation bitmap CRC error");
+    log_info(cds)("relocation bitmap CRC error");
     if (!os::unmap_memory(bitmap_base, si->used_aligned())) {
       fatal("os::unmap_memory of relocation bitmap failed");
     }

--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -1672,7 +1672,7 @@ char* FileMapInfo::map_bitmap_region() {
   }
 
   if (VerifySharedSpaces && !region_crc_check(bitmap_base, si->used_aligned(), si->crc())) {
-    log_info(cds)("relocation bitmap CRC error");
+    log_error(cds)("relocation bitmap CRC error");
     if (!os::unmap_memory(bitmap_base, si->used_aligned())) {
       fatal("os::unmap_memory of relocation bitmap failed");
     }

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1725,8 +1725,8 @@ MapArchiveResult MetaspaceShared::map_archive(FileMapInfo* mapinfo, char* mapped
   mapinfo->set_is_mapped(false);
 
   if (mapinfo->alignment() != (size_t)os::vm_allocation_granularity()) {
-    log_error(cds)("Unable to map CDS archive -- os::vm_allocation_granularity() expected: " SIZE_FORMAT
-                   " actual: %d", mapinfo->alignment(), os::vm_allocation_granularity());
+    log_info(cds)("Unable to map CDS archive -- os::vm_allocation_granularity() expected: " SIZE_FORMAT
+                  " actual: %d", mapinfo->alignment(), os::vm_allocation_granularity());
     return MAP_ARCHIVE_OTHER_FAILURE;
   }
 


### PR DESCRIPTION
There are some places where unconditional error messages are printed to tty for recoverable errors. This is not good since the VM may continue without problems, but those printouts may confuse scripts parsing the VM output, or end up at the wrong places:

See e.g.: https://mail.openjdk.java.net/pipermail/build-dev/2021-February/030256.html

One of these points are mapping errors in CDS. VM will just continue without CDS, so its not a fatal error. 

I fixed some places which clearly were non-fatal while leaving log_error in place for cases which are clearly fatal, or borderline fatal (like rs commit errors). I looked for tests which could have parsed these lines and found none.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260902](https://bugs.openjdk.java.net/browse/JDK-8260902): CDS mapping errors should not lead to unconditional output


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2348/head:pull/2348`
`$ git checkout pull/2348`
