### PR TITLE
8235140: Investigate deprecation of the Socket/ServerSocket impl factory mechanism

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,7 @@ import sun.net.PlatformSocketImpl;
  * based on that request, and then possibly returns a result to the requester.
  * <p>
  * The actual work of the server socket is performed by an instance
- * of the {@code SocketImpl} class. An application can
- * change the socket factory that creates the socket
- * implementation to configure itself to create sockets
- * appropriate to the local firewall.
+ * of the {@code SocketImpl} class.
  *
  * <p> The {@code ServerSocket} class defines convenience
  * methods to set and get several socket options. This class also
@@ -76,7 +73,6 @@ import sun.net.PlatformSocketImpl;
  * Additional (implementation specific) options may also be supported.
  *
  * @see     java.net.SocketImpl
- * @see     java.net.ServerSocket#setSocketFactory(java.net.SocketImplFactory)
  * @see     java.nio.channels.ServerSocketChannel
  * @since   1.0
  */
@@ -164,8 +160,6 @@ public class ServerSocket implements java.io.Closeable {
      *             0 and 65535, inclusive.
      *
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
-     * @see        java.net.ServerSocket#setSocketFactory(java.net.SocketImplFactory)
      * @see        SecurityManager#checkListen
      */
     public ServerSocket(int port) throws IOException {
@@ -217,8 +211,6 @@ public class ServerSocket implements java.io.Closeable {
      *             0 and 65535, inclusive.
      *
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
-     * @see        java.net.ServerSocket#setSocketFactory(java.net.SocketImplFactory)
      * @see        SecurityManager#checkListen
      */
     public ServerSocket(int port, int backlog) throws IOException {
@@ -303,6 +295,7 @@ public class ServerSocket implements java.io.Closeable {
     }
 
     private void setImpl() {
+        @SuppressWarnings("deprecation")
         SocketImplFactory factory = ServerSocket.factory;
         if (factory != null) {
             impl = factory.createSocketImpl();
@@ -623,6 +616,7 @@ public class ServerSocket implements java.io.Closeable {
             return platformImplAccept();
         } else {
             // custom server SocketImpl, client SocketImplFactory must be set
+            @SuppressWarnings("deprecation")
             SocketImplFactory factory = Socket.socketImplFactory();
             if (factory == null) {
                 throw new IOException("An instance of " + impl.getClass() +
@@ -903,6 +897,7 @@ public class ServerSocket implements java.io.Closeable {
     /**
      * The factory for all server sockets.
      */
+    @Deprecated(since = "17")
     private static volatile SocketImplFactory factory;
 
     /**
@@ -929,7 +924,10 @@ public class ServerSocket implements java.io.Closeable {
      *             {@code checkSetFactory} method doesn't allow the operation.
      * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkSetFactory
+     * @deprecated Use a {@link javax.net.ServerSocketFactory} and subclass
+     *             {@code ServerSocket} directly.
      */
+    @Deprecated(since = "17")
     public static synchronized void setSocketFactory(SocketImplFactory fac) throws IOException {
         if (factory != null) {
             throw new SocketException("factory already defined");

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Collections;
@@ -45,10 +43,7 @@ import java.util.Collections;
  * between two machines.
  * <p>
  * The actual work of the socket is performed by an instance of the
- * {@code SocketImpl} class. An application, by changing
- * the socket factory that creates the socket implementation,
- * can configure itself to create sockets appropriate to the local
- * firewall.
+ * {@code SocketImpl} class.
  *
  * <p> The {@code Socket} class defines convenience
  * methods to set and get several socket options. This class also
@@ -96,7 +91,6 @@ import java.util.Collections;
  * </blockquote>
  * Additional (implementation specific) options may also be supported.
  *
- * @see     java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
  * @see     java.net.SocketImpl
  * @see     java.nio.channels.SocketChannel
  * @since   1.0
@@ -208,6 +202,7 @@ public class Socket implements java.io.Closeable {
         } else {
             if (p == Proxy.NO_PROXY) {
                 // create a platform or custom SocketImpl for the DIRECT case
+                @SuppressWarnings("deprecation")
                 SocketImplFactory factory = Socket.factory;
                 if (factory == null) {
                     impl = SocketImpl.createPlatformSocketImpl(false);
@@ -282,9 +277,7 @@ public class Socket implements java.io.Closeable {
      * @throws     IllegalArgumentException if the port parameter is outside
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
-     * @see        java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkConnect
      */
     public Socket(String host, int port)
@@ -318,9 +311,7 @@ public class Socket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      * @throws     NullPointerException if {@code address} is null.
-     * @see        java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkConnect
      */
     public Socket(InetAddress address, int port) throws IOException {
@@ -448,9 +439,7 @@ public class Socket implements java.io.Closeable {
      * @throws     IllegalArgumentException if the port parameter is outside
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
-     * @see        java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkConnect
      * @deprecated Use DatagramSocket instead for UDP transport.
      */
@@ -492,9 +481,7 @@ public class Socket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      * @throws     NullPointerException if {@code host} is null.
-     * @see        java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
      * @see        java.net.SocketImpl
-     * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkConnect
      * @deprecated Use DatagramSocket instead for UDP transport.
      */
@@ -554,6 +541,7 @@ public class Socket implements java.io.Closeable {
      * Sets impl to the system-default type of SocketImpl.
      * @since 1.4
      */
+    @SuppressWarnings("deprecation")
     void setImpl() {
         SocketImplFactory factory = Socket.factory;
         if (factory != null) {
@@ -1732,8 +1720,10 @@ public class Socket implements java.io.Closeable {
     /**
      * The factory for all client sockets.
      */
+    @Deprecated(since = "17")
     private static volatile SocketImplFactory factory;
 
+    @Deprecated(since = "17")
     static SocketImplFactory socketImplFactory() {
         return factory;
     }
@@ -1761,7 +1751,17 @@ public class Socket implements java.io.Closeable {
      *             {@code checkSetFactory} method doesn't allow the operation.
      * @see        java.net.SocketImplFactory#createSocketImpl()
      * @see        SecurityManager#checkSetFactory
+     * @deprecated Use {@link SocketChannel}, or subclass {@code Socket}
+     *    directly.
+     *    <br> This method provided a way in early JDK releases to replace the
+     *    system wide implementation of {@code Socket}. It has been mostly
+     *    obsolete since Java 1.4. If required, a {@code Socket} can be
+     *    created to use a custom implementation by extending {@code Socket}
+     *    and using the {@linkplain #Socket(SocketImpl) protected
+     *    constructor} that takes an {@linkplain SocketImpl implementation}
+     *    as a parameter.
      */
+     @Deprecated(since = "17")
     public static synchronized void setSocketImplFactory(SocketImplFactory fac)
         throws IOException
     {

--- a/src/java.base/share/classes/java/net/SocketImplFactory.java
+++ b/src/java.base/share/classes/java/net/SocketImplFactory.java
@@ -35,10 +35,7 @@ package java.net;
  * @see     java.net.Socket
  * @see     java.net.ServerSocket
  * @since   1.0
- * @deprecated Use {@link java.nio.channels.SocketChannel} or subclass
- * {@link Socket} directly.
  */
-@Deprecated(since = "17")
 public interface SocketImplFactory {
     /**
      * Creates a new {@code SocketImpl} instance.

--- a/src/java.base/share/classes/java/net/SocketImplFactory.java
+++ b/src/java.base/share/classes/java/net/SocketImplFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,10 @@ package java.net;
  * @see     java.net.Socket
  * @see     java.net.ServerSocket
  * @since   1.0
+ * @deprecated Use {@link java.nio.channels.SocketChannel} or subclass
+ * {@link Socket} directly.
  */
+@Deprecated(since = "17")
 public interface SocketImplFactory {
     /**
      * Creates a new {@code SocketImpl} instance.


### PR DESCRIPTION
Hi,

Could someone please review my proposed change for JDK-8235140: '`Investigate deprecation of the Socket/ServerSocket impl factory mechanism`' ?

This fix proposes to deprecate (for the eventual removal) the API points for statically configuring a system-wide factory for the `Socket/SocketServer` types in the `java.net package`. Specifically, the following:

Methods:
  - `static void ServerSocket.setSocketFactory​(SocketImplFactory fac)`
  - `static void Socket.setSocketImplFactory​(SocketImplFactory fac)`
  
Types:
  - `java.net SocketImplFactory`

This issue is a sub-task to the umbrella issue JDK-8235139: '`Remove the socket impl factory mechanism`'. For more information, see https://bugs.openjdk.java.net/browse/JDK-8235139


Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8235140](https://bugs.openjdk.java.net/browse/JDK-8235140): Investigate deprecation of the Socket/ServerSocket impl factory mechanism


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2352/head:pull/2352`
`$ git checkout pull/2352`
