### PR TITLE
8261072: AArch64: Fix MacroAssembler::get_thread convention

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5267,7 +5267,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 // the call setup code.
 //
 // On Linux, aarch64_get_thread_helper() clobbers only r0, r1, and flags.
-// On Windows, the helper is a usual C function.
+// On other systems, the helper is a usual C function.
 //
 void MacroAssembler::get_thread(Register dst) {
   RegSet saved_regs =

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5266,10 +5266,14 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 // by the call to JavaThread::aarch64_get_thread_helper() or, indeed,
 // the call setup code.
 //
-// aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On Linux, aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On Windows, the helper is a usual C function.
 //
 void MacroAssembler::get_thread(Register dst) {
-  RegSet saved_regs = RegSet::range(r0, r1) + lr - dst;
+  RegSet saved_regs =
+    LINUX_ONLY(RegSet::range(r0, r1)  + lr - dst)
+    NOT_LINUX (RegSet::range(r0, r17) + lr - dst);
+
   push(saved_regs, sp);
 
   mov(lr, CAST_FROM_FN_PTR(address, JavaThread::aarch64_get_thread_helper));


### PR DESCRIPTION
Please review a fix in a special calling convention for aarch64_get_thread_helper for non-Linux platforms (windows/aarch64 for now). 

Preliminary review: https://mail.openjdk.java.net/pipermail/aarch64-port-dev/2021-January/011239.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261072](https://bugs.openjdk.java.net/browse/JDK-8261072): AArch64: Fix MacroAssembler::get_thread convention


### Reviewers
 * [Bernhard Urban-Forster](https://openjdk.java.net/census#burban) (@lewurm - Author) ⚠️ Review applies to 217d3c23e1bf81647fcdd18ceebe3213e2476866
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2451/head:pull/2451`
`$ git checkout pull/2451`
