### PR TITLE
8261209: isStandalone property: remove dependency on pretty-print

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToXMLStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToXMLStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -40,7 +40,7 @@ import org.xml.sax.SAXException;
  * be viewed as internal or package private, this is not an API.
  *
  * @xsl.usage internal
- * @LastModified: Aug 2019
+ * @LastModified: Feb 2021
  */
 public final class ToXMLStream extends ToStream
 {
@@ -171,7 +171,7 @@ public final class ToXMLStream extends ToStream
                     writer.write('\"');
                     writer.write(standalone);
                     writer.write("?>");
-                    if (m_doIndent) {
+                    if (m_doIndent || m_isStandalone) {
                         if (m_standaloneWasSpecified
                                 || getDoctypePublic() != null
                                 || getDoctypeSystem() != null

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -217,9 +217,7 @@
  * <th scope="row" style="font-weight:normal" id="ISSTANDALONE">isStandalone</th>
  * <td>indicates that the serializer should treat the output as a
  * standalone document. The property can be used to ensure a newline is written
- * after the XML declaration when the property
- * {@link org.w3c.dom.ls.LSSerializer#getDomConfig() format-pretty-print} is set
- * to true. Unlike the property
+ * after the XML declaration. Unlike the property
  * {@link org.w3c.dom.ls.LSSerializer#getDomConfig() xml-declaration}, this property
  * does not have an effect on whether an XML declaration should be written out.
  * </td>


### PR DESCRIPTION
A quick fix to remove isStandalone's dependency on pretty-print.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261209](https://bugs.openjdk.java.net/browse/JDK-8261209): isStandalone property: remove dependency on pretty-print


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2442/head:pull/2442`
`$ git checkout pull/2442`
