### PR TITLE
JDK-8259656: fixpath.sh changes broke _NT_SYMBOL_PATH in RunTests.gmk

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -189,8 +189,10 @@ ifeq ($(OPENJDK_TARGET_CPU), x86_64)
 endif
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
-  FIXPATH := $(BASH) $(TOPDIR)/make/scripts/fixpath.sh exec
+  FIXPATH_BASE := $(BASH) $(TOPDIR)/make/scripts/fixpath.sh
+  FIXPATH := $(FIXPATH_BASE) exec
 else
+  FIXPATH_BASE :=
   FIXPATH :=
 endif
 
@@ -273,6 +275,7 @@ $(call CreateNewSpec, $(NEW_SPEC), \
     MAKE := $(MAKE), \
     BASH := $(BASH), \
     JIB_JAR := $(JIB_JAR), \
+    FIXPATH_BASE := $(FIXPATH_BASE), \
     FIXPATH := $(FIXPATH), \
     OPENJDK_TARGET_OS := $(OPENJDK_TARGET_OS), \
     OPENJDK_TARGET_OS_TYPE := $(OPENJDK_TARGET_OS_TYPE), \


### PR DESCRIPTION
Adding FIXPATH_BASE in RunTestsPrebuilt.gmk as that's needed for the FixPath make macro to work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259656](https://bugs.openjdk.java.net/browse/JDK-8259656): fixpath.sh changes broke _NT_SYMBOL_PATH in RunTests.gmk


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2460/head:pull/2460`
`$ git checkout pull/2460`
