### PR TITLE
JDK-8261263: Simplify javadoc link code

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -32,11 +32,9 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.SimpleTypeVisitor14;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -97,7 +95,8 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         }
         content.add(signature);
 
-        return writer.getDocLink(MEMBER_DEPRECATED_PREVIEW, utils.getEnclosingTypeElement(member), member, content);
+        return writer.getDocLink(MEMBER_DEPRECATED_PREVIEW, utils.getEnclosingTypeElement(member),
+                member, content, false);
     }
 
     /**
@@ -113,7 +112,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
             Content tdSummary) {
         ExecutableElement ee = (ExecutableElement)member;
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, te, ee, name(ee), false));
+                writer.getDocLink(context, te, ee, name(ee)));
         Content code = HtmlTree.CODE(memberLink);
         addParameters(ee, code);
         tdSummary.add(code);
@@ -128,7 +127,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content linksTree) {
-        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member), false));
+        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member)));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
@@ -187,7 +187,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, member, name(member), false));
+                writer.getDocLink(context, member, name(member)));
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
      */
     private Content getNameColumn(VariableElement member) {
         Content nameContent = getDocLink(LinkInfoImpl.Kind.CONSTANT_SUMMARY,
-                member, member.getSimpleName(), false);
+                member, member.getSimpleName());
         return HtmlTree.CODE(nameContent);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -160,7 +160,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, member, name(member), false));
+                writer.getDocLink(context, member, name(member)));
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -161,7 +161,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement, false);
+                LinkInfoImpl.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -184,7 +184,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
         Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, typeElement , member, name(member), false));
+                writer.getDocLink(context, typeElement , member, name(member)));
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }
@@ -192,8 +192,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         linksTree.add(
-                writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member,
-                name(member), false));
+                writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member, name(member)));
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -763,7 +763,7 @@ public class HtmlDocletWriter {
      */
     public Content getTypeParameterLinks(LinkInfoImpl linkInfo) {
         LinkFactoryImpl factory = new LinkFactoryImpl(this);
-        return factory.getTypeParameterLinks(linkInfo, false);
+        return factory.getTypeParameterLinks(linkInfo);
     }
 
     /*************************************************************
@@ -853,18 +853,16 @@ public class HtmlDocletWriter {
      * link label.
      *
      * @param typeElement the class to link to.
-     * @param isStrong true if the link should be strong.
      * @return the link with the package portion of the label in plain text.
      */
-    public Content getPreQualifiedClassLink(LinkInfoImpl.Kind context,
-            TypeElement typeElement, boolean isStrong) {
+    public Content getPreQualifiedClassLink(LinkInfoImpl.Kind context, TypeElement typeElement) {
         ContentBuilder classlink = new ContentBuilder();
         PackageElement pkg = utils.containingPackage(typeElement);
         if (pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
             classlink.add(getEnclosingPackageName(typeElement));
         }
         classlink.add(getLink(new LinkInfoImpl(configuration,
-                context, typeElement).label(utils.getSimpleName(typeElement)).strong(isStrong)));
+                context, typeElement).label(utils.getSimpleName(typeElement))));
         return classlink;
     }
 
@@ -934,21 +932,7 @@ public class HtmlDocletWriter {
      */
     public Content getDocLink(LinkInfoImpl.Kind context, Element element, CharSequence label) {
         return getDocLink(context, utils.getEnclosingTypeElement(element), element,
-                new StringContent(label));
-    }
-
-    /**
-     * Return the link for the given member.
-     *
-     * @param context the id of the context where the link will be printed.
-     * @param element the member being linked to.
-     * @param label the label for the link.
-     * @param strong true if the link should be strong.
-     * @return the link for the given member.
-     */
-    public Content getDocLink(LinkInfoImpl.Kind context, Element element, CharSequence label,
-            boolean strong) {
-        return getDocLink(context, utils.getEnclosingTypeElement(element), element, label, strong);
+                new StringContent(label), false);
     }
 
     /**
@@ -960,17 +944,27 @@ public class HtmlDocletWriter {
                  inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
-     * @param strong true if the link should be strong.
      * @return the link for the given member.
      */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            CharSequence label, boolean strong) {
-        return getDocLink(context, typeElement, element, label, strong, false);
+                              CharSequence label) {
+        return getDocLink(context, typeElement, element, label, false);
     }
 
