### PR TITLE
6206189: Graphics2D.clip specifies incorrectly that a 'null' is a valid value for this method

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Graphics.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/Graphics.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics.java
@@ -354,7 +354,8 @@ public abstract class Graphics {
      * {@code Rectangle} objects.  This method sets the
      * user clip, which is independent of the clipping associated
      * with device bounds and window visibility.
-     * @param clip the {@code Shape} to use to set the clip
+     * @param clip the {@code Shape} to use to set the clip.
+     *             Passing {@code null} clears the current {@code clip}.
      * @see         java.awt.Graphics#getClip()
      * @see         java.awt.Graphics#clipRect
      * @see         java.awt.Graphics#setClip(int, int, int, int)

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1203,7 +1203,7 @@ public abstract class Graphics2D extends Graphics {
      * user clip.
      * <p>Since this method intersects the specified shape
      * with the current clip, it will throw {@code NullPointerException}
-     * for a null shape unless the user clip is also {@code null}.
+     * for a {@code null} shape unless the user clip is also {@code null}.
      * So calling this method with a {@code null} argument is not recommended.
      * @param s the {@code Shape} to be intersected with the current
      *          {@code Clip}. This method updates the current {@code Clip}.

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1204,7 +1204,7 @@ public abstract class Graphics2D extends Graphics {
      * <p>Since this method intersects the specified shape
      * with the current clip, it will throw {@code NullPointerException}
      * for a null shape unless the user clip is also {@code null}.
-     * So calling this method with a null argument is not recommended.
+     * So calling this method with a {@code null} argument is not recommended.
      * @param s the {@code Shape} to be intersected with the current
      *          {@code Clip}. This method updates the current {@code Clip}.
      * @throws NullPointerException if {@code s} is {@code null}

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1195,12 +1195,13 @@ public abstract class Graphics2D extends Graphics {
      * {@code Clip}.  This method is used to make the current
      * {@code Clip} smaller.
      * To make the {@code Clip} larger, use {@code setClip}.
-     * The <i>user clip</i> modified by this method is independent of the
+     * <p>The <i>user clip</i> modified by this method is independent of the
      * clipping associated with device bounds and visibility.  If no clip has
      * previously been set, or if the clip has been cleared using
      * {@link Graphics#setClip(Shape) setClip} with a {@code null}
      * argument, the specified {@code Shape} becomes the new
-     * user clip. Since this method intersects the specified shape
+     * user clip.
+     * <p>Since this method intersects the specified shape
      * with the current clip, it will throw {@code NullPointerException}
      * for a null shape unless the user clip is also {@code null}.
      * So calling this method with a null argument is not recommended.

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1201,7 +1201,7 @@ public abstract class Graphics2D extends Graphics {
      * {@link Graphics#setClip(Shape) setClip} with a {@code null}
      * argument, the specified {@code Shape} becomes the new
      * user clip. Since this method intersects the specified shape
-     * with the current clip, it will throw NPE for a null shape
+     * with the current clip, it will throw {@code NullPointerException} for a null shape
      * unless the user clip is also null.
      * So calling this method with a null argument is not recommended.
      * @param s the {@code Shape} to be intersected with the current

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1200,11 +1200,14 @@ public abstract class Graphics2D extends Graphics {
      * previously been set, or if the clip has been cleared using
      * {@link Graphics#setClip(Shape) setClip} with a {@code null}
      * argument, the specified {@code Shape} becomes the new
-     * user clip.
+     * user clip. Since this method intersects the specified shape
+     * with the current clip, it will throw NPE for a null shape
+     * unless the user clip is also null.
+     * So calling this method with a null argument is not recommended.
      * @param s the {@code Shape} to be intersected with the current
      *          {@code Clip}. This method updates the current {@code Clip}.
      * @throws NullPointerException if {@code s} is {@code null}
-     *         and clip is already set via {@code setClip}
+     *         and a user clip is currently set.
      */
      public abstract void clip(Shape s);
 

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1201,8 +1201,8 @@ public abstract class Graphics2D extends Graphics {
      * {@link Graphics#setClip(Shape) setClip} with a {@code null}
      * argument, the specified {@code Shape} becomes the new
      * user clip. Since this method intersects the specified shape
-     * with the current clip, it will throw {@code NullPointerException} for a null shape
-     * unless the user clip is also null.
+     * with the current clip, it will throw {@code NullPointerException}
+     * for a null shape unless the user clip is also {@code null}.
      * So calling this method with a null argument is not recommended.
      * @param s the {@code Shape} to be intersected with the current
      *          {@code Clip}. This method updates the current {@code Clip}.

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1202,7 +1202,7 @@ public abstract class Graphics2D extends Graphics {
      * argument, the specified {@code Shape} becomes the new
      * user clip.
      * @param s the {@code Shape} to be intersected with the current
-     *          {@code Clip}. This method clears the current {@code Clip}.
+     *          {@code Clip}. This method updates the current {@code Clip}.
      * @throws NullPointerException if {@code s} is {@code null}
      *         and clip is already set via {@code setClip}
      */

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1202,8 +1202,9 @@ public abstract class Graphics2D extends Graphics {
      * argument, the specified {@code Shape} becomes the new
      * user clip.
      * @param s the {@code Shape} to be intersected with the current
-     *          {@code Clip}.
+     *          {@code Clip}. This method clears the current {@code Clip}.
      * @throws NullPointerException if {@code s} is {@code null}
+     *         and clip is already set via {@code setClip}
      */
      public abstract void clip(Shape s);
 

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1202,8 +1202,8 @@ public abstract class Graphics2D extends Graphics {
      * argument, the specified {@code Shape} becomes the new
      * user clip.
      * @param s the {@code Shape} to be intersected with the current
-     *          {@code Clip}.  If {@code s} is {@code null},
-     *          this method clears the current {@code Clip}.
+     *          {@code Clip}.
+     * @throws NullPointerException if {@code s} is {@code null}
      */
      public abstract void clip(Shape s);
 

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -37,15 +37,15 @@ public class TestNullClip {
         BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = (Graphics2D)bi.getGraphics();
 
+        g2d.setClip(0, 0, 100, 100);
+        Shape clip = g2d.getClip();
+        g2d.setClip(null);
+        Shape clip1 = g2d.getClip();
+        if (clip1 != null) {
+            throw new RuntimeException("Clip is not cleared");
+        }
+        g2d.setClip(0, 0, 100, 100);
         try {
-            g2d.setClip(0, 0, 100, 100);
-            Shape clip = g2d.getClip();
-            g2d.setClip(null);
-            Shape clip1 = g2d.getClip();
-            if (clip1 != null) {
-                throw new RuntimeException("Clip is not cleared");
-            }
-            g2d.setClip(0, 0, 100, 100);
             g2d.clip(null);
             throw new RuntimeException("NPE is expected");
         } catch (NullPointerException e) {

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -37,8 +37,9 @@ public class TestNullClip {
         BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = (Graphics2D)bi.getGraphics();
 
+        g2d.clip(null); // silently return, no NPE should be thrown
+
         g2d.setClip(0, 0, 100, 100);
-        Shape clip = g2d.getClip();
         g2d.setClip(null);
         Shape clip1 = g2d.getClip();
         if (clip1 != null) {

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -24,6 +24,7 @@
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.awt.Shape;
 
 /**
  * @test
@@ -37,6 +38,13 @@ public class TestNullClip {
         Graphics2D g2d = (Graphics2D)bi.getGraphics();
 
         try {
+            g2d.setClip(0, 0, 100, 100);
+	    Shape clip = g2d.getClip();
+	    g2d.setClip(null);
+	    Shape clip1 = g2d.getClip();
+	    if (clip1 != null) {
+                throw new RuntimeException("Clip is not cleared");
+	    }
             g2d.setClip(0, 0, 100, 100);
             g2d.clip(null);
             throw new RuntimeException("NPE is expected");

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -39,9 +39,9 @@ public class TestNullClip {
 
         try {
             g2d.setClip(0, 0, 100, 100);
-	    Shape clip = g2d.getClip();
-	    g2d.setClip(null);
-	    Shape clip1 = g2d.getClip();
+            Shape clip = g2d.getClip();
+            g2d.setClip(null);
+            Shape clip1 = g2d.getClip();
 	    if (clip1 != null) {
                 throw new RuntimeException("Clip is not cleared");
 	    }

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -42,9 +42,9 @@ public class TestNullClip {
             Shape clip = g2d.getClip();
             g2d.setClip(null);
             Shape clip1 = g2d.getClip();
-	    if (clip1 != null) {
+            if (clip1 != null) {
                 throw new RuntimeException("Clip is not cleared");
-	    }
+            }
             g2d.setClip(0, 0, 100, 100);
             g2d.clip(null);
             throw new RuntimeException("NPE is expected");

--- a/test/jdk/java/awt/Graphics2D/TestNullClip.java
+++ b/test/jdk/java/awt/Graphics2D/TestNullClip.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * @test
+ * @bug 6206189
+ * @summary Verifies passing null to Graphics2D.clip(Shape) throws NPE.
+ */
+public class TestNullClip {
+
+    public static void main(String[] argv) {
+        BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = (Graphics2D)bi.getGraphics();
+
+        try {
+            g2d.setClip(0, 0, 100, 100);
+            g2d.clip(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException e) {
+            //expected
+            System.out.println("NPE is thrown");
+        }
+    }
+}


### PR DESCRIPTION
The API doc for Graphics2D.clip(shape s) claims that passing a null argument would actually clear the existing clipping area, which is incorrect.
This statement is applicable only to G2D.setClip() and not for the clip() method. G2D.clip() would throw a NullPointerException when it encounters a null argument. 
Updated spec to rectify this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6206189](https://bugs.openjdk.java.net/browse/JDK-6206189): Graphics2D.clip specifies incorrectly that a 'null' is a valid value for this method


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2476/head:pull/2476`
`$ git checkout pull/2476`
