### PR TITLE
8013527: calling MethodHandles.lookup on itself leads to errors

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.GenerateJLIClassesHelper.traceLambdaForm;
@@ -315,7 +316,7 @@ class InvokerBytecodeGenerator {
      * Extract the MemberName of a newly-defined method.
      */
     private MemberName loadMethod(byte[] classFile) {
-        Class<?> invokerClass = LOOKUP.makeHiddenClassDefiner(className(), classFile)
+        Class<?> invokerClass = LOOKUP.makeHiddenClassDefiner(className(), classFile, Set.of())
                                       .defineClass(true, classDataValues());
         return resolveInvokerMember(invokerClass, invokerName, invokerType);
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -116,7 +116,6 @@ public class MethodHandles {
     @ForceInline // to ensure Reflection.getCallerClass optimization
     public static Lookup lookup() {
         Class<?> caller = Reflection.getCallerClass();
-        assert !MethodHandleImpl.isInjectedInvoker(caller);
         return new Lookup(caller);
     }
 
@@ -139,7 +138,6 @@ public class MethodHandles {
      * non-caller-sensitive.
      */
     private static Lookup reflected$lookup(Class<?> caller) {
-        assert !MethodHandleImpl.isInjectedInvoker(caller);
         return new Lookup(caller);
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -129,7 +129,11 @@ public class MethodHandles {
         if (caller.getClassLoader() == null) {
             throw newIllegalArgumentException("illegal lookupClass: "+caller);
         }
-        return new Lookup(caller);
+        // find the original caller if the caller is an injected invoker
+        // i.e. MethodHandles::lookup is called via Method::invoke which is
+        // invoked via MethodHandle
+        Class<?> originalCaller = MethodHandleImpl.originalCallerBoundToInvoker(caller);
+        return originalCaller != null ? new Lookup(originalCaller) : new Lookup(caller);
     }
 
     /**

--- a/test/jdk/java/lang/invoke/callerSensitive/CallerSensitiveAccess.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/CallerSensitiveAccess.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8196830 8235351
+ * @bug 8196830 8235351 8257874
  * @modules java.base/jdk.internal.reflect
  * @run testng/othervm --illegal-access=deny CallerSensitiveAccess
  * @summary Check Lookup findVirtual, findStatic and unreflect behavior with
@@ -355,6 +355,40 @@ public class CallerSensitiveAccess {
         mh.invoke(inaccessibleField(), true);  // should throw ClassCastException
     }
 
+    /**
+     * Field::getInt and Field::setInt are caller-sensitive methods.
+     * Test access to private field.
+     */
+    private static int privateField = 0;
+    @Test
+    public void testPrivateField() throws Throwable {
+        Field f = CallerSensitiveAccess.class.getDeclaredField("privateField");
+        // Field::setInt
+        MethodType mtype = MethodType.methodType(void.class, Object.class, int.class);
+        MethodHandle mh = MethodHandles.lookup().findVirtual(Field.class, "setInt", mtype);
+        mh.invokeExact(f, (Object)null, 5);
+        // Field::getInt
+        mh = MethodHandles.lookup().findVirtual(Field.class, "getInt", MethodType.methodType(int.class, Object.class));
+        int value = (int)mh.invokeExact(f, (Object)null);
+        assertTrue(value == 5);
+    }
+
+    private static class Inner {
+        private static boolean privateField = false;
+    }
+
+    @Test
+    public void testInnerPrivateField() throws Throwable {
+        Field f = Inner.class.getDeclaredField("privateField");
+        // Field::setInt
+        MethodType mtype = MethodType.methodType(void.class, Object.class, boolean.class);
+        MethodHandle mh = MethodHandles.lookup().findVirtual(Field.class, "setBoolean", mtype);
+        mh.invokeExact(f, (Object)null, true);
+        // Field::getInt
+        mh = MethodHandles.lookup().findVirtual(Field.class, "getBoolean", MethodType.methodType(boolean.class, Object.class));
+        boolean value = (boolean)mh.invokeExact(f, (Object)null);
+        assertTrue(value);
+    }
 
     // -- supporting methods --
 

--- a/test/jdk/java/lang/invoke/callerSensitive/Main.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/Main.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8013527
+ * @library src
+ * @modules java.base/jdk.internal.reflect
+ * @build java.base/java.util.CSM csm/*
+ * @run main/othervm csm/jdk.test.MethodInvokeTest
+ * @run main/othervm csm/jdk.test.MethodInvokeTest sm
+ * @summary Test proper caller class is bound to method handle for caller-sensitive method
+ */
+public class Main {
+}
+

--- a/test/jdk/java/lang/invoke/callerSensitive/csm/jdk/test/MethodInvokeTest.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/csm/jdk/test/MethodInvokeTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test;
+
+import java.lang.StackWalker.StackFrame;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.CSM;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.util.function.Supplier;
+
+/**
+ * This test invokes caller-sensitive methods via static reference,
+ * reflection, MethodHandle, lambda.  If there is no alternate implementation
+ * of a CSM with a trailing caller class parameter, when a CSM is invoked
+ * via method handle, an invoker class is injected as the caller class
+ * which is defined by the same defining class loader, in the same runtime
+ * package, and protection domain as the lookup class.
+ */
+public class MethodInvokeTest {
+    static final Policy DEFAULT_POLICY = Policy.getPolicy();
+    private static final String CALLER_METHOD = "caller";
+    private static final String CALLER_NO_ALT_METHOD = "callerNoAlternateImpl";
+
+    public static void main(String... args) throws Throwable {
+        boolean sm = false;
+        if (args.length > 0 && args[0].equals("sm")) {
+            sm = true;
+            PermissionCollection perms = new Permissions();
+            perms.add(new RuntimePermission("getStackWalkerWithClassReference"));
+            Policy.setPolicy(new Policy() {
+                @Override
+                public boolean implies(ProtectionDomain domain, Permission p) {
+                    return perms.implies(p) || DEFAULT_POLICY.implies(domain, p);
+                }
+            });
+            System.setSecurityManager(new SecurityManager());
+        }
+
+        System.err.format("Test %s security manager.%n",
+                          sm ? "with" : "without");
+
+        MethodInvokeTest test = new MethodInvokeTest();
+        // test static call to java.util.CSM::caller
+        test.staticMethodCall();
+        // test java.lang.reflect.Method call
+        test.reflectMethodCall();
+        // test java.lang.invoke.MethodHandle
+        test.invokeMethodHandle();
+        // test method ref
+        test.lambda();
+    }
+
+    void staticMethodCall() {
+        checkCaller(java.util.CSM.caller(), MethodInvokeTest.class);
+        checkCaller(java.util.CSM.callerNoAlternateImpl(), MethodInvokeTest.class);
+    }
+
+    void reflectMethodCall() throws Throwable {
+        checkCaller(Caller1.invoke(CSM.class.getMethod(CALLER_METHOD)), Caller1.class);
+        checkCaller(Caller2.invoke(CSM.class.getMethod(CALLER_METHOD)), Caller2.class);
+        checkCaller(Caller1.invoke(CSM.class.getMethod(CALLER_NO_ALT_METHOD)), Caller1.class);
+        checkCaller(Caller2.invoke(CSM.class.getMethod(CALLER_NO_ALT_METHOD)), Caller2.class);
+    }
+
+    void invokeMethodHandle() throws Throwable {
+        checkCaller(Caller1.invokeExact(CALLER_METHOD), Caller1.class);
+        checkCaller(Caller2.invokeExact(CALLER_METHOD), Caller2.class);
+
+        checkInjectedInvoker(Caller1.invokeExact(CALLER_NO_ALT_METHOD), Caller1.class);
+        checkInjectedInvoker(Caller2.invokeExact(CALLER_NO_ALT_METHOD), Caller2.class);
+    }
+
+    void lambda() {
+        CSM caller = LambdaTest.caller.get();
+        LambdaTest.checkLambdaProxyClass(caller);
+
+        caller = LambdaTest.caller();
+        LambdaTest.checkLambdaProxyClass(caller);
+    }
+
+    static class Caller1 {
+        static CSM invoke(Method csm) throws ReflectiveOperationException {
+            return (CSM)csm.invoke(null);
+        }
+        static CSM invokeExact(String methodName) throws Throwable {
+            MethodHandle mh = MethodHandles.lookup().findStatic(java.util.CSM.class,
+                    methodName, MethodType.methodType(CSM.class));
+            return (CSM)mh.invokeExact();
+        }
+    }
+
+    static class Caller2 {
+        static CSM invoke(Method csm) throws ReflectiveOperationException {
+            return (CSM)csm.invoke(null);
+        }
+        static CSM invokeExact(String methodName) throws Throwable {
+            MethodHandle mh = MethodHandles.lookup().findStatic(java.util.CSM.class,
+                    methodName, MethodType.methodType(CSM.class));
+            return (CSM)mh.invokeExact();
+        }
+    }
+
+    static class LambdaTest {
+        static Supplier<CSM> caller = java.util.CSM::caller;
+
+        static CSM caller() {
+            return caller.get();
+        }
+
+        /*
+         * The class calling the caller-sensitive method is the lambda proxy class
+         * generated for LambdaTest.
+         */
+        static void checkLambdaProxyClass(CSM csm) {
+            Class<?> caller = csm.caller;
+            assertTrue(caller.isHidden(), caller + " should be a hidden class");
+            assertEquals(caller.getModule(), LambdaTest.class.getModule());
+
+            int index = caller.getName().indexOf('/');
+            String cn = caller.getName().substring(0, index);
+            assertTrue(cn.startsWith(LambdaTest.class.getName() + "$$Lambda$"), caller + " should be a lambda proxy class");
+        }
+    }
+    static void checkCaller(CSM csm, Class<?> expected) {
+        assertEquals(csm.caller, expected);
+        // verify no invoker class injected
+        for (StackFrame frame : csm.stackFrames) {
+            Class<?> c = frame.getDeclaringClass();
+            if (c == expected) break;
+
+            if (c.getName().startsWith(expected.getName() + "$$InjectedInvoker"))
+                throw new RuntimeException("should not have any invoker class injected");
+        }
+    }
+
+    /*
+     * The class calling the direct method handle of the caller-sensitive class
+     * is the InjectedInvoker class generated for the given caller.
+     */
+    static void checkInjectedInvoker(CSM csm, Class<?> expected) {
+        Class<?> invoker = csm.caller;
+        assertTrue(invoker.isHidden(), invoker + " should be a hidden class");
+        assertEquals(invoker.getModule(), expected.getModule());
+
+        int index = invoker.getName().indexOf('/');
+        String cn = invoker.getName().substring(0, index);
+        assertEquals(cn, expected.getName() + "$$InjectedInvoker");
+
+        // check the invoker class on the stack
+        for (StackFrame frame : csm.stackFrames) {
+            Class<?> c = frame.getDeclaringClass();
+            if (c.getName().startsWith(expected.getName() + "$$InjectedInvoker"))
+                break;
+
+            if (c == expected)
+                throw new RuntimeException("no invoker class found before the expected caller class");
+        }
+    }
+
+    static void assertTrue(boolean value, String msg) {
+        if (!value) {
+            throw new RuntimeException(msg);
+        }
+    }
+    static void assertEquals(Object o1, Object o2) {
+        if (!o1.equals(o2)) {
+            throw new RuntimeException(o1 + " != " + o2);
+        }
+    }
+}

--- a/test/jdk/java/lang/invoke/callerSensitive/csm/jdk/test/MethodInvokeTest.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/csm/jdk/test/MethodInvokeTest.java
@@ -50,22 +50,12 @@ public class MethodInvokeTest {
     private static final String CALLER_NO_ALT_METHOD = "callerNoAlternateImpl";
 
     public static void main(String... args) throws Throwable {
-        boolean sm = false;
-        if (args.length > 0 && args[0].equals("sm")) {
-            sm = true;
-            PermissionCollection perms = new Permissions();
-            perms.add(new RuntimePermission("getStackWalkerWithClassReference"));
-            Policy.setPolicy(new Policy() {
-                @Override
-                public boolean implies(ProtectionDomain domain, Permission p) {
-                    return perms.implies(p) || DEFAULT_POLICY.implies(domain, p);
-                }
-            });
-            System.setSecurityManager(new SecurityManager());
-        }
-
+        boolean sm = args.length > 0 && args[0].equals("sm");
         System.err.format("Test %s security manager.%n",
                           sm ? "with" : "without");
+        if (sm) {
+            setupSecurityManager();
+        }
 
         MethodInvokeTest test = new MethodInvokeTest();
         // test static call to java.util.CSM::caller
@@ -76,6 +66,18 @@ public class MethodInvokeTest {
         test.invokeMethodHandle();
         // test method ref
         test.lambda();
+    }
+
+    static void setupSecurityManager() {
+        PermissionCollection perms = new Permissions();
+        perms.add(new RuntimePermission("getStackWalkerWithClassReference"));
+        Policy.setPolicy(new Policy() {
+            @Override
+            public boolean implies(ProtectionDomain domain, Permission p) {
+                return perms.implies(p) || DEFAULT_POLICY.implies(domain, p);
+            }
+        });
+        System.setSecurityManager(new SecurityManager());
     }
 
     void staticMethodCall() {

--- a/test/jdk/java/lang/invoke/callerSensitive/csm/module-info.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/csm/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module csm {
+    exports jdk.test;
+}

--- a/test/jdk/java/lang/invoke/callerSensitive/src/java.base/java/util/CSM.java
+++ b/test/jdk/java/lang/invoke/callerSensitive/src/java.base/java/util/CSM.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.util;
+
+import java.lang.StackWalker.StackFrame;
+import java.util.stream.Stream;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+
+import static java.lang.StackWalker.Option.*;
+
+public class CSM {
+    public final Class<?> caller;
+    public final List<StackFrame> stackFrames;
+    CSM(Class<?> caller) {
+        this.caller = caller;
+        StackWalker sw = StackWalker.getInstance(Set.of(RETAIN_CLASS_REFERENCE, SHOW_HIDDEN_FRAMES));
+        this.stackFrames = sw.walk(Stream::toList);
+    }
+
+    /**
+     * Returns the caller of this caller-sensitive method returned by
+     * by Reflection::getCallerClass except if this method is called
+     * via method handle.
+     */
+    @CallerSensitive
+    public static CSM caller() {
+        return new CSM(Reflection.getCallerClass());
+    }
+
+    /**
+     * If caller() is invoked via method handle, this alternate method is
+     * called instead.  The caller class would be the lookup class.
+     */
+    private static CSM reflected$caller(Class<?> caller) {
+        return new CSM(caller);
+    }
+
+    /**
+     * Returns the caller of this caller-sensitive method returned by
+     * by Reflection::getCallerClass.
+     */
+    @CallerSensitive
+    public static CSM callerNoAlternateImpl() {
+        return new CSM(Reflection.getCallerClass());
+    }
+}

--- a/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
+++ b/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @bug 8013527 
+ * @bug 8013527
  * @run testng/othervm ChainedLookupTest
  * @summary Test MethodHandles.lookup method to produce the Lookup object with
  *          proper lookup class if invoked through reflection and method handle.

--- a/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
+++ b/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
@@ -63,7 +63,21 @@ public class ChainedLookupTest {
     }
 
     /**
-     * MethodHandle::invokeExaxt on MethodHandles::lookup
+     * Invoke Method::invoke on MethodHandles::lookup via MethodHandle
+     */
+    @Test()
+    void methodInvokeViaMethodHandle() throws Throwable {
+        Method m =  MethodHandles.class.getMethod("lookup");
+
+        MethodHandle mh = MethodHandles.lookup().findVirtual(Method.class, "invoke",
+                methodType(Object.class, Object.class, Object[].class));
+
+        Lookup lookup = (Lookup) mh.invokeExact(m, null);
+        test(lookup, "Lookup produced via Method::invoke via MethodHandle");
+    }
+
+    /**
+     * MethodHandle::invokeExact on MethodHandles::lookup
      */
     @Test()
     void methodHandle() throws Throwable {

--- a/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
+++ b/test/jdk/java/lang/invoke/lookup/ChainedLookupTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8013527 
+ * @run testng/othervm ChainedLookupTest
+ * @summary Test MethodHandles.lookup method to produce the Lookup object with
+ *          proper lookup class if invoked through reflection and method handle.
+ */
+
+import java.lang.invoke.*;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Method;
+
+import org.testng.annotations.Test;
+
+import static java.lang.invoke.MethodHandles.*;
+import static java.lang.invoke.MethodType.*;
+import static org.testng.Assert.*;
+
+public class ChainedLookupTest {
+    /**
+     * Direct call to MethodHandles::lookup
+     */
+    @Test()
+    void staticLookup() throws Throwable {
+        Lookup lookup =  lookup();
+        test(lookup, "Lookup produced via direct call to MethodHandles.lookup()");
+    }
+
+    /**
+     * Reflective Method::invoke on MethodHandles::lookup
+     */
+    @Test()
+    void methodInvoke() throws Throwable {
+        Method m =  MethodHandles.class.getMethod("lookup");
+        Lookup lookup = (Lookup) m.invoke(null);
+
+        test(lookup, "Lookup produced via reflective call");
+    }
+
+    /**
+     * MethodHandle::invokeExaxt on MethodHandles::lookup
+     */
+    @Test()
+    void methodHandle() throws Throwable {
+        MethodHandle MH_lookup2 = publicLookup().findStatic(MethodHandles.class, "lookup", methodType(Lookup.class));
+        Lookup lookup = (Lookup) MH_lookup2.invokeExact();
+
+        test(lookup, "Lookup produced via MethodHandle");
+    }
+
+    /**
+     * MethodHandles::unreflect the reflective Method representing MethodHandles::lookup
+     */
+    @Test()
+    void unreflect() throws Throwable {
+        MethodHandle MH_lookup = lookup().unreflect(MethodHandles.class.getMethod("lookup"));
+        Lookup lookup = (Lookup) MH_lookup.invokeExact();
+
+        test(lookup, "Lookup produced via unreflect MethodHandle");
+    }
+
+    /**
+     * Use the Lookup object returned from MethodHandle::invokeExact on MethodHandles::lookup
+     * to look up MethodHandle representing MethodHandles::lookup and then invoking it.
+     */
+    @Test()
+    void chainedMethodHandle() throws Throwable {
+        MethodHandle MH_lookup = lookup().findStatic(MethodHandles.class, "lookup", methodType(Lookup.class));
+        Lookup lookup = (Lookup) MH_lookup.invokeExact();
+        MethodHandle MH_lookup2 = lookup.unreflect(MethodHandles.class.getMethod("lookup"));
+        Lookup lookup2 = (Lookup) MH_lookup2.invokeExact();
+
+        test(lookup2, "Lookup produced via a chained call to MethodHandle");
+    }
+
+    void test(Lookup lookup, String msg) throws Throwable {
+        assertTrue(lookup.lookupClass() == ChainedLookupTest.class);
+        assertTrue(lookup.hasFullPrivilegeAccess());
+
+        MethodHandle mh = lookup.findStatic(lookup.lookupClass(), "say", methodType(void.class, String.class));
+        mh.invokeExact(msg);
+    }
+
+    private static void say(String msg) {
+        System.out.println(msg);
+    }
+}
+

--- a/test/jdk/jdk/internal/reflect/CallerSensitive/CheckCSMs.java
+++ b/test/jdk/jdk/internal/reflect/CallerSensitive/CheckCSMs.java
@@ -33,10 +33,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -62,13 +65,22 @@ public class CheckCSMs {
     // The goal is to remove this list of Non-final instance @CS methods
     // over time.  Do not add any new one to this list.
     private static Set<String> KNOWN_NON_FINAL_CSMS =
-      Set.of("java/io/ObjectStreamField#getType ()Ljava/lang/Class;",
-             "java/io/ObjectStreamClass#forClass ()Ljava/lang/Class;",
-             "java/lang/Runtime#load (Ljava/lang/String;)V",
-             "java/lang/Runtime#loadLibrary (Ljava/lang/String;)V",
-             "java/lang/Thread#getContextClassLoader ()Ljava/lang/ClassLoader;",
-             "javax/sql/rowset/serial/SerialJavaObject#getFields ()[Ljava/lang/reflect/Field;"
-      );
+        Set.of("java/io/ObjectStreamField#getType ()Ljava/lang/Class;",
+               "java/io/ObjectStreamClass#forClass ()Ljava/lang/Class;",
+               "java/lang/Runtime#load (Ljava/lang/String;)V",
+               "java/lang/Runtime#loadLibrary (Ljava/lang/String;)V",
+               "java/lang/Thread#getContextClassLoader ()Ljava/lang/ClassLoader;",
+               "javax/sql/rowset/serial/SerialJavaObject#getFields ()[Ljava/lang/reflect/Field;"
+        );
+
+    // These non-static non-final methods must not have alternate implementation
+    // that takes a trailing caller class parameter.  It's currently invoked
+    // by method handle if present.
+    private static Set<String> UNSUPPORTED_VIRTUAL_METHODS =
+        Set.of("java/io/ObjectStreamField#reflected$getType (Ljava/lang/Class;)Ljava/lang/Class;",
+               "java/lang/Thread#reflected$getContextClassLoader (Ljava/lang/Class;)Ljava/lang/ClassLoader;",
+               "javax/sql/rowset/serial/SerialJavaObject#reflected$getFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field;"
+        );
 
     public static void main(String[] args) throws Exception {
         if (args.length > 0 && args[0].equals("--list")) {
@@ -84,9 +96,19 @@ public class CheckCSMs {
                 result.stream().sorted()
                       .collect(Collectors.joining("\n", "\n", "")));
         }
+
+        // check if all reflected$xxx methods with a trailing Class parameter are supported
+        checkCSMs.reflectedMethods.values().stream()
+                 .flatMap(Set::stream)
+                 .forEach(m -> {
+                     if (UNSUPPORTED_VIRTUAL_METHODS.contains(m))
+                         throw new RuntimeException("Unsupported alternate impl method: " + m);
+                 });
     }
 
     private final Set<String> nonFinalCSMs = new ConcurrentSkipListSet<>();
+    private final Map<String, Set<String>> reflectedMethods = new ConcurrentHashMap<>();
+
     private final ReferenceFinder finder;
     public CheckCSMs() {
         this.finder = new ReferenceFinder(getFilter(), getVisitor());
@@ -129,9 +151,7 @@ public class CheckCSMs {
                         m.getName(cf.constant_pool).equals("getCallerClass"))
                         return;
 
-                    String name = String.format("%s#%s %s", cf.getName(),
-                                                m.getName(cf.constant_pool),
-                                                m.descriptor.getValue(cf.constant_pool));
+                    String name = methodSignature(cf, m);
                     if (!CheckCSMs.isStaticOrFinal(cf, m, cf.constant_pool)) {
                         System.err.println("Unsupported @CallerSensitive: " + name);
                         nonFinalCSMs.add(name);
@@ -140,11 +160,48 @@ public class CheckCSMs {
                             System.out.format("@CS  %s%n", name);
                         }
                     }
+
+                    // find the alternate implementation for CSM with a trailing
+                    // Class parameter
+                    if (!reflectedMethods.containsKey(cf.getName())) {
+                        reflectedMethods.put(cf.getName(),
+                                Arrays.stream(cf.methods)
+                                      .filter(m0 -> reflectedImpl(cf, m0))
+                                      .map(m0 -> methodSignature(cf, m0))
+                                      .collect(Collectors.toSet()));
+                        reflectedMethods.get(cf.getName()).stream().sorted().forEach(System.out::println);
+
+                    }
                 } catch (ConstantPoolException ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
+    }
+
+    private static String methodSignature(ClassFile cf, Method m) {
+        try {
+            return String.format("%s#%s %s", cf.getName(),
+                                 m.getName(cf.constant_pool),
+                                 m.descriptor.getValue(cf.constant_pool));
+        } catch (ConstantPoolException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static boolean reflectedImpl(ClassFile cf, Method m) {
+        ConstantPool cp = cf.constant_pool;
+        try {
+            int paramCount = m.descriptor.getParameterCount(cp);
+            String desc = m.descriptor.getParameterTypes(cp);
+            if (m.getName(cp).startsWith("reflected$")
+                    && paramCount > 0 && desc.endsWith("java.lang.Class)")) {
+                return true;
+            }
+        } catch (ConstantPoolException|Descriptor.InvalidDescriptor e) {
+            throw new RuntimeException(e);
+        }
+        return false;
     }
 
     private static final String CALLER_SENSITIVE_ANNOTATION


### PR DESCRIPTION
JDK-8013527: calling MethodHandles.lookup on itself leads to errors
JDK-8257874: MethodHandle injected invoker doesn't have necessary private access

Johannes Kuhn is also a contributor to this patch.

A caller-sensitive method can behave differently depending on the identity
of its immediate caller.  If a method handle for a caller-sensitive method is
requested, this resulting method handle behaves as if it were called from an
instruction contained in the lookup class.  The current implementation injects
a trampoline class (aka the invoker class) which is the caller class invoking
such caller-sensitive method handle.  It works in all CSMs except `MethodHandles::lookup`
because the caller-sensitive behavior depends on the module of the caller class,
the class loader of the caller class, the accessibility of the caller class, or
the protection domain of the caller class.  The invoker class is a hidden class
defined in the same runtime package with the same protection domain as the
lookup class, which is why the current implementation works for all CSMs except
`MethodHandles::lookup` which uses the caller class as the lookup class.

Two issues with current implementation:
1.  The invoker class only has the package access as the lookup class.  It cannot
    access private members of the lookup class and its nest members.

    The fix is to make the invoker class as a nestmate of the lookup class.

2.  `MethodHandles::lookup` if invoked via a method handle produces a `Lookup`
    object of an injected invoker class which is a bug.

There are two alternatives:
- define the invoker class with the lookup class as the class data such that
  `MethodHandles::lookup` will get the caller class from the class data if
  it's the injected invoker
- Johannes' proposal [1]: detect if an alternate implementation with an additional
  trailing caller class parameter is present, use the alternate implementation
  and bind the method handle with the lookup class as the caller class argument.

There has been several discussions on the improvement to support caller sensitive
methods for example the calling sequences and security implication.   I have
looked at how each CSM uses the caller class.  The second approach (i.e. 
defining an alternate implementation for a caller-sensitive method taking
an additional caller class parameter) does not work for non-static non-final
caller-sensitive method.  In addition, it is not ideal to pollute the source
code to provide an alternatve implementation for all 120+ caller-sensitive methods
whereas the injected invoker works for all except `MethodHandles::lookup`.

I propose to use both approaches.   We can add an alternative implementation for
a caller-sensitive method when desirable such as `MethodHandles::lookup` in
this PR.  For the injected invoker case, one could extract the original lookup
class from class data if needed.

test/jdk/jdk/internal/reflect/CallerSensitive/CheckCSM.java ensures that
no new non-static non-final caller-sensitive method will be added to the JDK.
I extend this test to catch that non-static non-final caller-sensitive method
cannot have the alternate implementation taking the additional caller class
parameter.

This fix for JDK-8013527 is needed by the prototype for JDK-6824466 I'm working on.

[1] https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-January/073184.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8013527](https://bugs.openjdk.java.net/browse/JDK-8013527): calling MethodHandles.lookup on itself leads to errors
 * [JDK-8257874](https://bugs.openjdk.java.net/browse/JDK-8257874): MethodHandle injected invoker doesn't have necessary private access


### Reviewers
 * [Johannes Kuhn](https://openjdk.java.net/census#jkuhn) (@DasBrain - Author)


### Contributors
 * Johannes Kuhn `<info@j-kuhn.de>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2367/head:pull/2367`
`$ git checkout pull/2367`