+    /**
+     * Return the link for the given member.
+     *
+     * @param context the id of the context where the link will be printed.
+     * @param typeElement the typeElement that we should link to.  This is not
+    necessarily equal to element.containingClass().  We may be
+    inheriting comments.
+     * @param element the member being linked to.
+     * @param label the label for the link.
+     * @return the link for the given member.
+     */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            Content label, boolean strong) {
-        return getDocLink(context, typeElement, element, label, strong, false);
+                              CharSequence label, boolean isProperty) {
+        return getDocLink(context, typeElement, element, new StringContent(label), isProperty);
     }
 
     /**
@@ -982,17 +976,11 @@ public class HtmlDocletWriter {
                  inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
-     * @param strong true if the link should be strong.
      * @param isProperty true if the element parameter is a JavaFX property.
      * @return the link for the given member.
      */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            CharSequence label, boolean strong, boolean isProperty) {
-        return getDocLink(context, typeElement, element, new StringContent(label), strong, isProperty);
-    }
-
-    public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            Content label, boolean strong, boolean isProperty) {
+            Content label, boolean isProperty) {
         if (!utils.isLinkable(typeElement, element)) {
             return label;
         }
@@ -1003,50 +991,17 @@ public class HtmlDocletWriter {
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(id.name())
-                .targetMember(element)
-                .strong(strong));
+                .targetMember(element));
         }
 
         if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(element.getSimpleName().toString())
-                .targetMember(element)
-                .strong(strong));
+                .targetMember(element));
         }
 
         return label;
-    }
-
-    /**
-     * Return the link for the given member.
-     *
-     * @param context the id of the context where the link will be added
-     * @param typeElement the typeElement that we should link to.  This is not
-                 necessarily equal to element.containingClass().  We may be
-                 inheriting comments
-     * @param element the member being linked to
-     * @param label the label for the link
-     * @return the link for the given member
-     */
-    public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            Content label) {
-        if (!(utils.isIncluded(element) || utils.isLinkable(typeElement))) {
-            return label;
-        } else if (utils.isExecutableElement(element)) {
-            ExecutableElement emd = (ExecutableElement) element;
-            return getLink(new LinkInfoImpl(configuration, context, typeElement)
-                    .label(label)
-                    .where(htmlIds.forMember(emd).name())
-                    .targetMember(element));
-        } else if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
-            return getLink(new LinkInfoImpl(configuration, context, typeElement)
-                    .label(label)
-                    .where(element.getSimpleName().toString())
-                    .targetMember(element));
-        } else {
-            return label;
-        }
     }
 
     public Content seeTagToContent(Element element, DocTree see) {
@@ -1900,8 +1855,7 @@ public class HtmlDocletWriter {
                 }
                 String simpleName = element.getSimpleName().toString();
                 if (multipleValues || !"value".equals(simpleName)) { // Omit "value=" where unnecessary
-                    annotation.add(getDocLink(LinkInfoImpl.Kind.ANNOTATION,
-                                                     element, simpleName, false));
+                    annotation.add(getDocLink(LinkInfoImpl.Kind.ANNOTATION, element, simpleName));
                     annotation.add("=");
                 }
                 AnnotationValue annotationValue = map.get(element);
@@ -2015,8 +1969,7 @@ public class HtmlDocletWriter {
             }
             @Override
             public Content visitEnumConstant(VariableElement c, Void p) {
-                return getDocLink(LinkInfoImpl.Kind.ANNOTATION,
-                        c, c.getSimpleName(), false);
+                return getDocLink(LinkInfoImpl.Kind.ANNOTATION, c, c.getSimpleName());
             }
             @Override
             public Content visitArray(List<? extends AnnotationValue> vals, Void p) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -939,9 +939,9 @@ public class HtmlDocletWriter {
      * Return the link for the given member.
      *
      * @param context the id of the context where the link will be printed.
-     * @param typeElement the typeElement that we should link to.  This is not
-                 necessarily equal to element.containingClass().  We may be
-                 inheriting comments.
+     * @param typeElement the typeElement that we should link to. This is not
+     *            not necessarily the type containing element since we may be
+     *            inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
      * @return the link for the given member.
@@ -955,9 +955,9 @@ public class HtmlDocletWriter {
      * Return the link for the given member.
      *
      * @param context the id of the context where the link will be printed.
-     * @param typeElement the typeElement that we should link to.  This is not
-    necessarily equal to element.containingClass().  We may be
-    inheriting comments.
+     * @param typeElement the typeElement that we should link to. This is not
+     *            not necessarily the type containing element since we may be
+     *            inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
      * @return the link for the given member.
@@ -971,9 +971,9 @@ public class HtmlDocletWriter {
      * Return the link for the given member.
      *
      * @param context the id of the context where the link will be printed.
-     * @param typeElement the typeElement that we should link to.  This is not
-                 necessarily equal to element.containingClass().  We may be
-                 inheriting comments.
+     * @param typeElement the typeElement that we should link to. This is not
+     *            not necessarily the type containing element since we may be
+     *            inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
      * @param isProperty true if the element parameter is a JavaFX property.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,7 +226,8 @@ public class IndexWriter extends HtmlDocletWriter {
             case ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
                 dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                        getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element, new StringContent(label))));
+                        getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element,
+                                new StringContent(label), false)));
                 dt.add(" - ");
                 addMemberDesc(element, containingType, dt);
                 break;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -39,7 +39,6 @@ import javax.lang.model.type.TypeMirror;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
