### PR TITLE
8259668: Make SubTasksDone use-once

### DIFF
--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -75,7 +75,7 @@ void G1RootProcessor::evacuate_roots(G1ParScanThreadState* pss, uint worker_id) 
   }
 
   // CodeCache is already processed in java roots
-  _process_strong_tasks.all_tasks_completed(G1RP_PS_CodeCache_oops_do);
+  _process_strong_tasks.all_tasks_claimed(G1RP_PS_CodeCache_oops_do);
 }
 
 // Adaptor to pass the closures to the strong roots in the VM.
@@ -106,8 +106,8 @@ void G1RootProcessor::process_strong_roots(OopClosure* oops,
 
   // CodeCache is already processed in java roots
   // refProcessor is not needed since we are inside a safe point
-  _process_strong_tasks.all_tasks_completed(G1RP_PS_CodeCache_oops_do,
-                                            G1RP_PS_refProcessor_oops_do);
+  _process_strong_tasks.all_tasks_claimed(G1RP_PS_CodeCache_oops_do,
+                                          G1RP_PS_refProcessor_oops_do);
 }
 
 // Adaptor to pass the closures to all the roots in the VM.
@@ -143,7 +143,7 @@ void G1RootProcessor::process_all_roots(OopClosure* oops,
   process_code_cache_roots(blobs, NULL, 0);
 
   // refProcessor is not needed since we are inside a safe point
-  _process_strong_tasks.all_tasks_completed(G1RP_PS_refProcessor_oops_do);
+  _process_strong_tasks.all_tasks_claimed(G1RP_PS_refProcessor_oops_do);
 }
 
 void G1RootProcessor::process_java_roots(G1RootClosures* closures,

--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -75,7 +75,7 @@ void G1RootProcessor::evacuate_roots(G1ParScanThreadState* pss, uint worker_id) 
   }
 
   // CodeCache is already processed in java roots
-  _process_strong_tasks.all_tasks_completed(n_workers(), G1RP_PS_CodeCache_oops_do);
+  _process_strong_tasks.all_tasks_completed(G1RP_PS_CodeCache_oops_do);
 }
 
 // Adaptor to pass the closures to the strong roots in the VM.
