### PR TITLE
8260998: Shenandoah: Restore reference processing statistics reporting

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -200,7 +200,8 @@ ShenandoahReferenceProcessor::ShenandoahReferenceProcessor(uint max_workers) :
   _ref_proc_thread_locals(NEW_C_HEAP_ARRAY(ShenandoahRefProcThreadLocal, max_workers, mtGC)),
   _pending_list(NULL),
   _pending_list_tail(&_pending_list),
-  _iterate_discovered_list_id(0U) {
+  _iterate_discovered_list_id(0U),
+  _stats() {
   for (size_t i = 0; i < max_workers; i++) {
     _ref_proc_thread_locals[i].reset();
   }
@@ -595,6 +596,12 @@ void ShenandoahReferenceProcessor::collect_statistics() {
       enqueued[type] += _ref_proc_thread_locals[i].enqueued((ReferenceType)type);
     }
   }
+
+  _stats = ReferenceProcessorStats(discovered[REF_SOFT],
+                                   discovered[REF_WEAK],
+                                   discovered[REF_FINAL],
+                                   discovered[REF_PHANTOM]);
+
   log_info(gc,ref)("Encountered references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
                    encountered[REF_SOFT], encountered[REF_WEAK], encountered[REF_FINAL], encountered[REF_PHANTOM]);
   log_info(gc,ref)("Discovered  references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
@@ -602,3 +609,4 @@ void ShenandoahReferenceProcessor::collect_statistics() {
   log_info(gc,ref)("Enqueued    references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
                    enqueued[REF_SOFT], enqueued[REF_WEAK], enqueued[REF_FINAL], enqueued[REF_PHANTOM]);
 }
+

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
@@ -27,6 +27,8 @@
 #define SHARE_VM_GC_SHENANDOAH_SHENANDOAHREFERENCEPROCESSOR_HPP
 
 #include "gc/shared/referenceDiscoverer.hpp"
+#include "gc/shared/referencePolicy.hpp"
+#include "gc/shared/referenceProcessorStats.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "memory/allocation.hpp"
 
@@ -136,6 +138,8 @@ private:
 
   volatile uint _iterate_discovered_list_id;
 
+  ReferenceProcessorStats _stats;
+
   template <typename T>
   bool is_inactive(oop reference, oop referent, ReferenceType type) const;
   bool is_strongly_live(oop referent) const;
@@ -178,6 +182,8 @@ public:
   bool discover_reference(oop obj, ReferenceType type) override;
 
   void process_references(ShenandoahPhaseTimings::Phase phase, WorkGang* workers, bool concurrent);
+
+  const ReferenceProcessorStats& reference_process_stats() { return _stats; }
 
   void work();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -28,10 +28,12 @@
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/gcTrace.hpp"
 #include "gc/shared/gcWhen.hpp"
+#include "gc/shared/referenceProcessorStats.hpp"
+#include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
-#include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "utilities/debug.hpp"
 
 ShenandoahPhaseTimings::Phase ShenandoahTimingsTracker::_current_phase = ShenandoahPhaseTimings::_invalid_phase;
@@ -65,6 +67,7 @@ ShenandoahGCSession::~ShenandoahGCSession() {
   _heap->heuristics()->record_cycle_end();
   _timer->register_gc_end();
   _heap->trace_heap_after_gc(_tracer);
+  _tracer->report_gc_reference_stats(_heap->ref_processor()->reference_process_stats());
   _tracer->report_gc_end(_timer->gc_end(), _timer->time_partitions());
   assert(!ShenandoahGCPhase::is_current_phase_valid(), "No current GC phase");
   _heap->set_gc_cause(GCCause::_no_gc);


### PR DESCRIPTION
Please review this patch that restores reporting of reference processing statistics after JDK-8254315

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260998](https://bugs.openjdk.java.net/browse/JDK-8260998): Shenandoah: Restore reference processing statistics reporting


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2362/head:pull/2362`
`$ git checkout pull/2362`
