### PR TITLE
8216358: [accessibility] [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,7 +169,13 @@ public abstract class AquaButtonLabeledUI extends AquaButtonToggleUI implements 
                 altIcon = b.getIcon();
             }
 
-            altIcon.paintIcon(c, g, iconRect.x, iconRect.y);
+            int offset = 0;
+            if (b.isFocusOwner()) {
+                offset = 2;
+                altIcon = AquaFocus.createFocusedIcon(altIcon, c, 2);
+            }
+
+            altIcon.paintIcon(c, g, iconRect.x - offset, iconRect.y - offset);
         }
 
         // Draw the Text

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -21,26 +21,15 @@
  * questions.
  */
 
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import javax.imageio.ImageIO;
-import javax.swing.BoxLayout;
 import javax.swing.Icon;
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
-
-import static java.awt.event.KeyEvent.VK_TAB;
 
 /*
  * @test
@@ -48,84 +37,35 @@ import static java.awt.event.KeyEvent.VK_TAB;
  * @bug 8216358
  * @summary [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"
  * @library ../../regtesthelpers/
- * @library /lib/client/
  * @build Util
- * @build ExtendedRobot
  * @run main ImageCheckboxTest
  */
 
 public class ImageCheckboxTest {
-    private static JFrame frame;
-    private static JButton testButton;
-    private static int locx, locy, frw, frh;
-
     public static void main(String[] args) throws Exception {
         new ImageCheckboxTest().performTest();
     }
 
     public void performTest() throws Exception {
         try {
-            BufferedImage imageFocus1 = null;
-            BufferedImage imageFocus2 = null;
-            ExtendedRobot robot = new ExtendedRobot();
+            BufferedImage imageNoFocus = new BufferedImage(100, 50,
+                    BufferedImage.TYPE_INT_ARGB);
+            BufferedImage imageFocus = new BufferedImage(100, 50,
+                    BufferedImage.TYPE_INT_ARGB);
 
-            SwingUtilities.invokeAndWait(() -> {
-                frame = new JFrame("Test frame");
-                JPanel panel = new JPanel();
-                panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
-                testButton = new JButton("Start");
-                panel.add(testButton);
-                for (int i = 1; i < 6; i++) {
-                    JCheckBox cb = new JCheckBox(" Box No. " + i, new MyIcon(Color.GREEN));
-                    panel.add(cb);
-                }
+            CustomCheckBox checkbox = new CustomCheckBox("Test", new MyIcon(Color.GREEN));
+            checkbox.setSize(100, 50);
+            checkbox.setFocused(false);
+            checkbox.paint(imageNoFocus.createGraphics());
+            checkbox.setFocused(true);
+            checkbox.paint(imageFocus.createGraphics());
 
-                frame.setLayout(new BorderLayout());
-                frame.add(panel, BorderLayout.CENTER);
-                frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-                frame.setLocationRelativeTo(null);
-                frame.pack();
-                frame.setVisible(true);
-
-            });
-            robot.setAutoDelay(200);
-            robot.delay(1000);
-            robot.waitForIdle(1000);
-
-            Rectangle bounds = frame.getBounds();
-            Insets insets = frame.getInsets();
-            locx = bounds.x + insets.left;
-            locy = bounds.y + insets.top;
-            frw = bounds.width - insets.left - insets.right;
-            frh = bounds.height - insets.top - insets.bottom;
-
-            Point btnLoc = testButton.getLocationOnScreen();
-            robot.mouseMove(btnLoc.x + 10, btnLoc.y + 10);
-            robot.click();
-
-            robot.keyPress(VK_TAB);
-            robot.keyRelease(VK_TAB);
-
-            robot.delay(1000);
-
-            imageFocus1 = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
-
-            robot.keyPress(VK_TAB);
-            robot.keyRelease(VK_TAB);
-
-            robot.delay(1000);
-
-            imageFocus2 = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
-
-            if (Util.compareBufferedImages(imageFocus1, imageFocus2)) {
-                ImageIO.write(imageFocus1, "png", new File("imageFocus1.png"));
-                ImageIO.write(imageFocus2, "png", new File("imageFocus2.png"));
+            if (Util.compareBufferedImages(imageFocus, imageNoFocus)) {
+                ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
+                ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
                 throw new Exception("Changing focus is not visualized");
             }
         } finally {
-            if (frame != null) {
-                frame.dispose();
-            }
         }
     }
 
@@ -151,6 +91,27 @@ public class ImageCheckboxTest {
         @Override
         public int getIconHeight() {
             return 18;
+        }
+    }
+
+    class CustomCheckBox extends JCheckBox {
+        public CustomCheckBox(String label, Icon icon) {
+            super(label, icon);
+        }
+
+        private boolean focused = false;
+        public void setFocused(boolean focused) {
+            this.focused = focused;
+        }
+
+        @Override
+        public boolean hasFocus() {
+            return focused;
+        }
+
+        @Override
+        public Dimension getMaximumSize() {
+            return new Dimension(4, 4);
         }
     }
 }

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -47,25 +47,22 @@ public class ImageCheckboxTest {
     }
 
     public void performTest() throws Exception {
-        try {
-            BufferedImage imageNoFocus = new BufferedImage(100, 50,
-                    BufferedImage.TYPE_INT_ARGB);
-            BufferedImage imageFocus = new BufferedImage(100, 50,
-                    BufferedImage.TYPE_INT_ARGB);
+        BufferedImage imageNoFocus = new BufferedImage(100, 50,
+                BufferedImage.TYPE_INT_ARGB);
+        BufferedImage imageFocus = new BufferedImage(100, 50,
+                BufferedImage.TYPE_INT_ARGB);
 
-            CustomCheckBox checkbox = new CustomCheckBox("Test", new MyIcon(Color.GREEN));
-            checkbox.setSize(100, 50);
-            checkbox.setFocused(false);
-            checkbox.paint(imageNoFocus.createGraphics());
-            checkbox.setFocused(true);
-            checkbox.paint(imageFocus.createGraphics());
+        CustomCheckBox checkbox = new CustomCheckBox("Test", new MyIcon(Color.GREEN));
+        checkbox.setSize(100, 50);
+        checkbox.setFocused(false);
+        checkbox.paint(imageNoFocus.createGraphics());
+        checkbox.setFocused(true);
+        checkbox.paint(imageFocus.createGraphics());
 
-            if (Util.compareBufferedImages(imageFocus, imageNoFocus)) {
-                ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
-                ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
-                throw new Exception("Changing focus is not visualized");
-            }
-        } finally {
+        if (Util.compareBufferedImages(imageFocus, imageNoFocus)) {
+            ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
+            ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
+            throw new Exception("Changing focus is not visualized");
         }
     }
 

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -105,10 +105,5 @@ public class ImageCheckboxTest {
         public boolean hasFocus() {
             return focused;
         }
-
-        @Override
-        public Dimension getMaximumSize() {
-            return new Dimension(4, 4);
-        }
     }
 }

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+import static java.awt.event.KeyEvent.VK_TAB;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8216358
+ * @summary [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"
+ * @library ../../regtesthelpers/
+ * @library /lib/client/
+ * @build Util
+ * @build ExtendedRobot
+ * @run main ImageCheckboxTest
+ */
+
+public class ImageCheckboxTest {
+    private static JFrame frame;
+    private static JButton testButton;
+    private static int locx, locy, frw, frh;
+
+    public static void main(String[] args) throws Exception {
+        new ImageCheckboxTest().performTest();
+    }
+
+    public void performTest() throws Exception {
+        try {
+            BufferedImage imageFocus1 = null;
+            BufferedImage imageFocus2 = null;
+            ExtendedRobot robot = new ExtendedRobot();
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("Test frame");
+                JPanel panel = new JPanel();
+                panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+                testButton = new JButton("Start");
+                panel.add(testButton);
+                for (int i = 1; i < 6; i++) {
+                    JCheckBox cb = new JCheckBox(" Box No. " + i, new MyIcon(Color.GREEN));
+                    panel.add(cb);
+                }
+
+                frame.setLayout(new BorderLayout());
+                frame.add(panel, BorderLayout.CENTER);
+                frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+
+            });
+            robot.setAutoDelay(200);
+            robot.delay(1000);
+            robot.waitForIdle(1000);
+
+            Rectangle bounds = frame.getBounds();
+            Insets insets = frame.getInsets();
+            locx = bounds.x + insets.left;
+            locy = bounds.y + insets.top;
+            frw = bounds.width - insets.left - insets.right;
+            frh = bounds.height - insets.top - insets.bottom;
+
+            Point btnLoc = testButton.getLocationOnScreen();
+            robot.mouseMove(btnLoc.x + 10, btnLoc.y + 10);
+            robot.click();
+
+            robot.keyPress(VK_TAB);
+            robot.keyRelease(VK_TAB);
+
+            robot.delay(1000);
+
+            imageFocus1 = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
+
+            robot.keyPress(VK_TAB);
+            robot.keyRelease(VK_TAB);
+
+            robot.delay(1000);
+
+            imageFocus2 = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
+
+            if (Util.compareBufferedImages(imageFocus1, imageFocus2)) {
+                ImageIO.write(imageFocus1, "png", new File("imageFocus1.png"));
+                ImageIO.write(imageFocus2, "png", new File("imageFocus2.png"));
+                throw new Exception("Changing focus is not visualized");
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    class MyIcon implements Icon {
+        Color color;
+        public MyIcon(Color color) {
+            this.color = color;
+        }
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Color old = g.getColor();
+            g.setColor(color);
+            g.fillArc(x+2, y+2, 12, 12, 0, 360);
+            g.setColor(old);
+        }
+
+        @Override
+        public int getIconWidth() {
+            return 18;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return 18;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8216358](https://bugs.openjdk.java.net/browse/JDK-8216358): [accessibility] [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2384/head:pull/2384`
`$ git checkout pull/2384`
