### PR TITLE
8058176: [mlvm] Tests should tolerate exceptions caused by code cache exhaustion.

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -142,13 +142,7 @@ vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening002.java 8208259 generic-all
 
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInBootstrap/TestDescription.java 8013267 generic-all
-vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java#id1 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8058176 generic-all
+vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8257761 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 8013267 generic-all

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,11 +55,15 @@ import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
 import vm.mlvm.meth.share.transform.v2.MHMacroTF;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
+import vm.mlvm.share.ThrowableTolerance;
 
 public class Test extends MlvmTest {
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    private static final ThrowableTolerance THROWABLE_TOLERANCE =
+        DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
 
     public static class Example {
         private Throwable t;
@@ -105,9 +109,24 @@ public class Test extends MlvmTest {
                 }
             }
 
+            if (THROWABLE_TOLERANCE.isAcceptable(t)) {
+                return true;
+            }
+
             getLog().complain("Got wrong exception!");
             t.printStackTrace(getLog().getOutStream());
             return false;
         }
     }
+
+    public static void main(String[] args) {
+        Env.setThrowableTolerance(THROWABLE_TOLERANCE);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            THROWABLE_TOLERANCE.ignoreOrRethrow(t);
+        }
+    }
+
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ import java.lang.invoke.MethodType;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
 import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 import vm.mlvm.share.MultiThreadedTest;
@@ -167,5 +168,14 @@ public class Test extends MultiThreadedTest {
         return true;
     }
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,16 +64,16 @@ import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
 import vm.mlvm.meth.share.transform.v2.MHMacroTF;
+import vm.mlvm.share.DefaultThrowableTolerance;
 import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
+import vm.mlvm.share.MultiThreadedTest;
+
+import nsk.share.ArgumentParser;
 
 // TODO: check that i2c/c2i adapters are really created
 // TODO: check deopt using vm.mlvm.share.comp framework
