### PR TITLE
8261023: Document why memory pretouch must be a store

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1813,10 +1813,10 @@ void os::print_memory_mappings(outputStream* st) {
 
 void os::pretouch_memory(void* start, void* end, size_t page_size) {
   for (volatile char *p = (char*)start; p < (char*)end; p += page_size) {
-    // This must be a store due to OS optimizations like e.g. the Linux zero page
-    // optimization where only writes trigger actual backing of memory. Reads
-    // access a single shared zero page at first and so will not achieve the
-    // desired effect.
+    // Note: this must be a store, not a load. On many OSes loads from fresh
+    // memory would be satisfied from a single mapped page containing all zeros.
+    // We need to store something to each page to get them backed by their own
+    // memory, which is the effect we want here.
     *p = 0;
   }
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1813,6 +1813,10 @@ void os::print_memory_mappings(outputStream* st) {
 
 void os::pretouch_memory(void* start, void* end, size_t page_size) {
   for (volatile char *p = (char*)start; p < (char*)end; p += page_size) {
+    // This must be a store due to OS optimizations like e.g. the Linux zero page
+    // optimization where only writes trigger actual backing of memory. Reads
+    // access a single shared zero page at first and so will not achieve the
+    // desired effect.
     *p = 0;
   }
 }


### PR DESCRIPTION
Hi all,

  may I have reviews for this additional comment that explains why `os::pretouch_memory` needs to use a store and must not use a read which would be more convenient?

Basically on some (all?) OSes memory pages are only actually backed with physical memory on a store to that page. Before that a common "zero page" may be used to satisfy reads. This is not what is intended here.

A previous comment (that has been removed long ago) seems to have been a bit confused about the actual issue:

```-      // Note the use of a write here; originally we tried just a read, but
-      // since the value read was unused, the optimizer removed the read.
-      // If we ever have a concurrent touchahead thread, we'll want to use
-      // a read, to avoid the potential of overwriting data (if a mutator
-      // thread beats the touchahead thread to a page).  There are various
-      // ways of making sure this read is not optimized away: for example,
-      // generating the code for a read procedure at runtime.
```

It indicates that the reason for using a store has been that the compiler would optimize away the reads (which begs the question why a `volatile` read has not been used).

Maybe these zero page optimizations came later than that original implementation though.

Testing: local compilation - it's adding a comment only, really.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261023](https://bugs.openjdk.java.net/browse/JDK-8261023): Document why memory pretouch must be a store


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to d30fff804391f5444487ff764e83f8647f23e809


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2373/head:pull/2373`
`$ git checkout pull/2373`
