### PR TITLE
src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -63,7 +63,10 @@ static struct perfbuf {
 #define DEC_64 "%"SCNd64
 
 static void next_line(FILE *f) {
-    while (fgetc(f) != '\n');
+    int c;
+    do {
+        c = fgetc(f);
+    } while (c != '\n' && c != EOF);
 }
 
 /**


### PR DESCRIPTION
Fix the dead loop
Summary: If the /proc/stat mount point is changed in container environment, the while loop may lead to 100% cpu usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2474/head:pull/2474`
`$ git checkout pull/2474`
