### PR TITLE
8261306: ServiceLoader documentation has malformed Unicode escape

### DIFF
--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,7 +280,7 @@ import jdk.internal.reflect.Reflection;
  * <p><a id="format">The provider-configuration file must be encoded in UTF-8. </a>
  * Space and tab characters surrounding each service provider's name, as well as
  * blank lines, are ignored. The comment character is {@code '#'}
- * ({@code '&#92;u0023'} <span style="font-size:smaller;">NUMBER SIGN</span>);
+ * ({@code U+0023} <span style="font-size:smaller;">NUMBER SIGN</span>);
  * on each line all characters following the first comment character are ignored.
  * If a service provider class name is listed more than once in a
  * provider-configuration file then the duplicate is ignored. If a service


### PR DESCRIPTION
Please review this really small correction to the class level documentation of `java.util.ServiceLoader`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261306](https://bugs.openjdk.java.net/browse/JDK-8261306): ServiceLoader documentation has malformed Unicode escape


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2468/head:pull/2468`
`$ git checkout pull/2468`
