### PR TITLE
8261270: MakeMethodNotCompilableTest fails with -XX:TieredStopAtLevel={1,2,3}

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
@@ -201,7 +201,7 @@ public class MakeMethodNotCompilableTest extends CompilerWhiteBoxTest {
                 deoptimize();
             }
 
-            if (!isCompilable(COMP_LEVEL_ANY)) {
+            if (!isCompilable(COMP_LEVEL_ANY) && TIERED_STOP_AT_LEVEL == COMP_LEVEL_FULL_OPTIMIZATION) {
                 throw new RuntimeException(method
                         + " must be compilable at 'CompLevel::CompLevel_any'"
                         + ", if it is not compilable only at " + testedTier);


### PR DESCRIPTION
JDK-8251462 changed semantics of CompilationPolicy::highest_compile_level() and CompilationPolicy::can_be_compiled() to take into the account compiler availability due to command line flags restrictions. For example, if C2 is not available because of the TieredStopAtLevel setting, the answer to these queries will be that the highest level is 3, and that methods can't be compiled at level 4. 

MakeMethodNotCompilableTest.java assumes (even in the presence of the mentioned restrictions) that with tiered compilation it is always the case that both compilers can be used.

This change fixes the test to take this into account.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261270](https://bugs.openjdk.java.net/browse/JDK-8261270): MakeMethodNotCompilableTest fails with -XX:TieredStopAtLevel={1,2,3}


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2443/head:pull/2443`
`$ git checkout pull/2443`
