### PR TITLE
8261413: Shenandoah: Disable class-unloading in I-U mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -34,10 +34,10 @@
 #include "runtime/java.hpp"
 
 void ShenandoahIUMode::initialize_flags() const {
-  if (FLAG_IS_CMDLINE(ClassUnloading) && ClassUnloading) {
-    log_warning(gc)("Shenandoah I-U mode sets -XX:-ClassUnloading; see JDK-8261341 for details");
+  if (FLAG_IS_CMDLINE(ClassUnloadingWithConcurrentMark) && ClassUnloading) {
+    log_warning(gc)("Shenandoah I-U mode sets -XX:-ClassUnloadingWithConcurrentMark; see JDK-8261341 for details");
   }
-  FLAG_SET_DEFAULT(ClassUnloading, false);
+  FLAG_SET_DEFAULT(ClassUnloadingWithConcurrentMark, false);
 
   if (ClassUnloading) {
     FLAG_SET_DEFAULT(ShenandoahSuspendibleWorkers, true);

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -34,6 +34,12 @@
 #include "runtime/java.hpp"
 
 void ShenandoahIUMode::initialize_flags() const {
+  // See: https://bugs.openjdk.java.net/browse/JDK-8261341
+  if (FLAG_IS_CMDLINE(ClassUnloading) && ClassUnloading) {
+    log_warning(gc)("Shenandoah I-U mode forces -XX:-ClassUnloading, for decails, see https://bugs.openjdk.java.net/browse/JDK-8261341");
+  }
+  FLAG_SET_DEFAULT(ClassUnloading, false);
+
   if (ClassUnloading) {
     FLAG_SET_DEFAULT(ShenandoahSuspendibleWorkers, true);
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -34,9 +34,8 @@
 #include "runtime/java.hpp"
 
 void ShenandoahIUMode::initialize_flags() const {
-  // See: https://bugs.openjdk.java.net/browse/JDK-8261341
   if (FLAG_IS_CMDLINE(ClassUnloading) && ClassUnloading) {
-    log_warning(gc)("Shenandoah I-U mode forces -XX:-ClassUnloading, for decails, see https://bugs.openjdk.java.net/browse/JDK-8261341");
+    log_warning(gc)("Shenandoah I-U mode sets -XX:-ClassUnloading; see JDK-8261341 for details");
   }
   FLAG_SET_DEFAULT(ClassUnloading, false);
 


### PR DESCRIPTION
JDK-8261341 describes a serious problem with I-U mode and class-unloading. Let's disable class-unloading in I-U for now as a workaround.

Testing:
 - [x] hotspot_gc_shenandoah
 - [x] tier1 (+UseShenandoahGC +IU)
 - [x] runtime/CreateMirror/ArraysNewInstanceBug.java (+UseShenandoahGC +IU +aggressive) many times in a row w/o failure

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261413](https://bugs.openjdk.java.net/browse/JDK-8261413): Shenandoah: Disable class-unloading in I-U mode


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to e3c1b459c8cb42381e8007a4fd06eec4bb5d227c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2477/head:pull/2477`
`$ git checkout pull/2477`
