### PR TITLE
8261598: Fix the link linked problem in SelectorProvider

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -52,11 +52,11 @@ import java.util.ServiceConfigurationError;
  *
  * <p> The system-wide default provider is used by the static {@code open}
  * methods of the {@link java.nio.channels.DatagramChannel#open()
- * DatagramChannel}, {@link java.nio.channels.Pipe#open() Pipe}, {@link
- * java.nio.channels.Selector#open() Selector}, {@link
+ * DatagramChannel}, {@link java.nio.channels.Pipe#open Pipe}, {@link
+ * java.nio.channels.Selector#open Selector}, {@link
  * java.nio.channels.ServerSocketChannel#open() ServerSocketChannel}, and {@link
  * java.nio.channels.SocketChannel#open() SocketChannel} classes.  It is also
- * used by the {@link java.lang.System#inheritedChannel() System.inheritedChannel()}
+ * used by the {@link java.lang.System#inheritedChannel System.inheritedChannel()}
  * method. A program may make use of a provider other than the default provider
  * by instantiating that provider and then directly invoking the {@code open}
  * methods defined in this class.

--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -51,12 +51,12 @@ import java.util.ServiceConfigurationError;
  * the default provider as specified below.
  *
  * <p> The system-wide default provider is used by the static {@code open}
- * methods of the {@link java.nio.channels.DatagramChannel#open
- * DatagramChannel}, {@link java.nio.channels.Pipe#open Pipe}, {@link
- * java.nio.channels.Selector#open Selector}, {@link
- * java.nio.channels.ServerSocketChannel#open ServerSocketChannel}, and {@link
- * java.nio.channels.SocketChannel#open SocketChannel} classes.  It is also
- * used by the {@link java.lang.System#inheritedChannel System.inheritedChannel()}
+ * methods of the {@link java.nio.channels.DatagramChannel#open()
+ * DatagramChannel}, {@link java.nio.channels.Pipe#open() Pipe}, {@link
+ * java.nio.channels.Selector#open() Selector}, {@link
+ * java.nio.channels.ServerSocketChannel#open() ServerSocketChannel}, and {@link
+ * java.nio.channels.SocketChannel#open() SocketChannel} classes.  It is also
+ * used by the {@link java.lang.System#inheritedChannel() System.inheritedChannel()}
  * method. A program may make use of a provider other than the default provider
  * by instantiating that provider and then directly invoking the {@code open}
  * methods defined in this class.


### PR DESCRIPTION
Some link is not right.
Such as: 
{@link java.nio.channels.DatagramChannel#open DatagramChannel}, 
{@link java.nio.channels.ServerSocketChannel#open ServerSocketChannel}, 
{@link java.nio.channels.SocketChannel#open SocketChannel}

The class exist field called open, so it will link to the field `open`. The comment should change to `open()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8261598](https://bugs.openjdk.java.net/browse/JDK-8261598)

### Issue
 * [JDK-8261598](https://bugs.openjdk.java.net/browse/JDK-8261598): Links in SelectorProvider javadoc not working in IDE ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2470/head:pull/2470` \
`$ git checkout pull/2470`

Update a local copy of the PR: \
`$ git checkout pull/2470` \
`$ git pull https://git.openjdk.java.net/jdk pull/2470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2470`

View PR using the GUI difftool: \
`$ git pr show -t 2470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2470.diff">https://git.openjdk.java.net/jdk/pull/2470.diff</a>

</details>
