### PR TITLE
8261109: [macOS] Remove disabled warning for JNF in make/autoconf/flags-cflags.m4

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -168,11 +168,6 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
 
       DISABLED_WARNINGS="unknown-warning-option unused-parameter unused"
 
-      if test "x$OPENJDK_TARGET_OS" = xmacosx; then
-        # missing-method-return-type triggers in JavaNativeFoundation framework
-        DISABLED_WARNINGS="$DISABLED_WARNINGS missing-method-return-type"
-      fi
-
       ;;
 
     xlc)

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -96,8 +96,6 @@ $(BUILD_LIBNIO): $(BUILD_LIBNET)
 # Create the macosx security library
 
 ifeq ($(call isTargetOs, macosx), true)
-  # JavaNativeFoundation framework not supported in static builds
-  ifneq ($(STATIC_BUILD), true)
 
     $(eval $(call SetupJdkLibrary, BUILD_LIBOSXSECURITY, \
         NAME := osxsecurity, \
@@ -120,7 +118,6 @@ ifeq ($(call isTargetOs, macosx), true)
 
     TARGETS += $(BUILD_LIBOSXSECURITY)
 
-  endif
 endif
 
 ################################################################################


### PR DESCRIPTION
remove un-needed disabling now JNF has gone ..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261109](https://bugs.openjdk.java.net/browse/JDK-8261109): [macOS] Remove disabled warning for JNF in make/autoconf/flags-cflags.m4


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 34dcbfb1a2fc9762fa621a07c2883b66c45bf6a7
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 34dcbfb1a2fc9762fa621a07c2883b66c45bf6a7
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2396/head:pull/2396`
`$ git checkout pull/2396`
