### PR TITLE
8260301: misc gc/g1/unloading tests fails with "RuntimeException: Method could not be enqueued for compilation at level N"

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -991,6 +991,15 @@ bool WhiteBox::compile_method(Method* method, int comp_level, int bci, Thread* T
   if ((!is_blocking && is_queued) || nm != NULL) {
     return true;
   }
+  // Check code again because compilation may be finished before Compile_lock is acquired.
+  if (bci == InvocationEntryBci) {
+    CompiledMethod* code = mh->code();
+    if (code != NULL && code->as_nmethod_or_null() != NULL) {
+      return true;
+    }
+  } else if (mh->lookup_osr_nmethod_for(bci, comp_level, false) != NULL) {
+    return true;
+  }
   tty->print("WB error: failed to %s compile at level %d method ", is_blocking ? "blocking" : "", comp_level);
   mh->print_short_name(tty);
   tty->cr();


### PR DESCRIPTION
On return WB wait to acquire Compile_lock before checking compilation status
https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/whitebox.cpp#L988 

This lock is used by ciEnv for compiled code publishing:
https://github.com/openjdk/jdk/blob/master/src/hotspot/share/ci/ciEnv.cpp#L981

So while WB waits the lock compiler thread can finish compilation, register nmethod and clear method's queued_for_compilation bit.

The problem is that WB check `nm` value (compiled code) which it got before the lock and when method compilation is not finished.

The fix is to check compiled code again similar to check in CompileBroker:
https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compileBroker.cpp#L1501 

Passed hs-tier1-4 testing and 100 x vmTestbase/gc/g1/unloading/tests/unloading_compilation_*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260301](https://bugs.openjdk.java.net/browse/JDK-8260301): misc gc/g1/unloading tests fails with "RuntimeException: Method could not be enqueued for compilation at level N"


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2356/head:pull/2356`
`$ git checkout pull/2356`
