### PR TITLE
8258799 : [Testbug] RandomCommandsTest must check if tested directive is added via jcmd

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdStateBuilder.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/JcmdStateBuilder.java
@@ -46,7 +46,7 @@ public class JcmdStateBuilder implements StateBuilder<JcmdCommand> {
     private final Map<MethodDescriptor, List<CompileCommand>> matchBlocks
             = new LinkedHashMap<>();
     private final List<CompileCommand> inlines = new ArrayList<>();
-    private boolean isFileValid = true;
+    public boolean isFileValid = true;
 
     public JcmdStateBuilder(String fileName) {
         directiveBuilder = new DirectiveBuilder(fileName);

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
@@ -49,18 +49,21 @@ import java.util.function.Consumer;
  */
 public final class Scenario {
     private final boolean isValid;
+    private final boolean isJcmdValid;
     private final Map<Executable, State> states;
     private final List<Consumer<OutputAnalyzer>> processors;
     private final Executor executor;
     private final Consumer<List<OutputAnalyzer>> jcmdProcessor;
 
     private Scenario(boolean isValid,
+    		     boolean isJcmdValid,
                      List<String> vmopts,
                      Map<Executable, State> states,
                      List<CompileCommand> compileCommands,
                      List<JcmdCommand> jcmdCommands,
                      List<CompileCommand> directives) {
         this.isValid = isValid;
+        this.isJcmdValid = isJcmdValid;
         this.states = states;
         processors = new ArrayList<>();
         processors.add(new LogProcessor(states));
@@ -121,7 +124,18 @@ public final class Scenario {
         } else {
             // two cases for invalid inputs.
             if (mainOutput.getExitValue() == 0) {
-                mainOutput.shouldContain("CompileCommand: An error occurred during parsing");
+                if (!isJcmdValid) {
+            	    boolean parse_error_found = false;
+            	    for(OutputAnalyzer out : outputList) {
+            	        if (out.getOutput().contains("Parsing of compiler directives failed")) {
+            	           parse_error_found = true;
+            	           break;
+            	        }
+            	    }
+            	    Asserts.assertTrue(parse_error_found, "'Parsing of compiler directives failed' missing from output");
+            	} else {
+            	    mainOutput.shouldContain("CompileCommand: An error occurred during parsing");
+            	}
             } else {
                 Asserts.assertNE(mainOutput.getExitValue(), 0, "VM should exit with "
                         + "error for incorrect directives");
@@ -253,6 +267,7 @@ public final class Scenario {
 
         public Scenario build() {
             boolean isValid = true;
+            boolean isJcmdValid = true;
 
             // Get states from each of the state builders
             Map<Executable, State> commandFileStates
@@ -315,6 +330,7 @@ public final class Scenario {
                 options.addAll(builder.getOptions());
                 isValid &= builder.isValid();
             }
+            isJcmdValid = jcmdStateBuilder.isFileValid;
             options.addAll(jcmdStateBuilder.getOptions());
 
             /*
@@ -328,7 +344,7 @@ public final class Scenario {
                         .forEach(entry -> entry.getValue().setLog(true));
             }
 
-            return new Scenario(isValid, options, finalStates, ccList,
+            return new Scenario(isValid, isJcmdValid, options, finalStates, ccList,
                     jcmdCommands, directives);
         }
 

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
@@ -56,7 +56,7 @@ public final class Scenario {
     private final Consumer<List<OutputAnalyzer>> jcmdProcessor;
 
     private Scenario(boolean isValid,
-    		     boolean isJcmdValid,
+                     boolean isJcmdValid,
                      List<String> vmopts,
                      Map<Executable, State> states,
                      List<CompileCommand> compileCommands,

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
@@ -125,17 +125,17 @@ public final class Scenario {
             // two cases for invalid inputs.
             if (mainOutput.getExitValue() == 0) {
                 if (!isJcmdValid) {
-            	    boolean parse_error_found = false;
-            	    for(OutputAnalyzer out : outputList) {
-            	        if (out.getOutput().contains("Parsing of compiler directives failed")) {
-            	           parse_error_found = true;
-            	           break;
-            	        }
-            	    }
-            	    Asserts.assertTrue(parse_error_found, "'Parsing of compiler directives failed' missing from output");
-            	} else {
-            	    mainOutput.shouldContain("CompileCommand: An error occurred during parsing");
-            	}
+                    boolean parse_error_found = false;
+                    for(OutputAnalyzer out : outputList) {
+                        if (out.getOutput().contains("Parsing of compiler directives failed")) {
+                            parse_error_found = true;
+                            break;
+                        }
+                    }
+                    Asserts.assertTrue(parse_error_found, "'Parsing of compiler directives failed' missing from output");
+                } else {
+                    mainOutput.shouldContain("CompileCommand: An error occurred during parsing");
+                }
             } else {
                 Asserts.assertNE(mainOutput.getExitValue(), 0, "VM should exit with "
                         + "error for incorrect directives");


### PR DESCRIPTION
RandomCommandsTest.java is checking a mix of valid and invalid compilecommands and compiler directives. When they fail they have different behaviour:

A compilecommand that is malformed will result in a printed error, and then the VM continues. 
A compiler directive that is malformed, that is added via commandline, will abort the VM, much like any other VM-flag would. 
A compiler directive that is malformed, that is added via jcmd will print an error, and the VM continues - just like with any other jcmd.

The RandomCommandsTest fails when generating a malformed compiler directive and adding it via jcmd - because it expects the VM to abort.

This patch fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258799](https://bugs.openjdk.java.net/browse/JDK-8258799): [Testbug] RandomCommandsTest must check if tested directive is added via jcmd


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2364/head:pull/2364`
`$ git checkout pull/2364`
