### PR TITLE
8248876: LoadObject with bad base address created for exec file on linux

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -455,13 +455,15 @@ static bool read_interp_segments(struct ps_prochandle* ph) {
 }
 
 // process segments of a a.out
-static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
+// returns base address of executable.
+static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
   int i = 0;
   ELF_PHDR* phbuf = NULL;
   ELF_PHDR* exec_php = NULL;
+  uintptr_t result = 0L;
 
   if ((phbuf = read_program_header_table(ph->core->exec_fd, exec_ehdr)) == NULL) {
-    return false;
+    return 0L;
   }
 
   for (exec_php = phbuf, i = 0; i < exec_ehdr->e_phnum; i++) {
@@ -502,8 +504,13 @@ static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
     // from PT_DYNAMIC we want to read address of first link_map addr
     case PT_DYNAMIC: {
       if (exec_ehdr->e_type == ET_EXEC) {
+        result = exec_php->p_vaddr;
         ph->core->dynamic_addr = exec_php->p_vaddr;
       } else { // ET_DYN
+        // Base address of executable is based on entry point (AT_ENTRY).
+        // See svr4_exec_displacement() in GDB.
+        result = ph->core->dynamic_addr - exec_ehdr->e_entry;
+
         // dynamic_addr has entry point of executable.
         // Thus we should substract it.
         ph->core->dynamic_addr += exec_php->p_vaddr - exec_ehdr->e_entry;
@@ -517,10 +524,10 @@ static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
   } // for
 
   free(phbuf);
-  return true;
+  return result;
  err:
   free(phbuf);
-  return false;
+  return 0L;
 }
 
 
@@ -772,14 +779,12 @@ Pgrab_core(const char* exec_file, const char* core_file) {
   }
 
   // process exec file segments
-  if (read_exec_segments(ph, &exec_ehdr) != true) {
+  uintptr_t exec_base_addr = read_exec_segments(ph, &exec_ehdr);
+  if (exec_base_addr == 0L) {
     goto err;
   }
-
-  // exec file is also treated like a shared object for symbol search
-  // FIXME: This is broken and ends up with a base address of 0. See JDK-8248876.
-  if (add_lib_info_fd(ph, exec_file, ph->core->exec_fd,
-                      (uintptr_t)0 + find_base_address(ph->core->exec_fd, &exec_ehdr)) == NULL) {
+  print_debug("DEBUG: exec_base_addr = 0x%lx\n", exec_base_addr);
+  if (add_lib_info_fd(ph, exec_file, ph->core->exec_fd, exec_base_addr) == NULL) {
     goto err;
   }
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -783,7 +783,7 @@ Pgrab_core(const char* exec_file, const char* core_file) {
   if (exec_base_addr == 0L) {
     goto err;
   }
-  print_debug("DEBUG: exec_base_addr = 0x%lx\n", exec_base_addr);
+  print_debug("exec_base_addr = 0x%lx\n", exec_base_addr);
   if (add_lib_info_fd(ph, exec_file, ph->core->exec_fd, exec_base_addr) == NULL) {
     goto err;
   }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -507,12 +507,7 @@ static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehd
         result = exec_php->p_vaddr;
         ph->core->dynamic_addr = exec_php->p_vaddr;
       } else { // ET_DYN
-        // Base address of executable is based on entry point (AT_ENTRY).
-        // See svr4_exec_displacement() in GDB.
         result = ph->core->dynamic_addr - exec_ehdr->e_entry;
-
-        // dynamic_addr has entry point of executable.
-        // Thus we should substract it.
         ph->core->dynamic_addr += exec_php->p_vaddr - exec_ehdr->e_entry;
       }
       print_debug("address of _DYNAMIC is 0x%lx\n", ph->core->dynamic_addr);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -69,7 +69,6 @@ class LinuxCDebugger implements CDebugger {
       LoadObject ob = (LoadObject) objs.get(i);
       Address base = ob.getBase();
       long size = ob.getSize();
-      if (base == null) continue; // Skip. LoadObject was not properly initialized.
       if (pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
         return ob;
       }


### PR DESCRIPTION
We could see NPE on `LinuxCDebugger::loadObjectContainingPC` which is used mainly by the clhsdb `findpc` command. (See [JDK-8248876](https://bugs.openjdk.java.net/browse/JDK-8248876) for more details)

It is caused by PIE executable handling.

Currently we use virtual address of top of PT_LOAD in executable as base address - it is valid for ET_EXEC binary.
However, in case of ET_DYN binary (PIE binary), we should handle it like a shared library.
In GDB, base address of executable would be calculated by dynamic section. SA should also do so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248876](https://bugs.openjdk.java.net/browse/JDK-8248876): LoadObject with bad base address created for exec file on linux


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to ed352edd00aff22748df2352901327cbe3800afd
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to ed352edd00aff22748df2352901327cbe3800afd


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2366/head:pull/2366`
`$ git checkout pull/2366`
