### PR TITLE
8260356: (tz) Upgrade time-zone data to tzdata2021a

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2020f
+tzdata2021a

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -1550,11 +1550,17 @@ Zone	Africa/Khartoum	2:10:08 -	LMT	1931
 			3:00	-	EAT	2017 Nov  1
 			2:00	-	CAT
 
+# From Steffen Thorsen (2021-01-18):
+# "South Sudan will change its time zone by setting the clock back 1
+# hour on February 1, 2021...."
+# from https://eyeradio.org/south-sudan-adopts-new-time-zone-makuei/
+
 # South Sudan
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Juba	2:06:28 -	LMT	1931
 			2:00	Sudan	CA%sT	2000 Jan 15 12:00
-			3:00	-	EAT
+			3:00	-	EAT	2021 Feb  1 00:00
+			2:00	-	CAT
 
 # Tanzania
 # See Africa/Nairobi.

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -95,11 +95,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2021	Jun	28	00:00:00
+#Expires 2021	Dec	28	00:00:00
 
 # POSIX timestamps for the data in this file:
 #updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1624838400 (2021-06-28 00:00:00 UTC)
+#expires 1640649600 (2021-12-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C60
-#	File expires on:  28 June 2021
+#	Updated through IERS Bulletin C61
+#	File expires on:  28 December 2021


### PR DESCRIPTION
Hi Guys,

Please review integrating tzdata2021a to JDK.

JBS: https://bugs.openjdk.java.net/browse/JDK-8260356

The fix has passed the regression and JCK tests. More information can be viewed at - https://mm.icann.org/pipermail/tz-announce/2021-January/000065.html

Thanks,
Kiran

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260356](https://bugs.openjdk.java.net/browse/JDK-8260356): (tz) Upgrade time-zone data to tzdata2021a


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2359/head:pull/2359`
`$ git checkout pull/2359`
