### PR TITLE
8257569: Failure observed with JfrVirtualMemory::initialize

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -213,6 +213,7 @@ class JfrVirtualMemoryManager : public JfrCHeapObj {
     return reserved_high() == committed_high();
   }
 
+  u1* top() const { return reinterpret_cast<u1*>(_current_segment->top()); }
   const u1* committed_low() const { return _current_segment->committed_low(); }
   const u1* committed_high() const { return _current_segment->committed_high(); }
   const u1* reserved_low() const { return _current_segment->reserved_low(); }
@@ -443,11 +444,10 @@ void* JfrVirtualMemory::initialize(size_t reservation_size_request_bytes,
   }
   _reserved_low = (const u1*)_vmm->reserved_low();
   _reserved_high = (const u1*)_vmm->reserved_high();
+  assert(static_cast<size_t>(_reserved_high - _reserved_low) == reservation_size_request_bytes, "invariant");
   // reservation complete
-  _top = (u1*)_vmm->committed_high();
-  _commit_point = _top;
+  _top = _vmm->top();
   assert(_reserved_low == _top, "invariant"); // initial empty state
-  assert((size_t)(_reserved_high - _reserved_low) == reservation_size_request_bytes, "invariant");
   // initial commit
   commit_memory_block();
   return _top;
@@ -470,8 +470,6 @@ bool JfrVirtualMemory::is_empty() const {
 bool JfrVirtualMemory::commit_memory_block() {
   assert(_vmm != NULL, "invariant");
   assert(!is_full(), "invariant");
-  assert(_top == _commit_point, "invariant");
-
   void* const block = _vmm->commit(_physical_commit_size_request_words);
   if (block != NULL) {
     _commit_point = _vmm->committed_high();


### PR DESCRIPTION
Greetings,

please review this small adjustment to improve the treatment of ReservedSpaces marked special with the entire memory pre-committed.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257569](https://bugs.openjdk.java.net/browse/JDK-8257569): Failure observed with JfrVirtualMemory::initialize 


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Poonam Bajaj](https://openjdk.java.net/census#poonam) (@poonamparhar - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2391/head:pull/2391`
`$ git checkout pull/2391`
