### PR TITLE
8261231: Windows IME was disabled after DnD operation

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -3215,10 +3215,12 @@ LRESULT AwtToolkit::InvokeInputMethodFunction(UINT msg, WPARAM wParam, LPARAM lP
      * function once the DND is active; otherwise a hang is possible since DND may wait for
      * the IME completion.
      */
+    CriticalSection::Lock lock(m_inputMethodLock);
     if (isInDoDragDropLoop) {
-        return SendMessage(msg, wParam, lParam);
+        SendMessage(msg, wParam, lParam);
+        ::ResetEvent(m_inputMethodWaitEvent);
+        return m_inputMethodData;
     } else {
-        CriticalSection::Lock lock(m_inputMethodLock);
         if (PostMessage(msg, wParam, lParam)) {
             ::WaitForSingleObject(m_inputMethodWaitEvent, INFINITE);
             return m_inputMethodData;


### PR DESCRIPTION
The function InvokeInputMethodFunction() is responsible for invocation of IME API. Typically it uses PostMessage() to execute corresponding IME function on the toolkit thread but if DnD operation takes place SendMessage() is used. The state of m_inputMethodWaitEvent event object remains signalled after SendMessage() execution. That causes failure of subsequent IME functions calls via PostMessage().

Fix:
SendMessage() and PostMessage() calls inside InvokeInputMethodFunction() should be synchronised. The state of m_inputMethodWaitEvent event object must be reseted right after SendMessage() execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261231](https://bugs.openjdk.java.net/browse/JDK-8261231): Windows IME was disabled after DnD operation


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2448/head:pull/2448`
`$ git checkout pull/2448`
