### PR TITLE
8261094: Open javax/swing/text/html/CSS/4765271/bug4765271.java

### DIFF
--- a/test/jdk/javax/swing/text/html/CSS/4765271/bug4765271.java
+++ b/test/jdk/javax/swing/text/html/CSS/4765271/bug4765271.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Shape;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.AbstractDocument.AbstractElement;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.View;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
+
+/*
+ * @test
+ * @bug 4765271 8231286
+ * @summary  Tests if JEditorPane displays text with proper size
+ * @run main bug4765271
+ */
+public class bug4765271 {
+
+    // The default resolution for screen
+    private static final int RES = 96;
+
+    private static final String TEXT =
+            "<html>" +
+            "<body>" +
+            "<span style=\"font-size: 72pt  \">A</span>" +
+            "<span style=\"font-size: 6pc   \">B</span>" +
+            "<span style=\"font-size: " + RES + "px  \">C</span>" +
+            "<span style=\"font-size: 25.4mm\">D</span>" +
+            "<span style=\"font-size: 2.54cm\">E</span>" +
+            "<span style=\"font-size: 1in   \">F</span>" +
+            "</body>" +
+            "</html>";
+
+    private JEditorPane jep;
+
+    private final boolean showFrame;
+    private final AtomicBoolean passed = new AtomicBoolean(true);
+
+    public bug4765271(boolean showFrame) {
+        this.showFrame = showFrame;
+    }
+
+    public void init() {
+        System.out.println("res = " + RES);
+
+        jep = new JEditorPane();
+        jep.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(TEXT);
+
+        if (showFrame) {
+            JFrame f = new JFrame("Reg test for bug4765271");
+            f.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            f.getContentPane().add(jep);
+            f.pack();
+            f.setVisible(true);
+        } else {
+            jep.setSize(jep.getPreferredSize());
+        }
+    }
+
+    public void test() {
+        Shape r = jep.getBounds();
+        View v = jep.getUI().getRootView(jep);
+        while (!(v instanceof javax.swing.text.html.InlineView)) {
+            String viewName = v.getClass().getName();
+            int n = v.getViewCount();
+            if (viewName.endsWith("Row")) {
+                break;
+            }
+            Shape sh = v.getChildAllocation(n - 1,  r);
+            if (sh != null) {
+                r = sh;
+            }
+            v = v.getView(n - 1);
+        }
+
+        Shape sh = v.getChildAllocation(0,  r);
+        int h1 = sh.getBounds().height;
+        StyleSheet ss = ((HTMLDocument) v.getDocument()).getStyleSheet();
+        View childView = v.getView(0);
+        AttributeSet attrs = childView.getAttributes();
+        Font font = ss.getFont(attrs);
+        int size1 = font.getSize();
+        System.out.println("Font Size for InlineView #0 = " + size1 + "; height = " + h1 + "; element = {");
+        ((AbstractElement) childView.getElement()).dump(System.out, 3);
+        System.out.println("}");
+
+        boolean testPassed = true;
+        int n = v.getViewCount() - 1;
+        for (int i = 1; i < n; i++) {
+            sh = v.getChildAllocation(i,  r);
+            int h2 = sh.getBounds().height;
+            childView = v.getView(i);
+            attrs = childView.getAttributes();
+            font = ss.getFont(attrs);
+            int size2 = font.getSize();
+            System.out.println("Font Size for InlineView #" + i + " = " + size2 + "; height = " + h2 + "; element = {");
+            ((AbstractElement) childView.getElement()).dump(System.out, 3);
+            System.out.println("}");
+            testPassed &= ((size1 == size2) && (h1 == h2));
+        }
+        passed.set(testPassed);
+    }
+
+    public static void main(String[] args) throws Exception {
+        bug4765271 test = new bug4765271(
+                (args.length > 0) && "-show".equals(args[0]));
+
+        SwingUtilities.invokeAndWait(() -> {
+            test.init();
+            test.test();
+        });
+
+        if (!test.passed.get()) {
+            throw new RuntimeException("Test failed");
+        } else {
+            System.out.println("Test succeeded");
+        }
+    }
+}


### PR DESCRIPTION
This test verifies the CSS unit mappings when `JEditorPane.W3C_LENGTH_UNITS` is in effect.

The test needs to be modified to take into account the changes under [JDK-8231286](https://bugs.openjdk.java.net/browse/JDK-8231286): _HTML font size too large with high-DPI scaling and W3C_LENGTH_UNITS_. Once the changeset for JDK-8231286 is integrated, the `bug4765271.java` test will fail on High DPI systems or systems where the default screen resolution (dpi) as returned by `Toolkit.getScreenResolution()` is not 96.

JDK-8231286 makes the font size consistent with what one sees in browsers. The scenarios where the dpi is higher are handled by Java 2D transforms. Thus the unit mappings should not depend on the resolution.

The updated test can be run headless. For debugging purposes and visual inspection, pass `-show` parameter to the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261094](https://bugs.openjdk.java.net/browse/JDK-8261094): Open javax/swing/text/html/CSS/4765271/bug4765271.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2445/head:pull/2445`
`$ git checkout pull/2445`