-import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.Resources;
@@ -78,7 +77,6 @@ public class LinkFactoryImpl extends LinkFactory {
     protected Content getClassLink(LinkInfo linkInfo) {
         BaseConfiguration configuration = m_writer.configuration;
         LinkInfoImpl classLinkInfo = (LinkInfoImpl) linkInfo;
-        boolean noLabel = linkInfo.label == null || linkInfo.label.isEmpty();
         TypeElement typeElement = classLinkInfo.typeElement;
         // Create a tool tip if we are linking to a class or interface.  Don't
         // create one if we are linking to a member.
@@ -121,9 +119,6 @@ public class LinkFactoryImpl extends LinkFactory {
                                     filename.fragment(m_writer.htmlIds.forPreviewSection(target).name()),
                                     m_writer.contents.previewMark)));
                         }
-                        if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-                            link.add(getTypeParameterLinks(linkInfo));
-                        }
                         return link;
                 }
             }
@@ -140,9 +135,6 @@ public class LinkFactoryImpl extends LinkFactory {
                         m_writer.contents.previewMark,
                         false, false)));
                 }
-                if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-                    link.add(getTypeParameterLinks(linkInfo));
-                }
                 return link;
             }
         }
@@ -151,14 +143,11 @@ public class LinkFactoryImpl extends LinkFactory {
         if (flags.contains(ElementFlag.PREVIEW)) {
             link.add(HtmlTree.SUP(m_writer.contents.previewMark));
         }
-        if (noLabel && !classLinkInfo.excludeTypeParameterLinks) {
-            link.add(getTypeParameterLinks(linkInfo));
-        }
         return link;
     }
 
     @Override
