### PR TITLE
8261298: LinuxPackage.c, getJvmLauncherLibPath RPM->DEB typo

### DIFF
--- a/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
@@ -312,7 +312,7 @@ char* getJvmLauncherLibPath(void) {
     } else {
         if (PACKAGE_TYPE_RPM == pkg->type) {
             pkgQueryCmd = "rpm -ql '%s' 2>/dev/null";
-        } else if (PACKAGE_TYPE_RPM == pkg->type) {
+        } else if (PACKAGE_TYPE_DEB == pkg->type) {
             pkgQueryCmd = "dpkg -L '%s' 2>/dev/null";
         } else {
             /* Should never happen */


### PR DESCRIPTION
SonarCloud instance reports as new warning after JDK-8254702:

This branch can not be reached because the condition duplicates a previous condition in the same sequence of "if/else if" statements.

```
char* getJvmLauncherLibPath(void) {
   ...
        if (PACKAGE_TYPE_RPM == pkg->type) {
            pkgQueryCmd = "rpm -ql '%s' 2>/dev/null";
        } else if (PACKAGE_TYPE_RPM == pkg->type) { <--- here
            pkgQueryCmd = "dpkg -L '%s' 2>/dev/null";
```

Seems like an obvious typo.

Additional tests:
 - [x] Linux x86_64 (Ubuntu) `tools/jpackage`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261298](https://bugs.openjdk.java.net/browse/JDK-8261298): LinuxPackage.c, getJvmLauncherLibPath RPM->DEB typo


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2452/head:pull/2452`
`$ git checkout pull/2452`
