### PR TITLE
8261179: Norwegian Bokmål Locale fallback issue

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2890,15 +2890,17 @@ public abstract class ResourceBundle {
                 }
                 if (language.equals("nb") || isNorwegianBokmal) {
                     List<Locale> tmpList = getDefaultList("nb", script, region, variant);
-                    // Insert a locale replacing "nb" with "no" for every list entry
+                    // Insert a locale replacing "nb" with "no" for every list entry with precedence
                     List<Locale> bokmalList = new LinkedList<>();
-                    for (Locale l : tmpList) {
-                        bokmalList.add(l);
-                        if (l.getLanguage().isEmpty()) {
+                    for (Locale l_nb : tmpList) {
+                        var isRoot = l_nb.getLanguage().isEmpty();
+                        var l_no = Locale.getInstance(isRoot ? "" : "no",
+                                l_nb.getScript(), l_nb.getCountry(), l_nb.getVariant(), null);
+                        bokmalList.add(isNorwegianBokmal ? l_no : l_nb);
+                        if (isRoot) {
                             break;
                         }
-                        bokmalList.add(Locale.getInstance("no", l.getScript(), l.getCountry(),
-                                l.getVariant(), null));
+                        bokmalList.add(isNorwegianBokmal ? l_nb : l_no);
                     }
                     return bokmalList;
                 } else if (language.equals("nn") || isNorwegianNynorsk) {

--- a/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 5102289 6278334
+ * @bug 5102289 6278334 8261179
  * @summary Test the default Control implementation. The expiration
  * functionality of newBundle, getTimeToLive, and needsReload is
  * tested by ExpirationTest.sh. The factory methods are tested
@@ -145,31 +145,50 @@ public class DefaultControlTest {
                               new Locale("ja", "JP", "YOK"),
                               new Locale("ja", "JP"),
                               new Locale("ja"),
-                              new Locale("") });
+                              Locale.ROOT });
         candidateData.put(new Locale("ja", "JP"), new Locale[] {
                               new Locale("ja", "JP"),
                               new Locale("ja"),
-                              new Locale("") });
+                              Locale.ROOT });
         candidateData.put(new Locale("ja"), new Locale[] {
                               new Locale("ja"),
-                              new Locale("") });
+                              Locale.ROOT });
 
         candidateData.put(new Locale("ja", "", "YOK"), new Locale[] {
                               new Locale("ja", "", "YOK"),
                               new Locale("ja"),
-                              new Locale("") });
+                              Locale.ROOT });
         candidateData.put(new Locale("", "JP", "YOK"), new Locale[] {
                               new Locale("", "JP", "YOK"),
                               new Locale("", "JP"),
-                              new Locale("") });
+                              Locale.ROOT });
         candidateData.put(new Locale("", "", "YOK"), new Locale[] {
                               new Locale("", "", "YOK"),
-                              new Locale("") });
+                              Locale.ROOT });
         candidateData.put(new Locale("", "JP"), new Locale[] {
                               new Locale("", "JP"),
-                              new Locale("") });
-        candidateData.put(new Locale(""), new Locale[] {
-                              new Locale("") });
+                              Locale.ROOT });
+        candidateData.put(Locale.ROOT, new Locale[] {
+                              Locale.ROOT });
+
+        // Norwegian Bokmal
+        candidateData.put(Locale.forLanguageTag("nb-NO-POSIX"), new Locale[] {
+                Locale.forLanguageTag("nb-NO-POSIX"),
+                Locale.forLanguageTag("no-NO-POSIX"),
+                Locale.forLanguageTag("nb-NO"),
+                Locale.forLanguageTag("no-NO"),
+                Locale.forLanguageTag("nb"),
+                Locale.forLanguageTag("no"),
+                Locale.ROOT});
+        candidateData.put(Locale.forLanguageTag("no-NO-POSIX"), new Locale[] {
+                Locale.forLanguageTag("no-NO-POSIX"),
+                Locale.forLanguageTag("nb-NO-POSIX"),
+                Locale.forLanguageTag("no-NO"),
+                Locale.forLanguageTag("nb-NO"),
+                Locale.forLanguageTag("no"),
+                Locale.forLanguageTag("nb"),
+                Locale.ROOT});
+
 
         for (Locale locale : candidateData.keySet()) {
             List<Locale> candidates = CONTROL.getCandidateLocales("any", locale);
@@ -233,7 +252,7 @@ public class DefaultControlTest {
             }
 
             testNo = 2;
-            rb = CONTROL.newBundle("TestResourceRB", new Locale(""),
+            rb = CONTROL.newBundle("TestResourceRB", Locale.ROOT,
                                    CLAZZ, LOADER, false);
             s = rb.getString("type");
             if (!s.equals(CLAZZ)) {
@@ -267,7 +286,7 @@ public class DefaultControlTest {
         }
 
         try {
-            rb = CONTROL.newBundle("NonResourceBundle", new Locale(""),
+            rb = CONTROL.newBundle("NonResourceBundle", Locale.ROOT,
                                    "java.class", LOADER, false);
             error("newBundle: doesn't throw ClassCastException with a non-ResourceBundle subclass.");
         } catch (ClassCastException cce) {
@@ -349,7 +368,7 @@ public class DefaultControlTest {
                         name + "_" + "" + "_" + "" + "_" + "YOK");
         bundleNames.put(new Locale("", "JP"),
                         name + "_" + "" + "_" + "JP");
-        bundleNames.put(new Locale(""),
+        bundleNames.put(Locale.ROOT,
                         name);
 
         for (Locale locale : bundleNames.keySet()) {


### PR DESCRIPTION
Please review this fix. The bug was revealed while porting CLDR v39 into the JDK, where they switch the Norwegian Bokmal from "nb" to "no". [1] Some regression tests started failing with it because COMPAT provider's "nb" resource was used according to the incorrect candidate locale order.

[1] https://unicode-org.atlassian.net/browse/CLDR-2698

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261179](https://bugs.openjdk.java.net/browse/JDK-8261179): Norwegian Bokmål Locale fallback issue


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2414/head:pull/2414`
`$ git checkout pull/2414`
