### PR TITLE
8261299: Use-after-free on failure path in LinuxPackage.c, getJvmLauncherLibPath

### DIFF
--- a/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
@@ -324,6 +324,7 @@ char* getJvmLauncherLibPath(void) {
                                                         &launcherLibPath);
         if (popenStatus) {
             free(launcherLibPath);
+            launcherLibPath = NULL;
             goto cleanup;
         }
     }


### PR DESCRIPTION
SonarCloud instance reports a new warning after JDK-8254702:
 "Use of memory after it is freed"

```
char* getJvmLauncherLibPath(void) {
       ...
        popenStatus = popenCommand(pkgQueryCmd, pkg->name, findLauncherLib,
                                                        &launcherLibPath);
        if (popenStatus) {
            free(launcherLibPath); <---- frees here
            goto cleanup;
        }
    }

cleanup:
    free(modulePath);
    freePackageDesc(pkg);

    return launcherLibPath; <--- here
}
```

We need to null it out before returning.

Additional testing:
 - [x] Linux x86_64 (Ubuntu) `tools/jpackage`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261299](https://bugs.openjdk.java.net/browse/JDK-8261299): Use-after-free on failure path in LinuxPackage.c, getJvmLauncherLibPath


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2453/head:pull/2453`
`$ git checkout pull/2453`
