### PR TITLE
8228988: AnnotationParser throws NullPointerException on incompatible member type

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -358,10 +358,14 @@ public class AnnotationParser {
               result = parseConst(tag, buf, constPool);
         }
 
-        if (!(result instanceof ExceptionProxy) &&
-            !memberType.isInstance(result))
+        if (result == null) {
+            result = new AnnotationTypeMismatchExceptionProxy(
+                memberType.getClass().getName());
+        } else if (!(result instanceof ExceptionProxy) &&
+            !memberType.isInstance(result)) {
             result = new AnnotationTypeMismatchExceptionProxy(
                 result.getClass() + "[" + result + "]");
+        }
         return result;
     }
 
@@ -469,8 +473,10 @@ public class AnnotationParser {
         String typeName  = constPool.getUTF8At(typeNameIndex);
         int constNameIndex = buf.getShort() & 0xFFFF;
         String constName = constPool.getUTF8At(constNameIndex);
-
-        if (!typeName.endsWith(";")) {
+        if (!enumType.isEnum()) {
+            return new AnnotationTypeMismatchExceptionProxy(
+                typeName + "." + constName);
+        } else if (!typeName.endsWith(";")) {
             // support now-obsolete early jsr175-format class files.
             if (!enumType.getName().equals(typeName))
             return new AnnotationTypeMismatchExceptionProxy(

--- a/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/AnnotationTypeMismatchTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/AnnotationTypeMismatchTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8228988
+ * @summary An annotation-typed property of an annotation that is represented as an
+ *          incompatible property of another type should yield an AnnotationTypeMismatchException.
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @run main AnnotationTypeMismatchTest
+ */
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.Type;
+
+import java.lang.annotation.AnnotationTypeMismatchException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class AnnotationTypeMismatchTest {
+
+    public static void main(String[] args) throws Exception {
+        /*
+         * @AnAnnotation(value = AnEnum.VALUE) // would now be: value = @Value
+         * class Carrier { }
+         */
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, 0, "sample/Carrier", null, Type.getInternalName(Object.class), null);
+        AnnotationVisitor v = writer.visitAnnotation(Type.getDescriptor(AnAnnotation.class), true);
+        v.visitEnum("value", Type.getDescriptor(AnEnum.class), "VALUE");
+        writer.visitEnd();
+        byte[] b = writer.toByteArray();
+        ByteArrayClassLoader cl = new ByteArrayClassLoader(AnnotationTypeMismatchTest.class.getClassLoader());
+        cl.init(b);
+        AnAnnotation sample = cl.loadClass("sample.Carrier").getAnnotation(AnAnnotation.class);
+        try {
+            Value value = sample.value();
+            throw new IllegalStateException("Found value: " + value);
+        } catch (AnnotationTypeMismatchException e) {
+            // correct
+        }
+    }
+
+    public enum AnEnum {
+        VALUE
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnAnnotation {
+        Value value() default @Value;
+    }
+
+    public @interface Value { }
+
+    public static class ByteArrayClassLoader extends ClassLoader {
+
+        public ByteArrayClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        public void init(byte[] b) {
+            defineClass("sample.Carrier", b, 0, b.length);
+        }
+    }
+}

--- a/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/EnumTypeMismatchTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/EnumTypeMismatchTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8228988
+ * @summary An enumeration-typed property of an annotation that is represented as an
+ *          incompatible property of another type should yield an AnnotationTypeMismatchException.
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @run main EnumTypeMismatchTest
+ */
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.Type;
+
+import java.lang.annotation.AnnotationTypeMismatchException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class EnumTypeMismatchTest {
+
+    public static void main(String[] args) throws Exception {
+        /*
+         * @AnAnnotation(value = @AnAnnotation) // would now be: value = AnEnum.VALUE
+         * class Carrier { }
+         */
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, 0, "sample/Carrier", null, Type.getInternalName(Object.class), null);
+        AnnotationVisitor v = writer.visitAnnotation(Type.getDescriptor(AnAnnotation.class), true);
+        v.visitAnnotation("value", Type.getDescriptor(AnAnnotation.class)).visitEnd();
+        writer.visitEnd();
+        byte[] b = writer.toByteArray();
+        ByteArrayClassLoader cl = new ByteArrayClassLoader(EnumTypeMismatchTest.class.getClassLoader());
+        cl.init(b);
+        AnAnnotation sample = cl.loadClass("sample.Carrier").getAnnotation(AnAnnotation.class);
+        try {
+            AnEnum value = sample.value();
+            throw new IllegalStateException("Found value: " + value);
+        } catch (AnnotationTypeMismatchException e) {
+            // correct
+        }
+    }
+
+    public enum AnEnum {
+        VALUE
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnAnnotation {
+        AnEnum value() default AnEnum.VALUE;
+    }
+
+    public static class ByteArrayClassLoader extends ClassLoader {
+
+        public ByteArrayClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        void init(byte[] b) {
+            defineClass("sample.Carrier", b, 0, b.length);
+        }
+    }
+}


### PR DESCRIPTION
When a class is compiled against a version of an annotation that is later loaded in an incompatible manner where an enum-typed member is changed into an annotation or vice versa, the reflection API currently throws a `NullPointerException` upon accessing the member. Instead an `AnnotationTypeMismatchException` should be thrown.

This change adjusts the parsing to trigger the correct exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8228988](https://bugs.openjdk.java.net/browse/JDK-8228988): AnnotationParser throws NullPointerException on incompatible member type


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2439/head:pull/2439` \
`$ git checkout pull/2439`

Update a local copy of the PR: \
`$ git checkout pull/2439` \
`$ git pull https://git.openjdk.java.net/jdk pull/2439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2439`

View PR using the GUI difftool: \
`$ git pr show -t 2439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2439.diff">https://git.openjdk.java.net/jdk/pull/2439.diff</a>

</details>
