### PR TITLE
6436374: Graphics.setColor(null) is not documented

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Graphics.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics.java
@@ -193,6 +193,7 @@ public abstract class Graphics {
      * Sets this graphics context's current color to the specified
      * color. All subsequent graphics operations using this graphics
      * context use this specified color.
+     * A null argument is silently ignored.
      * @param     c   the new rendering color.
      * @see       java.awt.Color
      * @see       java.awt.Graphics#getColor

--- a/test/jdk/java/awt/color/TestNullSetColor.java
+++ b/test/jdk/java/awt/color/TestNullSetColor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import java.awt.Graphics;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+/**
+ * @test
+ * @bug 6436374
+ * @summary Verifies that passing null to setColor() will be ignored.
+ */
+public class TestNullSetColor {
+
+    public static void main(String[] argv) {
+        BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = bi.getGraphics();
+
+        g.setColor(Color.RED);
+        g.setColor(null);
+
+        if (g.getColor() != Color.RED) {
+            throw new RuntimeException("Setting setColor(null) is not ignored");
+        }
+    }
+}


### PR DESCRIPTION
Document setting null setColor similar to way setFont(null) is documented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6436374](https://bugs.openjdk.java.net/browse/JDK-6436374): Graphics.setColor(null) is not documented


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to dc4fe3c5c17ce4b63e5fd0b93adb507b96bbf2c7


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2371/head:pull/2371`
`$ git checkout pull/2371`
