### PR TITLE
8261229: MethodData is not correctly initialized with TieredStopAtLevel=3

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -80,7 +80,7 @@ bool CompilationModeFlag::initialize() {
 
   // Now that the flag is parsed, we can use any methods of CompilerConfig.
   if (normal()) {
-    if (CompilerConfig::is_c1_only()) {
+    if (CompilerConfig::is_c1_simple_only()) {
       _mode = Mode::QUICK_ONLY;
     } else if (CompilerConfig::is_c2_or_jvmci_compiler_only()) {
       _mode = Mode::HIGH_ONLY;

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -662,7 +662,7 @@ MethodData* MethodData::allocate(ClassLoaderData* loader_data, const methodHandl
 }
 
 int MethodData::bytecode_cell_count(Bytecodes::Code code) {
-  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter && !WhiteBoxAPI) {
+  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter) {
     return no_profile_data;
   }
   switch (code) {
@@ -969,7 +969,7 @@ int MethodData::compute_allocation_size_in_words(const methodHandle& method) {
 // the segment in bytes.
 int MethodData::initialize_data(BytecodeStream* stream,
                                        int data_index) {
-  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter && !WhiteBoxAPI) {
+  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter) {
     return 0;
   }
   int cell_count = -1;

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -662,7 +662,7 @@ MethodData* MethodData::allocate(ClassLoaderData* loader_data, const methodHandl
 }
 
 int MethodData::bytecode_cell_count(Bytecodes::Code code) {
-  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter) {
+  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter && !WhiteBoxAPI) {
     return no_profile_data;
   }
   switch (code) {
@@ -969,7 +969,7 @@ int MethodData::compute_allocation_size_in_words(const methodHandle& method) {
 // the segment in bytes.
 int MethodData::initialize_data(BytecodeStream* stream,
                                        int data_index) {
-  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter) {
+  if (CompilerConfig::is_c1_simple_only() && !ProfileInterpreter && !WhiteBoxAPI) {
     return 0;
   }
   int cell_count = -1;


### PR DESCRIPTION
Mostly a typo in compilation mode ergonomics that selected a quick-only mode essentially when the user specified TieredStopAtLevel={1,2,3}. The quick-only mode has an optimization that eliminates parts of the MDO since they are not needed. Meanwhile, the WB API considered it a fair game to request a level 3 compile, that requires a full MDO.

The fix corrects the original issue and also tries to be extra defensive with WB API (since it's semantics is not clearly specified) by always allocating full MDO if WB API is on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261229](https://bugs.openjdk.java.net/browse/JDK-8261229): MethodData is not correctly initialized with TieredStopAtLevel=3


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2444/head:pull/2444`
`$ git checkout pull/2444`
