### PR TITLE
8261028: ZGC: SIGFPE when MaxVirtMemFraction=0

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -344,6 +344,7 @@
   develop(uintx, MaxVirtMemFraction, 2,                                     \
           "Maximum fraction (1/n) of virtual memory used for ergonomically "\
           "determining maximum heap size")                                  \
+          range(1, max_uintx)                                               \
                                                                             \
   product(bool, UseAdaptiveSizePolicy, true,                                \
           "Use adaptive generation sizing policies")                        \


### PR DESCRIPTION
Hi all,

The SIGFPE was caused by this line [1] when MaxVirtMemFraction=0.
But according to this comment [2], 0 should not be allowed for MaxVirtMemFraction.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp#L51
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shared/gc_globals.hpp#L345

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261028](https://bugs.openjdk.java.net/browse/JDK-8261028): ZGC: SIGFPE when MaxVirtMemFraction=0


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2374/head:pull/2374`
`$ git checkout pull/2374`
