### PR TITLE
8260637: Shenandoah: assert(_base == Tuple) failure during C2 compilation

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5299,7 +5299,7 @@ void PhaseIdealLoop::build_loop_late_post_work(Node *n, bool pinned) {
     case Op_HasNegatives:
       pinned = false;
     }
-    if (n->is_CMove()) {
+    if (n->is_CMove() || n->is_ConstraintCast()) {
       pinned = false;
     }
     if( pinned ) {


### PR DESCRIPTION
Another shenandoah bug with a fix in shared code.

LRBRightAfterMemBar.test2() has 2 allocations that are non escaping
but non scalarizable. As a result, the null check for a3.f is
optimized out but the CastPP is left in the graph. That CastPP becomes
control dependent on the o2 == null check which is later hoisted out
of the loop. The CastPP is then right after the membar of the barrier = 0x42
volatile access but with an out of loop control. Because the node is
considered pinned by loopopts, it is assigned the membar as
control. The input of the CastPP is a shenandoah barrier that's
sandwiched between the membar and the CastPP and so expanded right
after the membar (that is between the membar and its control
projection). That causes the crash. I don't think cast nodes need to
be pinned so I propose that as a fix.

/cc shenandoah,hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260637](https://bugs.openjdk.java.net/browse/JDK-8260637): Shenandoah: assert(_base == Tuple) failure during C2 compilation


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2400/head:pull/2400`
`$ git checkout pull/2400`