@@ -106,8 +106,7 @@ void G1RootProcessor::process_strong_roots(OopClosure* oops,
 
   // CodeCache is already processed in java roots
   // refProcessor is not needed since we are inside a safe point
-  _process_strong_tasks.all_tasks_completed(n_workers(),
-                                            G1RP_PS_CodeCache_oops_do,
+  _process_strong_tasks.all_tasks_completed(G1RP_PS_CodeCache_oops_do,
                                             G1RP_PS_refProcessor_oops_do);
 }
 
@@ -144,7 +143,7 @@ void G1RootProcessor::process_all_roots(OopClosure* oops,
   process_code_cache_roots(blobs, NULL, 0);
 
   // refProcessor is not needed since we are inside a safe point
-  _process_strong_tasks.all_tasks_completed(n_workers(), G1RP_PS_refProcessor_oops_do);
+  _process_strong_tasks.all_tasks_completed(G1RP_PS_refProcessor_oops_do);
 }
 
 void G1RootProcessor::process_java_roots(G1RootClosures* closures,

--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -360,7 +360,7 @@ SubTasksDone::SubTasksDone(uint n) :
 }
 
 #ifdef ASSERT
-void SubTasksDone::all_tasks_completed_impl(uint skipped[], size_t skipped_size) {
+void SubTasksDone::all_tasks_claimed_impl(uint skipped[], size_t skipped_size) {
   if (Atomic::cmpxchg(&_verification_done, false, true)) {
     // another thread has done the verification
     return;
@@ -387,17 +387,13 @@ void SubTasksDone::all_tasks_completed_impl(uint skipped[], size_t skipped_size)
 }
 #endif
 
-bool SubTasksDone::valid() {
-  return _tasks != NULL;
-}
-
 bool SubTasksDone::try_claim_task(uint t) {
   assert(t < _n_tasks, "bad task id.");
   return !_tasks[t] && !Atomic::cmpxchg(&_tasks[t], false, true);
 }
 
 SubTasksDone::~SubTasksDone() {
-  assert(_verification_done, "all_tasks_completed must have been called.");
+  assert(_verification_done, "all_tasks_claimed must have been called.");
   FREE_C_HEAP_ARRAY(bool, _tasks);
 }
 

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -305,38 +305,11 @@ class SubTasksDone: public CHeapObj<mtInternal> {
   volatile bool* _tasks;
   uint _n_tasks;
 
-  // make sure verification logic is run only once
 #ifdef ASSERT
+  // make sure verification logic is run exactly once
   volatile bool _verification_done = false;
+  void all_tasks_completed_impl(uint skipped[], size_t skipped_size);
 #endif
-
-  void all_tasks_completed_impl(uint skipped[], size_t skipped_size) {
-#ifdef ASSERT
-    if (Atomic::cmpxchg(&_verification_done, false, true)) {
-      // another thread has done the verification
-      return;
-    }
-    // all non-skipped tasks are claimed
-    for (uint i = 0; i < _n_tasks; ++i) {
-      if (!_tasks[i]) {
-        auto is_skipped = false;
-        for (size_t j = 0; j < skipped_size; ++j) {
-          if (i == skipped[j]) {
-            is_skipped = true;
-            break;
-          }
-        }
-        assert(is_skipped, "%d not claimed.", i);
-      }
-    }
-    // all skipped tasks are *not* claimed
-    for (size_t i = 0; i < skipped_size; ++i) {
-      auto task_index = skipped[i];
-      assert(task_index < _n_tasks, "Array in range.");
-      assert(!_tasks[task_index], "%d is both claimed and skipped.", task_index);
-    }
-#endif
-  }
 
   NONCOPYABLE(SubTasksDone);
 
@@ -359,7 +332,7 @@ public:
   // explicitly passed as extra arguments. Every thread in the parallel task
   // must execute this.
   void all_tasks_completed() {
-    all_tasks_completed_impl(nullptr, 0);
+    DEBUG_ONLY(all_tasks_completed_impl(nullptr, 0);)
   }
 
   // Augmented by variadic args, each for a skipped task.
@@ -368,7 +341,7 @@ public:
   void all_tasks_completed(T0 first_skipped, Ts... more_skipped) {
     static_assert(std::is_convertible<T0, uint>::value, "not convertible");
     uint skipped[] = { static_cast<uint>(first_skipped), static_cast<uint>(more_skipped)... };
-    all_tasks_completed_impl(skipped, ARRAY_SIZE(skipped));
+    DEBUG_ONLY(all_tasks_completed_impl(skipped, ARRAY_SIZE(skipped));)
   }
 
   // Destructor.

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -591,7 +591,7 @@ public:
       OopStorage::trigger_cleanup_if_needed();
     }
 
-    _subtasks.all_tasks_completed(_num_workers);
+    _subtasks.all_tasks_completed();
   }
 };
 

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -591,7 +591,7 @@ public:
       OopStorage::trigger_cleanup_if_needed();
     }
 
-    _subtasks.all_tasks_completed();
+    _subtasks.all_tasks_claimed();
   }
 };
 


### PR DESCRIPTION
After JDK-8260574, a instance of `SubTasksDone` is never reused, so part of its APIs could be revised: `clear()` and the code calling it is removed.

With this patch, `all_tasks_completed` contains only assertion. Kim suggested moving this assertion logic to `~SubTasksDone`, but that could defer the assertion violation. For example, in the case of `G1FullGCMarkTask::work`, there is a significant amount of code running btw the instance when all subtasks are claimed (where `all_tasks_completed` is called in this PR) and `~SubTasksDone`. In the interest of having more precise location where bugs may lie, I have kept `all_tasks_completed` in the original place. More comments on this are welcome.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259668](https://bugs.openjdk.java.net/browse/JDK-8259668): Make SubTasksDone use-once


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 90add10d418292bd4d236c5bf1eb74067aefec91
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2383/head:pull/2383`
`$ git checkout pull/2383`
