### PR TITLE
JDK-8261297: NMT: Final report should use scale 1

### DIFF
--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -40,14 +40,15 @@
 class MemReporterBase : public StackObj {
  private:
   const size_t  _scale;         // report in this scale
-  static const size_t default_scale = K;
   outputStream* const _output;  // destination
 
  public:
-  // scale = 0 -> default scale
-  MemReporterBase(outputStream* out = NULL, size_t scale = 0) :
-    _scale(scale == 0 ? default_scale : scale),
-    _output(out == NULL ? tty : out)
+
+  // Default scale to use if no scale given.
+  static const size_t default_scale = K;
+
+  MemReporterBase(outputStream* out, size_t scale = default_scale) :
+    _scale(scale), _output(out)
   {}
 
  protected:
@@ -101,7 +102,7 @@ class MemSummaryReporter : public MemReporterBase {
  public:
   // This constructor is for normal reporting from a recent baseline.
   MemSummaryReporter(MemBaseline& baseline, outputStream* output,
-    size_t scale = 0) : MemReporterBase(output, scale),
+    size_t scale = default_scale) : MemReporterBase(output, scale),
     _malloc_snapshot(baseline.malloc_memory_snapshot()),
     _vm_snapshot(baseline.virtual_memory_snapshot()),
     _instance_class_count(baseline.instance_class_count()),
@@ -126,7 +127,7 @@ class MemDetailReporter : public MemSummaryReporter {
   MemBaseline&   _baseline;
 
  public:
-  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = 0) :
+  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = default_scale) :
     MemSummaryReporter(baseline, output, scale),
      _baseline(baseline) { }
 
@@ -202,7 +203,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 class MemDetailDiffReporter : public MemSummaryDiffReporter {
  public:
   MemDetailDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = 0) :
+    outputStream* output, size_t scale = default_scale) :
     MemSummaryDiffReporter(early_baseline, current_baseline, output, scale) { }
 
   // Generate detail comparison report

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -164,7 +164,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 
  public:
   MemSummaryDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = 0) : MemReporterBase(output, scale),
