### PR TITLE
8261096: Convert jlink tool to use Stream.toList()

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
@@ -133,7 +133,7 @@ public final class ImageFileCreator {
                                     Archive::moduleName,
                                     a -> {
                                         try (Stream<Entry> entries = a.entries()) {
-                                            return entries.collect(Collectors.toList());
+                                            return entries.toList();
                                         }
                                     }));
             ByteOrder order = ByteOrder.nativeOrder();

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.lang.module.ModuleDescriptor;
 import java.nio.ByteOrder;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.internal.jimage.decompressor.Decompressor;
@@ -149,7 +148,7 @@ public final class ImagePluginStack {
                     Comparator.reverseOrder())).filter((e) -> {
                         return e.getValue() > 1;
                     }).map(java.util.Map.Entry::getKey).
-                    collect(Collectors.toList());
+                    toList();
             return result;
         }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.Collections;
 import java.util.Locale;
@@ -566,7 +565,7 @@ public final class TaskHelper {
                         if (option.isTerminal()) {
                             return ++i < args.length
                                         ? Stream.of(Arrays.copyOfRange(args, i, args.length))
-                                                .collect(Collectors.toList())
+                                                .toList()
                                         : Collections.emptyList();
 
                         }
@@ -576,7 +575,7 @@ public final class TaskHelper {
                     }
                 } else {
                     return Stream.of(Arrays.copyOfRange(args, i, args.length))
-                                 .collect(Collectors.toList());
+                                 .toList();
                 }
             }
             return Collections.emptyList();

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Utils.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Utils.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import jdk.tools.jlink.plugin.Plugin;
 
@@ -51,7 +50,7 @@ public class Utils {
         return Arrays.stream(arguments.split(","))
                      .map((p) -> p.trim())
                      .filter((p) -> !p.isEmpty())
-                     .collect(Collectors.toList());
+                     .toList();
     }
 
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.plugin.PluginException;
@@ -106,7 +105,7 @@ public final class ExcludeVMPlugin extends AbstractPlugin {
                 }
             }
             return false;
-        }).collect(Collectors.toList());
+        }).toList();
         return ret;
     }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -219,7 +219,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 .distinct()
                 .sorted()
                 .map(IncludeLocalesPlugin::tagToLocale)
-                .collect(Collectors.toList());
+                .toList();
         } else {
             // jdk.localedata is not added.
             throw new PluginException(PluginsResourceBundle.getMessage(getName() + ".localedatanotfound"));
@@ -236,7 +236,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 META_FILES.stream(),
                 filtered.stream().flatMap(s -> includeLocaleFilePatterns(s).stream()))
             .map(s -> "regex:" + s)
-            .collect(Collectors.toList());
+            .toList();
 
         predicate = ResourceFilter.includeFilter(value);
     }
@@ -266,7 +266,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
     private List<String> includeLocaleFiles(String localeStr) {
         return INCLUDE_LOCALE_FILES.stream()
             .map(s -> s + localeStr + ".class")
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private boolean stripUnsupportedLocales(byte[] bytes, ClassReader cr) {
@@ -299,7 +299,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
             locales = originalTags.stream()
                 .filter(tag -> !tag.isEmpty())
                 .map(IncludeLocalesPlugin::tagToLocale)
-                .collect(Collectors.toList());
+                .toList();
         } catch (IllformedLocaleException ile) {
             // Seems not an available locales string literal.
             return false;
@@ -342,7 +342,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 .flatMap(Optional::stream)
                 .flatMap(IncludeLocalesPlugin::localeToTags)
                 .distinct()
-                .collect(Collectors.toList());
+                .toList();
 
         return ret;
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import jdk.internal.jimage.decompressor.CompressIndexes;
 import jdk.internal.jimage.decompressor.SignatureParser;
 import jdk.internal.jimage.decompressor.StringSharingDecompressor;
@@ -264,7 +263,7 @@ public class StringSharingPlugin extends AbstractPlugin implements ResourcePrevi
                             List<Integer> indexes
                                     = parseResult.types.stream().map((type) -> {
                                         return strings.addString(type);
-                                    }).collect(Collectors.toList());
+                                    }).toList();
                             if (!indexes.isEmpty()) {
                                 out.write(StringSharingDecompressor.EXTERNALIZED_STRING_DESCRIPTOR);
                                 int sigIndex = strings.addString(parseResult.formatted);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
@@ -291,7 +291,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 .collect(Collectors.toSet());
         return moduleInfos.stream()
                 .filter(mi -> names.contains(mi.moduleName()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**


### PR DESCRIPTION
A subtask [JDK-8260559](https://bugs.openjdk.java.net/browse/JDK-8260559). This is an enhancement to update jlink's usage of `Collections.toList()` to `Stream.toList()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261096](https://bugs.openjdk.java.net/browse/JDK-8261096): Convert jlink tool to use Stream.toList()


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2416/head:pull/2416`
`$ git checkout pull/2416`
