### PR TITLE
8261010: Delete the Netbeans "default" license header

### DIFF
--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRGraphicsConfig.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRGraphicsConfig.java
@@ -23,11 +23,6 @@
  * questions.
  */
 
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package sun.java2d.xr;
 
 import java.awt.Transparency;

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -20,10 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.openjdk.bench.java.math;
 
 import org.openjdk.jmh.annotations.Benchmark;

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -20,11 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;


### PR DESCRIPTION
Trivial cleanup, the "default" license header is removed in a few components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261010](https://bugs.openjdk.java.net/browse/JDK-8261010): Delete the Netbeans "default" license header


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2368/head:pull/2368`
`$ git checkout pull/2368`
