### PR TITLE
8259430: C2: assert(in_vt->length() == out_vt->length()) failed: mismatch on number of elements

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,4 +29,3 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8256368 generic-all
-jdk/incubator/vector/VectorHash.java 8259430 generic-all


### PR DESCRIPTION
Another problem caused by pathological cases (in effectively dead code): `VectorUnboxNode::Ideal()/Value()` ignore cast nodes (even the ones carrying control dependency) to reveal `VectorBox` and sometimes it exposes type mismatches between box/unbox operations which are impossible in practice. 

Proposed fix turns the assert into a runtime check to ignore problematic IR shape.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259430](https://bugs.openjdk.java.net/browse/JDK-8259430): C2: assert(in_vt->length() == out_vt->length()) failed: mismatch on number of elements


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2353/head:pull/2353`
`$ git checkout pull/2353`
