### PR TITLE
8261279: sun/util/resources/cldr/TimeZoneNamesTest.java timed out

### DIFF
--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
  /*
  * @test
- * @bug 8181157 8202537 8234347 8236548
+ * @bug 8181157 8202537 8234347 8236548 8261279
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run testng/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -198,6 +198,7 @@ public class TimeZoneNamesTest {
     public void test_getZoneStrings() {
         assertFalse(
             Arrays.stream(Locale.getAvailableLocales())
+                .limit(30)
                 .peek(l -> System.out.println("Locale: " + l))
                 .map(l -> DateFormatSymbols.getInstance(l).getZoneStrings())
                 .flatMap(zs -> Arrays.stream(zs))


### PR DESCRIPTION
Please review this simple test case fix. By sampling locales to test, it reduces the possibility of the time out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261279](https://bugs.openjdk.java.net/browse/JDK-8261279): sun/util/resources/cldr/TimeZoneNamesTest.java timed out


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2465/head:pull/2465`
`$ git checkout pull/2465`
