### PR TITLE
8261030: Avoid loading GenerateJLIClassesHelper at runtime

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -46,7 +46,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import static java.lang.invoke.GenerateJLIClassesHelper.traceSpeciesType;
 import static java.lang.invoke.LambdaForm.*;
 import static java.lang.invoke.MethodHandleNatives.Constants.REF_getStatic;
 import static java.lang.invoke.MethodHandleNatives.Constants.REF_putStatic;
@@ -476,8 +475,10 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
             Class<?> salvage = null;
             try {
                 salvage = BootLoader.loadClassOrNull(className);
-                traceSpeciesType(className, salvage);
             } catch (Error ex) {
+                // ignore
+            } finally {
+                traceSpeciesType(className, salvage);
             }
             final Class<? extends T> speciesCode;
             if (salvage != null) {
@@ -488,7 +489,6 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
                 // Not pregenerated, generate the class
                 try {
                     speciesCode = generateConcreteSpeciesCode(className, speciesData);
-                    traceSpeciesType(className, salvage);
                     // This operation causes a lot of churn:
                     linkSpeciesDataToCode(speciesData, speciesCode);
                     // This operation commits the relation, but causes little churn:

--- a/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package java.lang.invoke;
 
-import jdk.internal.misc.CDS;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.Opcodes;
 import sun.invoke.util.Wrapper;

--- a/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -39,10 +39,9 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
-import static java.lang.invoke.LambdaForm.basicTypeSignature;
-import static java.lang.invoke.LambdaForm.shortenSignature;
 import static java.lang.invoke.LambdaForm.BasicType.*;
-import static java.lang.invoke.MethodHandleStatics.TRACE_RESOLVE;
+import static java.lang.invoke.MethodHandleStatics.LF_RESOLVE;
+import static java.lang.invoke.MethodHandleStatics.SPECIES_RESOLVE;
 import static java.lang.invoke.MethodTypeForm.*;
 import static java.lang.invoke.LambdaForm.Kind.*;
 
@@ -51,29 +50,6 @@ import static java.lang.invoke.LambdaForm.Kind.*;
  * generate classes ahead of time.
  */
 class GenerateJLIClassesHelper {
-    private static final String LF_RESOLVE = "[LF_RESOLVE]";
-    private static final String SPECIES_RESOLVE = "[SPECIES_RESOLVE]";
-
-    static void traceLambdaForm(String name, MethodType type, Class<?> holder, MemberName resolvedMember) {
-        if (TRACE_RESOLVE) {
-            System.out.println(LF_RESOLVE + " " + holder.getName() + " " + name + " " +
-                    shortenSignature(basicTypeSignature(type)) +
-                    (resolvedMember != null ? " (success)" : " (fail)"));
-        }
-        if (CDS.isDumpingClassList()) {
-            CDS.traceLambdaFormInvoker(LF_RESOLVE, holder.getName(), name, shortenSignature(basicTypeSignature(type)));
-        }
-    }
-
-    static void traceSpeciesType(String cn, Class<?> salvage) {
-        if (TRACE_RESOLVE) {
-            System.out.println(SPECIES_RESOLVE + " " + cn + (salvage != null ? " (salvaged)" : " (generated)"));
-        }
-        if (CDS.isDumpingClassList()) {
-            CDS.traceSpeciesType(SPECIES_RESOLVE, cn);
-        }
-    }
-
     // Map from DirectMethodHandle method type name to index to LambdForms
     static final Map<String, Integer> DMH_METHOD_TYPE_MAP =
             Map.of(

--- a/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -39,8 +39,6 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.LambdaForm.BasicType.*;
-import static java.lang.invoke.MethodHandleStatics.LF_RESOLVE;
-import static java.lang.invoke.MethodHandleStatics.SPECIES_RESOLVE;
 import static java.lang.invoke.MethodTypeForm.*;
 import static java.lang.invoke.LambdaForm.Kind.*;
 
@@ -298,7 +296,7 @@ class GenerateJLIClassesHelper {
         traces.map(line -> line.split(" "))
                 .forEach(parts -> {
                     switch (parts[0]) {
-                        case SPECIES_RESOLVE:
+                        case "[SPECIES_RESOLVE]":
                             // Allow for new types of species data classes being resolved here
                             assert parts.length >= 2;
                             if (parts[1].startsWith(BMH_SPECIES_PREFIX)) {
@@ -308,7 +306,7 @@ class GenerateJLIClassesHelper {
                                 }
                             }
                             break;
-                        case LF_RESOLVE:
+                        case "[LF_RESOLVE]":
                             assert parts.length > 3;
                             String methodType = parts[3];
                             if (parts[1].equals(INVOKERS_HOLDER_CLASS_NAME)) {

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static java.lang.invoke.GenerateJLIClassesHelper.traceLambdaForm;
 import static java.lang.invoke.LambdaForm.BasicType;
 import static java.lang.invoke.LambdaForm.BasicType.*;
 import static java.lang.invoke.LambdaForm.*;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -62,11 +62,6 @@ class MethodHandleStatics {
     static final int MAX_ARITY;
     static final boolean VAR_HANDLE_IDENTITY_ADAPT;
 
-    // Markers used by LambdaForm and Species resolution code to communicate
-    // classes that have been or could have be pre-generated
-    static final String LF_RESOLVE = "[LF_RESOLVE]";
-    static final String SPECIES_RESOLVE = "[SPECIES_RESOLVE]";
-
     static {
         Properties props = GetPropertyAction.privilegedGetProperties();
         DEBUG_METHOD_HANDLE_NAMES = Boolean.parseBoolean(
@@ -117,25 +112,33 @@ class MethodHandleStatics {
                 LOG_LF_COMPILATION_FAILURE);
     }
 
+    /**
+     * If requested, logs the result of resolving the LambdaForm to stdout
+     * and informs the CDS subsystem about it.
+     */
     /*non-public*/
     static void traceLambdaForm(String name, MethodType type, Class<?> holder, MemberName resolvedMember) {
         if (TRACE_RESOLVE) {
-            System.out.println(LF_RESOLVE + " " + holder.getName() + " " + name + " " +
+            System.out.println("[LF_RESOLVE] " + holder.getName() + " " + name + " " +
                     shortenSignature(basicTypeSignature(type)) +
                     (resolvedMember != null ? " (success)" : " (fail)"));
         }
         if (CDS.isDumpingClassList()) {
-            CDS.traceLambdaFormInvoker(LF_RESOLVE, holder.getName(), name, shortenSignature(basicTypeSignature(type)));
+            CDS.traceLambdaFormInvoker("[LF_RESOLVE]", holder.getName(), name, shortenSignature(basicTypeSignature(type)));
         }
     }
 
+    /**
+     * If requested, logs the result of resolving the species type to stdout
+     * and the CDS subsystem.
+     */
     /*non-public*/
     static void traceSpeciesType(String cn, Class<?> salvage) {
         if (TRACE_RESOLVE) {
-            System.out.println(SPECIES_RESOLVE + " " + cn + (salvage != null ? " (salvaged)" : " (generated)"));
+            System.out.println("[SPECIES_RESOLVE] " + cn + (salvage != null ? " (salvaged)" : " (generated)"));
         }
         if (CDS.isDumpingClassList()) {
-            CDS.traceSpeciesType(SPECIES_RESOLVE, cn);
+            CDS.traceSpeciesType("[SPECIES_RESOLVE]", cn);
         }
     }
     // handy shared exception makers (they simplify the common case code)


### PR DESCRIPTION
This moves the tracing methods added to GenerateJLIClassesHelper in JDK-8252725 to MethodHandleStatics, which avoids loading at runtime some code meant for jlink.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261030](https://bugs.openjdk.java.net/browse/JDK-8261030): Avoid loading GenerateJLIClassesHelper at runtime


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 2931ef8abfa63eaf76a53542f2b8d1a4cbfc7b2f


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2376/head:pull/2376`
`$ git checkout pull/2376`
