### PR TITLE
8260959: remove RECORDS from PreviewFeature.Feature enum

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -54,12 +54,6 @@ public @interface PreviewFeature {
     public boolean reflective() default false;
 
     public enum Feature {
-        // The RECORDS enum constant is not used in the JDK 16 codebase, but
-        // exists to support the bootcycle build of JDK 16. The bootcycle build
-        // of JDK 16 is performed with JDK 15 and the PreviewFeature type from
-        // JDK 16. Since the JDK 15 codebase uses the enum constant, it is
-        // necessary for PreviewFeature in JDK 16 to declare the enum constant.
-        RECORDS,
         SEALED_CLASSES,
         /**
          * A key for testing.


### PR DESCRIPTION
Please review this simple fix that is removing the RECORDS enum constant from the PreviewFeature.Feature enum, now that RECORDS are final in 16 this constant can be safely removed.

Thanks,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260959](https://bugs.openjdk.java.net/browse/JDK-8260959): remove RECORDS from PreviewFeature.Feature enum


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2360/head:pull/2360`
`$ git checkout pull/2360`
