### PR TITLE
8261190: restore original Alibaba copyright line in two files

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Alibaba Group Holding Limited. All rights reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Alibaba Group Holding Limited. All rights reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial fix to restore original Alibaba copyright line in two files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261190](https://bugs.openjdk.java.net/browse/JDK-8261190): restore original Alibaba copyright line in two files


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2417/head:pull/2417`
`$ git checkout pull/2417`
