### PR TITLE
8261161: Clean up warnings in hotspot/jtreg/vmTestbase tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/JumbleGC/Tree.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/JumbleGC/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class Tree {
       else
           q.right = newnode;
       elementCount++;
-      TreeValues.addElement(new Integer(o));
+      TreeValues.addElement(Integer.valueOf(o));
    }
 
 

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomHelper.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public final class PhantomHelper {
                 PRHelper prh = (PRHelper) rq.remove(1000);
 
                 if (prh != null) {
-                    Integer ik = new Integer(prh.getReferentHashCode());
+                    Integer ik = Integer.valueOf(prh.getReferentHashCode());
                     PhantomHelper ph = (PhantomHelper) hmHelper.get(ik);
 
                     if (ph != null) {
@@ -110,7 +110,7 @@ public final class PhantomHelper {
                             ph.decreaseHashCounter();
                             if (ph.getHashCounter() == 0) {
                                 hmHelper.remove(
-                                        new Integer(prh.getReferentHashCode()));
+                                        Integer.valueOf(prh.getReferentHashCode()));
                             } else {
                                 hmHelper.put(ik, ph);
                             }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomReferenceEvilTest/PhantomReferenceEvilTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomReferenceEvilTest/PhantomReferenceEvilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class PhantomReferenceEvilTest extends GCTestBase {
                     byte[] tmp = new byte[allocationSize];
 
                     if (counter % keepEveryXthObject == 0) {
-                        Integer ik = new Integer(tmp.hashCode());
+                        Integer ik = Integer.valueOf(tmp.hashCode());
                         if (hmHelper.containsKey(ik)) {
                             PhantomHelper ph = (PhantomHelper) hmHelper.get(ik);
                             ph.increaseHashCounter();

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomReferenceTest/PhantomReferenceTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/PhantomReferenceTest/PhantomReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ public class PhantomReferenceTest extends GCTestBase {
             int allocationSize = ((int) (rndGenerator.nextDouble()
                     * multiplier)) + minSize;
             byte[] tmp = new byte[allocationSize];
-            Integer ik = new Integer(tmp.hashCode());
+            Integer ik = Integer.valueOf(tmp.hashCode());
             if (hmHelper.containsKey(ik)) {
                 PhantomHelper ph = (PhantomHelper) hmHelper.get(ik);
                 ph.increaseHashCounter();

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/ReferencesGC/ReferencesGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/ReferencesGC/ReferencesGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,9 @@ public class ReferencesGC extends ThreadedGCTest {
     public static void parseArgs(String[] args) {
         for (int i = 0; i < args.length; i++) {
             if (args[i].compareTo("-range") == 0) {
-                RANGE = new Integer(args[++i]).intValue();
+                RANGE = Integer.valueOf(args[++i]).intValue();
             } else if (args[i].compareTo("-ratio") == 0) {
-                RATIO = new Float(args[++i]).floatValue();
+                RATIO = Float.valueOf(args[++i]).floatValue();
             }
         }
         REMOVE = (int) (RANGE * RATIO);

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReferenceGC/WeakReferenceGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReferenceGC/WeakReferenceGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,13 +170,13 @@ public class WeakReferenceGC extends ThreadedGCTest {
         private void parseTestParams(String args[]) {
                 for (int i = 0; i < args.length; i++) {
                         if (args[i].compareTo("-numList") == 0) {
-                                numLists = new Integer(args[++i]).intValue();
+                                numLists = Integer.valueOf(args[++i]).intValue();
                         } else if (args[i].compareTo("-qFactor") == 0) {
-                                qFactor = new Float(args[++i]).floatValue();
+                                qFactor = Float.valueOf(args[++i]).floatValue();
                         } else if (args[i].compareTo("-gcCount") == 0) {
-                                gcCount = new Integer(args[++i]).intValue();
+                                gcCount = Integer.valueOf(args[++i]).intValue();
                         } else if (args[i].compareTo("-iter") == 0) {
-                                loopCount = new Integer(args[++i]).intValue();
+                                loopCount = Integer.valueOf(args[++i]).intValue();
                                 // } else {
                                 // System.err.println("usage : " +
                                 // "java WeakReferenceGC [-numList <n>] " +

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest01/gctest01.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest01/gctest01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ public class gctest01 extends TestBase {
 
                 if (args.length > 0) {
                         try {
-                                peopleLimit = new Integer(args[0]).intValue();
+                                peopleLimit = Integer.valueOf(args[0]).intValue();
                         } catch (NumberFormatException e) {
                                 log.info(usage);
                                 throw new TestBug("Bad input to gctest01." +
@@ -205,7 +205,7 @@ public class gctest01 extends TestBase {
 
                 if (args.length > 1 ) {
                         try {
-                                LOOPCOUNT = new Integer(args[1]).intValue();
+                                LOOPCOUNT = Integer.valueOf(args[1]).intValue();
                         } catch (NumberFormatException e) {
                                 log.error(usage);
                                 throw new TestBug("Bad input to gctest01." +

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest02/gctest02.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest02/gctest02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class gctest02 {
                 {
                         try
                         {
-                                peopleLimit = new Integer(args[0]).intValue();
+                                peopleLimit = Integer.valueOf(args[0]).intValue();
                         }
                         catch (NumberFormatException e)
                         {

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest03/gctest03.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest03/gctest03.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class gctest03 extends TestBase {
 
                 if (args.length > 0) {
                         try {
-                                dataNodeLimit = new Integer(args[0]).intValue();
+                                dataNodeLimit = Integer.valueOf(args[0]).intValue();
                         } catch (NumberFormatException e) {
                                 throw new TestBug("Bad input to gctest03. Expected integer, " +
                                                 " got: ->" + args[0] + "<-", e);

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest04/gctest04.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/gctest04/gctest04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class gctest04 {
     {
         try
         {
-            queueLimit = new Integer(args[0]).intValue();
+            queueLimit = Integer.valueOf(args[0]).intValue();
         }
         catch (NumberFormatException e)
         {

--- a/test/hotspot/jtreg/vmTestbase/gc/hashcode/ExternalHashingTest/ExternalHashingTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/hashcode/ExternalHashingTest/ExternalHashingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ public final class ExternalHashingTest {
         for (int i = 0; i < BATCH_SIZE; i++) {
             /* Add all of the results of this pass to the global list. */
             allObjects.add(hashedList[i]);
-            allHashes.add(new Integer(foundHashes[i]));
+            allHashes.add(Integer.valueOf(foundHashes[i]));
 
             /* Create even more garbage for the GC to find */
             garbageMonger[i] = new Object();

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/FPCompare/TestFPBinop/TestFPBinop.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/FPCompare/TestFPBinop/TestFPBinop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,10 +68,10 @@ public class TestFPBinop {
      * from simplifying some of the expressions by using algebraic
      * identities. */
     static {
-        fOne = new Integer(1).floatValue();
-        fZero = new Integer(0).floatValue();
-        dOne = new Integer(1).doubleValue();
-        dZero = new Integer(0).doubleValue();
+        fOne = Integer.valueOf(1).floatValue();
+        fZero = Integer.valueOf(0).floatValue();
+        dOne = Integer.valueOf(1).doubleValue();
+        dZero = Integer.valueOf(0).doubleValue();
     }
 
     static final boolean DEBUG = false;
@@ -368,7 +368,7 @@ public class TestFPBinop {
 
     static int index(float x) {
         for (int i = 0; i < floatValues.length; i++) {
-            if (new Float(x).equals(new Float(floatValues[i])))
+            if (Float.valueOf(x).equals(Float.valueOf(floatValues[i])))
                 return i;
         }
         throw new TestFailure("ERROR: can't find " + x + " in floatValues.");
@@ -376,7 +376,7 @@ public class TestFPBinop {
 
     static int index(double x) {
         for (int i = 0; i < doubleValues.length; i++) {
-            if (new Double(x).equals(new Double(doubleValues[i])))
+            if (Double.valueOf(x).equals(Double.valueOf(doubleValues[i])))
                 return i;
         }
         throw new TestFailure("ERROR: can't find " + x + " in doubleValues.");

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test1.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,10 +53,10 @@ class test1 {
 
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(classID);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test2.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,12 +52,12 @@ class test2 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[1]);
 
             Globals.addFunctionIDToVector(methodCallStr.id, ID);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             Globals.addFunctionIDToVector(MethodID[0], ID);
             callMe(summation, ID, numFcalls, staticFcalls);
@@ -94,11 +94,11 @@ class test2 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[0]);
 
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test3.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,17 +59,17 @@ class test3 extends test1 {
         // make a static call
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[1]);
         } else if (localNumLoops > 0) { // make a recursive call
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             Globals.addFunctionIDToVector(MethodID[1], ID);
             localNumLoops--;
             selfRecursion(summation, ID, numFcalls, staticFcalls);
             return;
         } else { // make a random call
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
 
@@ -101,10 +101,10 @@ class test3 extends test1 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[0]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test4.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,12 +51,12 @@ class test4 extends test2 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[1]);
 
             Globals.addFunctionIDToVector(methodCallStr.id, ID);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             Globals.addFunctionIDToVector(MethodID[0], ID);
             super.callMe(summation, ID, numFcalls, staticFcalls);
@@ -89,11 +89,11 @@ class test4 extends test2 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[2]);
         } else {
             long temp = functionDepth.longValue() - 2;
-            numFcalls = new Long(temp / 2);
+            numFcalls = Long.valueOf(temp / 2);
             staticFcalls = staticFunctionDepth;
 
             if (Globals.VERBOSE) {
@@ -117,7 +117,7 @@ class test4 extends test2 {
             if (Globals.VERBOSE) {
                 System.out.println(" test4.callMe - Starting Branch 2");
             }
-            numFcalls = new Long(temp);
+            numFcalls = Long.valueOf(temp);
             methodCallStr = Globals.nextRandomMethod();
         }
         Globals.addFunctionIDToVector(methodCallStr.id, ID);

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test5.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,10 +164,10 @@ class test5 {
 
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[0]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }
@@ -205,10 +205,10 @@ class test5 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[1]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }
@@ -246,10 +246,10 @@ class test5 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[2]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }
@@ -291,10 +291,10 @@ class test5 {
         Integer staticFcalls;
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[3]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }

--- a/test/hotspot/jtreg/vmTestbase/jit/graph/test6.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/graph/test6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,10 +65,10 @@ public class test6 {
 
         if (staticFunctionDepth.intValue() > 0) {
             numFcalls = functionDepth;
-            staticFcalls = new Integer(staticFunctionDepth.intValue() - 1);
+            staticFcalls = Integer.valueOf(staticFunctionDepth.intValue() - 1);
             methodCallStr = Globals.returnNextStaticMethod(MethodID[0]);
         } else {
-            numFcalls = new Long(functionDepth.longValue() - 1);
+            numFcalls = Long.valueOf(functionDepth.longValue() - 1);
             staticFcalls = staticFunctionDepth;
             methodCallStr = Globals.nextRandomMethod();
         }
@@ -82,11 +82,11 @@ public class test6 {
         // code guarantees no duplicates
         for (int i = 0; i < numElements; i++) {
             int nextKey = localNumGen.nextInt(16385);
-            while (temp.indexOf(new Integer(nextKey)) != -1) {
+            while (temp.indexOf(Integer.valueOf(nextKey)) != -1) {
                 nextKey = localNumGen.nextInt(16385);
             }
 
-            temp.addElement(new Integer(nextKey));
+            temp.addElement(Integer.valueOf(nextKey));
             dataArray[i] = nextKey;
 
             insertArray[i] = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class pop_exception001a {
         if (i == 5) {
             throw new NullPointerException("Something went wrong");
         } else {
-            return new Integer(i);
+            return Integer.valueOf(i);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class unwatch001a {
         fS1 = flag ? fS1 :  new boolean[] {fS0};
         fS2 = flag ? fS2 :  new boolean[][] {fS1};
 
-        FS0 = flag ? FS0 : new Boolean(false);
+        FS0 = flag ? FS0 : Boolean.valueOf(false);
         FS1 = flag ? FS1 : new Boolean[] {FS0};
         FS2 = flag ? FS2 : new Boolean[][] {FS1};
 
@@ -102,11 +102,11 @@ public class unwatch001a {
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
-            FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
-            FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
-            FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
-            FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
+            FP0 = flag ? FP0 : Byte.valueOf(Byte.MIN_VALUE) ;
+            FU0 = flag ? FU0 : Character.valueOf(Character.MIN_VALUE);
+            FR0 = flag ? FR0 : Double.valueOf(Double.MIN_VALUE);
+            FT0 = flag ? FT0 : Float.valueOf(Float.MIN_VALUE);
+            FV0 = flag ? FV0 : Long.valueOf(Long.MIN_VALUE);
 
             fP1 = flag ? fP1 : new byte[] {fP0};
             fP2 = flag ? fP2 : new byte[][] {fP1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class unwatch002a {
         fS1 = flag ? fS1 : new boolean[] {fS0};
         fS2 = flag ? fS2 : new boolean[][] {fS1};
 
-        FS0 = flag ? FS0 : new Boolean(false);
+        FS0 = flag ? FS0 : Boolean.valueOf(false);
         FS1 = flag ? FS1 : new Boolean[] {FS0};
         FS2 = flag ? FS2 : new Boolean[][] {FS1};
 
@@ -102,11 +102,11 @@ public class unwatch002a {
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
-            FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
-            FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
-            FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
-            FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
+            FP0 = flag ? FP0 : Byte.valueOf(Byte.MIN_VALUE) ;
+            FU0 = flag ? FU0 : Character.valueOf(Character.MIN_VALUE);
+            FR0 = flag ? FR0 : Double.valueOf(Double.MIN_VALUE);
+            FT0 = flag ? FT0 : Float.valueOf(Float.MIN_VALUE);
+            FV0 = flag ? FV0 : Long.valueOf(Long.MIN_VALUE);
 
             fP1 = flag ? fP1 : new byte[] {fP0};
             fP2 = flag ? fP2 : new byte[][] {fP1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class watch001a {
         fS1 = flag ? fS1 :  new boolean[] {fS0};
         fS2 = flag ? fS2 :  new boolean[][] {fS1};
 
-        FS0 = flag ? FS0 : new Boolean(false);
+        FS0 = flag ? FS0 : Boolean.valueOf(false);
         FS1 = flag ? FS1 : new Boolean[] {FS0};
         FS2 = flag ? FS2 : new Boolean[][] {FS1};
 
@@ -98,11 +98,11 @@ public class watch001a {
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
-            FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
-            FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
-            FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
-            FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
+            FP0 = flag ? FP0 : Byte.valueOf(Byte.MIN_VALUE) ;
+            FU0 = flag ? FU0 : Character.valueOf(Character.MIN_VALUE);
+            FR0 = flag ? FR0 : Double.valueOf(Double.MIN_VALUE);
+            FT0 = flag ? FT0 : Float.valueOf(Float.MIN_VALUE);
+            FV0 = flag ? FV0 : Long.valueOf(Long.MIN_VALUE);
 
             fP1 = flag ? fP1 : new byte[] {fP0};
             fP2 = flag ? fP2 : new byte[][] {fP1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class watch002a {
         fS1 = flag ? fS1 : new boolean[] {fS0};
         fS2 = flag ? fS2 : new boolean[][] {fS1};
 
-        FS0 = flag ? FS0 : new Boolean(false);
+        FS0 = flag ? FS0 : Boolean.valueOf(false);
         FS1 = flag ? FS1 : new Boolean[] {FS0};
         FS2 = flag ? FS2 : new Boolean[][] {FS1};
 
@@ -98,11 +98,11 @@ public class watch002a {
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
-            FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
-            FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
-            FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
-            FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
+            FP0 = flag ? FP0 : Byte.valueOf(Byte.MIN_VALUE) ;
+            FU0 = flag ? FU0 : Character.valueOf(Character.MIN_VALUE);
+            FR0 = flag ? FR0 : Double.valueOf(Double.MIN_VALUE);
+            FT0 = flag ? FT0 : Float.valueOf(Float.MIN_VALUE);
+            FV0 = flag ? FV0 : Long.valueOf(Long.MIN_VALUE);
 
             fP1 = flag ? fP1 : new byte[] {fP0};
             fP2 = flag ? fP2 : new byte[][] {fP1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,16 +41,16 @@ public class accipp001a {
     long    l0, l1[]={l0}, l2[][]={l1}, l3[][][]={l2}, l4[][][][]={l3};
     short   s0, s1[]={s0}, s2[][]={s1}, s3[][][]={s2}, s4[][][][]={s3};
 
-    Boolean   Z0  = new Boolean(true),  Z1[] ={Z0},  Z2[][]={Z1},   Z3[][][]={Z2},   Z4[][][][]={Z3};
-    Byte      B0  = new Byte("0"),      B1[] ={B0},  B2[][]={B1},   B3[][][]={B2},   B4[][][][]={B3};
-    Character C0  = new Character('0'), C1[] ={C0},  C2[][]={C1},   C3[][][]={C2},   C4[][][][]={C3};
-    Double    D0  = new Double(0),      D1[] ={D0},  D2[][]={D1},   D3[][][]={D2},   D4[][][][]={D3};
-    Float     F0  = new Float(0),       F1[] ={F0},  F2[][]={F1},   F3[][][]={F2},   F4[][][][]={F3};
-    Integer   I0  = new Integer(0),     I1[] ={I0},  I2[][]={I1},   I3[][][]={I2},   I4[][][][]={I3};
-    Long      L0  = new Long(0),        L1[] ={L0},  L2[][]={L1},   L3[][][]={L2},   L4[][][][]={L3};
-    Short     Sh0 = new Short("1"),     Sh1[]={Sh0}, Sh2[][]={Sh1}, Sh3[][][]={Sh2}, Sh4[][][][]={Sh3};
-    String    S0  = new String(" "),    S1[] ={S0},  S2[][]={S1},   S3[][][]={S2},   S4[][][][]={S3};
-    Object    O0  = new Object(),       O1[] ={O0},  O2[][]={O1},   O3[][][]={O2},   O4[][][][]={O3};
+    Boolean   Z0  = Boolean.valueOf(true),  Z1[] ={Z0},  Z2[][]={Z1},   Z3[][][]={Z2},   Z4[][][][]={Z3};
+    Byte      B0  = Byte.valueOf("0"),      B1[] ={B0},  B2[][]={B1},   B3[][][]={B2},   B4[][][][]={B3};
+    Character C0  = Character.valueOf('0'), C1[] ={C0},  C2[][]={C1},   C3[][][]={C2},   C4[][][][]={C3};
+    Double    D0  = Double.valueOf(0),      D1[] ={D0},  D2[][]={D1},   D3[][][]={D2},   D4[][][][]={D3};
+    Float     F0  = Float.valueOf(0),       F1[] ={F0},  F2[][]={F1},   F3[][][]={F2},   F4[][][][]={F3};
+    Integer   I0  = Integer.valueOf(0),     I1[] ={I0},  I2[][]={I1},   I3[][][]={I2},   I4[][][][]={I3};
+    Long      L0  = Long.valueOf(0),        L1[] ={L0},  L2[][]={L1},   L3[][][]={L2},   L4[][][][]={L3};
+    Short     Sh0 = Short.valueOf("1"),     Sh1[]={Sh0}, Sh2[][]={Sh1}, Sh3[][][]={Sh2}, Sh4[][][][]={Sh3};
+    String    S0  = new String(" "),        S1[] ={S0},  S2[][]={S1},   S3[][][]={S2},   S4[][][][]={S3};
+    Object    O0  = new Object(),           O1[] ={O0},  O2[][]={O1},   O3[][][]={O2},   O4[][][][]={O3};
 
     private   static class  U {} // private ==> package private
     protected static class  V {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,15 +46,15 @@ public class isPrivate001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     private   static class  U {}
     protected static class  V {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,15 +46,15 @@ public class isProtected001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     private   static class  U {}
     protected static class  V {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,15 +46,15 @@ public class isPublic001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     private   static class  U {}
     protected static class  V {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ public class modifiers001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(false);
-    Byte      B0 = new Byte((byte)1);
-    Character C0 = new Character('c');
-    Double    D0 = new Double(1);
-    Float     F0 = new Float(1);
-    Integer   I0 = new Integer(1);
-    Long      L0 = new Long(1);
+    Boolean   Z0 = Boolean.valueOf(false);
+    Byte      B0 = Byte.valueOf((byte)1);
+    Character C0 = Character.valueOf('c');
+    Double    D0 = Double.valueOf(1);
+    Float     F0 = Float.valueOf(1);
+    Integer   I0 = Integer.valueOf(1);
+    Long      L0 = Long.valueOf(1);
     String    S0 = new String("s");
     Object    O0 = new Object();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValue/getvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValue/getvalue001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -343,11 +343,11 @@ public class getvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -388,11 +388,11 @@ public class getvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValue/getvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValue/getvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public class getvalue002 {
         for (int i = 0; i < FIELD_NAME.length; i++) {
             Field field;
             String name = FIELD_NAME[i][0];
-            Integer totalElements = new Integer(FIELD_NAME[i][1]);
+            Integer totalElements = Integer.valueOf(FIELD_NAME[i][1]);
             int lastElementIndex = totalElements.intValue() - 1;
             Value value;
             ArrayReference arrayRef;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues/getvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -297,12 +297,12 @@ public class getvalues001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -325,12 +325,12 @@ public class getvalues001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,8 +316,8 @@ public class getvaluesii001 {
 
                     // Check element's value
                     if (element != CHAR[j + i]) {
-                        Character c = new Character('c');
-                         Integer  n = new Integer(0);
+                        Character c = Character.valueOf('c');
+                         Integer  n = Integer.valueOf(0);
                         String sReal = n.toHexString(
                                            c.getNumericValue(CHAR[j + i])
                                        );
@@ -347,12 +347,12 @@ public class getvaluesii001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Double(DOUB[j + i]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j + i]))) {
                         log.complain("debuger FAILURE D2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + DOUB[j + i] + ", but returned " + element);
@@ -375,12 +375,12 @@ public class getvaluesii001 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Float(FLOAT[j + i]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j + i]))) {
                         log.complain("debuger FAILURE F2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + FLOAT[j + i] + ", but returned "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -331,8 +331,8 @@ public class getvaluesii002 {
 
                     // Check element's value
                     if (element != CHAR[j + i]) {
-                        Character c = new Character('c');
-                         Integer  n = new Integer(0);
+                        Character c = Character.valueOf('c');
+                         Integer  n = Integer.valueOf(0);
                         String sReal = n.toHexString(
                                            c.getNumericValue(CHAR[j + i])
                                        );
@@ -362,12 +362,12 @@ public class getvaluesii002 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Double(DOUB[j + i]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j + i]))) {
                         log.complain("debuger FAILURE D2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + DOUB[j + i] + ", but returned " + element);
@@ -390,12 +390,12 @@ public class getvaluesii002 {
                         testFailed = true;
                         continue;
                     }
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
                     // Check element's value
-                    if (!element.equals(new Float(FLOAT[j + i]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j + i]))) {
                         log.complain("debuger FAILURE F2> " + j + " element "
                                    + "of array " + name + " was expected "
                                    + FLOAT[j + i] + ", but returned "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class getvaluesii003 {
         for (int i = 0; i < FIELD_NAME.length; i++) {
             Field field;
             String name = FIELD_NAME[i][0];
-            Integer totalElements = new Integer(FIELD_NAME[i][1]);
+            Integer totalElements = Integer.valueOf(FIELD_NAME[i][1]);
             int lastElementIndex = totalElements.intValue() - 1;
             Value value;
             ArrayReference arrayRef;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/getValues_ii/getvaluesii004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class getvaluesii004 {
         for (int i = 0; i < FIELD_NAME.length; i++) {
             Field field;
             String name = FIELD_NAME[i][0];
-            Integer lengthOfArray = new Integer(FIELD_NAME[i][1]);
+            Integer lengthOfArray = Integer.valueOf(FIELD_NAME[i][1]);
             int length = lengthOfArray.intValue();
             Value value;
             ArrayReference arrayRef;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/length/length001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/length/length001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,12 +87,12 @@ class ClassToCheck {
     static Object O1[]={new Object(), new Object()};
     static Object O2[][]={};
 
-    static final     Long LF1[]={new Long(1), new Long(-2), new Long(3)};
-    static private   Long LP1[][]={{new Long(1)}, {new Long(2)}, {new Long(3)}};
-    static public    Long LU1[][][]={{{new Long(1)}}, {{new Long(-2)}}};
-    static protected Long LR1[][][][]={{{{new Long(1)}}}, {{{new Long(-2)}}}};
-    static transient Long LT1[][][][][]={{{{{new Long(1)}}}}};
-    static volatile  Long LV1[][][][][][]={{{{{{new Long(1)}}}}}};
+    static final     Long LF1[]={Long.valueOf(1), Long.valueOf(-2), Long.valueOf(3)};
+    static private   Long LP1[][]={{Long.valueOf(1)}, {Long.valueOf(2)}, {Long.valueOf(3)}};
+    static public    Long LU1[][][]={{{Long.valueOf(1)}}, {{Long.valueOf(-2)}}};
+    static protected Long LR1[][][][]={{{{Long.valueOf(1)}}}, {{{Long.valueOf(-2)}}}};
+    static transient Long LT1[][][][][]={{{{{Long.valueOf(1)}}}}};
+    static volatile  Long LV1[][][][][][]={{{{{{Long.valueOf(1)}}}}}};
 
     static final     Inter EF1[]={};
     static private   Inter EP1[][]={{}};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValue/setvalue001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValue/setvalue001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -495,7 +495,7 @@ public class setvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    dblSample = new Double(dblValue.value());
+                    dblSample = Double.valueOf(dblValue.value());
                     try {
                         dblValue = (DoubleValue)valueNew;
                     } catch (ClassCastException e) {
@@ -505,7 +505,7 @@ public class setvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    dblNew = new Double(dblValue.value());
+                    dblNew = Double.valueOf(dblValue.value());
 
                     // Check two primitive values
                     if (!dblNew.equals(dblSample)) {
@@ -535,7 +535,7 @@ public class setvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    fltSample = new Float(fltValue.value());
+                    fltSample = Float.valueOf(fltValue.value());
                     try {
                         fltValue = (FloatValue)valueNew;
                     } catch (ClassCastException e) {
@@ -545,7 +545,7 @@ public class setvalue001 {
                         testFailed = true;
                         continue;
                     }
-                    fltNew = new Float(fltValue.value());
+                    fltNew = Float.valueOf(fltValue.value());
 
                     // Check two primitive values
                     if (!fltNew.equals(fltSample)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValue/setvalue002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValue/setvalue002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,7 +218,7 @@ public class setvalue002 {
         for (int i = 0; i < FIELD_NAME.length; i++) {
             Field field;
             String name = FIELD_NAME[i][0];
-            Integer totalElements = new Integer(FIELD_NAME[i][1]);
+            Integer totalElements = Integer.valueOf(FIELD_NAME[i][1]);
             String type = FIELD_NAME[i][2];
             int lastElementIndex = totalElements.intValue() - 1;
             Value value;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_ilii/setvaluesilii001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_ilii/setvaluesilii001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -805,11 +805,11 @@ public class setvaluesilii001 {
                         continue;
                     }
 
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -833,11 +833,11 @@ public class setvaluesilii001 {
                         continue;
                     }
 
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_ilii/setvaluesilii002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_ilii/setvaluesilii002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -810,11 +810,11 @@ public class setvaluesilii002 {
                         continue;
                     }
 
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -838,11 +838,11 @@ public class setvaluesilii002 {
                         continue;
                     }
 
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -600,11 +600,11 @@ public class setvaluesl001 {
                         continue;
                     }
 
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -628,11 +628,11 @@ public class setvaluesl001 {
                         continue;
                     }
 
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayReference/setValues_l/setvaluesl002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -600,11 +600,11 @@ public class setvaluesl002 {
                         continue;
                     }
 
-                    element = new Double(doubleValue.value());
+                    element = Double.valueOf(doubleValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Double(DOUB[j]))) {
+                    if (!element.equals(Double.valueOf(DOUB[j]))) {
                         log.complain("debuger FAILURE D3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + DOUB[j] + ", but returned " + element);
@@ -628,11 +628,11 @@ public class setvaluesl002 {
                         continue;
                     }
 
-                    element = new Float(floatValue.value());
+                    element = Float.valueOf(floatValue.value());
                     log.display("debuger> " + i + " field has " + j
                               + " element " + element);
 
-                    if (!element.equals(new Float(FLOAT[j]))) {
+                    if (!element.equals(Float.valueOf(FLOAT[j]))) {
                         log.complain("debuger FAILURE F3> " + j + " element of "
                                    + "array " + name + " was expected "
                                    + FLOAT[j] + ", but returned " + element);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,15 +47,15 @@ public class reflectype001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     // Interfaces must be loaded and linked, so classes that implement
     // interfaces must be initialized.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/toString/tostring001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/toString/tostring001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,16 +69,16 @@ public class tostring001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    Short     H0 = new Short((short)-1),    H1[]={H0}, H2[][]={H1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    Short     H0 = Short.valueOf((short)-1),    H1[]={H0}, H2[][]={H1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     // Interfaces must be loaded and linked, so classes that implement
     // interfaces must be initialized.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,7 +219,7 @@ class ClassOfFields {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ class ClassToCheck {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class equals002a {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ class OverridenClass extends MainClass {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};
@@ -146,7 +146,7 @@ class MainClass {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/equals/equals005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class equals005a {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/hashCode/hashcode001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class hashcode001a {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/isTransient/istrans001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/isTransient/istrans001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,14 +88,14 @@ public class istrans001a {
     public    Long LU0, LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     transient static    Long LS0T, LS1T[]={LS0T}, LS2T[][]={LS1T};
     transient private   Long LP0T, LP1T[]={LP0T}, LP2T[][]={LP1T};
     transient public    Long LU0T, LU1T[]={LU0T}, LU2T[][]={LU1T};
     transient protected Long LR0T, LR1T[]={LR0T}, LR2T[][]={LR1T};
     transient volatile  Long LV0T, LV1T[]={LV0T}, LV2T[][]={LV1T};
-    transient final     Long LF0T = new Long(999), LF1T[]={LF0T},
+    transient final     Long LF0T = Long.valueOf(999), LF1T[]={LF0T},
                              LF2T[][]={LF1T};
 
     interface Inter {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/isVolatile/isvol001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/isVolatile/isvol001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class isvol001a {
     public    Long LU0, LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     volatile static    Long LS0V, LS1V[]={LS0V}, LS2V[][]={LS1V};
     volatile private   Long LP0V, LP1V[]={LP0V}, LP2V[][]={LP1V};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/type/type002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/type/type002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,23 +56,23 @@ class type002aClassToCheck {
     // No array fields
     class Class {}
     Class     X0 = new Class();
-    Boolean   Z0 = new Boolean(true);
-    Byte      B0 = new Byte(Byte.MIN_VALUE);
-    Character C0 = new Character('\u00ff');
-    Double    D0 = new Double(1);
-    Float     F0 = new Float(1f);
-    Integer   I0 = new Integer(1);
-    Long      L0 = new Long(1l);
+    Boolean   Z0 = Boolean.valueOf(true);
+    Byte      B0 = Byte.valueOf(Byte.MIN_VALUE);
+    Character C0 = Character.valueOf('\u00ff');
+    Double    D0 = Double.valueOf(1);
+    Float     F0 = Float.valueOf(1f);
+    Integer   I0 = Integer.valueOf(1);
+    Long      L0 = Long.valueOf(1l);
     String    S0 = new String();
     Object    O0 = new Object();
 
-    static    Long LS0 = new Long(1l);
-    private   Long LP0 = new Long(1l);
-    public    Long LU0 = new Long(1l);
-    protected Long LR0 = new Long(1l);
-    transient Long LT0 = new Long(1l);
-    volatile  Long LV0 = new Long(1l);
-    final     Long LF0 = new Long(1l);
+    static    Long LS0 = Long.valueOf(1l);
+    private   Long LP0 = Long.valueOf(1l);
+    public    Long LU0 = Long.valueOf(1l);
+    protected Long LR0 = Long.valueOf(1l);
+    transient Long LT0 = Long.valueOf(1l);
+    volatile  Long LV0 = Long.valueOf(1l);
+    final     Long LF0 = Long.valueOf(1l);
 
     interface Inter {}
     static class InterClass implements Inter {}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/typeName/typename001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Field/typeName/typename001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class typename001a {
     protected Long LR0, LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
-    final     Long LF0 = new Long(999), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(999), LF1[]={LF0}, LF2[][]={LF1};
 
     interface Inter {}
     Inter E0, E1[]={E0}, E2[][]={E1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/toString/tostring001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocalVariable/toString/tostring001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,14 +80,14 @@ public class tostring001a {
         long    l0 = (long)-1,   l1[] = {l0}, l2[][] = {l1};
         short   r0 = (short)-1,  r1[] = {r0}, r2[][] = {r1};
 
-        Boolean   Z0 = new Boolean(false),  Z1[] = {Z0}, Z2[][] = {Z1};
-        Byte B0 = new Byte((byte)1),        B1[] = {B0}, B2[][] = {B1};
-        Character C0 = new Character('z'),  C1[] = {C0}, C2[][] = {C1};
-        Double D0 = new Double((double)1),  D1[] = {D0}, D2[][] = {D1};
-        Float F0 = new Float((float)1),     F1[] = {F0}, F2[][] = {F1};
-        Integer I0 = new Integer(1),        I1[] = {I0}, I2[][] = {I1};
-        Long L0 = new Long((long)1),        L1[] = {L0}, L2[][] = {L1};
-        Short R0 = new Short((short)1),     R1[] = {R0}, R2[][] = {R1};
+        Boolean   Z0 = Boolean.valueOf(false),  Z1[] = {Z0}, Z2[][] = {Z1};
+        Byte B0 = Byte.valueOf((byte)1),        B1[] = {B0}, B2[][] = {B1};
+        Character C0 = Character.valueOf('z'),  C1[] = {C0}, C2[][] = {C1};
+        Double D0 = Double.valueOf((double)1),  D1[] = {D0}, D2[][] = {D1};
+        Float F0 = Float.valueOf((float)1),     F1[] = {F0}, F2[][] = {F1};
+        Integer I0 = Integer.valueOf(1),        I1[] = {I0}, I2[][] = {I1};
+        Long L0 = Long.valueOf((long)1),        L1[] = {L0}, L2[][] = {L1};
+        Short R0 = Short.valueOf((short)1),     R1[] = {R0}, R2[][] = {R1};
 
         String    s0 = "string", s1[] = {s0}, s2[][] = {s1};
         Object    o0 = new Object(), o1[] = {o0}, o2[][] = {o1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isBridge/isbridge001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isBridge/isbridge001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -213,7 +213,7 @@ public class isbridge001 {
                         log.complain("TEST BUG: Integer.parseInt: caught " + e);
                         return quitDebuggee();
                     }
-                    boolean bridge = new Boolean(methods[i][idx][2]);
+                    boolean bridge = Boolean.valueOf(methods[i][idx][2]);
                     if (bridge == meth.isBridge())
                         log.display("\tCHECK PASSED: Method.isBridge() returns "
                             + meth.isBridge() + " as expected\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isObsolete/isobsolete003/newclass/isobsolete003b.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isObsolete/isobsolete003/newclass/isobsolete003b.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ public class isobsolete003b {
     static Integer foo(int i) {
         Integer j = null;
         try {
-            j = new Integer(new String(String.valueOf(i)));
+            j = Integer.valueOf(new String(String.valueOf(i)));
         } catch (NumberFormatException e) {
         }
         return j;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isObsolete/isobsolete003b.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Method/isObsolete/isobsolete003b.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,6 @@ public class isobsolete003b {
 
     static Integer foo(int i) {
         int dummyInt = i;
-        return new Integer(i);  // isobsolete003.brkpFooLineNumber
+        return Integer.valueOf(i);  // isobsolete003.brkpFooLineNumber
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/_itself_/mwevent001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/_itself_/mwevent001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,28 +231,28 @@ class CheckedClass {
         X0  = new Class();
         X1  = new Class[]     {X0};
         X2  = new Class[][]   {X1};
-        Z0  = new Boolean(true);
+        Z0  = Boolean.valueOf(true);
         Z1  = new Boolean[]   {Z0};
         Z2  = new Boolean[][] {Z1};
-        B0  = new Byte(java.lang.Byte.MIN_VALUE);
+        B0  = Byte.valueOf(java.lang.Byte.MIN_VALUE);
         B1  = new Byte[]      {B0};
         B2  = new Byte[][]    {B1};
-        C0  = new Character(java.lang.Character.MIN_VALUE);
+        C0  = Character.valueOf(java.lang.Character.MIN_VALUE);
         C1  = new Character[] {C0};
         C2  = new Character[][]{C1};
-        D0  = new Double(java.lang.Double.MIN_VALUE);
+        D0  = Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = new Double[]    {D0};
         D2  = new Double[][]  {D1};
-        F0  = new Float(java.lang.Float.MIN_VALUE);
+        F0  = Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = new Float[]     {F0};
         F2  = new Float[][]   {F1};
-        I0  = new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = new Integer[]   {I0};
         I2  = new Integer[][] {I1};
-        L0  = new Long(java.lang.Long.MIN_VALUE);
+        L0  = Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = new Long[]      {L0};
         L2  = new Long[][]    {L1};
-        S0  = new Short(java.lang.Short.MIN_VALUE);
+        S0  = Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = new Short[]     {S0};
         S2  = new Short[][]   {S1};
         W0  = new String();
@@ -262,22 +262,22 @@ class CheckedClass {
         O1  = new Object[]    {O0};
         O2  = new Object[][]  {O1};
 
-        LS0 = new Long(java.lang.Long.MAX_VALUE);
+        LS0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = new Long[]      {LS0};
         LS2 = new Long[][]    {LS1};
-        LP0 = new Long(java.lang.Long.MAX_VALUE);
+        LP0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = new Long[]      {LP0};
         LP2 = new Long[][]    {LP1};
-        LU0 = new Long(java.lang.Long.MAX_VALUE);
+        LU0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = new Long[]      {LU0};
         LU2 = new Long[][]    {LU1};
-        LR0 = new Long(java.lang.Long.MAX_VALUE);
+        LR0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = new Long[]      {LR0};
         LR2 = new Long[][]    {LR1};
-        LT0 = new Long(java.lang.Long.MAX_VALUE);
+        LT0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = new Long[]      {LT0};
         LT2 = new Long[][]    {LT1};
-        LV0 = new Long(java.lang.Long.MAX_VALUE);
+        LV0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = new Long[]      {LV0};
         LV2 = new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/valueToBe/valuetobe001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/valueToBe/valuetobe001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,19 +212,19 @@ class valuetobe001aCheckedClass {
         C0  = new Character(java.lang.Character.MIN_VALUE);
         C1  = new Character[] {C0};
         C2  = new Character[][]{C1};
-        D0  = new Double(java.lang.Double.MIN_VALUE);
+        D0  = Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = new Double[]    {D0};
         D2  = new Double[][]  {D1};
-        F0  = new Float(java.lang.Float.MIN_VALUE);
+        F0  = Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = new Float[]     {F0};
         F2  = new Float[][]   {F1};
-        I0  = new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = new Integer[]   {I0};
         I2  = new Integer[][] {I1};
-        L0  = new Long(java.lang.Long.MIN_VALUE);
+        L0  = Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = new Long[]      {L0};
         L2  = new Long[][]    {L1};
-        S0  = new Short(java.lang.Short.MIN_VALUE);
+        S0  = Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = new Short[]     {S0};
         S2  = new Short[][]   {S1};
         W0  = new String();
@@ -234,22 +234,22 @@ class valuetobe001aCheckedClass {
         O1  = new Object[]    {O0};
         O2  = new Object[][]  {O1};
 
-        LS0 = new Long(java.lang.Long.MAX_VALUE);
+        LS0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = new Long[]      {LS0};
         LS2 = new Long[][]    {LS1};
-        LP0 = new Long(java.lang.Long.MAX_VALUE);
+        LP0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = new Long[]      {LP0};
         LP2 = new Long[][]    {LP1};
-        LU0 = new Long(java.lang.Long.MAX_VALUE);
+        LU0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = new Long[]      {LU0};
         LU2 = new Long[][]    {LU1};
-        LR0 = new Long(java.lang.Long.MAX_VALUE);
+        LR0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = new Long[]      {LR0};
         LR2 = new Long[][]    {LR1};
-        LT0 = new Long(java.lang.Long.MAX_VALUE);
+        LT0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = new Long[]      {LT0};
         LT2 = new Long[][]    {LT1};
-        LV0 = new Long(java.lang.Long.MAX_VALUE);
+        LV0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = new Long[]      {LV0};
         LV2 = new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/valueToBe/valuetobe002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ModificationWatchpointEvent/valueToBe/valuetobe002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,19 +201,19 @@ class valuetobe002aCheckedClass {
         C0  = flag ? C0  : new Character(java.lang.Character.MIN_VALUE);
         C1  = flag ? C1  : new Character[] {C0};
         C2  = flag ? C2  : new Character[][]{C1};
-        D0  = flag ? D0  : new Double(java.lang.Double.MIN_VALUE);
+        D0  = flag ? D0  : Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = flag ? D1  : new Double[]    {D0};
         D2  = flag ? D2  : new Double[][]  {D1};
-        F0  = flag ? F0  : new Float(java.lang.Float.MIN_VALUE);
+        F0  = flag ? F0  : Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = flag ? F1  : new Float[]     {F0};
         F2  = flag ? F2  : new Float[][]   {F1};
-        I0  = flag ? I0  : new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = flag ? I0  : Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = flag ? I1  : new Integer[]   {I0};
         I2  = flag ? I2  : new Integer[][] {I1};
-        L0  = flag ? L0  : new Long(java.lang.Long.MIN_VALUE);
+        L0  = flag ? L0  : Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = flag ? L1  : new Long[]      {L0};
         L2  = flag ? L2  : new Long[][]    {L1};
-        S0  = flag ? S0  : new Short(java.lang.Short.MIN_VALUE);
+        S0  = flag ? S0  : Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = flag ? S1  : new Short[]     {S0};
         S2  = flag ? S2  : new Short[][]   {S1};
         W0  = flag ? W0  : new String();
@@ -223,22 +223,22 @@ class valuetobe002aCheckedClass {
         O1  = flag ? O1  : new Object[]    {O0};
         O2  = flag ? O2  : new Object[][]  {O1};
 
-        LS0 = flag ? LS0 : new Long(java.lang.Long.MAX_VALUE);
+        LS0 = flag ? LS0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = flag ? LS1 : new Long[]      {LS0};
         LS2 = flag ? LS2 : new Long[][]    {LS1};
-        LP0 = flag ? LP0 : new Long(java.lang.Long.MAX_VALUE);
+        LP0 = flag ? LP0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = flag ? LP1 : new Long[]      {LP0};
         LP2 = flag ? LP2 : new Long[][]    {LP1};
-        LU0 = flag ? LU0 : new Long(java.lang.Long.MAX_VALUE);
+        LU0 = flag ? LU0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = flag ? LU1 : new Long[]      {LU0};
         LU2 = flag ? LU2 : new Long[][]    {LU1};
-        LR0 = flag ? LR0 : new Long(java.lang.Long.MAX_VALUE);
+        LR0 = flag ? LR0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = flag ? LR1 : new Long[]      {LR0};
         LR2 = flag ? LR2 : new Long[][]    {LR1};
-        LT0 = flag ? LT0 : new Long(java.lang.Long.MAX_VALUE);
+        LT0 = flag ? LT0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = flag ? LT1 : new Long[]      {LT0};
         LT2 = flag ? LT2 : new Long[][]    {LT1};
-        LV0 = flag ? LV0 : new Long(java.lang.Long.MAX_VALUE);
+        LV0 = flag ? LV0 : Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = flag ? LV1 : new Long[]      {LV0};
         LV2 = flag ? LV2 : new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class allfields005t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allLineLocations/alllinelocations002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allLineLocations/alllinelocations002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@ public class alllinelocations002t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allLineLocations_ss/alllinelocations_ss002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allLineLocations_ss/alllinelocations_ss002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@ public class alllinelocations_ss002t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class allmethods005t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,15 +47,15 @@ public class classobj001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     // Interfaces must be loaded and linked, so classes that implement
     // interfaces must be initialized.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,15 +48,15 @@ public class equals001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     static class  s_class {}
     s_class s_class_0 = new s_class(), s_class_1[]={s_class_0},

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class fields005t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,15 +48,15 @@ public class hashcode001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     static class  s_class {}
     s_class s_class_0 = new s_class(), s_class_1[]={s_class_0},

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isFinal/isfinal001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isFinal/isfinal001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,14 +151,14 @@ class TestClass {
     long    ln[][][][] = {{{{0}}}};
     short   sh[][][][] = {{{{0}}}};
 
-    Boolean   blBl = new Boolean(true);
-    Byte      btBt = new Byte((byte)1);
-    Character chCh = new Character('c');
-    Double    dbDb = new Double(0);
-    Float     flFl = new Float(0.0f);
-    Integer   inIn = new Integer(0);
-    Long      lnLn = new Long(0);
-    Short     shSh = new Short((short)1);
+    Boolean   blBl = Boolean.valueOf(true);
+    Byte      btBt = Byte.valueOf((byte)1);
+    Character chCh = Character.valueOf('c');
+    Double    dbDb = Double.valueOf(0);
+    Float     flFl = Float.valueOf(0.0f);
+    Integer   inIn = Integer.valueOf(0);
+    Long      lnLn = Long.valueOf(0);
+    Short     shSh = Short.valueOf((short)1);
 }
 
 interface OuterIface {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isStatic/isstatic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isStatic/isstatic001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,14 +149,14 @@ class isstatic001aTestClass {
     short   sh[][][][] = {{{{0}}}};
 
 
-    Boolean   blBl = new Boolean(true);
-    Byte      btBt = new Byte((byte)1);
-    Character chCh = new Character('c');
-    Double    dbDb = new Double(0);
-    Float     flFl = new Float(0.0f);
-    Integer   inIn = new Integer(0);
-    Long      lnLn = new Long(0);
-    Short     shSh = new Short((short)1);
+    Boolean   blBl = Boolean.valueOf(true);
+    Byte      btBt = Byte.valueOf((byte)1);
+    Character chCh = Character.valueOf('c');
+    Double    dbDb = Double.valueOf(0);
+    Float     flFl = Float.valueOf(0.0f);
+    Integer   inIn = Integer.valueOf(0);
+    Long      lnLn = Long.valueOf(0);
+    Short     shSh = Short.valueOf((short)1);
 }
 
 interface isstatic001aOuterIface {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/locationsOfLine_i/locationsofline_i002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/locationsOfLine_i/locationsofline_i002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@ public class locationsofline_i002t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/locationsOfLine_ssi/locationsofline_ssi002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/locationsOfLine_ssi/locationsofline_ssi002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@ public class locationsofline_ssi002t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class methods005t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,15 +48,15 @@ public class name001a {
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
-    Boolean   Z0 = new Boolean(true),       Z1[]={Z0}, Z2[][]={Z1};
-    Byte      B0 = new Byte((byte)1),       B1[]={B0}, B2[][]={B1};
-    Character C0 = new Character('\u00ff'), C1[]={C0}, C2[][]={C1};
-    Double    D0 = new Double(1.0),         D1[]={D0}, D2[][]={D1};
-    Float     F0 = new Float(1.0f),         F1[]={F0}, F2[][]={F1};
-    Integer   I0 = new Integer(-1),         I1[]={I0}, I2[][]={I1};
-    Long      L0 = new Long(-1l),           L1[]={L0}, L2[][]={L1};
-    String    S0 = new String("4434819"),   S1[]={S0}, S2[][]={S1};
-    Object    O0 = new Object(),            O1[]={O0}, O2[][]={O1};
+    Boolean   Z0 = Boolean.valueOf(true),       Z1[]={Z0}, Z2[][]={Z1};
+    Byte      B0 = Byte.valueOf((byte)1),       B1[]={B0}, B2[][]={B1};
+    Character C0 = Character.valueOf('\u00ff'), C1[]={C0}, C2[][]={C1};
+    Double    D0 = Double.valueOf(1.0),         D1[]={D0}, D2[][]={D1};
+    Float     F0 = Float.valueOf(1.0f),         F1[]={F0}, F2[][]={F1};
+    Integer   I0 = Integer.valueOf(-1),         I1[]={I0}, I2[][]={I1};
+    Long      L0 = Long.valueOf(-1l),           L1[]={L0}, L2[][]={L1};
+    String    S0 = new String("4434819"),       S1[]={S0}, S2[][]={S1};
+    Object    O0 = new Object(),                O1[]={O0}, O2[][]={O1};
 
     static class  s_class {}
     s_class s_class_0 = new s_class(), s_class_1[]={s_class_0},

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceNames/sourcenames002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,14 +88,14 @@ public class sourcenames002t {
 
     // arrays used to check AbsentInformationException throwing
     // in the debugger
-    Boolean boolClsArr[] = {new Boolean(false)};
-    Byte byteClsArr[] = {new Byte((byte) 127)};
-    Character charClsArr[] = {new Character('a')};
-    Double doubleClsArr[] = {new Double(6.2D)};
-    Float floatClsArr[] = {new Float(5.1F)};
-    Integer intClsArr[] = {new Integer(2147483647)};
-    Long longClsArr[] = {new Long(9223372036854775807L)};
-    Short shortClsArr[] = {new Short((short) -32768)};
+    Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    Character charClsArr[] = {Character.valueOf('a')};
+    Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    Float floatClsArr[] = {Float.valueOf(5.1F)};
+    Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     boolean boolArr[] = {boolVal};
     byte byteArr[] = {byteVal};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourcePaths/sourcepaths002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourcePaths/sourcepaths002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,14 +73,14 @@ public class sourcepaths002t {
 
     // arrays used to check AbsentInformationException throwing
     // in the debugger
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield005t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield005t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class visibfield005t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod006t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod006t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,14 +71,14 @@ public class visibmethod006t {
     static Class longCls = Long.TYPE;
     static Class shortCls = Short.TYPE;
 
-    static Boolean boolClsArr[] = {new Boolean(false)};
-    static Byte byteClsArr[] = {new Byte((byte) 127)};
-    static Character charClsArr[] = {new Character('a')};
-    static Double doubleClsArr[] = {new Double(6.2D)};
-    static Float floatClsArr[] = {new Float(5.1F)};
-    static Integer intClsArr[] = {new Integer(2147483647)};
-    static Long longClsArr[] = {new Long(9223372036854775807L)};
-    static Short shortClsArr[] = {new Short((short) -32768)};
+    static Boolean boolClsArr[] = {Boolean.valueOf(false)};
+    static Byte byteClsArr[] = {Byte.valueOf((byte) 127)};
+    static Character charClsArr[] = {Character.valueOf('a')};
+    static Double doubleClsArr[] = {Double.valueOf(6.2D)};
+    static Float floatClsArr[] = {Float.valueOf(5.1F)};
+    static Integer intClsArr[] = {Integer.valueOf(2147483647)};
+    static Long longClsArr[] = {Long.valueOf(9223372036854775807L)};
+    static Short shortClsArr[] = {Short.valueOf((short) -32768)};
 
     static boolean boolArr[] = {true};
     static byte byteArr[] = {Byte.MAX_VALUE};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class MainClass {
     Class     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};
@@ -115,9 +115,9 @@ interface MainInter {
     Class     X0 = new Class(),  X1[]={X0}, X2[][]={X1};
     Object    O0 = new Object(), O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
-    public    Long LU0 = new Long(1), LU1[]={LU0}, LU2[][]={LU1};
-    static    Long L0S = new Long(1), L1S[]={L0S}, L2S[][]={L1S};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
+    public    Long LU0 = Long.valueOf(1), LU1[]={LU0}, LU2[][]={LU1};
+    static    Long L0S = Long.valueOf(1), L1S[]={L0S}, L2S[][]={L1S};
 
     Inter     E0 = null, E1[]={E0}, E2[][]={E1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ class decltype002aMainClass {
     decltype002aClass     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};
@@ -124,9 +124,9 @@ interface decltype002aMainInter {
     decltype002aClass     X0 = new decltype002aClass(),  X1[]={X0}, X2[][]={X1};
     Object    O0 = new Object(), O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
-    public    Long LU0 = new Long(1), LU1[]={LU0}, LU2[][]={LU1};
-    static    Long L0S = new Long(1), L1S[]={L0S}, L2S[][]={L1S};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
+    public    Long LU0 = Long.valueOf(1), LU1[]={LU0}, LU2[][]={LU1};
+    static    Long L0S = Long.valueOf(1), L1S[]={L0S}, L2S[][]={L1S};
 
     decltype002aInter     E0 = null, E1[]={E0}, E2[][]={E1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ class decltype003aOverridenClass extends decltype003aMainClass {
     decltype003aClass     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};
@@ -119,7 +119,7 @@ class decltype003aMainClass {
     decltype003aClass     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};
@@ -159,9 +159,9 @@ interface decltype003aOverridenInter extends decltype003aMainInter {
     decltype003aClass     X0 = new decltype003aClass(),  X1[]={X0}, X2[][]={X1};
     Object    O0 = new Object(), O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
-    public    Long LU0 = new Long(1), LU1[]={LU0}, LU2[][]={LU1};
-    static    Long L0S = new Long(1), L1S[]={L0S}, L2S[][]={L1S};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
+    public    Long LU0 = Long.valueOf(1), LU1[]={LU0}, LU2[][]={LU1};
+    static    Long L0S = Long.valueOf(1), L1S[]={L0S}, L2S[][]={L1S};
 
     decltype003aInter     E0 = null, E1[]={E0}, E2[][]={E1};
 
@@ -187,9 +187,9 @@ interface decltype003aMainInter {
     decltype003aClass     X0 = new decltype003aClass(),  X1[]={X0}, X2[][]={X1};
     Object    O0 = new Object(), O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
-    public    Long LU0 = new Long(1), LU1[]={LU0}, LU2[][]={LU1};
-    static    Long L0S = new Long(1), L1S[]={L0S}, L2S[][]={L1S};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
+    public    Long LU0 = Long.valueOf(1), LU1[]={LU0}, LU2[][]={LU1};
+    static    Long L0S = Long.valueOf(1), L1S[]={L0S}, L2S[][]={L1S};
 
     decltype003aInter     E0 = null, E1[]={E0}, E2[][]={E1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype007a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class decltype007aMainClass {
     static long[] cl = new long[10];
 
     static { ci = 1; }
-    static { cL = new Long(1l); }
+    static { cL = Long.valueOf(1l); }
     static {
         for (int i = 0; i < 10; i++) {
             cl[i] = (long)i;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype008a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/declaringType/decltype008a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,13 +54,13 @@ public class decltype008a {
 class decltype008aOtherClass extends decltype008aMainClass {
     // All contructors from decltype008aOtherClass starts with reference to String object
     public decltype008aOtherClass(String S, float f) {
-        super(new Long(1), f);
+        super(Long.valueOf(1), f);
     };
     private decltype008aOtherClass(String S, Object obj){
-        super(new Long(1), obj);
+        super(Long.valueOf(1), obj);
     };
     protected decltype008aOtherClass(String S, long[] l) {
-        super(new Long(1), l);
+        super(Long.valueOf(1), l);
     };
 
     static double cd;
@@ -87,7 +87,7 @@ class decltype008aMainClass {
     static long[] cl = new long[10];
 
     static { ci = 1; }
-    static { cL = new Long(1l); }
+    static { cL = Long.valueOf(1l); }
     static {
         for (int i = 0; i < 10; i++) {
             cl[i] = (long)i;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isFinal/isfinal001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isFinal/isfinal001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,11 +100,11 @@ class isfinal001aClassToCheck {
     transient Long LT0, LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0, LV1[]={LV0}, LV2[][]={LV1};
 
-    final static    Long LS0F = new Long(1), LS1F[]={LS0F}, LS2F[][]={LS1F};
-    final private   Long LP0F = new Long(1), LP1F[]={LP0F}, LP2F[][]={LP1F};
-    final public    Long LU0F = new Long(1), LU1F[]={LU0F}, LU2F[][]={LU1F};
-    final protected Long LR0F = new Long(1), LR1F[]={LR0F}, LR2F[][]={LR1F};
-    final transient Long LT0F = new Long(1), LT1F[]={LT0F}, LT2F[][]={LT1F};
+    final static    Long LS0F = Long.valueOf(1), LS1F[]={LS0F}, LS2F[][]={LS1F};
+    final private   Long LP0F = Long.valueOf(1), LP1F[]={LP0F}, LP2F[][]={LP1F};
+    final public    Long LU0F = Long.valueOf(1), LU1F[]={LU0F}, LU2F[][]={LU1F};
+    final protected Long LR0F = Long.valueOf(1), LR1F[]={LR0F}, LR2F[][]={LR1F};
+    final transient Long LT0F = Long.valueOf(1), LT1F[]={LT0F}, LT2F[][]={LT1F};
 
     isfinal001aInter E0, E1[]={E0}, E2[][]={E1};
     final isfinal001aInter E0F = null, E1F[]={E0F}, E2F[][]={E1F};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isFinal/isfinal003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isFinal/isfinal003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class isfinal003aClassToCheck extends isfinal003aSuperClass {
     static long[] cl = new long[10];
 
     static { ci = 1; }
-    static { cL = new Long(1l); }
+    static { cL = Long.valueOf(1l); }
     static {
         for (int i = 0; i < 10; i++) {
             cl[i] = (long)i;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isStatic/isstatic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isStatic/isstatic001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,14 +94,14 @@ class ClassToCheck {
     static Class     X0S, X1S[]={X0S}, X2S[][]={X1S};
     static Object    O0S, O1S[]={O0S}, O2S[][]={O1S};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};
     transient Long LT0,               LT1[]={LT0}, LT2[][]={LT1};
     volatile  Long LV0,               LV1[]={LV0}, LV2[][]={LV1};
 
-    static final     Long LF0S = new Long(1), LF1S[]={LF0S}, LF2S[][]={LF1S};
+    static final     Long LF0S = Long.valueOf(1), LF1S[]={LF0S}, LF2S[][]={LF1S};
     static private   Long LP0S,               LP1S[]={LP0S}, LP2S[][]={LP1S};
     static public    Long LU0S,               LU1S[]={LU0S}, LU2S[][]={LU1S};
     static protected Long LR0S,               LR1S[]={LR0S}, LR2S[][]={LR1S};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isStatic/isstatic003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isStatic/isstatic003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class isstatic003aClassToCheck extends isstatic003aSuperClass {
     static long[] cl = new long[10];
 
     static { ci = 1; }
-    static { cL = new Long(1l); }
+    static { cL = Long.valueOf(1l); }
     static {
         for (int i = 0; i < 10; i++) {
             cl[i] = (long)i;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ class ClassToCheck {
         Class     X0, X1[]={X0}, X2[][]={X1};
         Object    O0, O1[]={O0}, O2[][]={O1};
 
-        final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+        final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
         private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
         public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
         protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/name/name001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ class ClassToCheck {
     Class     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/name/name003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/name/name003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class name003aClassToCheck extends name003aSuperClass {
     static long[] cl = new long[10];
 
     static { ci = 1; }
-    static { cL = new Long(1l); }
+    static { cL = Long.valueOf(1l); }
     static {
         for (int i = 0; i < 10; i++) {
             cl[i] = (long)i;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/signature/sign001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/signature/sign001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ class ClassToCheck {
     Class     X0, X1[]={X0}, X2[][]={X1};
     Object    O0, O1[]={O0}, O2[][]={O1};
 
-    final     Long LF0 = new Long(1), LF1[]={LF0}, LF2[][]={LF1};
+    final     Long LF0 = Long.valueOf(1), LF1[]={LF0}, LF2[][]={LF1};
     private   Long LP0,               LP1[]={LP0}, LP2[][]={LP1};
     public    Long LU0,               LU1[]={LU0}, LU2[][]={LU1};
     protected Long LR0,               LR1[]={LR0}, LR2[][]={LR1};

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/_itself_/wevent001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/_itself_/wevent001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,28 +210,28 @@ class CheckedClass {
         X0  = new Class();
         X1  = new Class[]     {X0};
         X2  = new Class[][]   {X1};
-        Z0  = new Boolean(true);
+        Z0  = Boolean.valueOf(true);
         Z1  = new Boolean[]   {Z0};
         Z2  = new Boolean[][] {Z1};
-        B0  = new Byte(java.lang.Byte.MIN_VALUE);
+        B0  = Byte.valueOf(java.lang.Byte.MIN_VALUE);
         B1  = new Byte[]      {B0};
         B2  = new Byte[][]    {B1};
-        C0  = new Character(java.lang.Character.MIN_VALUE);
+        C0  = Character.valueOf(java.lang.Character.MIN_VALUE);
         C1  = new Character[] {C0};
         C2  = new Character[][]{C1};
-        D0  = new Double(java.lang.Double.MIN_VALUE);
+        D0  = Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = new Double[]    {D0};
         D2  = new Double[][]  {D1};
-        F0  = new Float(java.lang.Float.MIN_VALUE);
+        F0  = Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = new Float[]     {F0};
         F2  = new Float[][]   {F1};
-        I0  = new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = new Integer[]   {I0};
         I2  = new Integer[][] {I1};
-        L0  = new Long(java.lang.Long.MIN_VALUE);
+        L0  = Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = new Long[]      {L0};
         L2  = new Long[][]    {L1};
-        S0  = new Short(java.lang.Short.MIN_VALUE);
+        S0  = Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = new Short[]     {S0};
         S2  = new Short[][]   {S1};
         W0  = new String();
@@ -241,22 +241,22 @@ class CheckedClass {
         O1  = new Object[]    {O0};
         O2  = new Object[][]  {O1};
 
-        LS0 = new Long(java.lang.Long.MAX_VALUE);
+        LS0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = new Long[]      {LS0};
         LS2 = new Long[][]    {LS1};
-        LP0 = new Long(java.lang.Long.MAX_VALUE);
+        LP0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = new Long[]      {LP0};
         LP2 = new Long[][]    {LP1};
-        LU0 = new Long(java.lang.Long.MAX_VALUE);
+        LU0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = new Long[]      {LU0};
         LU2 = new Long[][]    {LU1};
-        LR0 = new Long(java.lang.Long.MAX_VALUE);
+        LR0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = new Long[]      {LR0};
         LR2 = new Long[][]    {LR1};
-        LT0 = new Long(java.lang.Long.MAX_VALUE);
+        LT0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = new Long[]      {LT0};
         LT2 = new Long[][]    {LT1};
-        LV0 = new Long(java.lang.Long.MAX_VALUE);
+        LV0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = new Long[]      {LV0};
         LV2 = new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/object/object001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,28 +172,28 @@ class CheckedClass {
         X0  = new Class();
         X1  = new Class[]     {X0};
         X2  = new Class[][]   {X1};
-        Z0  = new Boolean(true);
+        Z0  = Boolean.valueOf(true);
         Z1  = new Boolean[]   {Z0};
         Z2  = new Boolean[][] {Z1};
-        B0  = new Byte(java.lang.Byte.MIN_VALUE);
+        B0  = Byte.valueOf(java.lang.Byte.MIN_VALUE);
         B1  = new Byte[]      {B0};
         B2  = new Byte[][]    {B1};
-        C0  = new Character(java.lang.Character.MIN_VALUE);
+        C0  = Character.valueOf(java.lang.Character.MIN_VALUE);
         C1  = new Character[] {C0};
         C2  = new Character[][]{C1};
-        D0  = new Double(java.lang.Double.MIN_VALUE);
+        D0  = Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = new Double[]    {D0};
         D2  = new Double[][]  {D1};
-        F0  = new Float(java.lang.Float.MIN_VALUE);
+        F0  = Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = new Float[]     {F0};
         F2  = new Float[][]   {F1};
-        I0  = new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = new Integer[]   {I0};
         I2  = new Integer[][] {I1};
-        L0  = new Long(java.lang.Long.MIN_VALUE);
+        L0  = Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = new Long[]      {L0};
         L2  = new Long[][]    {L1};
-        S0  = new Short(java.lang.Short.MIN_VALUE);
+        S0  = Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = new Short[]     {S0};
         S2  = new Short[][]   {S1};
         W0  = new String();
@@ -203,22 +203,22 @@ class CheckedClass {
         O1  = new Object[]    {O0};
         O2  = new Object[][]  {O1};
 
-        LS0 = new Long(java.lang.Long.MAX_VALUE);
+        LS0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = new Long[]      {LS0};
         LS2 = new Long[][]    {LS1};
-        LP0 = new Long(java.lang.Long.MAX_VALUE);
+        LP0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = new Long[]      {LP0};
         LP2 = new Long[][]    {LP1};
-        LU0 = new Long(java.lang.Long.MAX_VALUE);
+        LU0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = new Long[]      {LU0};
         LU2 = new Long[][]    {LU1};
-        LR0 = new Long(java.lang.Long.MAX_VALUE);
+        LR0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = new Long[]      {LR0};
         LR2 = new Long[][]    {LR1};
-        LT0 = new Long(java.lang.Long.MAX_VALUE);
+        LT0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = new Long[]      {LT0};
         LT2 = new Long[][]    {LT1};
-        LV0 = new Long(java.lang.Long.MAX_VALUE);
+        LV0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = new Long[]      {LV0};
         LV2 = new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/valueCurrent/valuecur001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/WatchpointEvent/valueCurrent/valuecur001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,28 +181,28 @@ class CheckedClass {
         X0  = new Class();
         X1  = new Class[]     {X0};
         X2  = new Class[][]   {X1};
-        Z0  = new Boolean(true);
+        Z0  = Boolean.valueOf(true);
         Z1  = new Boolean[]   {Z0};
         Z2  = new Boolean[][] {Z1};
-        B0  = new Byte(java.lang.Byte.MIN_VALUE);
+        B0  = Byte.valueOf(java.lang.Byte.MIN_VALUE);
         B1  = new Byte[]      {B0};
         B2  = new Byte[][]    {B1};
-        C0  = new Character(java.lang.Character.MIN_VALUE);
+        C0  = Character.valueOf(java.lang.Character.MIN_VALUE);
         C1  = new Character[] {C0};
         C2  = new Character[][]{C1};
-        D0  = new Double(java.lang.Double.MIN_VALUE);
+        D0  = Double.valueOf(java.lang.Double.MIN_VALUE);
         D1  = new Double[]    {D0};
         D2  = new Double[][]  {D1};
-        F0  = new Float(java.lang.Float.MIN_VALUE);
+        F0  = Float.valueOf(java.lang.Float.MIN_VALUE);
         F1  = new Float[]     {F0};
         F2  = new Float[][]   {F1};
-        I0  = new Integer(java.lang.Integer.MIN_VALUE);
+        I0  = Integer.valueOf(java.lang.Integer.MIN_VALUE);
         I1  = new Integer[]   {I0};
         I2  = new Integer[][] {I1};
-        L0  = new Long(java.lang.Long.MIN_VALUE);
+        L0  = Long.valueOf(java.lang.Long.MIN_VALUE);
         L1  = new Long[]      {L0};
         L2  = new Long[][]    {L1};
-        S0  = new Short(java.lang.Short.MIN_VALUE);
+        S0  = Short.valueOf(java.lang.Short.MIN_VALUE);
         S1  = new Short[]     {S0};
         S2  = new Short[][]   {S1};
         W0  = new String();
@@ -212,22 +212,22 @@ class CheckedClass {
         O1  = new Object[]    {O0};
         O2  = new Object[][]  {O1};
 
-        LS0 = new Long(java.lang.Long.MAX_VALUE);
+        LS0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LS1 = new Long[]      {LS0};
         LS2 = new Long[][]    {LS1};
-        LP0 = new Long(java.lang.Long.MAX_VALUE);
+        LP0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LP1 = new Long[]      {LP0};
         LP2 = new Long[][]    {LP1};
-        LU0 = new Long(java.lang.Long.MAX_VALUE);
+        LU0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LU1 = new Long[]      {LU0};
         LU2 = new Long[][]    {LU1};
-        LR0 = new Long(java.lang.Long.MAX_VALUE);
+        LR0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LR1 = new Long[]      {LR0};
         LR2 = new Long[][]    {LR1};
-        LT0 = new Long(java.lang.Long.MAX_VALUE);
+        LT0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LT1 = new Long[]      {LT0};
         LT2 = new Long[][]    {LT1};
-        LV0 = new Long(java.lang.Long.MAX_VALUE);
+        LV0 = Long.valueOf(java.lang.Long.MAX_VALUE);
         LV1 = new Long[]      {LV0};
         LV2 = new Long[][]    {LV1};
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ public class setvalues001 {
         // add new int values for array components
         for (int i = ARRAY_FIRST_INDEX; i < ARRAY_FIRST_INDEX + ARRAY_ITEMS_COUNT; i++) {
             int intValue = i * 100 + 1;
-            JDWP.UntaggedValue value = new JDWP.UntaggedValue(new Integer(intValue));
+            JDWP.UntaggedValue value = new JDWP.UntaggedValue(Integer.valueOf(intValue));
             log.display("  untagged_value: " + value);
             command.addUntaggedValue(value, JDWP.Tag.INT);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public class invokemeth001 {
         log.display("  arguments: " + ARGUMENTS_COUNT);
         command.addInt(ARGUMENTS_COUNT);
         for (int i = 0; i < ARGUMENTS_COUNT; i++) {
-            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, new Integer(ARGUMENT_VALUE));
+            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, Integer.valueOf(ARGUMENT_VALUE));
             log.display("    arg: " + value);
             command.addValue(value);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public class newinst001 {
         log.display("  arguments: " + ARGUMENTS_COUNT);
         command.addInt(ARGUMENTS_COUNT);
         for (int i = 0; i < ARGUMENTS_COUNT; i++) {
-            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, new Integer(ARGUMENT_VALUE));
+            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, Integer.valueOf(ARGUMENT_VALUE));
             log.display("    arg: " + value);
             command.addValue(value);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,15 +69,15 @@ public class getvalues001 {
 
     // names and expected values of the tested fields
     static final Object fields [][] = {
-                    { "booleanValue", "boolean",  new Boolean(true),           "own"},
-                    { "byteValue",    "byte",     new Byte((byte)0x0F),        "own"},
-                    { "charValue",    "char",     new Character('Z'),          "own"},
-                    { "intValue",     "int",      new Integer(100),            "own"},
-                    { "shortValue",   "short",    new Short((short)10),        "own"},
-                    { "longValue",    "long",     new Long((long)1000000),     "own"},
-                    { "floatValue",   "float",    new Float((float)3.14),      "own"},
-                    { "doubleValue",  "double",   new Double((double)2.8e-12), "own"},
-                    { "objectValue",  "objectID", new Long((long)0),           "own"},
+                    { "booleanValue", "boolean",  Boolean.valueOf(true),           "own"},
+                    { "byteValue",    "byte",     Byte.valueOf((byte)0x0F),        "own"},
+                    { "charValue",    "char",     Character.valueOf('Z'),          "own"},
+                    { "intValue",     "int",      Integer.valueOf(100),            "own"},
+                    { "shortValue",   "short",    Short.valueOf((short)10),        "own"},
+                    { "longValue",    "long",     Long.valueOf((long)1000000),     "own"},
+                    { "floatValue",   "float",    Float.valueOf((float)3.14),      "own"},
+                    { "doubleValue",  "double",   Double.valueOf((double)2.8e-12), "own"},
+                    { "objectValue",  "objectID", Long.valueOf((long)0),           "own"},
 
                 };
     static final int FIELDS_COUNT = fields.length;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ public class invokemeth001 {
         log.display("  arguments: " + ARGUMENTS_COUNT);
         command.addInt(ARGUMENTS_COUNT);
         for (int i = 0; i < ARGUMENTS_COUNT; i++) {
-            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, new Integer(ARGUMENT_VALUE));
+            JDWP.Value value = new JDWP.Value(JDWP.Tag.INT, Integer.valueOf(ARGUMENT_VALUE));
             log.display("    arg: " + value);
             command.addValue(value);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,15 +66,15 @@ public class getvalues001 {
 
     // nested classes names and signatures array
     static final Object fields [][] = {
-                    { "booleanValue", "boolean",  new Boolean(true),           "own"},
-                    { "byteValue",    "byte",     new Byte((byte)0x0F),        "own"},
-                    { "charValue",    "char",     new Character('Z'),          "own"},
-                    { "intValue",     "int",      new Integer(100),            "own"},
-                    { "shortValue",   "short",    new Short((short)10),        "own"},
-                    { "longValue",    "long",     new Long((long)1000000),     "own"},
-                    { "floatValue",   "float",    new Float((float)3.14),      "own"},
-                    { "doubleValue",  "double",   new Double((double)2.8e-12), "own"},
-                    { "objectValue",  "objectID", new Long((long)0),           "own"},
+                    { "booleanValue", "boolean",  Boolean.valueOf(true),           "own"},
+                    { "byteValue",    "byte",     Byte.valueOf((byte)0x0F),        "own"},
+                    { "charValue",    "char",     Character.valueOf('Z'),          "own"},
+                    { "intValue",     "int",      Integer.valueOf(100),            "own"},
+                    { "shortValue",   "short",    Short.valueOf((short)10),        "own"},
+                    { "longValue",    "long",     Long.valueOf((long)1000000),     "own"},
+                    { "floatValue",   "float",    Float.valueOf((float)3.14),      "own"},
+                    { "doubleValue",  "double",   Double.valueOf((double)2.8e-12), "own"},
+                    { "objectValue",  "objectID", Long.valueOf((long)0),           "own"},
 
                 };
     static final int FIELDS_COUNT = fields.length;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,15 +73,15 @@ public class getvalues001 {
 
     // list of tested variables names and values
     static final Object variables[][] = {
-                    { "booleanValue", "boolean",  new Boolean(true),           new Byte(JDWP.Tag.BOOLEAN)},
-                    { "byteValue",    "byte",     new Byte((byte)0x0F),        new Byte(JDWP.Tag.BYTE)   },
-                    { "charValue",    "char",     new Character('Z'),          new Byte(JDWP.Tag.CHAR)   },
-                    { "intValue",     "int",      new Integer(100),            new Byte(JDWP.Tag.INT)    },
-                    { "shortValue",   "short",    new Short((short)10),        new Byte(JDWP.Tag.SHORT)  },
-                    { "longValue",    "long",     new Long((long)1000000),     new Byte(JDWP.Tag.LONG)   },
-                    { "floatValue",   "float",    new Float((float)3.14),      new Byte(JDWP.Tag.FLOAT)  },
-                    { "doubleValue",  "double",   new Double((double)2.8e-12), new Byte(JDWP.Tag.DOUBLE) },
-                    { "objectValue",  "objectID", new Long((long)0),           new Byte(JDWP.Tag.OBJECT) }
+                    { "booleanValue", "boolean",  Boolean.valueOf(true),           Byte.valueOf(JDWP.Tag.BOOLEAN)},
+                    { "byteValue",    "byte",     Byte.valueOf((byte)0x0F),        Byte.valueOf(JDWP.Tag.BYTE)   },
+                    { "charValue",    "char",     Character.valueOf('Z'),          Byte.valueOf(JDWP.Tag.CHAR)   },
+                    { "intValue",     "int",      Integer.valueOf(100),            Byte.valueOf(JDWP.Tag.INT)    },
+                    { "shortValue",   "short",    Short.valueOf((short)10),        Byte.valueOf(JDWP.Tag.SHORT)  },
+                    { "longValue",    "long",     Long.valueOf((long)1000000),     Byte.valueOf(JDWP.Tag.LONG)   },
+                    { "floatValue",   "float",    Float.valueOf((float)3.14),      Byte.valueOf(JDWP.Tag.FLOAT)  },
+                    { "doubleValue",  "double",   Double.valueOf((double)2.8e-12), Byte.valueOf(JDWP.Tag.DOUBLE) },
+                    { "objectValue",  "objectID", Long.valueOf((long)0),           Byte.valueOf(JDWP.Tag.OBJECT) }
                 };
     static final int VARIABLES_COUNT = variables.length;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class attach001TestRunner extends AODTestRunner {
             try {
                 new TargetApplicationWaitingAgents().runTargetApplication(new String[] {
                         "-" + AODTargetArgParser.agentsNumberParam,
-                        new Integer(argParser.getAgents().size()).toString() });
+                        Integer.valueOf(argParser.getAgents().size()).toString() });
 
                 finishedSuccessfully = true;
             } catch (Throwable t) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe003p.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe003p.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,7 +220,7 @@ public class popframe003p extends Thread {
             charGlFld = 'd';
             booleanGlFld = false;
             strGlFld = "nstnc fld";
-            objGl = new Integer(1973);
+            objGl = Integer.valueOf(1973);
 
             // for the global public instance fields
             bytePubGlFld = 7;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass019/newclass_g/redefclass019a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass019/newclass_g/redefclass019a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ class redefclass019a extends Thread {
 
     // dummy method to be breakpointed in agent
     void checkPoint() {
-        new Integer("4");
+        Integer.valueOf("4");
         return;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/timers/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/timers/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class JvmtiTest {
             for (int i = iterations; i > 0; --i) {
                 List<Integer> list = new ArrayList<Integer>();
                 for (int j = 10000; j > 0; --j) {
-                    list.add(new Integer(j));
+                    list.add(Integer.valueOf(j));
                 }
                 Collections.sort(list);
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryUsage/from/from001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryUsage/from/from001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class from001 {
         Thread thread = Thread.currentThread();
         long id = thread.getId();
 
-        Object[] params = {new Long(id), new Integer(Integer.MAX_VALUE)};
+        Object[] params = {Long.valueOf(id), Integer.valueOf(Integer.MAX_VALUE)};
         String[] signature = {"long", "int"};
 
         ObjectName mbeanObjectName = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadInfo/from_c/from_c001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadInfo/from_c/from_c001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class from_c001 {
         Thread thread = Thread.currentThread();
         long id = thread.getId();
 
-        Object[] params = {new Long(id), new Integer(Integer.MAX_VALUE)};
+        Object[] params = {Long.valueOf(id), Integer.valueOf(Integer.MAX_VALUE)};
         String[] signature = {"long", "int"};
 
         cdata = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/CustomMBeanServer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/CustomMBeanServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,7 +172,7 @@ public class CustomMBeanServer implements MBeanServer {
                                try {
                                        newName = register.preRegister(this, name);
                                } catch (Exception e) {
-                                       register.postRegister(new Boolean(false));
+                                       register.postRegister(Boolean.valueOf(false));
                                        throw new MBeanRegistrationException(e);
                                }
 
@@ -182,7 +182,7 @@ public class CustomMBeanServer implements MBeanServer {
                                        log.trace(TRACE_ALL, "[registerMBean] " + newName);
 
                                if  (isRegistered(newName)) {
-                                       register.postRegister(new Boolean(false));
+                                       register.postRegister(Boolean.valueOf(false));
                                        throw new InstanceAlreadyExistsException("already registered");
                                }
 
@@ -193,7 +193,7 @@ public class CustomMBeanServer implements MBeanServer {
                                        throw new RuntimeOperationsException(e);
                                }
                                registeredMBeans.put(newName, new ObjectKeeper(instance, object));
-                               register.postRegister(new Boolean(true));
+                               register.postRegister(Boolean.valueOf(true));
                                return instance;
                        }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/Monitor.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/Monitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -423,7 +423,7 @@ public class Monitor {
      */
     protected void setLongAttribute(ObjectName object, String name,
                                                                    long value) {
-        Attribute attribute = new Attribute(name, new Long(value));
+        Attribute attribute = new Attribute(name, Long.valueOf(value));
 
         try {
             getMBeanServer().setAttribute(object, attribute);
@@ -442,7 +442,7 @@ public class Monitor {
      */
     protected void setBooleanAttribute(ObjectName object, String name,
                                                                 boolean value) {
-        Attribute attribute = new Attribute(name, new Boolean(value));
+        Attribute attribute = new Attribute(name, Boolean.valueOf(value));
 
         try {
             getMBeanServer().setAttribute(object, attribute);

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadMonitor.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public class ThreadMonitor extends Monitor {
             return mbean.getThreadInfo(id, maxDepth);
 
         case SERVER_MODE:
-            Object[] params = {new Long(id), new Integer(maxDepth)};
+            Object[] params = {Long.valueOf(id), Integer.valueOf(maxDepth)};
             String[] signature = {"long", "int"};
 
             try {
@@ -311,7 +311,7 @@ public class ThreadMonitor extends Monitor {
             return mbean.getThreadCpuTime(id);
 
         case SERVER_MODE:
-            Object[] params = {new Long(id)};
+            Object[] params = {Long.valueOf(id)};
             String[] signature = {"long"};
 
             try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/server/ServerMXBean.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/server/ServerMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public class ServerMXBean {
          * @return value of the attribute.
          */
         protected void setLongAttribute(String name, long value) {
-                Attribute attribute = new Attribute(name, new Long(value));
+                Attribute attribute = new Attribute(name, Long.valueOf(value));
                 try {
                         mbeanServer.setAttribute(objectName, attribute);
                 } catch (Exception e) {
@@ -119,7 +119,7 @@ public class ServerMXBean {
          * @param value value of the attribute.
          */
         protected void setBooleanAttribute(String name, boolean value) {
-                Attribute attribute = new Attribute(name, new Boolean(value));
+                Attribute attribute = new Attribute(name, Boolean.valueOf(value));
                 try {
                         mbeanServer.setAttribute(objectName, attribute);
                 } catch (Exception e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/cmon001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/cmon001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class cmon001 {
 
     private static volatile boolean testFailed = false;
     private static Integer calculated;
+    private static String calculatedSync = "abc";
     private static Object common = new Object();
     private static Object[] finishBarriers;
     private static long[] startTime;
@@ -83,7 +84,7 @@ public class cmon001 {
         for (int time = 0; time < ITERATIONS; time++) {
             log.display("Iteration: " + time);
 
-            calculated = new Integer(0);
+            calculated = Integer.valueOf(0);
 
             // Start all threads. Half of them are user threads,
             // others - daemon.
@@ -203,8 +204,8 @@ public class cmon001 {
 
             // Increase "calculated" value by one
             synchronized (common) {
-                synchronized (calculated) {
-                    calculated = new Integer(calculated.intValue() + 1);
+                synchronized (calculatedSync) {
+                    calculated = Integer.valueOf(calculated.intValue() + 1);
                 }
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public class strace001 {
     public static volatile boolean testFailed = false;
     public static Object common = new Object();
     public static Integer activeThreads;
+    public static String activeThreadsSync = "abc";
     private static Log log;
     private static int depth;
     private static int threadCount;
@@ -69,7 +70,7 @@ public class strace001 {
 
         for (int i = 0; i < ITERATIONS; i++) {
             log.display("\nIteration: " + i);
-            activeThreads = new Integer(0);
+            activeThreads = Integer.valueOf(0);
             finish = false;
 
             // Start all threads. Half of them are user threads,
@@ -292,9 +293,9 @@ class RunningThread extends Thread {
 
         // This instance of the thread is alive
         synchronized (strace001.common) {
-            synchronized (strace001.activeThreads) {
+            synchronized (strace001.activeThreadsSync) {
                 strace001.activeThreads
-                    = new Integer(strace001.activeThreads.intValue() + 1);
+                    = Integer.valueOf(strace001.activeThreads.intValue() + 1);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/TreeNodesDenotation.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/TreeNodesDenotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ public class TreeNodesDenotation extends Denotation {
         int length = this.alphabeth.length();
         Set<Character> pool = new HashSet<Character>(); // still empty
         for (int i=0; i<length; i++)
-            pool.add(new Character(this.alphabeth.charAt(i)));
+            pool.add(Character.valueOf(this.alphabeth.charAt(i)));
         if (pool.size() != length)
             throw new IllegalArgumentException("collision: " + alphabeth);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class AODTestRunner {
     }
 
     public static String createApplicationId() {
-        return new Long(System.currentTimeMillis()).toString();
+        return Long.valueOf(System.currentTimeMillis()).toString();
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/classload/GeneratingClassLoader.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/classload/GeneratingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,7 +169,7 @@ public class GeneratingClassLoader extends ClassLoader {
                                         }
                                         if (i == bytecode.length)
                                                 break;
-                                        offsets.add(new Integer(i));
+                                        offsets.add(Integer.valueOf(i));
                                         i++;
                                 }
                         } catch (UnsupportedEncodingException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ValueConversionDebugger.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ValueConversionDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,25 +70,25 @@ public class ValueConversionDebugger extends TestDebuggerType2 {
 
         if (value instanceof ByteValue) {
             methodNameToCall += "ByteTo";
-            param = new Byte(value.byteValue());
+            param = Byte.valueOf(value.byteValue());
         } else if (value instanceof ShortValue) {
             methodNameToCall += "ShortTo";
-            param = new Short(value.shortValue());
+            param = Short.valueOf(value.shortValue());
         } else if (value instanceof CharValue) {
             methodNameToCall += "CharTo";
-            param = new Character(value.charValue());
+            param = Character.valueOf(value.charValue());
         } else if (value instanceof IntegerValue) {
             methodNameToCall += "IntTo";
-            param = new Integer(value.intValue());
+            param = Integer.valueOf(value.intValue());
         } else if (value instanceof LongValue) {
             methodNameToCall += "LongTo";
-            param = new Long(value.longValue());
+            param = Long.valueOf(value.longValue());
         } else if (value instanceof FloatValue) {
             methodNameToCall += "FloatTo";
-            param = new Float(value.floatValue());
+            param = Float.valueOf(value.floatValue());
         } else if (value instanceof DoubleValue) {
             methodNameToCall += "DoubleTo";
-            param = new Double(value.doubleValue());
+            param = Double.valueOf(value.doubleValue());
         } else
             throw new IllegalArgumentException("Illegal PrimitiveValue: " + value);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Debugee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1442,7 +1442,7 @@ abstract public class Debugee extends DebugeeProcess {
                         addSupertypes(typeID, supertypes, interfaces, superclasses,
                                         true, declared);
                     }
-                    Long value = new Long(typeID);
+                    Long value = Long.valueOf(typeID);
                     if (supertypes != null) {
                         supertypes.add(value);
                     }
@@ -1477,7 +1477,7 @@ abstract public class Debugee extends DebugeeProcess {
                         addSupertypes(typeID, supertypes, interfaces, superclasses,
                                     false, declared);
                     }
-                    Long value = new Long(typeID);
+                    Long value = Long.valueOf(typeID);
                     if (supertypes != null) {
                         supertypes.add(value);
                     }
@@ -1536,13 +1536,13 @@ abstract public class Debugee extends DebugeeProcess {
                 int modBits = reply.getInt();
 
                 if (IDs != null)
-                    IDs.add(new Long(id));
+                    IDs.add(Long.valueOf(id));
                 if (names != null)
                     names.add(name);
                 if (signatures != null)
                     signatures.add(signature);
                 if (modifiers != null)
-                    modifiers.add(new Integer(modBits));
+                    modifiers.add(Integer.valueOf(modBits));
             }
 
         } catch (BoundException e) {
@@ -1594,13 +1594,13 @@ abstract public class Debugee extends DebugeeProcess {
                 int modBits = reply.getInt();
 
                 if (IDs != null)
-                    IDs.add(new Long(id));
+                    IDs.add(Long.valueOf(id));
                 if (names != null)
                     names.add(name);
                 if (signatures != null)
                     signatures.add(signature);
                 if (modifiers != null)
-                    modifiers.add(new Integer(modBits));
+                    modifiers.add(Integer.valueOf(modBits));
             }
 
         } catch (BoundException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/JDWP.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/JDWP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -810,38 +810,38 @@ public class JDWP {
             switch (tag) {
                 case JDWP.Tag.BYTE: {
                     byte castedValue = packet.getByte();
-                    value = new Byte(castedValue);
+                    value = Byte.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.CHAR: {
                     char castedValue = packet.getChar();
-                    value = new Character(castedValue);
+                    value = Character.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.FLOAT: {
                     float castedValue = packet.getFloat();
-                    value = new Float(castedValue);
+                    value = Float.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.DOUBLE: {
                     double castedValue = packet.getDouble();
-                    value = new Double(castedValue);
+                    value = Double.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.INT: {
                     int castedValue = packet.getInt();
-                    value = new Integer(castedValue);
+                    value = Integer.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.SHORT: {
                     short castedValue = packet.getShort();
-                    value = new Short(castedValue);
+                    value = Short.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.BOOLEAN: {
                     byte castedValue = packet.getByte();
-                    value = new Boolean(castedValue != 0);
+                    value = Boolean.valueOf(castedValue != 0);
                 } break;
                 case JDWP.Tag.LONG: {
                     long castedValue = packet.getLong();
-                    value = new Long(castedValue);
+                    value = Long.valueOf(castedValue);
                 } break;
                 case JDWP.Tag.VOID: {
-                    value = new Long(0);
+                    value = Long.valueOf(0);
                 } break;
                 case JDWP.Tag.ARRAY:
                 case JDWP.Tag.OBJECT:
@@ -851,7 +851,7 @@ public class JDWP {
                 case JDWP.Tag.CLASS_LOADER:
                 case JDWP.Tag.CLASS_OBJECT: {
                     long castedValue = packet.getObjectID();
-                    value = new Long(castedValue);
+                    value = Long.valueOf(castedValue);
                 } break;
                 default: {
                     throw new Failure("Unknown tag found while reading value from packet: " + tag);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/ForceEarlyReturnTestThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/ForceEarlyReturnTestThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -451,14 +451,14 @@ extends Thread
     public static ClassLoader expectedClassLoaderValue = new URLClassLoader(new URL[]{});
     public static String expectedStringValue = "EXPECTED STRING";
     public static Object expectedObjectValue = new Object();
-    public static Boolean expectedBooleanWrapperValue = new Boolean(Boolean.TRUE);
-    public static Byte expectedByteWrapperValue = new Byte(Byte.MAX_VALUE);
-    public static Character expectedCharWrapperValue = new Character(Character.MAX_VALUE);
-    public static Short expectedShortWrapperValue = new Short(Short.MAX_VALUE);
-    public static Integer expectedIntWrapperValue = new Integer(Integer.MAX_VALUE);
-    public static Long expectedLongWrapperValue = new Long(Long.MAX_VALUE);
-    public static Float expectedFloatWrapperValue = new Float(Float.MAX_VALUE);
-    public static Double expectedDoubleWrapperValue = new Double(Double.MAX_VALUE);
+    public static Boolean expectedBooleanWrapperValue = Boolean.valueOf(Boolean.TRUE);
+    public static Byte expectedByteWrapperValue = Byte.valueOf(Byte.MAX_VALUE);
+    public static Character expectedCharWrapperValue = Character.valueOf(Character.MAX_VALUE);
+    public static Short expectedShortWrapperValue = Short.valueOf(Short.MAX_VALUE);
+    public static Integer expectedIntWrapperValue = Integer.valueOf(Integer.MAX_VALUE);
+    public static Long expectedLongWrapperValue = Long.valueOf(Long.MAX_VALUE);
+    public static Float expectedFloatWrapperValue = Float.valueOf(Float.MAX_VALUE);
+    public static Double expectedDoubleWrapperValue = Double.valueOf(Double.MAX_VALUE);
 
     // values which should be returned from test methods without forceEarlyReturn():
 
@@ -477,14 +477,14 @@ extends Thread
     public static Class<?> unexpectedClassObjectValue = Object.class;
     public static ClassLoader unexpectedClassLoaderValue = new URLClassLoader(new URL[]{});
     public static Object unexpectedObjectValue = new Object();
-    public static Boolean unexpectedBooleanWrapperValue = new Boolean(Boolean.FALSE);
-    public static Byte unexpectedByteWrapperValue = new Byte((byte)0);
-    public static Character unexpectedCharWrapperValue = new Character((char)0);
-    public static Short unexpectedShortWrapperValue = new Short((short)0);
-    public static Integer unexpectedIntWrapperValue = new Integer(0);
-    public static Long unexpectedLongWrapperValue = new Long(0);
-    public static Float unexpectedFloatWrapperValue = new Float(0);
-    public static Double unexpectedDoubleWrapperValue = new Double(0);
+    public static Boolean unexpectedBooleanWrapperValue = Boolean.valueOf(Boolean.FALSE);
+    public static Byte unexpectedByteWrapperValue = Byte.valueOf((byte)0);
+    public static Character unexpectedCharWrapperValue = Character.valueOf((char)0);
+    public static Short unexpectedShortWrapperValue = Short.valueOf((short)0);
+    public static Integer unexpectedIntWrapperValue = Integer.valueOf(0);
+    public static Long unexpectedLongWrapperValue = Long.valueOf(0);
+    public static Float unexpectedFloatWrapperValue = Float.valueOf(0);
+    public static Double unexpectedDoubleWrapperValue = Double.valueOf(0);
 
     public static int[] breakpointLines = {
         49,
@@ -534,13 +534,13 @@ extends Thread
     public static Class<?> invalidThreadGroupValue = ForceEarlyReturnTestThread.class;
     public static ClassLoader invalidClassObjectValue = new URLClassLoader(new URL[]{});
     public static Object invalidClassLoaderValue = new Object();
-    public static Byte invalidBooleanWrapperValue = new Byte(Byte.MAX_VALUE);
-    public static Short invalidByteWrapperValue = new Short(Short.MAX_VALUE);
-    public static Character invalidShortWrapperValue = new Character(Character.MAX_VALUE);
-    public static Integer invalidCharWrapperValue = new Integer(Integer.MAX_VALUE);
-    public static Long invalidIntWrapperValue = new Long(Long.MAX_VALUE);
-    public static Float invalidLongWrapperValue = new Float(Float.MAX_VALUE);
-    public static Double invalidFloatWrapperValue = new Double(Double.MAX_VALUE);
+    public static Byte invalidBooleanWrapperValue = Byte.valueOf(Byte.MAX_VALUE);
+    public static Short invalidByteWrapperValue = Short.valueOf(Short.MAX_VALUE);
+    public static Character invalidShortWrapperValue = Character.valueOf(Character.MAX_VALUE);
+    public static Integer invalidCharWrapperValue = Integer.valueOf(Integer.MAX_VALUE);
+    public static Long invalidIntWrapperValue = Long.valueOf(Long.MAX_VALUE);
+    public static Float invalidLongWrapperValue = Float.valueOf(Float.MAX_VALUE);
+    public static Double invalidFloatWrapperValue = Double.valueOf(Double.MAX_VALUE);
     public static Object[] invalidDoubleWrapperValue = new Object[1000];
 
     // names of tested types, this names can be used to derive names of tested methods(typeName + 'Method'),

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/NativeMethodsTestThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/NativeMethodsTestThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,21 +116,21 @@ public class NativeMethodsTestThread extends Thread {
 
     public static Object expectedObjectValue = new Object();
 
-    public static Boolean expectedBooleanWrapperValue = new Boolean(Boolean.TRUE);
+    public static Boolean expectedBooleanWrapperValue = Boolean.valueOf(Boolean.TRUE);
 
-    public static Byte expectedByteWrapperValue = new Byte(Byte.MAX_VALUE);
+    public static Byte expectedByteWrapperValue = Byte.valueOf(Byte.MAX_VALUE);
 
-    public static Character expectedCharWrapperValue = new Character(Character.MAX_VALUE);
+    public static Character expectedCharWrapperValue = Character.valueOf(Character.MAX_VALUE);
 
-    public static Short expectedShortWrapperValue = new Short(Short.MAX_VALUE);
+    public static Short expectedShortWrapperValue = Short.valueOf(Short.MAX_VALUE);
 
-    public static Integer expectedIntWrapperValue = new Integer(Integer.MAX_VALUE);
+    public static Integer expectedIntWrapperValue = Integer.valueOf(Integer.MAX_VALUE);
 
-    public static Long expectedLongWrapperValue = new Long(Long.MAX_VALUE);
+    public static Long expectedLongWrapperValue = Long.valueOf(Long.MAX_VALUE);
 
-    public static Float expectedFloatWrapperValue = new Float(Float.MAX_VALUE);
+    public static Float expectedFloatWrapperValue = Float.valueOf(Float.MAX_VALUE);
 
-    public static Double expectedDoubleWrapperValue = new Double(Double.MAX_VALUE);
+    public static Double expectedDoubleWrapperValue = Double.valueOf(Double.MAX_VALUE);
 
     // names of tested types, this names can be used to derive names of tested methods(typeName + 'Method'),
     public static String testedTypesNames[] = {"Void", "Boolean", "Byte", "Short", "Char", "Int", "Long", "Float", "Double", "ObjectArray",

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,8 +208,8 @@ public class except004 {
 
         // Prepare some items, which will be used by the test:
         Object stringArray[] = new String[1];
-        Object integerValue = new Integer(0);
-        Object doubleValue = new Double(0);
+        Object integerValue = Integer.valueOf(0);
+        Object doubleValue = Double.valueOf(0);
         Object trash = null;
         Field abraIntegerField;
         Field abraBooleanField;

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/RandomValueGen.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/RandomValueGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class RandomValueGen {
 
         // A workaround for booleans. Sometimes RNG produces long series of trues or falses
         if ( type.equals(Boolean.class) || type.equals(boolean.class) )
-            return new Boolean(! (Boolean) notEqualTo);
+            return Boolean.valueOf(! (Boolean) notEqualTo);
 
         throw new InstantiationException("Can't create distinct value for type=[" + type.getName() + "]; value=[" + notEqualTo + "]");
     }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/SimpleUnitTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/SimpleUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class SimpleUnitTest extends MlvmTest {
             retArg = new Argument(SimpleUnitTest.class, sut);
             retArg.setPreserved(true);
 
-            Argument intArg = new Argument(int.class, new Integer(1));
+            Argument intArg = new Argument(int.class, Integer.valueOf(1));
 
             for ( ;; ) {
                 try {
@@ -86,7 +86,7 @@ public class SimpleUnitTest extends MlvmTest {
                                     "test1",
                                     MethodType.methodType(SimpleUnitTest.class, int.class, float.class)
                             ),
-                            new Argument[] { new Argument(int.class, new Integer(1)), new Argument(float.class, new Float(1.0)) },
+                            new Argument[] { new Argument(int.class, Integer.valueOf(1)), new Argument(float.class, Float.valueOf(1.0)) },
                             true);
                         break;
 
@@ -99,7 +99,7 @@ public class SimpleUnitTest extends MlvmTest {
                                         "test2",
                                         MethodType.methodType(SimpleUnitTest.class, int.class, float.class)
                                 ),
-                                new Argument[] { new Argument(int.class, new Integer(1)), new Argument(float.class, new Float(1.0)) },
+                                new Argument[] { new Argument(int.class, Integer.valueOf(1)), new Argument(float.class, Float.valueOf(1.0)) },
                                 true);
                             break;
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/TestTypes.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/TestTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,28 +255,28 @@ public class TestTypes {
             return null;
 
         if (type.equals(boolean.class) || type.equals(Boolean.class))
-            return new Boolean(Env.getRNG().nextInt(2) == 0);
+            return Boolean.valueOf(Env.getRNG().nextInt(2) == 0);
 
         if (type.equals(byte.class) || type.equals(Byte.class))
-            return new Byte((byte) Env.getRNG().nextInt(1 << Byte.SIZE));
+            return Byte.valueOf((byte) Env.getRNG().nextInt(1 << Byte.SIZE));
 
         if (type.equals(int.class) || type.equals(Integer.class))
-            return new Integer(Env.getRNG().nextInt());
+            return Integer.valueOf(Env.getRNG().nextInt());
 
         if (type.equals(short.class) || type.equals(Short.class))
-            return new Short((short) Env.getRNG().nextInt(1 << Short.SIZE));
+            return Short.valueOf((short) Env.getRNG().nextInt(1 << Short.SIZE));
 
         if (type.equals(long.class) || type.equals(Long.class))
-            return new Long(Env.getRNG().nextLong());
+            return Long.valueOf(Env.getRNG().nextLong());
 
         if (type.equals(float.class) || type.equals(Float.class))
-            return new Float(Env.getRNG().nextFloat());
+            return Float.valueOf(Env.getRNG().nextFloat());
 
         if (type.equals(double.class) || type.equals(Double.class))
-            return new Double(Env.getRNG().nextDouble());
+            return Double.valueOf(Env.getRNG().nextDouble());
 
         if (type.equals(char.class) || type.equals(Character.class))
-            return new Character((char) (32 + Env.getRNG().nextInt(96)));
+            return Character.valueOf((char) (32 + Env.getRNG().nextInt(96)));
 
         if (type.equals(Object.class))
             return new Object();

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,14 +91,14 @@ public class Test extends MultiThreadedTest {
 
     static class A {
         Object m() {
-            return new Integer(0);
+            return Integer.valueOf(0);
         }
     }
 
     static class B extends A {
         @Override
         Object m() {
-            return new Integer(1);
+            return Integer.valueOf(1);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class Test extends MlvmTest {
             = Runtime.getRuntime().availableProcessors();
 
     Object finalTarget() {
-        return new Integer(0);
+        return Integer.valueOf(0);
     }
 
     static class A {
@@ -102,7 +102,7 @@ public class Test extends MlvmTest {
         Object m() throws Throwable {
             Env.traceNormal("Deoptimized m() in thread "
                     + Thread.currentThread().getName());
-            return new Integer(1);
+            return Integer.valueOf(1);
         }
     }
 
@@ -122,7 +122,7 @@ public class Test extends MlvmTest {
         final MethodHandle mhB = MethodHandles.lookup().findVirtual(Test.class,
                 "finalTarget", MethodType.methodType(Object.class));
 
-        final Argument finalRetVal = Argument.fromValue(new Integer(0));
+        final Argument finalRetVal = Argument.fromValue(Integer.valueOf(0));
         finalRetVal.setPreserved(true);
 
         this.intermediateTarget = new A(

--- a/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/ClassFileGenerator.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/ClassFileGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -718,7 +718,7 @@ public class ClassFileGenerator implements Visitor {
         if (value == 0L) {
             mv.visitInsn(LCONST_0);
         } else {
-            mv.visitLdcInsn(new Long(value));
+            mv.visitLdcInsn(Long.valueOf(value));
         }
     }
 
@@ -733,7 +733,7 @@ public class ClassFileGenerator implements Visitor {
         } else if (value == 2.0f) {
             mv.visitInsn(FCONST_2);
         } else {
-            mv.visitLdcInsn(new Float(value));
+            mv.visitLdcInsn(Float.valueOf(value));
         }
     }
 
@@ -746,7 +746,7 @@ public class ClassFileGenerator implements Visitor {
         } else if (value == 1.0d) {
             mv.visitInsn(DCONST_1);
         } else {
-            mv.visitLdcInsn(new Double(value));
+            mv.visitLdcInsn(Double.valueOf(value));
         }
     }
 


### PR DESCRIPTION
Please review this change to clean up warnings, such as the following, in the vmTestbase tests.  

warning: [synchronization] attempt to synchronize on an instance of a value-based class 
warning: [removal] Integer(int) in Integer has been deprecated and marked for removal

This change cleans up the warnings by using a non-value based class to synchronize on, and replacing calls such as Integer(int) with Integer.valueOf(int).

The change was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-8 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261161](https://bugs.openjdk.java.net/browse/JDK-8261161): Clean up warnings in hotspot/jtreg/vmTestbase tests


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2427/head:pull/2427`
`$ git checkout pull/2427`
