### PR TITLE
JDK-8261003 : Bad Copyright header format after JDK-8183372

### DIFF
--- a/test/jdk/java/lang/Class/getEnclosingClass/EnclosingClassTest.java
+++ b/test/jdk/java/lang/Class/getEnclosingClass/EnclosingClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261003](https://bugs.openjdk.java.net/browse/JDK-8261003): Bad Copyright header format after JDK-8183372


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2365/head:pull/2365`
`$ git checkout pull/2365`