+    outputStream* output, size_t scale = default_scale) : MemReporterBase(output, scale),
     _early_baseline(early_baseline), _current_baseline(current_baseline) {
     assert(early_baseline.baseline_type()   != MemBaseline::Not_baselined, "Not baselined");
     assert(current_baseline.baseline_type() != MemBaseline::Not_baselined, "Not baselined");

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -39,14 +39,16 @@
 */
 class MemReporterBase : public StackObj {
  private:
-  size_t        _scale;  // report in this scale
-  outputStream* _output; // destination
+  const size_t  _scale;         // report in this scale
+  static const size_t default_scale = K;
+  outputStream* const _output;  // destination
 
  public:
-  MemReporterBase(outputStream* out = NULL, size_t scale = K)
-    : _scale(scale) {
-    _output = (out == NULL) ? tty : out;
-  }
+  // scale = 0 -> default scale
+  MemReporterBase(outputStream* out = NULL, size_t scale = 0) :
+    _scale(scale == 0 ? default_scale : scale),
+    _output(out == NULL ? tty : out)
+  {}
 
  protected:
   inline outputStream* output() const {
@@ -74,7 +76,6 @@ class MemReporterBase : public StackObj {
   size_t reserved_total(const MallocMemory* malloc, const VirtualMemory* vm) const;
   size_t committed_total(const MallocMemory* malloc, const VirtualMemory* vm) const;
 
-
   // Print summary total, malloc and virtual memory
   void print_total(size_t reserved, size_t committed) const;
   void print_malloc(size_t amount, size_t count, MEMFLAGS flag = mtNone) const;
@@ -100,7 +101,7 @@ class MemSummaryReporter : public MemReporterBase {
  public:
   // This constructor is for normal reporting from a recent baseline.
   MemSummaryReporter(MemBaseline& baseline, outputStream* output,
-    size_t scale = K) : MemReporterBase(output, scale),
+    size_t scale = 0) : MemReporterBase(output, scale),
     _malloc_snapshot(baseline.malloc_memory_snapshot()),
     _vm_snapshot(baseline.virtual_memory_snapshot()),
     _instance_class_count(baseline.instance_class_count()),
@@ -125,7 +126,7 @@ class MemDetailReporter : public MemSummaryReporter {
   MemBaseline&   _baseline;
 
  public:
-  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = K) :
+  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = 0) :
     MemSummaryReporter(baseline, output, scale),
      _baseline(baseline) { }
 
@@ -162,7 +163,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 
  public:
   MemSummaryDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = K) : MemReporterBase(output, scale),
+    outputStream* output, size_t scale = 0) : MemReporterBase(output, scale),
     _early_baseline(early_baseline), _current_baseline(current_baseline) {
     assert(early_baseline.baseline_type()   != MemBaseline::Not_baselined, "Not baselined");
     assert(current_baseline.baseline_type() != MemBaseline::Not_baselined, "Not baselined");
@@ -201,7 +202,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 class MemDetailDiffReporter : public MemSummaryDiffReporter {
  public:
   MemDetailDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = K) :
+    outputStream* output, size_t scale = 0) :
     MemSummaryDiffReporter(early_baseline, current_baseline, output, scale) { }
 
   // Generate detail comparison report

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -173,7 +173,7 @@ bool MemTracker::transition_to(NMT_TrackingLevel level) {
 // Report during error reporting.
 void MemTracker::error_report(outputStream* output) {
   if (tracking_level() >= NMT_summary) {
-    report(true, output, 0); // just print summary for error case.
+    report(true, output, K); // just print summary for error case.
   }
 }
 

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -173,7 +173,7 @@ bool MemTracker::transition_to(NMT_TrackingLevel level) {
 // Report during error reporting.
 void MemTracker::error_report(outputStream* output) {
   if (tracking_level() >= NMT_summary) {
-    report(true, output, K); // just print summary for error case.
+    report(true, output, MemReporterBase::default_scale); // just print summary for error case.
   }
 }
 
@@ -206,9 +206,7 @@ void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
       output->print("Metaspace:");
       // The basic metaspace report avoids any locking and should be safe to
       // be called at any time.
-      // (Note: scale = 0 in NMT is default scale, in metaspace reporting
-      //  it means dynamic, human readable scale.)
-      MetaspaceUtils::print_basic_report(output, scale == 0 ? K : scale);
+      MetaspaceUtils::print_basic_report(output, scale);
     }
   }
 }

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -116,6 +116,7 @@ class MemTracker : AllStatic {
   friend class VirtualMemoryTrackerTest;
 
  public:
+
   static inline NMT_TrackingLevel tracking_level() {
     if (_tracking_level == NMT_unknown) {
       // No fencing is needed here, since JVM is in single-threaded
@@ -286,13 +287,10 @@ class MemTracker : AllStatic {
     return NMTQuery_lock;
   }
 
-  // Make a final report or report for hs_err file.
-  static void error_report(outputStream* output) {
-    if (tracking_level() >= NMT_summary) {
-      report(true, output);  // just print summary for error case.
-    }
-   }
+  // Report during error reporting.
+  static void error_report(outputStream* output);
 
+  // Report when handling PrintNMTStatistics before VM shutdown.
   static void final_report(outputStream* output);
 
   // Stored baseline
@@ -308,7 +306,7 @@ class MemTracker : AllStatic {
 
  private:
   static NMT_TrackingLevel init_tracking_level();
-  static void report(bool summary_only, outputStream* output);
+  static void report(bool summary_only, outputStream* output, size_t scale);
 
  private:
   // Tracking level

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -116,7 +116,6 @@ class MemTracker : AllStatic {
   friend class VirtualMemoryTrackerTest;
 
  public:
-
   static inline NMT_TrackingLevel tracking_level() {
     if (_tracking_level == NMT_unknown) {
       // No fencing is needed here, since JVM is in single-threaded


### PR DESCRIPTION
If PrintNMTStatistics is specified, we write a NMT report to stdout before exiting the VM. This is useful for leak analysis.

However, the report uses the standard "K" scale, which is shouldn't, since this omits small leaks < 1K. Hence it should use scale=1. This would provide us with a precise exit report. Note that for this to work JDK-8261238 has to be fixed too, which is a separate issue.

This patch:
- changes the scale of the final report to 1
- does some minor cleanup work in the MemReporter class hierarchy (const-ifying scale and the output stream, and establishing 0 as "default scale" as to avoid having the default scale hard coded in four places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261297](https://bugs.openjdk.java.net/browse/JDK-8261297): NMT: Final report should use scale 1


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to d24794612c8a91173f4ec19edbbc5c4889b9ade9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2450/head:pull/2450`
`$ git checkout pull/2450`
