### PR TITLE
JDK-8260926: Trace resource exhausted events unconditionally

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1506,7 +1506,7 @@ void JvmtiExport::post_resource_exhausted(jint resource_exhausted_flags, const c
 
   JavaThread *thread  = JavaThread::current();
 
-  log_error(os)("Resource Exhausted (%s)", description != nullptr ? description : "no info");
+  log_error(jvmti)("Resource Exhausted (%s)", description != nullptr ? description : "unknown");
 
   // JDK-8213834: handlers of ResourceExhausted may attempt some analysis
   // which often requires running java.

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1506,6 +1506,8 @@ void JvmtiExport::post_resource_exhausted(jint resource_exhausted_flags, const c
 
   JavaThread *thread  = JavaThread::current();
 
+  log_error(os)("Resource Exhausted (%s)", description != nullptr ? description : "no info");
+
   // JDK-8213834: handlers of ResourceExhausted may attempt some analysis
   // which often requires running java.
   // This will cause problems on threads not able to run java, e.g. compiler

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1506,7 +1506,8 @@ void JvmtiExport::post_resource_exhausted(jint resource_exhausted_flags, const c
 
   JavaThread *thread  = JavaThread::current();
 
-  log_error(jvmti)("Resource Exhausted (%s)", description != nullptr ? description : "unknown");
+  log_error(jvmti)("Posting Resource Exhausted event: %s",
+                   description != nullptr ? description : "unknown");
 
   // JDK-8213834: handlers of ResourceExhausted may attempt some analysis
   // which often requires running java.


### PR DESCRIPTION
Analyzing out-of-resource situations in cloud scenarios is no fun. With CloudFoundry, a JVMTI agent (jvmkill) is hooked up intercepting the jvmti "resource exhausted" event, then attempts to write up a heap report. That may fail, e.g. due to bugs in the agent [1], but also because that report runs java code and may suffer from the same resource exhaustion. Successful or not, it unceremoniously kills the VM when done, often leaving us with no information about the actual resource.

It would be very helpful if we had unconditional tracing here. We do have tracing, but it requires a non-product build and is triggered with TraceJVMTI. Also, it traces at trace level which is way to fine granular.

I'd like to introduce another, unconditional trace line here. Arguably, resource exhausted is fatal enough that it justifies unconditional tracing.

This is a bit of a coin toss. Tracing unconditionally would help in most scenarios, where it would be either difficult or even impossible to specify a trace command line switch. OTOH it may trip up scripts parsing the VM output, or some of our tests (which can be fixed).

Thoughts?

..Thomas

[1] https://github.com/cloudfoundry/jvmkill/issues/18

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260926](https://bugs.openjdk.java.net/browse/JDK-8260926): Trace resource exhausted events unconditionally


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 40e3af872c90c3c868fef659697f8a3d2eb4980b
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 40e3af872c90c3c868fef659697f8a3d2eb4980b


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2350/head:pull/2350`
`$ git checkout pull/2350`
