### PR TITLE
    JDK-8259927: Windows jpackage installer issues

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixSourcesBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixSourcesBuilder.java
@@ -551,9 +551,6 @@ class WixSourcesBuilder {
         }
 
         List<String> componentIds = new ArrayList<>();
-        while (!SYSTEM_DIRS.contains(path = path.getParent())) {
-            componentIds.add(addRemoveDirectoryComponent(xml, path));
-        }
 
         return componentIds;
     }


### PR DESCRIPTION
Remove lines in WixSourceBuilder that adds directive to rm-rf the parent dir(s) of the install-dir.  These directories get removed anyway if they are empty without these lines, and should be left alone if not empty after removing the install dir itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `JDK-8259927`.


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2382/head:pull/2382`
`$ git checkout pull/2382`
