### PR TITLE
JDK-8261237: remove isClassPathAttributePresent method

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
@@ -80,25 +80,6 @@ public class VMSupport {
     }
 
     /*
-     * Returns true if the given JAR file has the Class-Path attribute in the
-     * main section of the JAR manifest. Throws RuntimeException if the given
-     * path is not a JAR file or some other error occurs.
-     */
-    public static boolean isClassPathAttributePresent(String path) {
-        try (JarFile jarFile = new JarFile(path)) {
-            Manifest man = jarFile.getManifest();
-            if (man != null) {
-                if (man.getMainAttributes().getValue(Attributes.Name.CLASS_PATH) != null) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (IOException ioe) {
-            throw new RuntimeException(ioe.getMessage());
-        }
-    }
-
-    /*
      * Return the temporary directory that the VM uses for the attach
      * and perf data files.
      *

--- a/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ public class VMSupport {
      * path is not a JAR file or some other error occurs.
      */
     public static boolean isClassPathAttributePresent(String path) {
-        try {
-            Manifest man = (new JarFile(path)).getManifest();
+        try (JarFile jarFile = new JarFile(path)) {
+            Manifest man = jarFile.getManifest();
             if (man != null) {
                 if (man.getMainAttributes().getValue(Attributes.Name.CLASS_PATH) != null) {
                     return true;


### PR DESCRIPTION
Hello,
Currently in jdk/internal/vm/VMSupport.java , we create a JarFile without a related finally clause or try with resources. That should better be changed.
See also the Sonar check result :

https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=java&open=AXcqM8zf8sPJZZzON5qG&resolved=false&severities=BLOCKER&types=BUG

    public static boolean isClassPathAttributePresent(String path) {
        try {
            Manifest man = (new JarFile(path)).getManifest();
Use try-with-resources or close this "JarFile" in a "finally" clause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261237](https://bugs.openjdk.java.net/browse/JDK-8261237): remove isClassPathAttributePresent  method


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2429/head:pull/2429`
`$ git checkout pull/2429`
