### PR TITLE
8261431: SA: Add comments about load address of executable

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -507,7 +507,11 @@ static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehd
         result = exec_php->p_vaddr;
         ph->core->dynamic_addr = exec_php->p_vaddr;
       } else { // ET_DYN
+        // Base address of executable is based on entry point (AT_ENTRY).
         result = ph->core->dynamic_addr - exec_ehdr->e_entry;
+
+        // dynamic_addr has entry point of executable.
+        // Thus we should subtract it.
         ph->core->dynamic_addr += exec_php->p_vaddr - exec_ehdr->e_entry;
       }
       print_debug("address of _DYNAMIC is 0x%lx\n", ph->core->dynamic_addr);


### PR DESCRIPTION
I removed the comment about load address of executable in [JDK-8248876](https://bugs.openjdk.java.net/browse/JDK-8248876) (#2366), but it contained useful information for maintenance.

So I re-add them, and add comment for the change in JDK-8248876. Please see https://github.com/openjdk/jdk/pull/2366#issuecomment-775362982

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261431](https://bugs.openjdk.java.net/browse/JDK-8261431): SA: Add comments about load address of executable


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2478/head:pull/2478`
`$ git checkout pull/2478`
