### PR TITLE
8261107: ArrayIndexOutOfBoundsException in the ICC_Profile.getInstance(InputStream)

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -975,10 +975,10 @@ public class ICC_Profile implements Serializable {
     static byte[] getProfileDataFromStream(InputStream s) throws IOException {
 
         BufferedInputStream bis = new BufferedInputStream(s);
-        bis.mark(128);
+        bis.mark(128); // 128 is the length of the ICC profile header
 
         byte[] header = bis.readNBytes(128);
-        if (header[36] != 0x61 || header[37] != 0x63 ||
+        if (header.length < 128 || header[36] != 0x61 || header[37] != 0x63 ||
             header[38] != 0x73 || header[39] != 0x70) {
             return null;   /* not a valid profile */
         }

--- a/test/jdk/java/awt/color/ICC_Profile/GetInstanceBrokenStream.java
+++ b/test/jdk/java/awt/color/ICC_Profile/GetInstanceBrokenStream.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ICC_Profile;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * @test
+ * @bug 8261107
+ * @summary Short and broken streams should be reported as unsupported
+ */
+public final class GetInstanceBrokenStream {
+
+    public static void main(String[] args) throws IOException {
+        // Empty header
+        testHeader(new byte[]{});
+        // Short header
+        testHeader(new byte[]{-12, 3, 45});
+        // Broken header
+        testHeader(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                31, 32, 33, 34, 35, 0x61, 0x63, 0x73, 0x70});
+    }
+
+    private static void testHeader(byte[] data) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        try {
+            ICC_Profile.getInstance(bais);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Some broken data in the InputStream may cause the wrong exception to be thrown - ArrayIndexOutOfBoundsException instead of IllegalArgumentException, if the data is too small and we try to validate it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261107](https://bugs.openjdk.java.net/browse/JDK-8261107): ArrayIndexOutOfBoundsException in the ICC_Profile.getInstance(InputStream)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2394/head:pull/2394`
`$ git checkout pull/2394`
