### PR TITLE
8261281: Linking jdk.jpackage fails for linux aarch32 builds after 8254702

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -74,7 +74,7 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHEREXE, \
     LDFLAGS := $(LDFLAGS_JDKEXE), \
     LIBS_macosx := $(LIBCXX) -framework Cocoa, \
     LIBS_windows := $(LIBCXX), \
-    LIBS_linux := -nodefaultlibs -lc -ldl, \
+    LIBS_linux := -ldl, \
 ))
 
 JPACKAGE_TARGETS += $(BUILD_JPACKAGE_APPLAUNCHEREXE)


### PR DESCRIPTION
Remove accidently added Linux build flags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261281](https://bugs.openjdk.java.net/browse/JDK-8261281): Linking jdk.jpackage fails for linux aarch32 builds after 8254702


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2459/head:pull/2459`
`$ git checkout pull/2459`
