### PR TITLE
8261356: Clean up enum G1Mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -156,13 +156,7 @@ enum G1Barrier {
   G1BarrierNoOptRoots  // Do not collect optional roots.
 };
 
-enum G1Mark {
-  G1MarkNone,
-  G1MarkFromRoot,
-  G1MarkPromotedFromRoot
-};
-
-template <G1Barrier barrier, G1Mark do_mark_object>
+template <G1Barrier barrier, bool should_mark>
 class G1ParCopyClosure : public G1ParCopyHelper {
 public:
   G1ParCopyClosure(G1CollectedHeap* g1h, G1ParScanThreadState* par_scan_state) :

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -215,9 +215,9 @@ void G1ParCopyHelper::trim_queue_partially() {
   _par_scan_state->trim_queue_partially();
 }
 
-template <G1Barrier barrier, G1Mark do_mark_object>
+template <G1Barrier barrier, bool should_mark>
 template <class T>
-void G1ParCopyClosure<barrier, do_mark_object>::do_oop_work(T* p) {
+void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
 
   if (CompressedOops::is_null(heap_oop)) {
@@ -250,9 +250,10 @@ void G1ParCopyClosure<barrier, do_mark_object>::do_oop_work(T* p) {
       _par_scan_state->remember_root_into_optional_region(p);
     }
 
-    // The object is not in collection set. If we're a root scanning
-    // closure during a concurrent start pause then attempt to mark the object.
-    if (do_mark_object == G1MarkFromRoot) {
+    // The object is not in the collection set. should_mark is true iff the
+    // current closure is applied on strong roots (and weak roots when class
+    // unloading is disabled) in a concurrent mark start pause.
+    if (should_mark) {
       mark_object(obj);
     }
   }

--- a/src/hotspot/share/gc/g1/g1RootClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1RootClosures.cpp
@@ -50,10 +50,10 @@ public:
 // Closures used during concurrent start.
 // The treatment of "weak" roots is selectable through the template parameter,
 // this is usually used to control unloading of classes and interned strings.
-template <bool mark_weak>
+template <bool should_mark_weak>
 class G1ConcurrentStartMarkClosures : public G1EvacuationRootClosures {
   G1SharedClosures<true>        _strong;
-  G1SharedClosures<mark_weak>   _weak;
+  G1SharedClosures<should_mark_weak>   _weak;
 
 public:
   G1ConcurrentStartMarkClosures(G1CollectedHeap* g1h,

--- a/src/hotspot/share/gc/g1/g1RootClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1RootClosures.cpp
@@ -29,7 +29,7 @@
 
 // Closures used for standard G1 evacuation.
 class G1EvacuationClosures : public G1EvacuationRootClosures {
-  G1SharedClosures<G1MarkNone> _closures;
+  G1SharedClosures<false> _closures;
 
 public:
   G1EvacuationClosures(G1CollectedHeap* g1h,
@@ -50,10 +50,10 @@ public:
 // Closures used during concurrent start.
 // The treatment of "weak" roots is selectable through the template parameter,
 // this is usually used to control unloading of classes and interned strings.
-template <G1Mark MarkWeak>
+template <bool mark_weak>
 class G1ConcurrentStartMarkClosures : public G1EvacuationRootClosures {
-  G1SharedClosures<G1MarkFromRoot> _strong;
-  G1SharedClosures<MarkWeak>       _weak;
+  G1SharedClosures<true>        _strong;
+  G1SharedClosures<mark_weak>   _weak;
 
 public:
   G1ConcurrentStartMarkClosures(G1CollectedHeap* g1h,
@@ -75,9 +75,9 @@ G1EvacuationRootClosures* G1EvacuationRootClosures::create_root_closures(G1ParSc
   G1EvacuationRootClosures* res = NULL;
   if (g1h->collector_state()->in_concurrent_start_gc()) {
     if (ClassUnloadingWithConcurrentMark) {
-      res = new G1ConcurrentStartMarkClosures<G1MarkPromotedFromRoot>(g1h, pss);
+      res = new G1ConcurrentStartMarkClosures<false>(g1h, pss);
     } else {
-      res = new G1ConcurrentStartMarkClosures<G1MarkFromRoot>(g1h, pss);
+      res = new G1ConcurrentStartMarkClosures<true>(g1h, pss);
     }
   } else {
     res = new G1EvacuationClosures(g1h, pss, g1h->collector_state()->in_young_only_phase());

--- a/src/hotspot/share/gc/g1/g1RootClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1RootClosures.cpp
@@ -52,8 +52,8 @@ public:
 // this is usually used to control unloading of classes and interned strings.
 template <bool should_mark_weak>
 class G1ConcurrentStartMarkClosures : public G1EvacuationRootClosures {
-  G1SharedClosures<true>        _strong;
-  G1SharedClosures<should_mark_weak>   _weak;
+  G1SharedClosures<true>             _strong;
+  G1SharedClosures<should_mark_weak> _weak;
 
 public:
   G1ConcurrentStartMarkClosures(G1CollectedHeap* g1h,


### PR DESCRIPTION
After removing the effectively dead entry in `G1Mark`, the whole enum could be turned into a bool. The call-chain is updated and existing comments are revised.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261356](https://bugs.openjdk.java.net/browse/JDK-8261356): Clean up enum G1Mark


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 946660de937f7affde72db58dc667cc34496a46b
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 1a17ae195d7a3d7a09caff3904d4202ede27f5f3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2461/head:pull/2461`
`$ git checkout pull/2461`
