### PR TITLE
8260221: java.util.Formatter throws wrong exception for mismatched flags in %% conversion

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -1832,7 +1832,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <p> The {@code '-'} flag defined for <a href="#dFlags">General
  * conversions</a> applies.  If any other flags are provided, then a
- * {@link FormatFlagsConversionMismatchException} will be thrown.
+ * {@link IllegalFormatFlagsException } will be thrown.
  *
  * <p> The precision is not applicable.  If the precision is specified an
  * {@link IllegalFormatPrecisionException} will be thrown.


### PR DESCRIPTION
Updating the specification to reflect well-established behavior in Formatter when incorrect flags used for `%`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260221](https://bugs.openjdk.java.net/browse/JDK-8260221): java.util.Formatter throws wrong exception for mismatched flags in %% conversion


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2389/head:pull/2389`
`$ git checkout pull/2389`
