### PR TITLE
8261282: Lazy initialization of built-in ICC_Profile/ColorSpace classes is too lazy

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -116,14 +116,14 @@ public abstract class ColorSpace implements Serializable {
     private interface BuiltInSpace {
         ICC_ColorSpace SRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
+        ICC_ColorSpace LRGB =
+                new ICC_ColorSpace(ICC_Profile.getInstance(CS_LINEAR_RGB));
         ICC_ColorSpace XYZ =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_CIEXYZ));
         ICC_ColorSpace PYCC =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_PYCC));
         ICC_ColorSpace GRAY =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_GRAY));
-        ICC_ColorSpace LRGB =
-                new ICC_ColorSpace(ICC_Profile.getInstance(CS_LINEAR_RGB));
     }
 
     /**
@@ -306,10 +306,10 @@ public abstract class ColorSpace implements Serializable {
     public static ColorSpace getInstance(int cspace) {
         return switch (cspace) {
             case CS_sRGB -> BuiltInSpace.SRGB;
+            case CS_LINEAR_RGB -> BuiltInSpace.LRGB;
             case CS_CIEXYZ -> BuiltInSpace.XYZ;
             case CS_PYCC -> BuiltInSpace.PYCC;
             case CS_GRAY -> BuiltInSpace.GRAY;
-            case CS_LINEAR_RGB -> BuiltInSpace.LRGB;
             default -> {
                 throw new IllegalArgumentException("Unknown color space");
             }

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -114,11 +114,16 @@ public abstract class ColorSpace implements Serializable {
      * The lazy cache of singletons for the predefined built-in color spaces.
      */
     private interface BuiltInSpace {
+
         ColorSpace SRGB = new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
+
         ColorSpace LRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_LINEAR_RGB));
+
         ColorSpace XYZ = new ICC_ColorSpace(ICC_Profile.getInstance(CS_CIEXYZ));
+
         ColorSpace PYCC = new ICC_ColorSpace(ICC_Profile.getInstance(CS_PYCC));
+
         ColorSpace GRAY = new ICC_ColorSpace(ICC_Profile.getInstance(CS_GRAY));
     }
 

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -39,8 +39,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.lang.annotation.Native;
 
-import sun.java2d.cmm.CMSManager;
-
 /**
  * This abstract class is used to serve as a color space tag to identify the
  * specific color space of a {@code Color} object or, via a {@code ColorModel}
@@ -115,24 +113,17 @@ public abstract class ColorSpace implements Serializable {
     /**
      * The cache of singletons for the predefined built-in color spaces.
      */
