### PR TITLE
6211242: AreaAveragingScaleFilter(int, int): IAE is not specified

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
@@ -73,7 +73,7 @@ public class AreaAveragingScaleFilter extends ReplicateScaleFilter {
      * @param width the target width to scale the image
      * @param height the target height to scale the image
      * @throws IllegalArgumentException if {@code width} equals
-     *      *         zero or {@code height} equals zero
+     *         zero or {@code height} equals zero
      */
     public AreaAveragingScaleFilter(int width, int height) {
         super(width, height);

--- a/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
@@ -72,6 +72,8 @@ public class AreaAveragingScaleFilter extends ReplicateScaleFilter {
      * its source Image as specified by the width and height parameters.
      * @param width the target width to scale the image
      * @param height the target height to scale the image
+     * @throws IllegalArgumentException if {@code width} equals
+     *      *         zero or {@code height} equals zero
      */
     public AreaAveragingScaleFilter(int width, int height) {
         super(width, height);

--- a/test/jdk/java/awt/image/TestNullAASF.java
+++ b/test/jdk/java/awt/image/TestNullAASF.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 6211242
+ * @summary Verifies IAE is thrown if 0 is passed to 
+ * 	    AreaAveragingScaleFilter(width,height) constructor.
+ */
+import java.awt.image.AreaAveragingScaleFilter;
+
+public class TestNullAASF {
+    public static void main(String[] args) {
+        AreaAveragingScaleFilter filter = null;
+        try {
+            filter = new AreaAveragingScaleFilter(0, Integer.MAX_VALUE);
+            System.out.println("result: false");
+            throw new RuntimeException("IAE expected for width=0");
+        } catch (IllegalArgumentException e) {
+            System.out.println("result (iae): true");
+        }
+        try {
+            filter = new AreaAveragingScaleFilter(Integer.MAX_VALUE, 0);
+            System.out.println("result: false");
+            throw new RuntimeException("IAE expected for height=0");
+        } catch (IllegalArgumentException e) {
+            System.out.println("result (iae): true");
+        }
+    }
+}

--- a/test/jdk/java/awt/image/TestNullAASF.java
+++ b/test/jdk/java/awt/image/TestNullAASF.java
@@ -23,8 +23,8 @@
 /**
  * @test
  * @bug 6211242
- * @summary Verifies IAE is thrown if 0 is passed to 
- * 	    AreaAveragingScaleFilter(width,height) constructor.
+ * @summary Verifies IAE is thrown if 0 is passed to
+ *          AreaAveragingScaleFilter(width,height) constructor.
  */
 import java.awt.image.AreaAveragingScaleFilter;
 


### PR DESCRIPTION
Constructor AreaAveragingScaleFilter(int, int) for java.awt.image.AreaAveragingScaleFilter class throws IllegalArgumentException when 0 is passed for width,height but it's not specified in the spec.
Updated spec to illustrate this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6211242](https://bugs.openjdk.java.net/browse/JDK-6211242): AreaAveragingScaleFilter(int, int): IAE is not specified


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2456/head:pull/2456`
`$ git checkout pull/2456`