-    protected Content getTypeParameterLinks(LinkInfo linkInfo, boolean isClassLabel) {
+    protected Content getTypeParameterLinks(LinkInfo linkInfo) {
         Content links = newContent();
         List<TypeMirror> vars = new ArrayList<>();
         TypeMirror ctype = linkInfo.type != null
@@ -176,8 +165,7 @@ public class LinkFactoryImpl extends LinkFactory {
             // Nothing to document.
             return links;
         }
-        if (((linkInfo.includeTypeInClassLinkLabel && isClassLabel)
-                || (linkInfo.includeTypeAsSepLink && !isClassLabel)) && !vars.isEmpty()) {
+        if (!vars.isEmpty()) {
             links.add("<");
             boolean many = false;
             for (TypeMirror t : vars) {
@@ -284,11 +272,6 @@ public class LinkFactoryImpl extends LinkFactory {
      * @param linkInfo the information about the link.
      */
     private DocPath getPath(LinkInfoImpl linkInfo) {
-        if (linkInfo.context == LinkInfoImpl.Kind.PACKAGE_FRAME) {
-            //Not really necessary to do this but we want to be consistent
-            //with 1.4.2 output.
-            return docPaths.forName(linkInfo.typeElement);
-        }
         return m_writer.pathToRoot.resolve(docPaths.forClass(linkInfo.typeElement));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -109,11 +109,6 @@ public class LinkInfoImpl extends LinkInfo {
         TREE,
 
         /**
-         * Indicate that the link appears in a class list.
-         */
-        PACKAGE_FRAME,
-
-        /**
          * The header in the class documentation.
          */
         CLASS_HEADER,
@@ -246,7 +241,8 @@ public class LinkInfoImpl extends LinkInfo {
      */
     public Element targetMember;
 
-    public  final Utils utils;
+    public final Utils utils;
+
     /**
      * Construct a LinkInfo object.
      *
@@ -362,22 +358,8 @@ public class LinkInfoImpl extends LinkInfo {
      * @param c the context id to set.
      */
     public final void setContext(Kind c) {
-        //NOTE:  Put context specific link code here.
         switch (c) {
-            case PACKAGE_FRAME:
-            case IMPLEMENTED_CLASSES:
-            case SUBCLASSES:
-            case EXECUTABLE_ELEMENT_COPY:
-            case PROPERTY_COPY:
-            case CLASS_USE_HEADER:
-                includeTypeInClassLinkLabel = false;
-                break;
-
             case ANNOTATION:
-                excludeTypeParameterLinks = true;
-                excludeTypeBounds = true;
-                break;
-
             case IMPLEMENTED_INTERFACES:
             case SUPER_INTERFACES:
             case SUBINTERFACES:
@@ -387,8 +369,6 @@ public class LinkInfoImpl extends LinkInfo {
             case PERMITTED_SUBCLASSES:
                 excludeTypeParameterLinks = true;
                 excludeTypeBounds = true;
-                includeTypeInClassLinkLabel = false;
-                includeTypeAsSepLink = true;
                 break;
 
             case PACKAGE:
@@ -397,13 +377,6 @@ public class LinkInfoImpl extends LinkInfo {
             case CLASS_SIGNATURE:
             case RECEIVER_TYPE:
                 excludeTypeParameterLinks = true;
-                includeTypeAsSepLink = true;
-                includeTypeInClassLinkLabel = false;
-                break;
-
-            case MEMBER_TYPE_PARAMS:
-                includeTypeAsSepLink = true;
-                includeTypeInClassLinkLabel = false;
                 break;
 
             case RETURN_TYPE:
@@ -414,11 +387,6 @@ public class LinkInfoImpl extends LinkInfo {
                 break;
         }
         context = c;
-        if (type != null &&
-            utils.isTypeVariable(type) &&
-            utils.isExecutableElement(utils.asTypeElement(type).getEnclosingElement())) {
-                excludeTypeParameterLinks = true;
-        }
     }
 
     /**
@@ -431,6 +399,33 @@ public class LinkInfoImpl extends LinkInfo {
     @Override
     public boolean isLinkable() {
         return configuration.utils.isLinkable(typeElement);
+    }
+
+    @Override
+    public boolean includeTypeParameterLinks() {
+        return switch (context) {
+            case IMPLEMENTED_INTERFACES,
+                 SUPER_INTERFACES,
+                 SUBINTERFACES,
+                 CLASS_TREE_PARENT,
+                 TREE,
+                 CLASS_SIGNATURE_PARENT_NAME,
+                 PERMITTED_SUBCLASSES,
+                 PACKAGE,
+                 CLASS_USE,
+                 CLASS_HEADER,
+                 CLASS_SIGNATURE,
+                 RECEIVER_TYPE,
+                 MEMBER_TYPE_PARAMS -> true;
+
+            case IMPLEMENTED_CLASSES,
+                 SUBCLASSES,
+                 EXECUTABLE_ELEMENT_COPY,
+                 PROPERTY_COPY,
+                 CLASS_USE_HEADER -> false;
+
+            default -> label == null || label.isEmpty();
+        };
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -154,8 +154,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                         holder, method,
                         utils.isIncluded(holder)
                                 ? utils.getSimpleName(holder)
-                                : utils.getFullyQualifiedName(holder),
-                            false);
+                                : utils.getFullyQualifiedName(holder));
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)
@@ -214,7 +213,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement, false);
+                LinkInfoImpl.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -328,7 +327,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
             dl.add(HtmlTree.DT(contents.specifiedByLabel));
             Content methlink = writer.getDocLink(
                     LinkInfoImpl.Kind.MEMBER, implementedMeth,
-                    implementedMeth.getSimpleName(), false);
+                    implementedMeth.getSimpleName());
             Content codeMethLink = HtmlTree.CODE(methlink);
             Content dd = HtmlTree.DD(codeMethLink);
             dd.add(Entity.NO_BREAK_SPACE);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -101,8 +101,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
 
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
-        Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement, false);
+        Content classLink = writer.getPreQualifiedClassLink(LinkInfoImpl.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isInterface(typeElement)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -115,8 +115,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                         writer.getDocLink(LinkInfoImpl.Kind.PROPERTY_COPY,
                         holder, property,
                         utils.isIncluded(holder)
-                                ? holder.getSimpleName() : holder.getQualifiedName(),
-                            false);
+                                ? holder.getSimpleName() : holder.getQualifiedName());
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)
@@ -168,7 +167,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement, false);
+                LinkInfoImpl.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -194,7 +193,6 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                 writer.getDocLink(context, typeElement,
                 member,
                 utils.getPropertyLabel(name(member)),
-                false,
                 true));
 
         Content code = HtmlTree.CODE(memberLink);
@@ -205,8 +203,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         String mname = name(member);
         Content content = writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member,
-                utils.isProperty(mname) ? utils.getPropertyName(mname) : mname,
-                false, true);
+                utils.isProperty(mname) ? utils.getPropertyName(mname) : mname, true);
         linksTree.add(content);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -352,7 +352,7 @@ public class TagletWriterImpl extends TagletWriter {
     @Override
     public Content valueTagOutput(VariableElement field, String constantVal, boolean includeLink) {
         return includeLink
-                ? htmlWriter.getDocLink(LinkInfoImpl.Kind.VALUE_TAG, field, constantVal, false)
+                ? htmlWriter.getDocLink(LinkInfoImpl.Kind.VALUE_TAG, field, constantVal)
                 : new StringContent(constantVal);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,6 @@ public abstract class LinkInfo {
     public boolean isVarArg = false;
 
     /**
-     * Set this to true to indicate that you are linking to a type parameter.
-     */
-    public boolean isTypeBound = false;
-
-    /**
      * The label for the link.
      */
     public Content label;
@@ -80,16 +75,6 @@ public abstract class LinkInfo {
     public boolean isStrong = false;
 
     /**
-     * True if we should include the type in the link label.  False otherwise.
-     */
-    public boolean includeTypeInClassLinkLabel = true;
-
-    /**
-     * True if we should include the type as separate link.  False otherwise.
-     */
-    public boolean includeTypeAsSepLink = false;
-
-    /**
      * True if we should exclude the type bounds for the type parameter.
      */
     public boolean excludeTypeBounds = false;
@@ -98,11 +83,6 @@ public abstract class LinkInfo {
      * True if we should print the type parameters, but not link them.
      */
     public boolean excludeTypeParameterLinks = false;
-
-    /**
-     * True if we should print the type bounds, but not link them.
-     */
-    public boolean excludeTypeBoundsLinks = false;
 
     /**
      * By default, the link can be to the page it's already on.  However,
@@ -116,20 +96,28 @@ public abstract class LinkInfo {
     public boolean skipPreview;
 
     /**
-     * Return an empty instance of a content object.
+     * Returns an empty instance of a content object.
      *
      * @return an empty instance of a content object.
      */
     protected abstract Content newContent();
 
     /**
-     * Return true if this link is linkable and false if we can't link to the
+     * Returns true if this link is linkable and false if we can't link to the
      * desired place.
      *
      * @return true if this link is linkable and false if we can't link to the
      * desired place.
      */
     public abstract boolean isLinkable();
+
+    /**
+     * Returns true if links to declared types should include links to the
+     * type parameters.
+     *
+     * @return true if type parameter links should be included
+     */
+    public abstract boolean includeTypeParameterLinks();
 
     /**
      * Return the label for this class link.
@@ -157,14 +145,10 @@ public abstract class LinkInfo {
                 ", executableElement=" + executableElement +
                 ", type=" + type +
                 ", isVarArg=" + isVarArg +
-                ", isTypeBound=" + isTypeBound +
                 ", label=" + label +
                 ", isStrong=" + isStrong +
-                ", includeTypeInClassLinkLabel=" + includeTypeInClassLinkLabel +
-                ", includeTypeAsSepLink=" + includeTypeAsSepLink +
                 ", excludeTypeBounds=" + excludeTypeBounds +
                 ", excludeTypeParameterLinks=" + excludeTypeParameterLinks +
-                ", excludeTypeBoundsLinks=" + excludeTypeBoundsLinks +
                 ", linkToSelf=" + linkToSelf + '}';
     }
 }


### PR DESCRIPTION
This is a cleanup of the javadoc link generating code.

There is a simple "horizontal" component to this change that removes the `strong` parameters from most `HtmlDocletWriter#getDocLink` methods which where the value used was always `false`, and related changes in all the code using these methods. 

The slightly more complex part of this change are changes in `LinkInfo[Impl]` and `LinkFactory[Impl]`. Here the target was to reduce the number of booean fields in `LinkInfo` and their interaction with the code, which was quite hard to grasp. I managed to replace several fields controlling generation of type parameter links with a single `includeTypeParameterLinks()` method. The use of this method and the remaining boolean fields in the code is quite straightforward. 

I also removed some bits of dead code and simplified the control flow a bit by trying to do things only in one place and one way when possible.

The code passes all javadoc tests and generates documentation identical to the old code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261263](https://bugs.openjdk.java.net/browse/JDK-8261263): Simplify javadoc link code


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2437/head:pull/2437`
`$ git checkout pull/2437`
