### PR TITLE
8261036: Reduce classes loaded by CleanerFactory initialization

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -51,8 +51,7 @@ public final class InnocuousThread extends Thread {
 
     /**
      * Returns a new InnocuousThread with an auto-generated thread name,
-     * inheriting the current thread priority, and its context class loader
-     * is set to the system class loader.
+     * and its context class loader is set to the system class loader.
      */
     public static Thread newThread(Runnable target) {
         return newThread(newName(), target);
@@ -60,15 +59,15 @@ public final class InnocuousThread extends Thread {
 
     /**
      * Returns a new InnocuousThread with its context class loader
-     * set to the system class loader, inheriting the current thread priority
+     * set to the system class loader.
      */
     public static Thread newThread(String name, Runnable target) {
         return newThread(name, target, -1);
     }
     /**
      * Returns a new InnocuousThread with its context class loader
-     * set to the system class loader, with the thread priority set to
-     * the given priority.
+     * set to the system class loader. The thread priority will be
+     * set to the given priority.
      */
     public static Thread newThread(String name, Runnable target, int priority) {
         if (System.getSecurityManager() == null) {
@@ -84,8 +83,7 @@ public final class InnocuousThread extends Thread {
     }
 
     /**
-     * Returns a new InnocuousThread with an auto-generated thread name,
-     * inheriting the current thread priority.
+     * Returns a new InnocuousThread with an auto-generated thread name.
      * Its context class loader is set to null.
      */
     public static Thread newSystemThread(Runnable target) {
@@ -93,16 +91,15 @@ public final class InnocuousThread extends Thread {
     }
 
     /**
-     * Returns a new InnocuousThread with null context class loader,
-     * inheriting the current thread priority.
+     * Returns a new InnocuousThread with null context class loader.
      */
     public static Thread newSystemThread(String name, Runnable target) {
         return newSystemThread(name, target, -1);
     }
 
     /**
-     * Returns a new InnocuousThread with null context class loader,
-     * with priority set to the given priority.
+     * Returns a new InnocuousThread with null context class loader.
+     * Thread priority is set to the given priority.
      */
     public static Thread newSystemThread(String name, Runnable target, int priority) {
         if (System.getSecurityManager() == null) {

--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -63,7 +63,7 @@ public final class InnocuousThread extends Thread {
      * set to the system class loader, inheriting the current thread priority
      */
     public static Thread newThread(String name, Runnable target) {
-        return newThread(name, target, currentThread().getPriority());
+        return newThread(name, target, -1);
     }
     /**
      * Returns a new InnocuousThread with its context class loader
@@ -97,7 +97,7 @@ public final class InnocuousThread extends Thread {
      * inheriting the current thread priority.
      */
     public static Thread newSystemThread(String name, Runnable target) {
-        return newSystemThread(name, target, currentThread().getPriority());
+        return newSystemThread(name, target, -1);
     }
 
     /**
@@ -120,7 +120,7 @@ public final class InnocuousThread extends Thread {
     private static Thread createThread(String name, Runnable target, ClassLoader loader, int priority) {
         Thread t = new InnocuousThread(INNOCUOUSTHREADGROUP,
                 target, name, loader);
-        if (t.getPriority() != priority) {
+        if (priority >= 0) {
             t.setPriority(priority);
         }
         return t;

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package jdk.internal.ref;
 import jdk.internal.misc.InnocuousThread;
 
 import java.lang.ref.Cleaner;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.ThreadFactory;
 
 /**
@@ -42,14 +40,8 @@ public final class CleanerFactory {
     private final static Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
-            return AccessController.doPrivileged(new PrivilegedAction<>() {
-                @Override
-                public Thread run() {
-                    Thread t = InnocuousThread.newSystemThread("Common-Cleaner", r);
-                    t.setPriority(Thread.MAX_PRIORITY - 2);
-                    return t;
-                }
-            });
+            return InnocuousThread.newSystemThread("Common-Cleaner",
+                    r, Thread.MAX_PRIORITY - 2);
         }
     });
 

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -213,15 +213,8 @@ public final class CleanerImpl implements Runnable {
         final AtomicInteger cleanerThreadNumber = new AtomicInteger();
 
         public Thread newThread(Runnable r) {
-            return AccessController.doPrivileged(new PrivilegedAction<>() {
-                @Override
-                public Thread run() {
-                    Thread t = InnocuousThread.newThread(r);
-                    t.setPriority(Thread.MAX_PRIORITY - 2);
-                    t.setName("Cleaner-" + cleanerThreadNumber.getAndIncrement());
-                    return t;
-                }
-            });
+            return InnocuousThread.newThread("Cleaner-" + cleanerThreadNumber.getAndIncrement(),
+                r, Thread.MIN_PRIORITY - 2);
         }
     }
 


### PR DESCRIPTION
This patch refactors CleanerFactory and InnocuousThread so that we need to load fewer PrivilegedActions. This slightly reduce the number of classes we always load on bootstrap, slightly reducing static and dynamic footprint (default CDS archive -4Kb).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261036](https://bugs.openjdk.java.net/browse/JDK-8261036): Reduce classes loaded by CleanerFactory initialization


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 89a16eb6af35fd4892ed8e00c0b3d438e2b2517a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2380/head:pull/2380`
`$ git checkout pull/2380`
