### PR TITLE
8261198: [macOS] Incorrect JNI parameters in number conversion in A11Y code

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -968,14 +968,14 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
     }
     DECLARE_CLASS_RETURN(jnumber_Class, "java/lang/Number", nil);
     DECLARE_CLASS_RETURN(jinteger_Class, "java/lang/Integer", nil);
-    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()D", nil);
+    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()I", nil);
     DECLARE_METHOD_RETURN(jm_doubleValue, jnumber_Class, "doubleValue", "()D", nil);
     if ((*env)->IsInstanceOf(env, jnumber, jinteger_Class)) {
-        jint i = (*env)->CallIntMethod(env, jnumber_Class, jm_intValue);
+        jint i = (*env)->CallIntMethod(env, jnumber, jm_intValue);
         CHECK_EXCEPTION();
         return [NSNumber numberWithInteger:i];
     } else {
-        jdouble d = (*env)->CallDoubleMethod(env, jnumber_Class, jm_doubleValue);
+        jdouble d = (*env)->CallDoubleMethod(env, jnumber, jm_doubleValue);
         CHECK_EXCEPTION();
         return [NSNumber numberWithDouble:d];
     }


### PR DESCRIPTION
we need to specify ()I for the signature of the method that returns int.
Additionally number (the instance!) needs to be passed to the method up call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261198](https://bugs.openjdk.java.net/browse/JDK-8261198): [macOS] Incorrect JNI parameters in number conversion in A11Y code


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2418/head:pull/2418`
`$ git checkout pull/2418`
