### PR TITLE
8198343: Test java/awt/print/PrinterJob/TestPgfmtSetMPA.java may fail  w/o printer

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -254,7 +254,6 @@ java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
 java/awt/image/DrawImage/BlitRotateClippedArea.java 8255724 linux-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all,windows-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
-java/awt/print/PrinterJob/TestPgfmtSetMPA.java 8198343 generic-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all

--- a/test/jdk/java/awt/print/PrinterJob/TestPgfmtSetMPA.java
+++ b/test/jdk/java/awt/print/PrinterJob/TestPgfmtSetMPA.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 6789262
+ * @key printer
  * @summary  Verifies if getPageFormat returns correct mediaprintable value
  * @run main TestPgfmtSetMPA
  */
@@ -38,6 +39,10 @@ public class TestPgfmtSetMPA {
         PrinterJob job;
 
         job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            System.out.println("No printers. Test cannot continue");
+            return;
+        }
 
         PrintRequestAttributeSet pras = new HashPrintRequestAttributeSet();
 


### PR DESCRIPTION
This test require a printer to test its objective, so printer existence check is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198343](https://bugs.openjdk.java.net/browse/JDK-8198343): Test java/awt/print/PrinterJob/TestPgfmtSetMPA.java may fail w/o printer


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2370/head:pull/2370`
`$ git checkout pull/2370`