-    private static final class BuiltInSpace {
-
-        private static final ColorSpace SRGB =
+    private interface BuiltInSpace {
+        ICC_ColorSpace SRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
-        private static final ColorSpace XYZ =
+        ICC_ColorSpace XYZ =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_CIEXYZ));
-        private static final ColorSpace PYCC =
+        ICC_ColorSpace PYCC =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_PYCC));
-        private static final ColorSpace GRAY =
+        ICC_ColorSpace GRAY =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_GRAY));
-        private static final ColorSpace LRGB =
+        ICC_ColorSpace LRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_LINEAR_RGB));
-
-        static {
-            /* to allow access from java.awt.ColorModel */
-            CMSManager.GRAYspace = GRAY;
-            CMSManager.LINEAR_RGBspace = LRGB;
-        }
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -113,11 +113,11 @@ public abstract class ColorSpace implements Serializable {
     private transient String [] compName = null;
 
     // Cache of singletons for the predefined color spaces.
-    private static ColorSpace sRGBspace;
-    private static ColorSpace XYZspace;
-    private static ColorSpace PYCCspace;
-    private static ColorSpace GRAYspace;
-    private static ColorSpace LINEAR_RGBspace;
+    private static volatile ColorSpace sRGBspace;
+    private static volatile ColorSpace XYZspace;
+    private static volatile ColorSpace PYCCspace;
+    private static volatile ColorSpace GRAYspace;
+    private static volatile ColorSpace LINEAR_RGBspace;
 
     /**
      * Any of the family of XYZ color spaces.
@@ -289,88 +289,76 @@ public abstract class ColorSpace implements Serializable {
      * Returns a {@code ColorSpace} representing one of the specific predefined
      * color spaces.
      *
-     * @param  colorspace a specific color space identified by one of the
-     *         predefined class constants (e.g. {@code CS_sRGB},
-     *         {@code CS_LINEAR_RGB}, {@code CS_CIEXYZ}, {@code CS_GRAY}, or
-     *         {@code CS_PYCC})
+     * @param  cspace a specific color space identified by one of the predefined
+     *         class constants (e.g. {@code CS_sRGB}, {@code CS_LINEAR_RGB},
+     *         {@code CS_CIEXYZ}, {@code CS_GRAY}, or {@code CS_PYCC})
      * @return the requested {@code ColorSpace} object
      */
     // NOTE: This method may be called by privileged threads.
     //       DO NOT INVOKE CLIENT CODE ON THIS THREAD!
-    public static ColorSpace getInstance (int colorspace)
-    {
-    ColorSpace    theColorSpace;
-
-        switch (colorspace) {
-        case CS_sRGB:
-            synchronized(ColorSpace.class) {
+    public static ColorSpace getInstance(int cspace) {
+        switch (cspace) {
+            case CS_sRGB -> {
                 if (sRGBspace == null) {
-                    ICC_Profile theProfile = ICC_Profile.getInstance (CS_sRGB);
-                    sRGBspace = new ICC_ColorSpace (theProfile);
+                    synchronized (ColorSpace.class) {
+                        if (sRGBspace == null) {
+                            sRGBspace = new ICC_ColorSpace(
+                                    ICC_Profile.getInstance(cspace));
+                        }
+                    }
                 }
-
-                theColorSpace = sRGBspace;
+                return sRGBspace;
             }
-            break;
-
-        case CS_CIEXYZ:
-            synchronized(ColorSpace.class) {
+            case CS_CIEXYZ -> {
                 if (XYZspace == null) {
-                    ICC_Profile theProfile =
-                        ICC_Profile.getInstance (CS_CIEXYZ);
-                    XYZspace = new ICC_ColorSpace (theProfile);
+                    synchronized (ColorSpace.class) {
+                        if (XYZspace == null) {
+                            XYZspace = new ICC_ColorSpace(
+                                    ICC_Profile.getInstance(cspace));
+                        }
+                    }
                 }
-
-                theColorSpace = XYZspace;
+                return XYZspace;
             }
-            break;
-
-        case CS_PYCC:
-            synchronized(ColorSpace.class) {
+            case CS_PYCC -> {
                 if (PYCCspace == null) {
-                    ICC_Profile theProfile = ICC_Profile.getInstance (CS_PYCC);
-                    PYCCspace = new ICC_ColorSpace (theProfile);
+                    synchronized (ColorSpace.class) {
+                        if (PYCCspace == null) {
+                            PYCCspace = new ICC_ColorSpace(
+                                    ICC_Profile.getInstance(cspace));
+                        }
+                    }
                 }
-
-                theColorSpace = PYCCspace;
+                return PYCCspace;
             }
-            break;
-
-
-        case CS_GRAY:
-            synchronized(ColorSpace.class) {
+            case CS_GRAY -> {
                 if (GRAYspace == null) {
-                    ICC_Profile theProfile = ICC_Profile.getInstance (CS_GRAY);
-                    GRAYspace = new ICC_ColorSpace (theProfile);
-                    /* to allow access from java.awt.ColorModel */
-                    CMSManager.GRAYspace = GRAYspace;
+                    synchronized (ColorSpace.class) {
+                        if (GRAYspace == null) {
+                            /* to allow access from java.awt.ColorModel */
+                            CMSManager.GRAYspace = new ICC_ColorSpace(
+                                    ICC_Profile.getInstance(cspace));
+                            GRAYspace = CMSManager.GRAYspace;
+                        }
+                    }
                 }
-
-                theColorSpace = GRAYspace;
+                return GRAYspace;
             }
-            break;
-
-
-        case CS_LINEAR_RGB:
-            synchronized(ColorSpace.class) {
+            case CS_LINEAR_RGB -> {
                 if (LINEAR_RGBspace == null) {
-                    ICC_Profile theProfile =
-                        ICC_Profile.getInstance(CS_LINEAR_RGB);
-                    LINEAR_RGBspace = new ICC_ColorSpace (theProfile);
-                    /* to allow access from java.awt.ColorModel */
-                    CMSManager.LINEAR_RGBspace = LINEAR_RGBspace;
+                    synchronized (ColorSpace.class) {
+                        if (LINEAR_RGBspace == null) {
+                            /* to allow access from java.awt.ColorModel */
+                            CMSManager.LINEAR_RGBspace = new ICC_ColorSpace(
+                                    ICC_Profile.getInstance(cspace));
+                            LINEAR_RGBspace = CMSManager.LINEAR_RGBspace;
+                        }
+                    }
                 }
-
-                theColorSpace = LINEAR_RGBspace;
+                return LINEAR_RGBspace;
             }
-            break;
-
-
-        default:
-            throw new IllegalArgumentException ("Unknown color space");
+            default -> throw new IllegalArgumentException("Unknown color space");
         }
-
-        return theColorSpace;
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -116,6 +116,7 @@ public abstract class ColorSpace implements Serializable {
      * The cache of singletons for the predefined built-in color spaces.
      */
     private static final class BuiltInSpace {
+
         private static final ColorSpace SRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
         private static final ColorSpace XYZ =

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -111,7 +111,7 @@ public abstract class ColorSpace implements Serializable {
     private transient String [] compName = null;
 
     /**
-     * The cache of singletons for the predefined built-in color spaces.
+     * The lazy cache of singletons for the predefined built-in color spaces.
      */
     private interface BuiltInSpace {
         ICC_ColorSpace SRGB =

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -114,16 +114,12 @@ public abstract class ColorSpace implements Serializable {
      * The lazy cache of singletons for the predefined built-in color spaces.
      */
     private interface BuiltInSpace {
-        ICC_ColorSpace SRGB =
-                new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
-        ICC_ColorSpace LRGB =
+        ColorSpace SRGB = new ICC_ColorSpace(ICC_Profile.getInstance(CS_sRGB));
+        ColorSpace LRGB =
                 new ICC_ColorSpace(ICC_Profile.getInstance(CS_LINEAR_RGB));
-        ICC_ColorSpace XYZ =
-                new ICC_ColorSpace(ICC_Profile.getInstance(CS_CIEXYZ));
-        ICC_ColorSpace PYCC =
-                new ICC_ColorSpace(ICC_Profile.getInstance(CS_PYCC));
-        ICC_ColorSpace GRAY =
-                new ICC_ColorSpace(ICC_Profile.getInstance(CS_GRAY));
+        ColorSpace XYZ = new ICC_ColorSpace(ICC_Profile.getInstance(CS_CIEXYZ));
+        ColorSpace PYCC = new ICC_ColorSpace(ICC_Profile.getInstance(CS_PYCC));
+        ColorSpace GRAY = new ICC_ColorSpace(ICC_Profile.getInstance(CS_GRAY));
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -97,11 +97,11 @@ public class ICC_Profile implements Serializable {
     // Registry of singleton profile objects for specific color spaces
     // defined in the ColorSpace class (e.g. CS_sRGB), see
     // getInstance(int cspace) factory method.
-    private static ICC_Profile sRGBprofile;
-    private static ICC_Profile XYZprofile;
-    private static ICC_Profile PYCCprofile;
-    private static ICC_Profile GRAYprofile;
-    private static ICC_Profile LINEAR_RGBprofile;
+    private static volatile ICC_Profile sRGBprofile;
+    private static volatile ICC_Profile XYZprofile;
+    private static volatile ICC_Profile PYCCprofile;
+    private static volatile ICC_Profile GRAYprofile;
+    private static volatile ICC_Profile LINEAR_RGBprofile;
 
     /**
      * Profile class is input.
@@ -817,89 +817,71 @@ public class ICC_Profile implements Serializable {
      * @throws IllegalArgumentException If {@code cspace} is not one of the
      *         predefined color space types
      */
-    public static ICC_Profile getInstance (int cspace) {
-        ICC_Profile thisProfile = null;
+    public static ICC_Profile getInstance(int cspace) {
+        /*
+         * Deferral is only used for standard profiles. Enabling the appropriate
+         * access privileges is handled at a lower level.
+         */
         switch (cspace) {
-        case ColorSpace.CS_sRGB:
-            synchronized(ICC_Profile.class) {
+            case ColorSpace.CS_sRGB:
                 if (sRGBprofile == null) {
-                    /*
-                     * Deferral is only used for standard profiles.
-                     * Enabling the appropriate access privileges is handled
-                     * at a lower level.
-                     */
-                    ProfileDeferralInfo pdi =
-                        new ProfileDeferralInfo("sRGB.pf",
-                                                ColorSpace.TYPE_RGB, 3,
-                                                CLASS_DISPLAY);
-                    sRGBprofile = new ICC_ProfileRGB(pdi);
+                    synchronized (ICC_Profile.class) {
+                        if (sRGBprofile == null) {
+                            var pdi = new ProfileDeferralInfo("sRGB.pf",
+                                    ColorSpace.TYPE_RGB, 3, CLASS_DISPLAY);
+                            sRGBprofile = new ICC_ProfileRGB(pdi);
+                        }
+                    }
                 }
-                thisProfile = sRGBprofile;
-            }
-
-            break;
-
-        case ColorSpace.CS_CIEXYZ:
-            synchronized(ICC_Profile.class) {
+                return sRGBprofile;
+            case ColorSpace.CS_CIEXYZ:
                 if (XYZprofile == null) {
-                    ProfileDeferralInfo pdi =
-                        new ProfileDeferralInfo("CIEXYZ.pf",
-                                                ColorSpace.TYPE_XYZ, 3,
-                                                CLASS_ABSTRACT);
-                    XYZprofile = new ICC_Profile(pdi);
+                    synchronized (ICC_Profile.class) {
+                        if (XYZprofile == null) {
+                            var pdi = new ProfileDeferralInfo("CIEXYZ.pf",
+                                    ColorSpace.TYPE_XYZ, 3, CLASS_ABSTRACT);
+                            XYZprofile = new ICC_Profile(pdi);
+                        }
+                    }
                 }
-                thisProfile = XYZprofile;
-            }
-
-            break;
-
-        case ColorSpace.CS_PYCC:
-            synchronized(ICC_Profile.class) {
+                return XYZprofile;
+            case ColorSpace.CS_PYCC:
                 if (PYCCprofile == null) {
-                    ProfileDeferralInfo pdi =
-                        new ProfileDeferralInfo("PYCC.pf",
-                                                ColorSpace.TYPE_3CLR, 3,
-                                                CLASS_COLORSPACECONVERSION);
-                    PYCCprofile = new ICC_Profile(pdi);
+                    synchronized (ICC_Profile.class) {
+                        if (PYCCprofile == null) {
+                            var pdi = new ProfileDeferralInfo("PYCC.pf",
+                                    ColorSpace.TYPE_3CLR, 3,
+                                    CLASS_COLORSPACECONVERSION);
+                            PYCCprofile = new ICC_Profile(pdi);
+                        }
+                    }
                 }
-                thisProfile = PYCCprofile;
-            }
-
-            break;
-
-        case ColorSpace.CS_GRAY:
-            synchronized(ICC_Profile.class) {
+                return PYCCprofile;
+            case ColorSpace.CS_GRAY:
                 if (GRAYprofile == null) {
-                    ProfileDeferralInfo pdi =
-                        new ProfileDeferralInfo("GRAY.pf",
-                                                ColorSpace.TYPE_GRAY, 1,
-                                                CLASS_DISPLAY);
-                    GRAYprofile = new ICC_ProfileGray(pdi);
+                    synchronized (ICC_Profile.class) {
+                        if (GRAYprofile == null) {
+                            var pdi = new ProfileDeferralInfo("GRAY.pf",
+                                    ColorSpace.TYPE_GRAY, 1, CLASS_DISPLAY);
+                            GRAYprofile = new ICC_ProfileGray(pdi);
+                        }
+                    }
                 }
-                thisProfile = GRAYprofile;
-            }
-
-            break;
-
-        case ColorSpace.CS_LINEAR_RGB:
-            synchronized(ICC_Profile.class) {
+                return GRAYprofile;
+            case ColorSpace.CS_LINEAR_RGB:
                 if (LINEAR_RGBprofile == null) {
-                    ProfileDeferralInfo pdi =
-                        new ProfileDeferralInfo("LINEAR_RGB.pf",
-                                                ColorSpace.TYPE_RGB, 3,
-                                                CLASS_DISPLAY);
-                    LINEAR_RGBprofile = new ICC_ProfileRGB(pdi);
+                    synchronized (ICC_Profile.class) {
+                        if (LINEAR_RGBprofile == null) {
+                            var pdi = new ProfileDeferralInfo("LINEAR_RGB.pf",
+                                    ColorSpace.TYPE_RGB, 3, CLASS_DISPLAY);
+                            LINEAR_RGBprofile = new ICC_ProfileRGB(pdi);
+                        }
+                    }
                 }
-                thisProfile = LINEAR_RGBprofile;
-            }
-
-            break;
-
-        default:
-            throw new IllegalArgumentException("Unknown color space");
+                return LINEAR_RGBprofile;
+            default:
+                throw new IllegalArgumentException("Unknown color space");
         }
-
-        return thisProfile;
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -48,6 +48,7 @@ import java.io.ObjectStreamException;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.io.Serializable;
+import java.lang.annotation.Native;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.StringTokenizer;
@@ -107,6 +108,9 @@ public class ICC_Profile implements Serializable {
         ICC_Profile SRGB = new ICC_ProfileRGB(new ProfileDeferralInfo(
                "sRGB.pf", ColorSpace.TYPE_RGB, 3, CLASS_DISPLAY));
 
+        ICC_Profile LRGB = new ICC_ProfileRGB(new ProfileDeferralInfo(
+                "LINEAR_RGB.pf", ColorSpace.TYPE_RGB, 3, CLASS_DISPLAY));
+
         ICC_Profile XYZ = new ICC_Profile(new ProfileDeferralInfo(
                "CIEXYZ.pf", ColorSpace.TYPE_XYZ, 3, CLASS_ABSTRACT));
 
@@ -115,9 +119,6 @@ public class ICC_Profile implements Serializable {
 
         ICC_Profile GRAY = new ICC_ProfileGray(new ProfileDeferralInfo(
                "GRAY.pf", ColorSpace.TYPE_GRAY, 1, CLASS_DISPLAY));
-
-        ICC_Profile LRGB = new ICC_ProfileRGB(new ProfileDeferralInfo(
-               "LINEAR_RGB.pf", ColorSpace.TYPE_RGB, 3, CLASS_DISPLAY));
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -96,8 +96,8 @@ public class ICC_Profile implements Serializable {
     private transient volatile ProfileDeferralInfo deferralInfo;
 
     /**
-     * Registry of singleton profile objects for specific built-in color spaces
-     * defined in the ColorSpace class (e.g. CS_sRGB),
+     * Lazy registry of singleton profile objects for specific built-in color
+     * spaces defined in the ColorSpace class (e.g. CS_sRGB),
      * see getInstance(int cspace) factory method.
      */
     private interface BuiltInProfile {
@@ -838,10 +838,10 @@ public class ICC_Profile implements Serializable {
     public static ICC_Profile getInstance(int cspace) {
         return switch (cspace) {
             case ColorSpace.CS_sRGB -> BuiltInProfile.SRGB;
+            case ColorSpace.CS_LINEAR_RGB -> BuiltInProfile.LRGB;
             case ColorSpace.CS_CIEXYZ -> BuiltInProfile.XYZ;
             case ColorSpace.CS_PYCC -> BuiltInProfile.PYCC;
             case ColorSpace.CS_GRAY -> BuiltInProfile.GRAY;
-            case ColorSpace.CS_LINEAR_RGB -> BuiltInProfile.LRGB;
             default -> {
                 throw new IllegalArgumentException("Unknown color space");
             }

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -96,8 +96,8 @@ public class ICC_Profile implements Serializable {
     private transient volatile ProfileDeferralInfo deferralInfo;
 
     /**
-     * Lazy registry of singleton profile objects for specific built-in color
-     * spaces defined in the ColorSpace class (e.g. CS_sRGB),
+     * The lazy registry of singleton profile objects for specific built-in
+     * color spaces defined in the ColorSpace class (e.g. CS_sRGB),
      * see getInstance(int cspace) factory method.
      */
     private interface BuiltInProfile {

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -48,7 +48,6 @@ import java.io.ObjectStreamException;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.io.Serializable;
-import java.lang.annotation.Native;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.StringTokenizer;

--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1705,15 +1705,11 @@ public abstract class ColorModel implements Transparency{
     static Map<ICC_ColorSpace, short[]> lg16Toog16Map = null; // 16-bit linear to 16-bit "other" gray
 
     static boolean isLinearRGBspace(ColorSpace cs) {
-        // Note: CMM.LINEAR_RGBspace will be null if the linear
-        // RGB space has not been created yet.
-        return (cs == CMSManager.LINEAR_RGBspace);
+        return cs == ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB);
     }
 
     static boolean isLinearGRAYspace(ColorSpace cs) {
-        // Note: CMM.GRAYspace will be null if the linear
-        // gray space has not been created yet.
-        return (cs == CMSManager.GRAYspace);
+        return cs == ColorSpace.getInstance(ColorSpace.CS_GRAY);
     }
 
     static byte[] getLinearRGB8TosRGB8LUT() {

--- a/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
@@ -26,20 +26,12 @@
 package sun.java2d.cmm;
 
 import java.awt.color.CMMException;
-import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
 import java.security.AccessController;
 
 import sun.security.action.GetPropertyAction;
 
 public final class CMSManager {
-    /**
-     * These two fields allow access to java.awt.color.ColorSpace private fields
-     * from other packages. The fields are set by java.awt.color.ColorSpace and
-     * read by java.awt.image.ColorModel.
-     */
-    public static volatile ColorSpace GRAYspace;
-    public static volatile ColorSpace LINEAR_RGBspace;
 
     private static PCMM cmmImpl = null;
 

--- a/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,14 +32,14 @@ import java.security.AccessController;
 
 import sun.security.action.GetPropertyAction;
 
-public class CMSManager {
-    public static ColorSpace GRAYspace;       // These two fields allow access
-    public static ColorSpace LINEAR_RGBspace; // to java.awt.color.ColorSpace
-                                              // private fields from other
-                                              // packages.  The fields are set
-                                              // by java.awt.color.ColorSpace
-                                              // and read by
-                                              // java.awt.image.ColorModel.
+public final class CMSManager {
+    /**
+     * These two fields allow access to java.awt.color.ColorSpace private fields
+     * from other packages. The fields are set by java.awt.color.ColorSpace and
+     * read by java.awt.image.ColorModel.
+     */
+    public static volatile ColorSpace GRAYspace;
+    public static volatile ColorSpace LINEAR_RGBspace;
 
     private static PCMM cmmImpl = null;
 

--- a/test/jdk/java/awt/color/BuiltInDataVariation.java
+++ b/test/jdk/java/awt/color/BuiltInDataVariation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.util.Arrays;
+import java.util.Set;
+
+import static java.awt.color.ColorSpace.*;
+
+/**
+ * @test
+ * @bug 8261282
+ * @summary Checks that all built-in profiles and data are different.
+ */
+public final class BuiltInDataVariation {
+
+    public static void main(String[] args) {
+        testColorProfiles();
+        testColorSpaces();
+    }
+
+    private static void testColorProfiles() {
+        ICC_Profile srgb = ICC_Profile.getInstance(CS_sRGB);
+        ICC_Profile lrgb = ICC_Profile.getInstance(CS_LINEAR_RGB);
+        ICC_Profile xyz = ICC_Profile.getInstance(CS_CIEXYZ);
+        ICC_Profile pycc = ICC_Profile.getInstance(CS_PYCC);
+        ICC_Profile gray = ICC_Profile.getInstance(CS_GRAY);
+
+        test(srgb, lrgb, xyz, pycc, gray);
+        test(Arrays.hashCode(srgb.getData()), Arrays.hashCode(lrgb.getData()),
+             Arrays.hashCode(xyz.getData()), Arrays.hashCode(pycc.getData()),
+             Arrays.hashCode(gray.getData()));
+    }
+
+    private static void testColorSpaces() {
+        var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
+        var lrgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_LINEAR_RGB);
+        var xyz = (ICC_ColorSpace) ColorSpace.getInstance(CS_CIEXYZ);
+        var pycc = (ICC_ColorSpace) ColorSpace.getInstance(CS_PYCC);
+        var gray = (ICC_ColorSpace) ColorSpace.getInstance(CS_GRAY);
+
+        test(srgb, lrgb, xyz, pycc, gray);
+        test(srgb.getProfile(), lrgb.getProfile(), xyz.getProfile(),
+             pycc.getProfile(), gray.getProfile());
+        test(Arrays.hashCode(srgb.getProfile().getData()),
+             Arrays.hashCode(lrgb.getProfile().getData()),
+             Arrays.hashCode(xyz.getProfile().getData()),
+             Arrays.hashCode(pycc.getProfile().getData()),
+             Arrays.hashCode(gray.getProfile().getData()));
+    }
+
+    private static void test(Object srgb, Object lrgb, Object xyz,
+                             Object pycc, Object gray) {
+        Set.of(srgb, lrgb, xyz, pycc, gray);
+    }
+}

--- a/test/jdk/java/awt/color/HotStaticLocks.java
+++ b/test/jdk/java/awt/color/HotStaticLocks.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
+
+import static java.awt.color.ColorSpace.CS_CIEXYZ;
+import static java.awt.color.ColorSpace.CS_GRAY;
+import static java.awt.color.ColorSpace.CS_LINEAR_RGB;
+import static java.awt.color.ColorSpace.CS_PYCC;
+import static java.awt.color.ColorSpace.CS_sRGB;
+
+/**
+ * @test
+ * @bug 8261282
+ * @summary Checks static locks in the ColorSpace/ICC_Profile classes.
+ */
+public final class HotStaticLocks {
+
+    public static void main(String[] args) throws Exception {
+        testICCProfile();
+        testColorSpace();
+    }
+
+    private static void testICCProfile() throws Exception {
+        int[] spaces = {CS_sRGB, CS_LINEAR_RGB, CS_CIEXYZ, CS_PYCC, CS_GRAY};
+        for (int cs : spaces) {
+            synchronized (ICC_Profile.class) {
+                Thread t = new Thread(() -> ICC_Profile.getInstance(cs));
+                t.start();
+                t.join();
+            }
+        }
+    }
+
+    private static void testColorSpace() throws Exception {
+        int[] spaces = {CS_sRGB, CS_LINEAR_RGB, CS_CIEXYZ, CS_PYCC, CS_GRAY};
+        for (int cs : spaces) {
+            synchronized (ColorSpace.class) {
+                Thread t = new Thread(() -> ColorSpace.getInstance(cs));
+                t.start();
+                t.join();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Short fix description:

The fix changes the initialization of the built-in color profiles/spaces from the lazy initialization per requested profile via static synchronization to the lazy initialization of all profiles/spaces on the first request via class initialization(holder idiom).

Long fix description:

1. A long time ago the factory method ICC_Profile#getInstance() was a heavyweight method. For each requested profile it used the data of the icc file(ex: sRGB: 6kb and pycc: 200kb).
As a result, in our code, we have tried to skip this method as much as possible or delay its usage. But we found that we have to use it anyway during startup. So we implemented the deferral mechanic for the sRGB profile. When this profile is requested we did not read the data but return the stub that contained some known in advance properties, such as num of color components, etc. The icc data is used only if the user request some of it later -> in this case we "activate" the profile and drop the stub data.

2. Later we found that we may need some other profiles at startup, and the deferral mechanics was implemented for all profiles by the JDK-6793818. But profile activation was implemented as one step for all profiles at once, so if one profile such as sRGB was activated then the next profiles returned from the "ICC_Profile#getInstance" if not requested before was activated as well(used the icc file data).

3. The deferral mechanics were updated in the JDK-6986863. Now activation of one profile does not affect other profiles and as a result, the "ICC_Profile#getInstance" always returns the stubs of the requested profiles.

4. Each profile stub contains just a few lightweight objects, but still, use the heavyweight static synchronization to access/create it, see:
   https://github.com/openjdk/jdk/blob/9d59dec200490f11bfc1c661b30f10c7edee3a6d/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java#L821
   Note that we have separate blocks for each profile("stub"). That looks an overkill.
   
5. Note that in theory, it is not necessary to create these stubs lazily, each stub is a ICC_Profile object and ProfileDeferralInfo object, so we can use them as static fields in the ICC_Profile class. But here that classes initialization order come to play -> it is a bad idea to refer to the ICC_ProfileRGB(a subclass of the ICC_Profile) in the static block of ICC_Profile class because this could cause a deadlock.

6. So this change merged initialization of all stubs to the one-step, still initialize stubs lazily, and maintains the singleton property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261282](https://bugs.openjdk.java.net/browse/JDK-8261282): Lazy initialization of built-in ICC_Profile/ColorSpace classes is too lazy


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2447/head:pull/2447`
`$ git checkout pull/2447`
