### PR TITLE
8261213: [BACKOUT] MutableSpace's end should be atomic

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -200,6 +200,9 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool supports_inline_contig_alloc() const { return !UseNUMA; }
 
+  HeapWord* volatile* top_addr() const { return !UseNUMA ? young_gen()->top_addr() : (HeapWord* volatile*)-1; }
+  HeapWord** end_addr() const { return !UseNUMA ? young_gen()->end_addr() : (HeapWord**)-1; }
+
   void ensure_parsability(bool retire_tlabs);
   void resize_all_tlabs();
 

--- a/src/hotspot/share/gc/parallel/psYoungGen.hpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.hpp
@@ -133,6 +133,9 @@ class PSYoungGen : public CHeapObj<mtGC> {
     return result;
   }
 
+  HeapWord* volatile* top_addr() const   { return eden_space()->top_addr(); }
+  HeapWord** end_addr() const   { return eden_space()->end_addr(); }
+
   // Iteration.
   void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* cl);

--- a/src/hotspot/share/gc/parallel/vmStructs_parallelgc.hpp
+++ b/src/hotspot/share/gc/parallel/vmStructs_parallelgc.hpp
@@ -46,7 +46,7 @@
   nonstatic_field(PSVirtualSpace,              _committed_high_addr,                          char*)                                 \
                                                                                                                                      \
   nonstatic_field(MutableSpace,                _bottom,                                       HeapWord*)                             \
-  volatile_nonstatic_field(MutableSpace,       _end,                                          HeapWord*)                             \
+  nonstatic_field(MutableSpace,                _end,                                          HeapWord*)                             \
   volatile_nonstatic_field(MutableSpace,       _top,                                          HeapWord*)                             \
                                                                                                                                      \
   nonstatic_field(PSYoungGen,                  _reserved,                                     MemRegion)                             \


### PR DESCRIPTION
This reverts commit 1e0a1013efcb3983d277134f04f5e38f687e88c5.

Please review this backout of
JDK-8259862: MutableSpace's end should be atomic

With that change:
gc/TestVerifyDuringStartup.java with -XX:+UseParallelGC -XX:-UseNUMA fails with:
\# guarantee(false) failed: inline contiguous allocation not supported 

Testing:
Locally (linux-x64) verified the failure is reproducible.
Locally (linux-x64) verified no failure with the backout applied.
Locally (linux-x64) hotspot:tier1 with -XX:+UseParallelGC -XX:-UseNUMA
  is fine except for two serviceability tests that always fail locally with
  UseParallelGC
mach5 tier1-2 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261213](https://bugs.openjdk.java.net/browse/JDK-8261213): [BACKOUT] MutableSpace's end should be atomic


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2426/head:pull/2426`
`$ git checkout pull/2426`
