### PR TITLE
8223188: Removed unnecessary #ifdef __cplusplus from .cpp sources

### DIFF
--- a/src/jdk.jpackage/windows/native/libjpackage/WindowsRegistry.cpp
+++ b/src/jdk.jpackage/windows/native/libjpackage/WindowsRegistry.cpp
@@ -68,9 +68,9 @@ std::wstring GetLongPath(const std::wstring& path) {
 
 } // namespace
 
-#ifdef __cplusplus
+
 extern "C" {
-#endif
+
 #undef jdk_jpackage_internal_WindowsRegistry_HKEY_LOCAL_MACHINE
 #define jdk_jpackage_internal_WindowsRegistry_HKEY_LOCAL_MACHINE 1L
 
@@ -216,6 +216,4 @@ extern "C" {
          return JNI_FALSE;
      }
 
-#ifdef __cplusplus
-}
-#endif
+} // extern "C"

--- a/src/jdk.jpackage/windows/native/libjpackage/jpackage.cpp
+++ b/src/jdk.jpackage/windows/native/libjpackage/jpackage.cpp
@@ -30,9 +30,7 @@
 #include "JniUtils.h"
 #include "MsiDb.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
     /*
      * Class:     jdk_jpackage_internal_ExecutableRebrander
@@ -159,6 +157,4 @@ extern "C" {
         return 1;
     }
 
-#ifdef __cplusplus
-}
-#endif
+} // extern "C"


### PR DESCRIPTION
Remove needless `#ifdef __cplusplus` from .cpp sources

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223188](https://bugs.openjdk.java.net/browse/JDK-8223188): Removed unnecessary #ifdef __cplusplus from .cpp sources


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to e924131986aaa60ed5569eabe045476b58e4e765
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer) ⚠️ Review applies to e924131986aaa60ed5569eabe045476b58e4e765
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2466/head:pull/2466`
`$ git checkout pull/2466`
