### PR TITLE
8260928: InitArrayShortSize constraint func should print a helpful error message

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -302,6 +302,9 @@ JVMFlag::Error TypeProfileLevelConstraintFunc(uintx value, bool verbose) {
 
 JVMFlag::Error InitArrayShortSizeConstraintFunc(intx value, bool verbose) {
   if (value % BytesPerLong != 0) {
+    JVMFlag::printError(verbose,
+                       "InitArrayShortSize (" INTX_FORMAT ") must be "
+                        "a multiple of %d\n", value, BytesPerLong);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
     return JVMFlag::SUCCESS;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -303,7 +303,7 @@ JVMFlag::Error TypeProfileLevelConstraintFunc(uintx value, bool verbose) {
 JVMFlag::Error InitArrayShortSizeConstraintFunc(intx value, bool verbose) {
   if (value % BytesPerLong != 0) {
     JVMFlag::printError(verbose,
-                       "InitArrayShortSize (" INTX_FORMAT ") must be "
+                        "InitArrayShortSize (" INTX_FORMAT ") must be "
                         "a multiple of %d\n", value, BytesPerLong);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {


### PR DESCRIPTION
The `InitArrayShortSize` flag requires a value that is a multiple of `BytesPerLong` but no corresponding error message is printed:
```
java -XX:InitArrayShortSize=7
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260928](https://bugs.openjdk.java.net/browse/JDK-8260928): InitArrayShortSize constraint func should print a helpful error message


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 92dd1316f3f8057df0fa88e6d5fd40a632bdf108
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2351/head:pull/2351`
`$ git checkout pull/2351`
