### PR TITLE
8261239: Upstream 8258238: Some jextract samples crash with: "updating map that does not need updating"

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -355,7 +355,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
-  if (jfa->saved_fp_address()) {
+  if (map->update_map() && jfa->saved_fp_address()) {
     update_map_with_saved_link(map, jfa->saved_fp_address());
   }
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -346,7 +346,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
-  if (jfa->saved_rbp_address()) {
+  if (map->update_map() && jfa->saved_rbp_address()) {
     update_map_with_saved_link(map, jfa->saved_rbp_address());
   }
 

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2282,13 +2282,13 @@ WB_ENTRY(void, WB_CheckThreadObjOfTerminatingThread(JNIEnv* env, jobject wb, job
   }
 WB_END
 
-WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log))
+WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean update_map))
   intx tty_token = -1;
   if (log) {
     tty_token = ttyLocker::hold_tty();
     tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
   }
-  for (StackFrameStream fst(JavaThread::current(), true, true); !fst.is_done(); fst.next()) {
+  for (StackFrameStream fst(JavaThread::current(), update_map, true); !fst.is_done(); fst.next()) {
     frame* current_frame = fst.current();
     if (log) {
       current_frame->print_value();
@@ -2545,7 +2545,7 @@ static JNINativeMethod methods[] = {
   {CC"handshakeWalkStack", CC"(Ljava/lang/Thread;Z)I", (void*)&WB_HandshakeWalkStack },
   {CC"asyncHandshakeWalkStack", CC"(Ljava/lang/Thread;)V", (void*)&WB_AsyncHandshakeWalkStack },
   {CC"checkThreadObjOfTerminatingThread", CC"(Ljava/lang/Thread;)V", (void*)&WB_CheckThreadObjOfTerminatingThread },
-  {CC"verifyFrames",                CC"(Z)V",            (void*)&WB_VerifyFrames },
+  {CC"verifyFrames",                CC"(ZZ)V",            (void*)&WB_VerifyFrames },
   {CC"addCompilerDirective",    CC"(Ljava/lang/String;)I",
                                                       (void*)&WB_AddCompilerDirective },
   {CC"removeCompilerDirective",   CC"(I)V",           (void*)&WB_RemoveCompilerDirective },

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1107,7 +1107,9 @@ void frame::verify(const RegisterMap* map) const {
 #if COMPILER2_OR_JVMCI
   assert(DerivedPointerTable::is_empty(), "must be empty before verify");
 #endif
-  oops_do_internal(&VerifyOopClosure::verify_oop, NULL, map, false, DerivedPointerIterationMode::_ignore);
+  if (map->update_map()) { // The map has to be up-to-date for the current frame
+    oops_do_internal(&VerifyOopClosure::verify_oop, NULL, map, false, DerivedPointerIterationMode::_ignore);
+  }
 }
 
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -105,7 +105,8 @@ public class TestStackWalk {
 
     static void m() {
         if (armed) {
-            WB.verifyFrames(true);
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/true);
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/false); // triggers different code paths
         }
     }
 

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -638,7 +638,7 @@ public class WhiteBox {
   public native String getLibcName();
 
   // Walk stack frames of current thread
-  public native void verifyFrames(boolean log);
+  public native void verifyFrames(boolean log, boolean updateRegisterMap);
 
   public native boolean isJVMTIIncluded();
 


### PR DESCRIPTION
Hi,

This patch upstreams a fix and the accompanying test from the panama-foreign repo, that fixes an assertion when walking the stack with a register map that does not need updating.

While updating the map any ways seems benign, the fix avoids running into the assertion in certain test configurations when running foreign-linker tests.

Testing: Tier 1-2

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261239](https://bugs.openjdk.java.net/browse/JDK-8261239): Upstream 8258238: Some jextract samples crash with: "updating map that does not need updating"


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2430/head:pull/2430`
`$ git checkout pull/2430`
