### PR TITLE
JDK-8261034: improve jcmd GC.class_histogram to support parallel

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -554,13 +554,17 @@ int HeapDumpDCmd::num_arguments() {
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :
                                        DCmdWithParser(output, heap),
   _all("-all", "Inspect all objects, including unreachable objects",
-       "BOOLEAN", false, "false") {
+       "BOOLEAN", false, "false"),
+  _parallel_thread_num("-parallel", "parallel threads number for heap iteration",
+       "INT", false, "0")     {
   _dcmdparser.add_dcmd_option(&_all);
+  _dcmdparser.add_dcmd_option(&_parallel_thread_num);
 }
 
 void ClassHistogramDCmd::execute(DCmdSource source, TRAPS) {
   VM_GC_HeapInspection heapop(output(),
-                              !_all.value() /* request full gc if false */);
+                              !_all.value(), /* request full gc if false */
+                              (uint)_parallel_thread_num.value());
   VMThread::execute(&heapop);
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -357,6 +357,7 @@ public:
 class ClassHistogramDCmd : public DCmdWithParser {
 protected:
   DCmdArgument<bool> _all;
+  DCmdArgument<jlong> _parallel_thread_num;
 public:
   ClassHistogramDCmd(outputStream* output, bool heap);
   static const char* name() {


### PR DESCRIPTION
parallel -histo of jmap was added by JDK-8214535, it's better to support parallel for jcmd GC.class_histogram too.