### PR TITLE
8195744: Avoid calling ClassLoader.checkPackageAccess if security manager is not installed

### DIFF
--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,14 +153,7 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
   void set_pd_set(ProtectionDomainEntry* new_head) {  _pd_set = new_head; }
 
   // Tells whether the initiating class' protection domain can access the klass in this entry
-  bool is_valid_protection_domain(Handle protection_domain) {
-    if (!ProtectionDomainVerification) return true;
-
-    return protection_domain() == NULL
-         ? true
-         : contains_protection_domain(protection_domain());
-  }
-
+  inline bool is_valid_protection_domain(Handle protection_domain);
   void verify_protection_domain_set();
 
   bool equals(const Symbol* class_name) const {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4382,16 +4382,32 @@ int java_lang_System::_static_in_offset;
 int java_lang_System::_static_out_offset;
 int java_lang_System::_static_err_offset;
 int java_lang_System::_static_security_offset;
+int java_lang_System::_static_allow_security_offset;
 
 #define SYSTEM_FIELDS_DO(macro) \
   macro(_static_in_offset,  k, "in",  input_stream_signature, true); \
   macro(_static_out_offset, k, "out", print_stream_signature, true); \
   macro(_static_err_offset, k, "err", print_stream_signature, true); \
-  macro(_static_security_offset, k, "security", security_manager_signature, true)
+  macro(_static_security_offset, k, "security", security_manager_signature, true); \
+  macro(_static_allow_security_offset, k, "allowSecurityManager", int_signature, true)
 
 void java_lang_System::compute_offsets() {
   InstanceKlass* k = vmClasses::System_klass();
   SYSTEM_FIELDS_DO(FIELD_COMPUTE_OFFSET);
+}
+
+// This field means that a security manager can be installed so still have to
+// populate the ProtectionDomainCacheTable
+bool java_lang_System::has_security_manager() {
+  oop base = vmClasses::System_klass()->static_field_base_raw();
+  return base->obj_field(_static_security_offset) != NULL;
+}
+
+// This field means that a security manager is never installed so we can completely
+// skip populating the ProtectionDomainCacheTable
+bool java_lang_System::allow_security_manager() {
+  oop base = vmClasses::System_klass()->static_field_base_raw();
+  return base->int_field(_static_allow_security_offset) != 1; // NEVER
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4383,17 +4383,32 @@ int java_lang_System::_static_out_offset;
 int java_lang_System::_static_err_offset;
 int java_lang_System::_static_security_offset;
 int java_lang_System::_static_allow_security_offset;
+int java_lang_System::_static_never_offset;
 
 #define SYSTEM_FIELDS_DO(macro) \
   macro(_static_in_offset,  k, "in",  input_stream_signature, true); \
   macro(_static_out_offset, k, "out", print_stream_signature, true); \
   macro(_static_err_offset, k, "err", print_stream_signature, true); \
   macro(_static_security_offset, k, "security", security_manager_signature, true); \
-  macro(_static_allow_security_offset, k, "allowSecurityManager", int_signature, true)
+  macro(_static_allow_security_offset, k, "allowSecurityManager", int_signature, true); \
+  macro(_static_never_offset, k, "NEVER", int_signature, true)
 
 void java_lang_System::compute_offsets() {
   InstanceKlass* k = vmClasses::System_klass();
   SYSTEM_FIELDS_DO(FIELD_COMPUTE_OFFSET);
+}
+
+// This field means that a security manager is never installed so we can completely
+// skip populating the ProtectionDomainCacheTable
+bool java_lang_System::allow_security_manager() {
+  static int initialized = false;
+  static bool allowed = true; // default
+  if (!initialized) {
+    oop base = vmClasses::System_klass()->static_field_base_raw();
+    int never = base->int_field(_static_never_offset);
+    allowed = (base->int_field(_static_allow_security_offset) != never);
+  }
+  return allowed;
 }
 
 // This field means that a security manager can be installed so still have to
@@ -4401,13 +4416,6 @@ void java_lang_System::compute_offsets() {
 bool java_lang_System::has_security_manager() {
   oop base = vmClasses::System_klass()->static_field_base_raw();
   return base->obj_field(_static_security_offset) != NULL;
-}
-
-// This field means that a security manager is never installed so we can completely
-// skip populating the ProtectionDomainCacheTable
-bool java_lang_System::allow_security_manager() {
-  oop base = vmClasses::System_klass()->static_field_base_raw();
-  return base->int_field(_static_allow_security_offset) != 1; // NEVER
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4398,8 +4398,8 @@ void java_lang_System::compute_offsets() {
   SYSTEM_FIELDS_DO(FIELD_COMPUTE_OFFSET);
 }
 
-// This field means that a security manager is never installed so we can completely
-// skip populating the ProtectionDomainCacheTable
+// This field tells us that a security manager can never be installed so we
+// can completely skip populating the ProtectionDomainCacheTable.
 bool java_lang_System::allow_security_manager() {
   static int initialized = false;
   static bool allowed = true; // default
@@ -4411,8 +4411,8 @@ bool java_lang_System::allow_security_manager() {
   return allowed;
 }
 
-// This field means that a security manager can be installed so still have to
-// populate the ProtectionDomainCacheTable
+// This field means that a security manager can be installed so we still have to
+// populate the ProtectionDomainCacheTable.
 bool java_lang_System::has_security_manager() {
   oop base = vmClasses::System_klass()->static_field_base_raw();
   return base->obj_field(_static_security_offset) != NULL;

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4411,8 +4411,7 @@ bool java_lang_System::allow_security_manager() {
   return allowed;
 }
 
-// This field means that a security manager can be installed so we still have to
-// populate the ProtectionDomainCacheTable.
+// This field tells us that a security manager is installed.
 bool java_lang_System::has_security_manager() {
   oop base = vmClasses::System_klass()->static_field_base_raw();
   return base->obj_field(_static_security_offset) != NULL;

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1373,6 +1373,7 @@ class java_lang_System : AllStatic {
   static int _static_err_offset;
   static int _static_security_offset;
   static int _static_allow_security_offset;
+  static int _static_never_offset;
 
  public:
   static int  in_offset() { CHECK_INIT(_static_in_offset); }

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1372,11 +1372,14 @@ class java_lang_System : AllStatic {
   static int _static_out_offset;
   static int _static_err_offset;
   static int _static_security_offset;
+  static int _static_allow_security_offset;
 
  public:
   static int  in_offset() { CHECK_INIT(_static_in_offset); }
   static int out_offset() { CHECK_INIT(_static_out_offset); }
   static int err_offset() { CHECK_INIT(_static_err_offset); }
+  static bool allow_security_manager();
+  static bool has_security_manager();
 
   static void compute_offsets();
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/dictionary.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/protectionDomainCache.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -66,6 +67,9 @@ class CleanProtectionDomainEntries : public CLDClosure {
 };
 
 void ProtectionDomainCacheTable::unlink() {
+  // The dictionary entries _pd_set field should be null also, so nothing to do.
+  assert(java_lang_System::allow_security_manager(), "should not be called otherwise");
+
   {
     // First clean cached pd lists in loaded CLDs
     // It's unlikely, but some loaded classes in a dictionary might

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -463,21 +463,6 @@ void SystemDictionary::validate_protection_domain(InstanceKlass* klass,
   assert(class_loader() != NULL, "Should not call this");
   assert(protection_domain() != NULL, "Should not call this");
 
-  JavaValue result(T_VOID);
-  LogTarget(Debug, protectiondomain) lt;
-  if (lt.is_enabled()) {
-    ResourceMark rm(THREAD);
-    // Print out trace information
-    LogStream ls(lt);
-    ls.print_cr("Checking package access");
-    ls.print("class loader: ");
-    class_loader()->print_value_on(&ls);
-    ls.print(" protection domain: ");
-    protection_domain()->print_value_on(&ls);
-    ls.print(" loading: "); klass->print_value_on(&ls);
-    ls.cr();
-  }
-
   // We only have to call checkPackageAccess if there's a security manager installed.
   if (java_lang_System::has_security_manager()) {
 
@@ -487,6 +472,7 @@ void SystemDictionary::validate_protection_domain(InstanceKlass* klass,
     Handle mirror(THREAD, klass->java_mirror());
 
     InstanceKlass* system_loader = vmClasses::ClassLoader_klass();
+    JavaValue result(T_VOID);
     JavaCalls::call_special(&result,
                            class_loader,
                            system_loader,
@@ -496,10 +482,22 @@ void SystemDictionary::validate_protection_domain(InstanceKlass* klass,
                            protection_domain,
                            THREAD);
 
-    if (HAS_PENDING_EXCEPTION) {
-      log_debug(protectiondomain)("DENIED !!!!!!!!!!!!!!!!!!!!!");
-    } else {
-     log_debug(protectiondomain)("granted");
+    LogTarget(Debug, protectiondomain) lt;
+    if (lt.is_enabled()) {
+      ResourceMark rm(THREAD);
+      // Print out trace information
+      LogStream ls(lt);
+      ls.print_cr("Checking package access");
+      ls.print("class loader: ");
+      class_loader()->print_value_on(&ls);
+      ls.print(" protection domain: ");
+      protection_domain()->print_value_on(&ls);
+      ls.print(" loading: "); klass->print_value_on(&ls);
+      if (HAS_PENDING_EXCEPTION) {
+        ls.print_cr(" DENIED !!!!!!!!!!!!!!!!!!!!!");
+      } else {
+        ls.print_cr(" granted");
+      }
     }
 
     if (HAS_PENDING_EXCEPTION) return;

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -460,6 +460,9 @@ void SystemDictionary::validate_protection_domain(InstanceKlass* klass,
                                                   Handle protection_domain,
                                                   TRAPS) {
   // Now we have to call back to java to check if the initating class has access
+  assert(class_loader() != NULL, "Should not call this");
+  assert(protection_domain() != NULL, "Should not call this");
+
   JavaValue result(T_VOID);
   LogTarget(Debug, protectiondomain) lt;
   if (lt.is_enabled()) {
@@ -467,47 +470,46 @@ void SystemDictionary::validate_protection_domain(InstanceKlass* klass,
     // Print out trace information
     LogStream ls(lt);
     ls.print_cr("Checking package access");
-    if (class_loader() != NULL) {
-      ls.print("class loader: ");
-      class_loader()->print_value_on(&ls);
-    } else {
-      ls.print_cr("class loader: NULL");
-    }
-    if (protection_domain() != NULL) {
-      ls.print(" protection domain: ");
-      protection_domain()->print_value_on(&ls);
-    } else {
-      ls.print_cr(" protection domain: NULL");
-    }
+    ls.print("class loader: ");
+    class_loader()->print_value_on(&ls);
+    ls.print(" protection domain: ");
+    protection_domain()->print_value_on(&ls);
     ls.print(" loading: "); klass->print_value_on(&ls);
     ls.cr();
   }
 
-  // This handle and the class_loader handle passed in keeps this class from
-  // being unloaded through several GC points.
-  // The class_loader handle passed in is the initiating loader.
-  Handle mirror(THREAD, klass->java_mirror());
+  // We only have to call checkPackageAccess if there's a security manager installed.
+  if (java_lang_System::has_security_manager()) {
 
-  InstanceKlass* system_loader = vmClasses::ClassLoader_klass();
-  JavaCalls::call_special(&result,
-                         class_loader,
-                         system_loader,
-                         vmSymbols::checkPackageAccess_name(),
-                         vmSymbols::class_protectiondomain_signature(),
-                         mirror,
-                         protection_domain,
-                         THREAD);
+    // This handle and the class_loader handle passed in keeps this class from
+    // being unloaded through several GC points.
+    // The class_loader handle passed in is the initiating loader.
+    Handle mirror(THREAD, klass->java_mirror());
 
-  if (HAS_PENDING_EXCEPTION) {
-    log_debug(protectiondomain)("DENIED !!!!!!!!!!!!!!!!!!!!!");
-  } else {
-   log_debug(protectiondomain)("granted");
+    InstanceKlass* system_loader = vmClasses::ClassLoader_klass();
+    JavaCalls::call_special(&result,
+                           class_loader,
+                           system_loader,
+                           vmSymbols::checkPackageAccess_name(),
+                           vmSymbols::class_protectiondomain_signature(),
+                           mirror,
+                           protection_domain,
+                           THREAD);
+
+    if (HAS_PENDING_EXCEPTION) {
+      log_debug(protectiondomain)("DENIED !!!!!!!!!!!!!!!!!!!!!");
+    } else {
+     log_debug(protectiondomain)("granted");
+    }
+
+    if (HAS_PENDING_EXCEPTION) return;
   }
-
-  if (HAS_PENDING_EXCEPTION) return;
 
   // If no exception has been thrown, we have validated the protection domain
   // Insert the protection domain of the initiating class into the set.
+  // We still have to add the protection_domain to the dictionary in case a new
+  // security manager is installed later. Calls to load the same class with class loader
+  // and protection domain are expected to succeed.
   {
     ClassLoaderData* loader_data = class_loader_data(class_loader);
     Dictionary* dictionary = loader_data->dictionary();
@@ -889,17 +891,14 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
   // Make sure we have the right class in the dictionary
   DEBUG_ONLY(verify_dictionary_entry(name, loaded_class));
 
-  // return if the protection domain in NULL
-  if (protection_domain() == NULL) return loaded_class;
-
-  // Check the protection domain has the right access
-  if (dictionary->is_valid_protection_domain(name_hash, name,
+  // Check if the protection domain is present it has the right access
+  if (protection_domain() != NULL &&
+     java_lang_System::allow_security_manager() &&
+     !dictionary->is_valid_protection_domain(name_hash, name,
                                              protection_domain)) {
-    return loaded_class;
+    // Verify protection domain. If it fails an exception is thrown
+    validate_protection_domain(loaded_class, class_loader, protection_domain, CHECK_NULL);
   }
-
-  // Verify protection domain. If it fails an exception is thrown
-  validate_protection_domain(loaded_class, class_loader, protection_domain, CHECK_NULL);
 
   return loaded_class;
 }
@@ -1761,12 +1760,16 @@ bool SystemDictionary::do_unloading(GCTimer* gc_timer) {
   if (unloading_occurred) {
     SymbolTable::trigger_cleanup();
 
-    // Oops referenced by the protection domain cache table may get unreachable independently
-    // of the class loader (eg. cached protection domain oops). So we need to
-    // explicitly unlink them here.
-    // All protection domain oops are linked to the caller class, so if nothing
-    // unloads, this is not needed.
-    _pd_cache_table->trigger_cleanup();
+    if (java_lang_System::allow_security_manager()) {
+      // Oops referenced by the protection domain cache table may get unreachable independently
+      // of the class loader (eg. cached protection domain oops). So we need to
+      // explicitly unlink them here.
+      // All protection domain oops are linked to the caller class, so if nothing
+      // unloads, this is not needed.
+      _pd_cache_table->trigger_cleanup();
+    } else {
+      assert(_pd_cache_table->number_of_entries() == 0, "should be empty");
+    }
   }
 
   return unloading_occurred;

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -677,9 +677,6 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, UsePrivilegedStack, true,                                   \
           "Enable the security JVM functions")                              \
                                                                             \
-  develop(bool, ProtectionDomainVerification, true,                         \
-          "Verify protection domain before resolution in system dictionary")\
-                                                                            \
   product(bool, ClassUnloading, true,                                       \
           "Do unloading of classes")                                        \
                                                                             \

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -160,6 +160,7 @@ public final class System {
     public static final PrintStream err = null;
 
     // indicates if a security manager is possible
+    // @implNote The HotSpot JVM hardcodes the value of NEVER.
     private static final int NEVER = 1;
     private static final int MAYBE = 2;
     private static @Stable int allowSecurityManager;

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -160,7 +160,6 @@ public final class System {
     public static final PrintStream err = null;
 
     // indicates if a security manager is possible
-    // @implNote The HotSpot JVM hardcodes the value of NEVER.
     private static final int NEVER = 1;
     private static final int MAYBE = 2;
     private static @Stable int allowSecurityManager;

--- a/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,17 +41,29 @@ public class ProtectionDomainVerificationTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=trace",
                                                                   "-Xmx128m",
                                                                   Hello.class.getName());
-        OutputAnalyzer out = new OutputAnalyzer(pb.start());
-        out.shouldContain("[protectiondomain] Checking package access");
-        out.shouldContain("[protectiondomain] pd set count = #");
+        new OutputAnalyzer(pb.start())
+        .shouldContain("[protectiondomain] Checking package access")
+        .shouldContain("[protectiondomain] pd set count = #")
+        .shouldHaveExitValue(0);
 
         // -Xlog:protectiondomain=debug
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=debug",
                                                                   "-Xmx128m",
                                                                   Hello.class.getName());
-        out = new OutputAnalyzer(pb.start());
-        out.shouldContain("[protectiondomain] Checking package access");
-        out.shouldNotContain("pd set count = #");
+        new OutputAnalyzer(pb.start())
+        .shouldContain("[protectiondomain] Checking package access")
+        .shouldNotContain("pd set count = #")
+        .shouldHaveExitValue(0);
+
+        // -Xlog:protectiondomain=debug
+        pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=trace",
+                                                   "-Xmx128m",
+                                                   "-Djava.security.manager=disallow",
+                                                   Hello.class.getName());
+        new OutputAnalyzer(pb.start())
+        .shouldNotContain("[protectiondomain] Checking package access")
+        .shouldNotContain("pd set count = #")
+        .shouldHaveExitValue(0);
     }
 
     public static class Hello {

--- a/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,18 +42,18 @@ public class ProtectionDomainVerificationTest {
                                                                   "-Xmx128m",
                                                                   Hello.class.getName());
         new OutputAnalyzer(pb.start())
+        .shouldHaveExitValue(0)
         .shouldContain("[protectiondomain] Checking package access")
-        .shouldContain("[protectiondomain] pd set count = #")
-        .shouldHaveExitValue(0);
+        .shouldContain("[protectiondomain] pd set count = #");
 
         // -Xlog:protectiondomain=debug
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=debug",
                                                                   "-Xmx128m",
                                                                   Hello.class.getName());
         new OutputAnalyzer(pb.start())
+        .shouldHaveExitValue(0)
         .shouldContain("[protectiondomain] Checking package access")
-        .shouldNotContain("pd set count = #")
-        .shouldHaveExitValue(0);
+        .shouldNotContain("pd set count = #");
 
         // -Xlog:protectiondomain=debug
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=trace",
@@ -61,9 +61,9 @@ public class ProtectionDomainVerificationTest {
                                                    "-Djava.security.manager=disallow",
                                                    Hello.class.getName());
         new OutputAnalyzer(pb.start())
+        .shouldHaveExitValue(0)
         .shouldNotContain("[protectiondomain] Checking package access")
-        .shouldNotContain("pd set count = #")
-        .shouldHaveExitValue(0);
+        .shouldNotContain("pd set count = #");
     }
 
     public static class Hello {

--- a/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
@@ -40,7 +40,7 @@ public class ProtectionDomainVerificationTest {
         // -Xlog:protectiondomain=trace
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=trace",
                                                                   "-Xmx128m",
-                                                                  Hello.class.getName());
+                                                                  Hello.class.getName(), "security_manager");
         new OutputAnalyzer(pb.start())
         .shouldHaveExitValue(0)
         .shouldContain("[protectiondomain] Checking package access")
@@ -49,7 +49,7 @@ public class ProtectionDomainVerificationTest {
         // -Xlog:protectiondomain=debug
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:protectiondomain=debug",
                                                                   "-Xmx128m",
-                                                                  Hello.class.getName());
+                                                                  Hello.class.getName(), "security_manager");
         new OutputAnalyzer(pb.start())
         .shouldHaveExitValue(0)
         .shouldContain("[protectiondomain] Checking package access")
@@ -68,6 +68,10 @@ public class ProtectionDomainVerificationTest {
 
     public static class Hello {
         public static void main(String[] args) {
+            if (args.length == 1) {
+              // Need a security manager to trigger logging.
+              System.setSecurityManager(new SecurityManager());
+            }
             System.out.print("Hello!");
         }
     }


### PR DESCRIPTION
This change does not call up to Java for checkPackageAccess if the security manager is NULL, but still saves the protection domain in the pd_set for that dictionary entry.  If the option -Djava.security.manager=disallow is set, that means that there will never be a security manager and the JVM code can avoid saving the protection domains completely. 
See the two functions java_lang_System::has_security_manager() and java_lang_System::allow_security_manager() for details.
Also deleted ProtectionDomainVerification because there's no use for this option.

Tested with tier1 hotspot, jdk and langtools.
and tier2-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8195744](https://bugs.openjdk.java.net/browse/JDK-8195744): Avoid calling ClassLoader.checkPackageAccess if security manager is not installed


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2410/head:pull/2410`
`$ git checkout pull/2410`
