### PR TITLE
8261250: Dependencies: Remove unused dependency types

### DIFF
--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1270,8 +1270,8 @@ static bool count_find_witness_calls() {
 
 
 Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
-                                               Klass* context_type,
-                                               bool participants_hide_witnesses) {
+                                             Klass* context_type,
+                                             bool participants_hide_witnesses) {
   assert(changes.involves_context(context_type), "irrelevant dependency");
   Klass* new_type = changes.new_type();
 
@@ -1321,8 +1321,8 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
 // If top_level_call is false, skip testing the context type,
 // because the caller has already considered it.
 Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
-                                                     bool participants_hide_witnesses,
-                                                     bool top_level_call) {
+                                                   bool participants_hide_witnesses,
+                                                   bool top_level_call) {
   // Current thread must be in VM (not native mode, as in CI):
   assert(must_be_in_vm(), "raw oops here");
   // Must not move the class hierarchy during this check:
@@ -1421,8 +1421,8 @@ Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
         // since the recursive call sees sub as the context_type.)
         if (do_counts) { NOT_PRODUCT(deps_find_witness_recursions++); }
         Klass* witness = find_witness_anywhere(sub,
-                                                 participants_hide_witnesses,
-                                                 /*top_level_call=*/ false);
+                                               participants_hide_witnesses,
+                                               /*top_level_call=*/ false);
         if (witness != NULL)  return witness;
       }
     }

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1529,8 +1529,8 @@ Klass* Dependencies::check_leaf_type(Klass* ctxk) {
 // This allows the compiler to narrow occurrences of ctxk by conck,
 // when dealing with the types of actual instances.
 Klass* Dependencies::check_abstract_with_unique_concrete_subtype(Klass* ctxk,
-                                                                   Klass* conck,
-                                                                   KlassDepChange* changes) {
+                                                                 Klass* conck,
+                                                                 KlassDepChange* changes) {
   ClassHierarchyWalker wf(conck);
   return wf.find_witness_subtype(ctxk, changes);
 }
@@ -1569,8 +1569,9 @@ Klass* Dependencies::find_unique_concrete_subtype(Klass* ctxk) {
 
 // If a class (or interface) has a unique concrete method uniqm, return NULL.
 // Otherwise, return a class that contains an interfering method.
-Klass* Dependencies::check_unique_concrete_method(Klass* ctxk, Method* uniqm,
-                                                    KlassDepChange* changes) {
+Klass* Dependencies::check_unique_concrete_method(Klass*  ctxk,
+                                                  Method* uniqm,
+                                                  KlassDepChange* changes) {
   // Here is a missing optimization:  If uniqm->is_final(),
   // we don't really need to search beneath it for overrides.
   // This is probably not important, since we don't use dependencies

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -245,33 +245,6 @@ void Dependencies::assert_common_2(DepType dept,
   deps->append(x1);
 }
 
-void Dependencies::assert_common_3(DepType dept,
-                                   ciKlass* ctxk, ciBaseObject* x, ciBaseObject* x2) {
-  assert(dep_context_arg(dept) == 0, "sanity");
-  assert(dep_args(dept) == 3, "sanity");
-  log_dependency(dept, ctxk, x, x2);
-  GrowableArray<ciBaseObject*>* deps = _deps[dept];
-
-  // see if the same (or a similar) dep is already recorded
-  if (note_dep_seen(dept, x) && note_dep_seen(dept, x2)) {
-    // look in this bucket for redundant assertions
-    const int stride = 3;
-    for (int i = deps->length(); (i -= stride) >= 0; ) {
-      ciBaseObject* y  = deps->at(i+1);
-      ciBaseObject* y2 = deps->at(i+2);
-      if (x == y && x2 == y2) {  // same subjects; check the context
-        if (maybe_merge_ctxk(deps, i+0, ctxk)) {
-          return;
-        }
-      }
-    }
-  }
-  // append the assertion in the correct bucket:
-  deps->append(ctxk);
-  deps->append(x);
-  deps->append(x2);
-}
-
 #if INCLUDE_JVMCI
 bool Dependencies::maybe_merge_ctxk(GrowableArray<DepValue>* deps,
                                     int ctxk_i, DepValue ctxk2_dv) {

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1593,49 +1593,6 @@ Klass* Dependencies::find_unique_concrete_subtype(Klass* ctxk) {
   }
 }
 
-// Search ctxk for concrete implementations.  If there are klen or fewer,
-// pack them into the given array and return the number.
-// Otherwise, return -1, meaning the given array would overflow.
-// (Note that a return of 0 means there are exactly no concrete subtypes.)
-// In this search, if ctxk is concrete, it will be reported alone.
-// For any type CC reported, no proper subtypes of CC will be reported.
-int Dependencies::find_exclusive_concrete_subtypes(Klass* ctxk,
-                                                   int klen,
-                                                   Klass* karray[]) {
-  ClassHierarchyWalker wf;
-  wf.record_witnesses(klen);
-  Klass* wit = wf.find_witness_subtype(ctxk);
-  if (wit != NULL)  return -1;  // Too many witnesses.
-  int num = wf.num_participants();
-  assert(num <= klen, "oob");
-  // Pack the result array with the good news.
-  for (int i = 0; i < num; i++)
-    karray[i] = wf.participant(i);
-#ifndef PRODUCT
-  // Make sure the dependency mechanism will pass this discovery:
-  if (VerifyDependencies) {
-    // Turn off dependency tracing while actually testing deps.
-    FlagSetting fs(TraceDependencies, false);
-    switch (Dependencies::is_concrete_klass(ctxk)? -1: num) {
-    case -1: // ctxk was itself concrete
-      guarantee(num == 1 && karray[0] == ctxk, "verify dep.");
-      break;
-    case 0:
-      break;
-    case 1:
-      guarantee(NULL == (void *)
-                check_abstract_with_unique_concrete_subtype(ctxk, karray[0]),
-                "verify dep.");
-      break;
-    case 2:
-      break;
-    default:
-      ShouldNotReachHere();  // klen > 2 yet supported
-    }
-  }
-#endif //PRODUCT
-  return num;
-}
 
 // If a class (or interface) has a unique concrete method uniqm, return NULL.
 // Otherwise, return a class that contains an interfering method.

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -421,7 +421,6 @@ class Dependencies: public ResourceObj {
   // Detecting possible new assertions:
   static Klass*    find_unique_concrete_subtype(Klass* ctxk);
   static Method*   find_unique_concrete_method(Klass* ctxk, Method* m);
-  static int       find_exclusive_concrete_subtypes(Klass* ctxk, int klen, Klass* k[]);
 
   // Create the encoding which will be stored in an nmethod.
   void encode_content_bytes();

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -153,9 +153,6 @@ class Dependencies: public ResourceObj {
     // and C2 is a proper subtype of C1.
     abstract_with_exclusive_concrete_subtypes_2,
 
-    // This dependency asserts that MM(CX, M1) is no greater than {M1,M2}.
-    exclusive_concrete_methods_2,
-
     // This dependency asserts that no instances of class or it's
     // subclasses require finalization registration.
     no_finalizable_subclasses,
@@ -358,7 +355,6 @@ class Dependencies: public ResourceObj {
   void assert_concrete_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm);
   void assert_abstract_with_exclusive_concrete_subtypes(ciKlass* ctxk, ciKlass* k1, ciKlass* k2);
-  void assert_exclusive_concrete_methods(ciKlass* ctxk, ciMethod* m1, ciMethod* m2);
   void assert_has_no_finalizable_subclasses(ciKlass* ctxk);
   void assert_call_site_target_value(ciCallSite* call_site, ciMethodHandle* method_handle);
 
@@ -435,8 +431,6 @@ class Dependencies: public ResourceObj {
                                                KlassDepChange* changes = NULL);
   static Klass* check_abstract_with_exclusive_concrete_subtypes(Klass* ctxk, Klass* k1, Klass* k2,
                                                                   KlassDepChange* changes = NULL);
-  static Klass* check_exclusive_concrete_methods(Klass* ctxk, Method* m1, Method* m2,
-                                                   KlassDepChange* changes = NULL);
   static Klass* check_has_no_finalizable_subclasses(Klass* ctxk, KlassDepChange* changes = NULL);
   static Klass* check_call_site_target_value(oop call_site, oop method_handle, CallSiteDepChange* changes = NULL);
   // A returned Klass* is NULL if the dependency assertion is still

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -397,10 +397,8 @@ class Dependencies: public ResourceObj {
   // Checking old assertions at run-time (in the VM only):
   static Klass* check_evol_method(Method* m);
   static Klass* check_leaf_type(Klass* ctxk);
-  static Klass* check_abstract_with_unique_concrete_subtype(Klass* ctxk, Klass* conck,
-                                                              KlassDepChange* changes = NULL);
-  static Klass* check_unique_concrete_method(Klass* ctxk, Method* uniqm,
-                                               KlassDepChange* changes = NULL);
+  static Klass* check_abstract_with_unique_concrete_subtype(Klass* ctxk, Klass* conck, KlassDepChange* changes = NULL);
+  static Klass* check_unique_concrete_method(Klass* ctxk, Method* uniqm, KlassDepChange* changes = NULL);
   static Klass* check_has_no_finalizable_subclasses(Klass* ctxk, KlassDepChange* changes = NULL);
   static Klass* check_call_site_target_value(oop call_site, oop method_handle, CallSiteDepChange* changes = NULL);
   // A returned Klass* is NULL if the dependency assertion is still
@@ -418,8 +416,8 @@ class Dependencies: public ResourceObj {
   // It is used by DepStream::spot_check_dependency_at.
 
   // Detecting possible new assertions:
-  static Klass*    find_unique_concrete_subtype(Klass* ctxk);
-  static Method*   find_unique_concrete_method(Klass* ctxk, Method* m);
+  static Klass*  find_unique_concrete_subtype(Klass* ctxk);
+  static Method* find_unique_concrete_method(Klass* ctxk, Method* m);
 
   // Create the encoding which will be stored in an nmethod.
   void encode_content_bytes();

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -115,9 +115,6 @@ class Dependencies: public ResourceObj {
     // An abstract class CX has exactly one concrete subtype CC.
     abstract_with_unique_concrete_subtype,
 
-    // The type CX is purely abstract, with no concrete subtype* at all.
-    abstract_with_no_concrete_subtype,
-
     // The concrete CX is free of concrete proper subtypes.
     concrete_with_no_concrete_subtype,
 
@@ -337,7 +334,6 @@ class Dependencies: public ResourceObj {
   void assert_evol_method(ciMethod* m);
   void assert_leaf_type(ciKlass* ctxk);
   void assert_abstract_with_unique_concrete_subtype(ciKlass* ctxk, ciKlass* conck);
-  void assert_abstract_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_concrete_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm);
   void assert_has_no_finalizable_subclasses(ciKlass* ctxk);
@@ -408,8 +404,6 @@ class Dependencies: public ResourceObj {
   static Klass* check_leaf_type(Klass* ctxk);
   static Klass* check_abstract_with_unique_concrete_subtype(Klass* ctxk, Klass* conck,
                                                               KlassDepChange* changes = NULL);
-  static Klass* check_abstract_with_no_concrete_subtype(Klass* ctxk,
-                                                          KlassDepChange* changes = NULL);
   static Klass* check_concrete_with_no_concrete_subtype(Klass* ctxk,
                                                           KlassDepChange* changes = NULL);
   static Klass* check_unique_concrete_method(Klass* ctxk, Method* uniqm,

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -115,9 +115,6 @@ class Dependencies: public ResourceObj {
     // An abstract class CX has exactly one concrete subtype CC.
     abstract_with_unique_concrete_subtype,
 
-    // The concrete CX is free of concrete proper subtypes.
-    concrete_with_no_concrete_subtype,
-
     // Given a method M1 and a context class CX, the set MM(CX, M1) of
     // "concrete matching methods" in CX of M1 is the set of every
     // concrete M2 for which it is possible to create an invokevirtual
@@ -334,7 +331,6 @@ class Dependencies: public ResourceObj {
   void assert_evol_method(ciMethod* m);
   void assert_leaf_type(ciKlass* ctxk);
   void assert_abstract_with_unique_concrete_subtype(ciKlass* ctxk, ciKlass* conck);
-  void assert_concrete_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm);
   void assert_has_no_finalizable_subclasses(ciKlass* ctxk);
   void assert_call_site_target_value(ciCallSite* call_site, ciMethodHandle* method_handle);
@@ -404,8 +400,6 @@ class Dependencies: public ResourceObj {
   static Klass* check_leaf_type(Klass* ctxk);
   static Klass* check_abstract_with_unique_concrete_subtype(Klass* ctxk, Klass* conck,
                                                               KlassDepChange* changes = NULL);
-  static Klass* check_concrete_with_no_concrete_subtype(Klass* ctxk,
-                                                          KlassDepChange* changes = NULL);
   static Klass* check_unique_concrete_method(Klass* ctxk, Method* uniqm,
                                                KlassDepChange* changes = NULL);
   static Klass* check_has_no_finalizable_subclasses(Klass* ctxk, KlassDepChange* changes = NULL);

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -324,7 +324,6 @@ class Dependencies: public ResourceObj {
 
   void assert_common_1(DepType dept, ciBaseObject* x);
   void assert_common_2(DepType dept, ciBaseObject* x0, ciBaseObject* x1);
-  void assert_common_3(DepType dept, ciKlass* ctxk, ciBaseObject* x1, ciBaseObject* x2);
 
  public:
   // Adding assertions to a new dependency set at compile time:

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -139,20 +139,6 @@ class Dependencies: public ResourceObj {
     // than {M1}.
     unique_concrete_method,       // one unique concrete method under CX
 
-    // An "exclusive" assertion concerns two methods or subtypes, and
-    // declares that there are at most two (or perhaps later N>2)
-    // specific items that jointly satisfy the restriction.
-    // We list all items explicitly rather than just giving their
-    // count, for robustness in the face of complex schema changes.
-
-    // A context class CX (which may be either abstract or concrete)
-    // has two exclusive concrete subtypes* C1, C2 if every concrete
-    // subtype* of CX is either C1 or C2.  Note that if neither C1 or C2
-    // are equal to CX, then CX itself must be abstract.  But it is
-    // also possible (for example) that C1 is CX (a concrete class)
-    // and C2 is a proper subtype of C1.
-    abstract_with_exclusive_concrete_subtypes_2,
-
     // This dependency asserts that no instances of class or it's
     // subclasses require finalization registration.
     no_finalizable_subclasses,
@@ -354,7 +340,6 @@ class Dependencies: public ResourceObj {
   void assert_abstract_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_concrete_with_no_concrete_subtype(ciKlass* ctxk);
   void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm);
-  void assert_abstract_with_exclusive_concrete_subtypes(ciKlass* ctxk, ciKlass* k1, ciKlass* k2);
   void assert_has_no_finalizable_subclasses(ciKlass* ctxk);
   void assert_call_site_target_value(ciCallSite* call_site, ciMethodHandle* method_handle);
 
@@ -429,8 +414,6 @@ class Dependencies: public ResourceObj {
                                                           KlassDepChange* changes = NULL);
   static Klass* check_unique_concrete_method(Klass* ctxk, Method* uniqm,
                                                KlassDepChange* changes = NULL);
-  static Klass* check_abstract_with_exclusive_concrete_subtypes(Klass* ctxk, Klass* k1, Klass* k2,
-                                                                  KlassDepChange* changes = NULL);
   static Klass* check_has_no_finalizable_subclasses(Klass* ctxk, KlassDepChange* changes = NULL);
   static Klass* check_call_site_target_value(oop call_site, oop method_handle, CallSiteDepChange* changes = NULL);
   // A returned Klass* is NULL if the dependency assertion is still


### PR DESCRIPTION
Remove support of unused dependency types from Dependencies.

Testing: 
- [x] hs-precheckin-comp, hs-tier1, hs-tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261250](https://bugs.openjdk.java.net/browse/JDK-8261250): Dependencies: Remove unused dependency types


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2431/head:pull/2431`
`$ git checkout pull/2431`
