### PR TITLE
8259647: Add support for JFR event ObjectCountAfterGC to Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1126,6 +1126,12 @@ void ShenandoahHeap::gclabs_retire(bool resize) {
   }
 }
 
+void ShenandoahHeap::mark_complete_marking_context() {
+  _marking_context->mark_complete();
+  ShenandoahIsAliveClosure is_alive;
+  tracer()->report_object_count_after_gc(&is_alive);
+}
+
 // Returns size in bytes
 size_t ShenandoahHeap::unsafe_max_tlab_alloc(Thread *thread) const {
   if (ShenandoahElasticTLAB) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -564,7 +564,7 @@ private:
 public:
   inline ShenandoahMarkingContext* complete_marking_context() const;
   inline ShenandoahMarkingContext* marking_context() const;
-  inline void mark_complete_marking_context();
+  void mark_complete_marking_context();
   inline void mark_incomplete_marking_context();
 
   template<class T>

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2015, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -482,10 +482,6 @@ inline ShenandoahHeapRegion* const ShenandoahHeap::get_region(size_t region_idx)
   } else {
     return NULL;
   }
-}
-
-inline void ShenandoahHeap::mark_complete_marking_context() {
-  _marking_context->mark_complete();
 }
 
 inline void ShenandoahHeap::mark_incomplete_marking_context() {


### PR DESCRIPTION
Please review this patch that adds JFR ObjectCountAfterGC event support.

AFAICT, the event is off by default. If it is enabled, it distorts Shenandoah pause characteristics, since it performs heap walk during final mark pause. 

When event is disabled:
`[191.033s][info][gc,stats] Pause Init Mark (G)                 454 us`
`[191.033s][info][gc,stats] Pause Init Mark (N)                  13 us`

When event is enabled:
`[396.631s][info][gc,stats] Pause Final Mark (G)              43199 us`
`[396.631s][info][gc,stats] Pause Final Mark (N)              42982 us`

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259647](https://bugs.openjdk.java.net/browse/JDK-8259647): Add support for JFR event ObjectCountAfterGC to Shenandoah


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2386/head:pull/2386`
`$ git checkout pull/2386`
