### PR TITLE
8261251: Shenandoah: Use object size for full GC humongous compaction

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -958,7 +958,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
 
       Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
                                    heap->get_region(new_start)->bottom(),
-                                   ShenandoahHeapRegion::region_size_words()*num_regions);
+                                   words_size);
 
       oop new_obj = oop(heap->get_region(new_start)->bottom());
       new_obj->init_mark();


### PR DESCRIPTION
Currently, copying objects in full GC humongous object comaction copies the full region. We can limit that to copying only the object size and save some wasted cycles. Also, this fixes a test failure with loom where object copy checks that the given size matches the object size.

 - [x] hotspot_gc_shenandoah
 - [x] tier1(+Shenandoah)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261251](https://bugs.openjdk.java.net/browse/JDK-8261251): Shenandoah: Use object size for full GC humongous compaction


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2433/head:pull/2433`
`$ git checkout pull/2433`
