### PR TITLE
8271396: Spelling errors

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_ext_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_ext_x86.cpp
@@ -948,7 +948,7 @@ const char* const VM_Version_Ext::_feature_ecx_id[] = {
 
 const char* const VM_Version_Ext::_feature_extended_ecx_id[] = {
   "LAHF/SAHF instruction support",
-  "Core multi-processor leagacy mode",
+  "Core multi-processor legacy mode",
   "",
   "",
   "",

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -788,7 +788,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   // JDK-8187028: It was observed that on some configurations (4K backed thread stacks)
   // the real thread stack size may be smaller than the requested stack size, by as much as 64K.
   // This very much looks like a pthread lib error. As a workaround, increase the stack size
-  // by 64K for small thread stacks (arbitrarily choosen to be < 4MB)
+  // by 64K for small thread stacks (arbitrarily chosen to be < 4MB)
   if (stack_size < 4096 * K) {
     stack_size += 64 * K;
   }

--- a/src/hotspot/os/bsd/semaphore_bsd.cpp
+++ b/src/hotspot/os/bsd/semaphore_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include <semaphore.h>
 
 #ifdef __APPLE__
-// OS X doesn't support unamed POSIX semaphores, so the implementation in os_posix.cpp can't be used.
+// OS X doesn't support unnamed POSIX semaphores, so the implementation in os_posix.cpp can't be used.
 
 static const char* sem_init_strerror(kern_return_t value) {
   switch (value) {

--- a/src/hotspot/os/bsd/semaphore_bsd.hpp
+++ b/src/hotspot/os/bsd/semaphore_bsd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 # include "semaphore_posix.hpp"
 
 #else
-// OS X doesn't support unamed POSIX semaphores, so the implementation in os_posix.cpp can't be used.
+// OS X doesn't support unnamed POSIX semaphores, so the implementation in os_posix.cpp can't be used.
 # include "memory/allocation.hpp"
 # include <mach/semaphore.h>
 

--- a/src/hotspot/os/posix/semaphore_posix.cpp
+++ b/src/hotspot/os/posix/semaphore_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "precompiled.hpp"
 #ifndef __APPLE__
 #include "runtime/os.hpp"
-// POSIX unamed semaphores are not supported on OS X.
+// POSIX unnamed semaphores are not supported on OS X.
 #include "semaphore_posix.hpp"
 #include <semaphore.h>
 

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -698,7 +698,7 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
       ls.print("get_module(): module ");
       java_lang_String::print(module_name, tty);
     } else {
-      ls.print("get_module(): Unamed Module");
+      ls.print("get_module(): Unnamed Module");
     }
     if (klass != NULL) {
       ls.print_cr(" for class %s", klass->external_name());

--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -317,7 +317,7 @@ bool PSYoungGen::resize_generation(size_t eden_size, size_t survivor_size) {
     if (orig_size == max_gen_size()) {
       log_trace(gc)("PSYoung generation size at maximum: " SIZE_FORMAT "K", orig_size/K);
     } else if (orig_size == min_gen_size()) {
-      log_trace(gc)("PSYoung generation size at minium: " SIZE_FORMAT "K", orig_size/K);
+      log_trace(gc)("PSYoung generation size at minimum: " SIZE_FORMAT "K", orig_size/K);
     }
   }
 

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -66,7 +66,7 @@ static const char* display_unit_for_scale(size_t scale) {
 // Print a human readable size.
 // byte_size: size, in bytes, to be printed.
 // scale: one of 1 (byte-wise printing), sizeof(word) (word-size printing), K, M, G (scaled by KB, MB, GB respectively,
-//         or 0, which means the best scale is choosen dynamically.
+//         or 0, which means the best scale is chosen dynamically.
 // width: printing width.
 void print_human_readable_size(outputStream* st, size_t byte_size, size_t scale, int width)  {
   if (scale == 0) {

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -67,7 +67,7 @@ void print_scaled_words_and_percentage(outputStream* st, size_t word_size, size_
 // Print a human readable size.
 // byte_size: size, in bytes, to be printed.
 // scale: one of 1 (byte-wise printing), sizeof(word) (word-size printing), K, M, G (scaled by KB, MB, GB respectively,
-//         or 0, which means the best scale is choosen dynamically.
+//         or 0, which means the best scale is chosen dynamically.
 // width: printing width.
 void print_human_readable_size(outputStream* st, size_t byte_size, size_t scale = 0, int width = -1);
 

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
@@ -43,7 +43,7 @@ MetaspaceDCmd::MetaspaceDCmd(outputStream* output, bool heap) :
   _by_chunktype("by-chunktype", "Break down numbers by chunk type.", "BOOLEAN", false, "false"),
   _show_vslist("vslist", "Shows details about the underlying virtual space.", "BOOLEAN", false, "false"),
   _scale("scale", "Memory usage in which to scale. Valid values are: 1, KB, MB or GB (fixed scale) "
-         "or \"dynamic\" for a dynamically choosen scale.",
+         "or \"dynamic\" for a dynamically chosen scale.",
          "STRING", false, "dynamic"),
   _show_classes("show-classes", "If show-loaders is set, shows loaded classes for each loader.", "BOOLEAN", false, "false")
 {

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -371,7 +371,7 @@ public:
     return "VM.class_hierarchy";
   }
   static const char* description() {
-    return "Print a list of all loaded classes, indented to show the class hiearchy. "
+    return "Print a list of all loaded classes, indented to show the class hierarchy. "
            "The name of each class is followed by the ClassLoaderData* of its ClassLoader, "
            "or \"null\" if loaded by the bootstrap class loader.";
   }

--- a/src/hotspot/share/services/nmtDCmd.cpp
+++ b/src/hotspot/share/services/nmtDCmd.cpp
@@ -35,7 +35,7 @@ NMTDCmd::NMTDCmd(outputStream* output,
   bool heap): DCmdWithParser(output, heap),
   _summary("summary", "request runtime to report current memory summary, " \
            "which includes total reserved and committed memory, along " \
-           "with memory usage summary by each subsytem.",
+           "with memory usage summary by each subsystem.",
            "BOOLEAN", false, "false"),
   _detail("detail", "request runtime to report memory allocation >= "
            "1K by each callsite.",

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -527,7 +527,7 @@ public class Proxy implements java.io.Serializable {
             if (proxyPkg == null) {
                 // all proxy interfaces are public and exported
                 if (!m.isNamed())
-                    throw new InternalError("ununamed module: " + m);
+                    throw new InternalError("unnamed module: " + m);
                 proxyPkg = nonExported ? PROXY_PACKAGE_PREFIX + "." + m.getName()
                                        : m.getName();
             } else if (proxyPkg.isEmpty() && m.isNamed()) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XMSelection.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XMSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import sun.util.logging.PlatformLogger;
 public class  XMSelection {
 
     /*
-     * A method for a subsytem to express its interest in a certain
+     * A method for a subsystem to express its interest in a certain
      * manager selection.
      *
      * If owner changes, the ownerChanged of the XMSelectionListener

--- a/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -22,7 +22,7 @@
  */
 
 /* @test TestLargePagesFlags
- * @summary Tests how large pages are choosen depending on the given large pages flag combinations.
+ * @summary Tests how large pages are chosen depending on the given large pages flag combinations.
  * @requires vm.gc != "Z"
  * @requires os.family == "linux"
  * @library /test/lib

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@
  *     4448603: JDI spec: ArrayReference.setValues(List) has discrepancy
  *     Evaluation:
  *     There is indeed an inconsistency.  The safer of the two options should be
- *     choosen: ignore tail elements in Lists that are too long. This is also what
+ *     chosen: ignore tail elements in Lists that are too long. This is also what
  *     the reference implementation does.
  *     4419982: JDI: two StackFrame methods return incorrect values for double
  *

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/ClassPrepareEvents/ClassPrepareEvents001/ClassPrepareEvents001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/stress/ClassPrepareEvents/ClassPrepareEvents001/ClassPrepareEvents001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * VM Testbase readme:
  * DESCRIPTION
  *         Test covers bug 6426321. Test stress event queue forcing loading of 3000 classes in debuggee.
- *         Debugger in loop sends commad to debuggee to load class and waits READY answer.
+ *         Debugger in loop sends command to debuggee to load class and waits READY answer.
  *         Test passes if no hangs or any other errors occur in debuggee (if debuggee successfully sends answers for all commands).
  *         (number of classes to load can be changed through parameter -classesToLoad (for example -classesToLoad 1000)).
  *

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,20 +38,20 @@
  *           during the OnLoad phase
  *         - enables events via SetEventNotificationMode during the OnLoad phase
  *           for all optional events
- *         - provides the state to provoke generation of choosen events
- *         - checks that VM_INIT and choosen events were sent.
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that VM_INIT and chosen events were sent.
  *       (2)
  *         - sets off callbacks for all optional events
- *         - changes callbacks for choosen events
- *         - provides the state to provoke generation of choosen events
- *         - checks that choosen events were sent
+ *         - changes callbacks for chosen events
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that chosen events were sent
  *         - checks that altered callback works.
  *       (3)
- *         - sets off callbacks for choosen events
+ *         - sets off callbacks for chosen events
  *         - sets callback for VM_DEATH event
- *         - checks that no choosen events are sent until VMDeath event.
+ *         - checks that no chosen events are sent until VMDeath event.
  *     This test checks that:
- *     (a) except for choosen events no other optional events are generated on
+ *     (a) except for chosen events no other optional events are generated on
  *         steps (1) and (2).
  *     (b) Numbers of expected event on steps (1) and (2) is equal to 1.
  *     (c) except for VM_DEATH no other events are generated on step (3).

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,20 +41,20 @@
  *           during the OnLoad phase
  *         - enables events via SetEventNotificationMode during the OnLoad phase
  *           for all optional events
- *         - provides the state to provoke generation of choosen events
- *         - checks that VM_INIT and choosen events were sent.
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that VM_INIT and chosen events were sent.
  *       (2)
  *         - sets off callbacks for all optional events
- *         - changes callbacks for choosen events
- *         - provides the state to provoke generation of choosen events
- *         - checks that choosen events were sent
+ *         - changes callbacks for chosen events
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that chosen events were sent
  *         - checks that altered callback works.
  *       (3)
- *         - sets off callbacks for choosen events
+ *         - sets off callbacks for chosen events
  *         - sets callback for VM_DEATH event
- *         - checks that no choosen events are sent until VMDeath event.
+ *         - checks that no chosen events are sent until VMDeath event.
  *     This test checks that:
- *     (a) except for choosen events no other optional events are generated on
+ *     (a) except for chosen events no other optional events are generated on
  *         steps (1) and (2).
  *     (b) Numbers of expected event on steps (1) and (2) is equal to 1.
  *     (c) except for VM_DEATH no other events are generated on step (3).

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,20 +36,20 @@
  *       1)
  *         - adds the <can_generate_compiled_method_load_events> capability in
  *           the OnLoad phase
- *         - sets callbacks for VM_INIT and choosen events during the OnLoad phase
+ *         - sets callbacks for VM_INIT and chosen events during the OnLoad phase
  *         - enables events via SetEventNotificationMode during the OnLoad phase
  *           for all optional events.
- *         - provides the state to provoke generation of choosen events
- *         - checks that VM_INIT and choosen events were sent
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that VM_INIT and chosen events were sent
  *       2)
- *         - changes callbacks for choosen events
- *         - provides the state to provoke generation of choosen events
- *         - checks that choosen events were sent
+ *         - changes callbacks for chosen events
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that chosen events were sent
  *         - checks that altered callback works.
  *       3)
- *         - sets off callbacks for choosen events
+ *         - sets off callbacks for chosen events
  *         - sets callback for VM_DEATH event
- *         - checks that no choosen events are sent until VMDeath event.
+ *         - checks that no chosen events are sent until VMDeath event.
  * COMMENTS
  *     #4033759 JIT compiler must support unloading of classes containing compiled methods
  *     Adjusted according to J2SE CCC updates:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,20 +38,20 @@
  *           during the OnLoad phase
  *         - enables events via SetEventNotificationMode during the OnLoad phase
  *           for all optional events
- *         - provides the state to provoke generation of choosen events
- *         - checks that VM_INIT and choosen events were sent.
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that VM_INIT and chosen events were sent.
  *       (2)
  *         - sets off callbacks for all optional events
- *         - changes callbacks for choosen events
- *         - provides the state to provoke generation of choosen events
- *         - checks that choosen events were sent
+ *         - changes callbacks for chosen events
+ *         - provides the state to provoke generation of chosen events
+ *         - checks that chosen events were sent
  *         - checks that altered callback works.
  *       (3)
- *         - sets off callbacks for choosen events
+ *         - sets off callbacks for chosen events
  *         - sets callback for VM_DEATH event
- *         - checks that no choosen events are sent until VMDeath event.
+ *         - checks that no chosen events are sent until VMDeath event.
  *     This test checks that:
- *     (a) except for choosen events no other optional events are generated on
+ *     (a) except for chosen events no other optional events are generated on
  *         steps (1) and (2).
  *     (b) Numbers of expected event on steps (1) and (2) is equal to 1.
  *     (c) except for VM_DEATH no other events are generated on step (3).

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t008/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,21 @@
  *     1)
  *     - adds the <can_generate_exception_events> capability during
  *       the OnLoad phase;
- *     - sets callbacks for VM_INIT and choosen events during the OnLoad phase;
+ *     - sets callbacks for VM_INIT and chosen events during the OnLoad phase;
  *     - enables all optional events via SetEventNotificationMode during
  *       the OnLoad phase;
  *     - starts debuggee's threads which throw exceptions;
  *     - expects that at least one EXCEPTION and EXCEPTION_CATCH events will
  *       be sent.
  *     2)
- *     - changes callbacks for choosen event;
+ *     - changes callbacks for chosen event;
  *     - starts debuggee's threads which throw exceptions;
  *     - checks that altered callback works and at least one EXCEPTION and
  *       EXCEPTION_CATCH events will be sent.
  *     3)
- *     - sets off callbacks for choosen event;
+ *     - sets off callbacks for chosen event;
  *     - sets callback for VM_DEATH event;
- *     - checks that no choosen events are sent until VMDeath event.
+ *     - checks that no chosen events are sent until VMDeath event.
  * COMMENTS
  *     Modified due to fix of the bug
  *     5010571 TEST_BUG: jvmti tests with VMObjectAlloc callbacks should

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t009/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,20 +34,20 @@
  *     1)
  *     - adds the <can_generate_method_entry_events>,
  *       <can_generate_method_exit_events> capabilities during the OnLoad phase;
- *     - sets callbacks for VM_INIT and choosen events during the OnLoad phase;
+ *     - sets callbacks for VM_INIT and chosen events during the OnLoad phase;
  *     - enables all optional events via SetEventNotificationMode during
  *       the OnLoad phase;
  *     - starts debuggee's method 1000 times;
  *     - expects that METHOD_ENTRY and METHOD_EXIT events are sent 1000 times.
  *     2)
- *     - changes callbacks for choosen event;
+ *     - changes callbacks for chosen event;
  *     - starts debuggee's method 1000 times;
  *     - checks that altered callback works and METHOD_ENTRY and METHOD_EXIT
  *       events will be sent 1000 times..
  *     3)
- *     - sets off callbacks for choosen event;
+ *     - sets off callbacks for chosen event;
  *     - sets callback for VM_DEATH event;
- *     - checks that no choosen events are sent until VMDeath event.
+ *     - checks that no chosen events are sent until VMDeath event.
  * COMMENTS
  *     Modified due to fix of the bug
  *     5010571 TEST_BUG: jvmti tests with VMObjectAlloc callbacks should

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t010/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,20 +35,20 @@
  *     1)
  *     - adds the <can_generate_field_modification_events>,
  *       <can_generate_field_access_events> capabilities during the OnLoad phase;
- *     - sets callbacks for VM_INIT and choosen events during the OnLoad phase;
+ *     - sets callbacks for VM_INIT and chosen events during the OnLoad phase;
  *     - enables all optional events via SetEventNotificationMode during
  *       the OnLoad phase;
  *     - reads and modifies static integer fields;
- *     - expects that each of choosen events is sent at least 1 time.
+ *     - expects that each of chosen events is sent at least 1 time.
  *     2)
- *     - changes callbacks for choosen event;
+ *     - changes callbacks for chosen event;
  *     - reads and modifies static integer fields;
- *     - checks that altered callback works and each of choosen events
+ *     - checks that altered callback works and each of chosen events
  *       is sent at least 1 time.
  *     3)
- *     - sets off callbacks for choosen event;
+ *     - sets off callbacks for chosen event;
  *     - sets callback for VM_DEATH event;
- *     - checks that no choosen events are sent until VMDeath event.
+ *     - checks that no chosen events are sent until VMDeath event.
  * COMMENTS
  *     Modified due to fix of the bug
  *     5010571 TEST_BUG: jvmti tests with VMObjectAlloc callbacks should

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t011/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,20 +34,20 @@
  *     1)
  *     - adds the <can_generate_breakpoint_events> capabilities during the
  *       OnLoad phase;
- *     - sets callbacks for VM_INIT and choosen events during the OnLoad phase;
+ *     - sets callbacks for VM_INIT and chosen events during the OnLoad phase;
  *     - enables all optional events via SetEventNotificationMode during
  *       the OnLoad phase;
  *     - reads and modifies static integer fields;
- *     - expects that each of choosen events is sent at least 1 time.
+ *     - expects that each of chosen events is sent at least 1 time.
  *     2)
- *     - changes callbacks for choosen event;
+ *     - changes callbacks for chosen event;
  *     - reads and modifies static integer fields;
- *     - checks that altered callback works and each of choosen events
+ *     - checks that altered callback works and each of chosen events
  *       is sent at least 1 time.
  *     3)
- *     - sets off callbacks for choosen event;
+ *     - sets off callbacks for chosen event;
  *     - sets callback for VM_DEATH event;
- *     - checks that no choosen events are sent until VMDeath event.
+ *     - checks that no chosen events are sent until VMDeath event.
  * COMMENTS
  *     Modified due to fix of the bug
  *     5010571 TEST_BUG: jvmti tests with VMObjectAlloc callbacks should

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  *       has been reached, jvmti agent suspend thread and calls NotifyFramePop;
  *     - expects FRAME_POP event is sent 1000 time.
  *     2)
- *     - changes callbacks for choosen event;
+ *     - changes callbacks for chosen event;
  *     - debuggee starts recurisve method with depth=1000 and when defined depth
  *       has been reached, jvmti agent suspend thread and calls NotifyFramePop;
  *     - checks that altered callback works and FRAME_POP event is sent 1000 time.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import nsk.share.jvmti.*;
  *    <li>sets callbacks for <code>COMPILED_METHOD_LOAD</code>,
  *        <code>COMPILED_METHOD_UNLOAD</code> events during the OnLoad phase;</li>
  *    <li>enables these events during the <code>OnLoad</code> phase;</li>
- *    <li>provides the state to provoke generation of choosen events (see details below);</li>
+ *    <li>provides the state to provoke generation of chosen events (see details below);</li>
  *    <li>checks number of <code>COMPILED_METHOD_UNLOAD</code> events is less than
  *        <code>COMPILED_METHOD_LOAD</code> or equal.</li>
  * </ol>

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  *     (2) sets callbacks for COMPILED_METHOD_LOAD, COMPILED_METHOD_UNLOAD events
  *         during the OnLoad phase;
  *     (3) enables these events during the OnLoad phase;
- *     (4) provides the state to provoke generation of choosen events (see details
+ *     (4) provides the state to provoke generation of chosen events (see details
  *         in comments of em07t002.java)
  *     (5) checks number of COMPILED_METHOD_UNLOAD events is less than
  *         COMPILED_METHOD_LOAD or equal.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/StandardThreadMonitoringScenarioFactory.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/StandardThreadMonitoringScenarioFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class StandardThreadMonitoringScenarioFactory implements ThreadMonitoring
         }
 
         public int getScenarioCount(int basicThreadCount) {
-                // This is choosen to have one scenario of each type and recursionType.
+                // This is chosen to have one scenario of each type and recursionType.
                 basicThreadCount = Math.min(basicThreadCount, 3);
                 return basicThreadCount * typeCount * 3;
         }

--- a/test/jdk/java/rmi/module/ModuleTest.java
+++ b/test/jdk/java/rmi/module/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ public class ModuleTest {
      * @throws Exception
      */
     @Test
-    public void testClientInUnamedModule() throws Exception {
+    public void testClientInUnnamedModule() throws Exception {
         assertEquals(executeTestJava("--module-path", pathJoin(MTEST_JAR, SERVER_JAR),
                 "--add-modules", "mserver",
                 "-cp", CLIENT_JAR,

--- a/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -390,7 +390,7 @@ public class Main {
                     }
                     try {
                         //This is the hack code because named package class has
-                        //difficulty in accessing unamed package class. This
+                        //difficulty in accessing unnamed package class. This
                         //should be removed ater JDK-8003358 is finished.
                         port = (int) Class.forName("TestLibrary")
                                 .getMethod("getUnusedRandomPort")

--- a/test/jdk/javax/swing/JTabbedPane/4310381/bug4310381.java
+++ b/test/jdk/javax/swing/JTabbedPane/4310381/bug4310381.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,7 @@ class TestUI {
         String instructions
             = "See for different look and feel tabbed panes titles \n"
             + "   contain three dots(...) at the end if the pane size \n"
-            + "   cannot accommadate the title completely.\n"
+            + "   cannot accommodate the title completely.\n"
             + "If yes, click on 'pass' else click on 'fail'\n";
 
         instructionTextArea = new JTextArea();

--- a/test/jdk/sun/net/www/protocol/http/spnegoReadme
+++ b/test/jdk/sun/net/www/protocol/http/spnegoReadme
@@ -105,7 +105,7 @@ several configurations are needed to perform a success communication:
    It's only needed when you encounter a server which knows Negotiate
    but doesn't know about SPNEGO.
 
-   If http.auth.preference is not set, the internal order choosen is:
+   If http.auth.preference is not set, the internal order chosen is:
       GSS/SPNEGO -> Digest -> BTLM -> Basic
 
    Noticed that Kerberos does not appear in this list, since whenever

--- a/test/jdk/sun/tools/jrunscript/jrunscript-eTest.sh
+++ b/test/jdk/sun/tools/jrunscript/jrunscript-eTest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ if [ $? -eq 2 ]; then
     exit 0
 fi
 
-# -e option with JavaScript explicitly choosen as language
+# -e option with JavaScript explicitly chosen as language
 
 rm -f jrunscript-eTest.out 2>/dev/null
 ${JRUNSCRIPT} -J-Dnashorn.args.prepend=--no-deprecation-warning -J-Djava.awt.headless=true -l nashorn -e "println('hello')" > jrunscript-eTest.out 2>&1


### PR DESCRIPTION
This PR fixes the following spelling errors:

 choosen  -> chosen
 commad   -> command
 hiearchy -> hierarchy
 leagacy  -> legacy
 minium   -> minimum
 subsytem -> subsystem
 unamed   -> unnamed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271396](https://bugs.openjdk.java.net/browse/JDK-8271396): Spelling errors


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to a0937d2619186488ebf50db2da50b78c73d41033
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to a0937d2619186488ebf50db2da50b78c73d41033
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to 31cfcba7eef6c5557f928f7285b4f9b5fdeff5ba
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 31cfcba7eef6c5557f928f7285b4f9b5fdeff5ba


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2385/head:pull/2385` \
`$ git checkout pull/2385`

Update a local copy of the PR: \
`$ git checkout pull/2385` \
`$ git pull https://git.openjdk.java.net/jdk pull/2385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2385`

View PR using the GUI difftool: \
`$ git pr show -t 2385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2385.diff">https://git.openjdk.java.net/jdk/pull/2385.diff</a>

</details>