-// TODO: use multi-threaded test framework
-public class Test extends MlvmTest {
-
-    private static final int THREADS
-            = Runtime.getRuntime().availableProcessors();
+public class Test extends MultiThreadedTest {
 
     Object finalTarget() {
         return new Integer(0);
@@ -106,80 +106,112 @@ public class Test extends MlvmTest {
         }
     }
 
-    volatile A intermediateTarget;
-
     Object callIntemediateTarget() throws Throwable {
         return this.intermediateTarget.m();
     }
 
-    CyclicBarrier startBarrier = new CyclicBarrier(THREADS + 1);
-
+    private int threadsQty;
     volatile boolean testDone = false;
+    MHMacroTF tLists[];
+    MethodHandle mhM;
+    Argument[] finalArgs;
+    Argument finalRetVal;
+    MethodHandle mhB;
+    volatile A intermediateTarget;
 
     @Override
     public boolean run() throws Throwable {
+        threadsQty = calcThreadNum();
+        tLists = new MHMacroTF[threadsQty - 1];
 
-        final MethodHandle mhB = MethodHandles.lookup().findVirtual(Test.class,
+        mhB = MethodHandles.lookup().findVirtual(Test.class,
                 "finalTarget", MethodType.methodType(Object.class));
 
-        final Argument finalRetVal = Argument.fromValue(new Integer(0));
+        finalRetVal = Argument.fromValue(new Integer(0));
         finalRetVal.setPreserved(true);
 
-        this.intermediateTarget = new A(
+        intermediateTarget = new A(
                 MHTransformationGen.createSequence(finalRetVal, Test.this, mhB,
                         RandomArgumentsGen.createRandomArgs(true, mhB.type())));
 
-        final MethodHandle mhM = MethodHandles.lookup().findVirtual(Test.class,
+        mhM = MethodHandles.lookup().findVirtual(Test.class,
                 "callIntemediateTarget", MethodType.methodType(Object.class));
 
-        final Argument[] finalArgs = RandomArgumentsGen.createRandomArgs(true,
-                mhM.type());
+        finalArgs = RandomArgumentsGen.createRandomArgs(true, mhM.type());
 
-        Thread[] threads = new Thread[THREADS];
-        for (int t = 0; t < THREADS; t++) {
-            (threads[t] = new Thread("Stresser " + t) {
+        return super.run();
+    }
 
-                public void run() {
-                    try {
-                        MHMacroTF tList = MHTransformationGen.createSequence(
-                                finalRetVal, Test.this, mhM, finalArgs);
-                        Test.this.startBarrier.await();
-                        while ( ! Test.this.testDone) {
-                            int e = (Integer) Test.this.intermediateTarget.m();
-                            int r = (Integer) MHTransformationGen.callSequence(
-                                    tList, false);
-                            if (r != e)
-                                Env.traceNormal("Wrong result in thread "
-                                        + getName() + ", but this is OK");
-                        }
-                        Env.traceVerbose("Thread " + getName()+ ": work done");
-                    } catch (Throwable t) {
-                        markTestFailed("Exception in thread " + getName(), t);
-                    }
-                }
-            }).start();
+    @Override
+    protected void prepareThread(int threadNum) throws Throwable {
+        if (isStresserThread(threadNum)) {
+            Thread.currentThread().setName("Stresser " + threadNum);
+            tLists[threadNum] = MHTransformationGen.createSequence(
+                    finalRetVal, Test.this, mhM, finalArgs);
+        } else {
+            Thread.currentThread().setName("Controller");
+        }
+    };
+
+    @Override
+    public boolean runThread(int t) throws Throwable {
+        if (isStresserThread(t)) {
+            runStresserThread(t);
+        } else {
+            runControllerThread();
         }
 
-        this.startBarrier.await();
-        Env.traceImportant("Threads started");
-
-        Thread.sleep(3000);
-
-        Env.traceImportant("Deoptimizing");
-        // Force deoptimization in uncommon trap logic
-        this.intermediateTarget = (A) Test.class.getClassLoader().loadClass(
-                Test.class.getName() + "$B").newInstance();
-
-        Thread.sleep(3000);
-
-        this.testDone = true;
-        for (int t = 0; t < THREADS; t++)  {
-            threads[t].join();
-        }
+        // It's exceptions and errors are what we're hunting for, not some
+        // correct values. Hence always true
         return true;
     }
 
+    private boolean isStresserThread(int threadNum) { return threadNum < threadsQty - 1; }
+
+    private void runStresserThread(int t) throws Throwable {
+        while ( ! Test.this.testDone) {
+            int e = (Integer) Test.this.intermediateTarget.m();
+            int r = (Integer) MHTransformationGen.callSequence(
+                    tLists[t], false);
+            if (r != e)
+                Env.traceNormal("Wrong result in thread "
+                        + getName() + ", but this is OK");
+        }
+        Env.traceVerbose("Thread " + getName()+ ": work done");
+    }
+
+    private void runControllerThread() {
+        try {
+            Env.traceImportant("Threads started");
+
+            Thread.sleep(3000);
+
+            Env.traceImportant("Deoptimizing");
+            // Force deoptimization in uncommon trap logic
+            this.intermediateTarget = (A) Test.class.getClassLoader().loadClass(
+                    Test.class.getName() + "$B").newInstance();
+
+            Thread.sleep(3000);
+        } catch (Throwable t) {
+            Env.getThrowableTolerance().ignoreOrRethrow(t);
+        } finally {
+            this.testDone = true;
+        }
+    }
+
     public static void main(String[] args) {
-        MlvmTest.launch(args);
+        var parser = new ArgumentParser(args);
+        if (!parser.getOptions().containsKey("threadsPerCpu")) {
+            parser.setOption("-", "threadsPerCpu", "1");
+        }
+
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(parser);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ import nsk.share.test.Stresser;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 import vm.mlvm.share.MultiThreadedTest;
 
@@ -105,5 +107,14 @@ public class Test extends MultiThreadedTest {
         return true;
     }
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,13 +61,11 @@ import nsk.share.test.Stresser;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 
 public class Test extends MlvmTest {
-
-    public static void main(String[] args) {
-        MlvmTest.launch(args);
-    }
 
     @Override
     public boolean run() throws Throwable {
@@ -139,4 +137,16 @@ public class Test extends MlvmTest {
         }
 
     }
+
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
+
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,13 +60,11 @@ import java.lang.invoke.MethodType;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 
 public class Test extends MlvmTest {
-
-    public static void main(String[] args) {
-        MlvmTest.launch(args);
-    }
 
     public static class Example {
         private Argument[] finalArgs;
@@ -115,5 +113,16 @@ public class Test extends MlvmTest {
         }
 
         return true;
+    }
+
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/DefaultThrowableTolerance.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/DefaultThrowableTolerance.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package vm.mlvm.share;
+
+/**
+ * A collection of default implementations for {@link ThrowableTolerance}.
+ */
+public class DefaultThrowableTolerance {
+
+    /**
+     * Does not accept any Throwable
+     *
+     * @param ignored Added to satisfy the interface API, always ignored.
+     * @return Always false
+     */
+    public static final ThrowableTolerance INTOLERANT = (Throwable ignored) -> { return false; };
+
+    /**
+     * Accepts only OutOfMemoryError with cause having 'Out of space' substring.
+     *
+     * Is useful for Code Cache depletion errors, for example. Scans the Throwable
+     * hierarchy in search for acceptable Throwable as an underlying cause.
+     * @param what Added to satisfy the interface API, is ignored.
+     * @return Always false
+     */
+    public static final ThrowableTolerance CODE_CACHE_OOME_ALLOWED = (Throwable what) -> {
+        Throwable cause = what;
+        do {
+            if (cause instanceof VirtualMachineError
+                    && cause.getMessage().matches(".*[Oo]ut of space.*")) {
+                return true;
+            }
+            cause = cause != null ? cause.getCause() : null;
+        } while (cause != null && cause != what);
+        return false;
+    };
+}

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/Env.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class Env {
     private static class StaticHolder {
         public static ArgumentParser argParser;
         public static Log log;
+        public static ThrowableTolerance throwableTolerance = DefaultThrowableTolerance.INTOLERANT;
         static {
             init(new String[0]);
         }
@@ -48,6 +49,14 @@ public class Env {
             StaticHolder.argParser = ap;
             StaticHolder.log = new Log(System.out, StaticHolder.argParser);
         }
+    }
+
+    public static ThrowableTolerance getThrowableTolerance() {
+        return StaticHolder.throwableTolerance;
+    }
+
+    public static void setThrowableTolerance(ThrowableTolerance to) {
+        StaticHolder.throwableTolerance = to;
     }
 
     public static ArgumentParser getArgParser() {
@@ -169,7 +178,9 @@ public class Env {
     }
 
     public static void complain(Throwable t, String msg, Object... args) {
-        getLog().complain(new LazyFormatString(msg, args), t);
+        if (!StaticHolder.throwableTolerance.isAcceptable(t)) {
+           getLog().complain(new LazyFormatString(msg, args), t);
+        }
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -378,20 +378,18 @@ public class MlvmTestExecutor {
                 }
 
                 boolean instancePassed;
-                if (expectedExceptions.size() == 0) {
+                try {
                     instancePassed = instance.run();
-                } else {
-                    try {
-                        instance.run();
+                    if (!expectedExceptions.isEmpty()) {
                         Env.complain("Expected exceptions: " + expectedExceptions + ", but caught none");
                         instancePassed = false;
-                    } catch (Throwable e) {
-                        if (checkExpectedException(expectedExceptions, e)) {
-                            instancePassed = true;
-                        } else {
-                            Env.complain(e, "Expected exceptions: " + expectedExceptions + ", but caught: ");
-                            instancePassed = false;
-                        }
+                    }
+                } catch (Throwable t) {
+                    if (checkExpectedException(expectedExceptions, t)) {
+                        instancePassed = true;
+                    } else {
+                        Env.complain(t, "Expected exceptions: " + expectedExceptions + ", but caught: ");
+                        instancePassed = false;
                     }
                 }
 
@@ -468,7 +466,7 @@ public class MlvmTestExecutor {
             }
         }
 
-        return false;
+        return Env.getThrowableTolerance().isAcceptable(caught);
     }
 
     private static class RunnableWrapper extends MlvmTest {

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MultiThreadedTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MultiThreadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public abstract class MultiThreadedTest extends MlvmTest {
     }
 
     protected abstract boolean runThread(int threadNum) throws Throwable;
+    protected void prepareThread(int threadNum) throws Throwable { };
 
     protected int calcThreadNum() {
         // TODO: multiply by StressThreadFactor: JDK-8142970
@@ -66,8 +67,11 @@ public abstract class MultiThreadedTest extends MlvmTest {
             final int ii = i;
             threads[i] = new Thread(() -> {
                 boolean passed = false;
+                boolean needToTriggerBarrier = true;
                 try {
+                    prepareThread(ii);
                     startBarrier.await();
+                    needToTriggerBarrier = false;
                     if (runThread(ii)) {
                         passed = true;
                     } else {
@@ -75,8 +79,17 @@ public abstract class MultiThreadedTest extends MlvmTest {
                                 Thread.currentThread());
                     }
                 } catch (Throwable e) {
-                    Env.complain(e, "Caught exception in %s",
-                            Thread.currentThread());
+                    if (Env.getThrowableTolerance().isAcceptable(e)) {
+                        passed = true;
+                        if (needToTriggerBarrier) try {
+                            startBarrier.await();
+                        } catch (Throwable tt) {
+                            Env.getThrowableTolerance().ignoreOrRethrow(tt);
+                        }
+                    } else {
+                        Env.complain(e, "Caught exception in %s",
+                                Thread.currentThread());
+                    }
                 }
                 if (!passed) {
                     markTestFailed("Thread " + Thread.currentThread()

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/ThrowableTolerance.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/ThrowableTolerance.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+package vm.mlvm.share;
+
+/**
+ * A utility interface for allowing to control ignored or acceptable exceptions
+ */
+public interface ThrowableTolerance {
+
+    /**
+     * Checks if passed Throwable is acceptable.
+     * @param what Exception to check
+     * @return Whether the exception is acceptable or not.
+     */
+    boolean isAcceptable(Throwable what);
+
+    /**
+     * Checks if passed Throwable is acceptable and ignores it, or rethrows otherwise.
+     * @param what Exception to check
+     */
+    default void ignoreOrRethrow(Throwable what) {
+        if (!isAcceptable(what)) {
+            Env.throwAsUncheckedException(what); // Report inacceptable exception
+        }
+    }
+
+}


### PR DESCRIPTION
A repetition of the #1622.

1. Normalise meth/stress/compiler/i2c_c2i/Test.java to use MultiThreadedTest framework;
2. Adjust MultiThreadedTest in order to accomodate the i2c_c2i test (add prepareThread method and logic);
3. Add ThrowableTolerance and DefaultThrowableTolerance as ways to control what Throwables are accepted;
4. Adjust MultiThreadedTest to catch Throwables and check if they are accepted;
5. Adjust individual tests to catch possible Throwables and check if they are accepted;
6. Un-problemlist the failing tests.

Testing vmTestBase/vm/mlvm/meth/stress run on macos-linux-windows (30 runs each) in x64 configurations, rebased on top of latest code base. Code cache was limited `-XX:ReservedCodeCacheSize=8M` as suggested in the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8058176](https://bugs.openjdk.java.net/browse/JDK-8058176)

### Issue
 * [JDK-8058176](https://bugs.openjdk.java.net/browse/JDK-8058176): [mlvm] tests should tolerate exceptions caused by code cache exhaustion ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2440/head:pull/2440`
`$ git checkout pull/2440`
