### PR TITLE
8261340: Fix 'deprecated' warnings in the vmTestbase/nsk tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ public class IORedirector extends Thread {
      *
      * @see #IORedirector(BufferedReader,Log,String)
      */
+    @Deprecated
     public IORedirector(InputStream in, OutputStream out) {
         this();
         bin  = new BufferedReader(new InputStreamReader(in));

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,7 @@ public class Log extends FinalizableObject {
      *
      * @deprecated  Tests should not use this field directly.
      */
+    @Deprecated
     protected PrintStream out = null;
 
     /**
@@ -185,6 +186,7 @@ public class Log extends FinalizableObject {
      *
      * @deprecated  Extending test class with Log is obsolete.
      */
+    @Deprecated
     protected Log() {
         // install finalizer to print errors summary at exit
         Finalizer finalizer = new Finalizer(this);
@@ -311,6 +313,7 @@ public class Log extends FinalizableObject {
      *              <code>display()</code> and <code>complain()</code>
      *              are enough for testing purposes.
      */
+    @Deprecated
     public synchronized void println(String message) {
         doPrint(message);
         if (!verbose() && isVerboseOnErrorEnabled()) {
@@ -327,6 +330,7 @@ public class Log extends FinalizableObject {
      *              <code>display()</code> and <code>complain()</code>
      *              are enough for testing purposes.
      */
+    @Deprecated
     public synchronized void comment(String message) {
         if (!verbose()) {
             doPrint(message);
@@ -464,6 +468,7 @@ public class Log extends FinalizableObject {
      *
      * @deprecated  This method is obsolete.
      */
+    @Deprecated
     protected synchronized void logTo(PrintStream stream) {
         finalize(); // flush older log stream
         out = stream;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,6 +93,7 @@ public class Binder extends DebugeeBinder {
      *              <code>Binder(ArgumentHandler,Log)</code>
      *              constructor.
      */
+    @Deprecated
     public Binder (String args[]) {
         this(args, new Log(System.err));
     }
@@ -105,6 +106,7 @@ public class Binder extends DebugeeBinder {
      *              <code>Binder(ArgumentHandler,Log)</code>
      *              constructor.
      */
+    @Deprecated
     public Binder (String args[], Log log) {
         this(new ArgumentHandler(args), log);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,6 +307,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
      *
      * @deprecated Use redirectStdout(Log, String) instead.
      */
+    @Deprecated
     public void redirectStdout(OutputStream out) {
         if (stdoutRedirector != null) {
             return;
@@ -343,6 +344,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
      *
      * @deprecated Use redirectStderr(Log, String) instead.
      */
+    @Deprecated
     public void redirectStderr(OutputStream err) {
         if (stderrRedirector != null) {
             return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ public class IOPipe extends SocketIOPipe {
       *
       * @see DebugeeArgumentHandler#createDebugeeIOPipe(Log)
       */
+    @Deprecated
     public IOPipe(DebugeeArgumentHandler argumentHandler, Log log) {
         this(log, getTestHost(argumentHandler), argumentHandler.getPipePortNumber(),
                 (long)argumentHandler.getWaitTime() * 60 * 1000, false);
@@ -62,6 +63,7 @@ public class IOPipe extends SocketIOPipe {
       *
       * @deprecated Use Debugee.createIOPipe() instead.
       */
+    @Deprecated
     public IOPipe(DebugeeProcess debugee) {
         this(debugee.getLog(),
                 debugee.getArgumentHandler().getDebugeeHost(),


### PR DESCRIPTION
Please review this small fix for JDK-8261340 to clean up deprecation warnings, such as the following, in the vmTestbase/nsk tests.

    warning: [dep-ann] deprecated item is not annotated with @Deprecated

The change was tested by running the tests locally and checking for the warnings.  It was regression tested with tiers 1-2 on Linux, Mac OS, and Windows and tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261340](https://bugs.openjdk.java.net/browse/JDK-8261340): Fix 'deprecated' warnings in the vmTestbase/nsk tests


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2462/head:pull/2462`
`$ git checkout pull/2462`
