### PR TITLE
JDK-8241995: Clarify InetSocketAddress::toString specification

### DIFF
--- a/src/java.base/share/classes/java/net/InetSocketAddress.java
+++ b/src/java.base/share/classes/java/net/InetSocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -373,11 +373,18 @@ public class InetSocketAddress
 
     /**
      * Constructs a string representation of this InetSocketAddress.
-     * This String is constructed by calling toString() on the InetAddress
-     * and concatenating the port number (with a colon). If the address
-     * is an IPv6 address, the IPv6 literal is enclosed in square brackets.
+     * This string is constructed by calling {@link InetAddress#toString()}
+     * on the InetAddress and concatenating the port number (with a colon).
+     * <p>
+     * If the address is an IPv6 address, the IPv6 literal is enclosed in
+     * square brackets, for example: {@code "localhost/[0:0:0:0:0:0:0:1]:80"}.
      * If the address is {@linkplain #isUnresolved() unresolved},
-     * {@code <unresolved>} is displayed in place of the address literal.
+     * {@code <unresolved>} is displayed in place of the address literal, for
+     * example {@code "foo/<unresolved>:80"}.
+     * <p>
+     * To retrieve a string representation of the hostname or the address, use
+     * {@link #getHostString()}, rather than parsing the string representation
+     * returned by this method.
      *
      * @return  a string representation of this object.
      */

--- a/src/java.base/share/classes/java/net/InetSocketAddress.java
+++ b/src/java.base/share/classes/java/net/InetSocketAddress.java
@@ -383,8 +383,8 @@ public class InetSocketAddress
      * example {@code "foo/<unresolved>:80"}.
      * <p>
      * To retrieve a string representation of the hostname or the address, use
-     * {@link #getHostString()}, rather than parsing the string representation
-     * returned by this method.
+     * {@link #getHostString()}, rather than parsing the string returned by this
+     * {@link #toString()} method.
      *
      * @return  a string representation of this object.
      */


### PR DESCRIPTION
This change clarifies the InetSocketAddress::toString specification, which was recently updated to reflect an implementation change [1]. The specification is not changed, but it is enhanced with two examples and some more verbiage, as per earlier suggestions on the net-dev mailing list [2][3].

[1] https://bugs.openjdk.java.net/browse/JDK-8225499
[2] https://mail.openjdk.java.net/pipermail/net-dev/2020-April/013776.html
[3] https://mail.openjdk.java.net/pipermail/net-dev/2021-February/015297.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241995](https://bugs.openjdk.java.net/browse/JDK-8241995): Clarify InetSocketAddress::toString specification


### Reviewers
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to f3394178581eb7c7cf56283874ffe9ec13f7d8b3
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to f3394178581eb7c7cf56283874ffe9ec13f7d8b3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2357/head:pull/2357`
`$ git checkout pull/2357`
