### PR TITLE
8261088: Repeatable annotations without @Target cannot have containers that target module declarations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -119,9 +119,6 @@ public class Check {
         context.put(checkKey, this);
 
         names = Names.instance(context);
-        dfltTargetMeta = new Name[] { names.PACKAGE, names.TYPE,
-            names.FIELD, names.RECORD_COMPONENT, names.METHOD, names.CONSTRUCTOR,
-            names.ANNOTATION_TYPE, names.LOCAL_VARIABLE, names.PARAMETER, names.MODULE };
         log = Log.instance(context);
         rs = Resolve.instance(context);
         syms = Symtab.instance(context);
@@ -161,6 +158,7 @@ public class Check {
 
         deferredLintHandler = DeferredLintHandler.instance(context);
 
+        allowModules = Feature.MODULES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         allowSealed = Feature.SEALED_CLASSES.allowedInSource(source);
     }
@@ -193,6 +191,10 @@ public class Check {
     /** A handler for deferred lint warnings.
      */
     private DeferredLintHandler deferredLintHandler;
+
+    /** Are modules allowed
+     */
+    private final boolean allowModules;
 
     /** Are records allowed
      */
@@ -3215,20 +3217,7 @@ public class Check {
     /* get a set of names for the default target */
     private Set<Name> getDefaultTargetSet() {
         if (defaultTargets == null) {
-            Set<Name> targets = new HashSet<>();
-            targets.add(names.ANNOTATION_TYPE);
-            targets.add(names.CONSTRUCTOR);
-            targets.add(names.FIELD);
-            if (allowRecords) {
-                targets.add(names.RECORD_COMPONENT);
-            }
-            targets.add(names.LOCAL_VARIABLE);
-            targets.add(names.METHOD);
-            targets.add(names.PACKAGE);
-            targets.add(names.PARAMETER);
-            targets.add(names.TYPE);
-
-            defaultTargets = java.util.Collections.unmodifiableSet(targets);
+            defaultTargets = Set.of(defaultTargetMetaInfo());
         }
 
         return defaultTargets;
@@ -3428,8 +3417,26 @@ public class Check {
         return (atValue instanceof Attribute.Array attributeArray) ? attributeArray : null;
     }
 
-    public final Name[] dfltTargetMeta;
+    private Name[] dfltTargetMeta;
     private Name[] defaultTargetMetaInfo() {
+        if (dfltTargetMeta == null) {
+            ArrayList<Name> defaultTargets = new ArrayList<>();
+            defaultTargets.add(names.PACKAGE);
+            defaultTargets.add(names.TYPE);
+            defaultTargets.add(names.FIELD);
+            defaultTargets.add(names.METHOD);
+            defaultTargets.add(names.CONSTRUCTOR);
+            defaultTargets.add(names.ANNOTATION_TYPE);
+            defaultTargets.add(names.LOCAL_VARIABLE);
+            defaultTargets.add(names.PARAMETER);
+            if (allowRecords) {
+              defaultTargets.add(names.RECORD_COMPONENT);
+            }
+            if (allowModules) {
+              defaultTargets.add(names.MODULE);
+            }
+            dfltTargetMeta = defaultTargets.toArray(new Name[0]);
+        }
         return dfltTargetMeta;
     }
 

--- a/test/langtools/tools/javac/annotations/8261088/T8261088.java
+++ b/test/langtools/tools/javac/annotations/8261088/T8261088.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Alphabet LLC. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,21 @@
  * questions.
  */
 
-import java.lang.annotation.*;
-
-/**
+/*
  * @test
- * @bug 8006547 8261088
- * @compile NoTargetOnContainer.java
+ * @bug 8261088
+ * @summary Repeatable annotations without Target cannot have containers that target module declarations
+ * @compile T8261088.java
  */
 
-@interface FooContainer {
-  Foo[] value();
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Target;
+
+@Target(ElementType.MODULE)
+@interface TC {
+    T[] value() default {};
 }
 
-@Target({
-    ElementType.CONSTRUCTOR,
-    ElementType.PARAMETER,
-    ElementType.TYPE,
-    ElementType.METHOD,
-    ElementType.LOCAL_VARIABLE,
-    ElementType.PACKAGE,
-    ElementType.ANNOTATION_TYPE,
-    ElementType.FIELD,
-    ElementType.RECORD_COMPONENT,
-    ElementType.MODULE,
-})
-@Repeatable(FooContainer.class)
-@interface Foo {}
-
-class NoTargetOnContainer {}
+@Repeatable(TC.class)
+@interface T {}

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer2.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/NoTargetOnContainer2.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
 
 /**
  * @test
- * @bug 8006547
+ * @bug 8006547 8261088
  * @compile NoTargetOnContainer2.java
  */
 
@@ -44,7 +44,8 @@ import java.lang.annotation.*;
     ElementType.FIELD,
     ElementType.TYPE_USE,
     ElementType.TYPE_PARAMETER,
-    ElementType.RECORD_COMPONENT
+    ElementType.RECORD_COMPONENT,
+    ElementType.MODULE,
 })
 @Repeatable(FooContainer.class)
 @interface Foo {}


### PR DESCRIPTION
Please review this fix to consolidate handling of default `@Target`s for repeated annotations, and permit repeatable annotations without an `@Target` to have container annotations that explicitly target `MODULE`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261088](https://bugs.openjdk.java.net/browse/JDK-8261088): Repeatable annotations without @Target cannot have containers that target module declarations


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**) ⚠️ Review applies to 1d5c298c1c6dd6432ddf0fa4f450d692633bd579


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2412/head:pull/2412` \
`$ git checkout pull/2412`

Update a local copy of the PR: \
`$ git checkout pull/2412` \
`$ git pull https://git.openjdk.java.net/jdk pull/2412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2412`

View PR using the GUI difftool: \
`$ git pr show -t 2412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2412.diff">https://git.openjdk.java.net/jdk/pull/2412.diff</a>

</details>
