### PR TITLE
8261029: Code heap page sizes not traced correctly using os::trace_page_sizes

### DIFF
--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -207,17 +207,12 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   _log2_segment_size = exact_log2(segment_size);
 
   // Reserve and initialize space for _memory.
-  size_t page_size = os::vm_page_size();
-  if (os::can_execute_large_page_memory()) {
-    const size_t min_pages = 8;
-    page_size = MIN2(os::page_size_for_region_aligned(committed_size, min_pages),
-                     os::page_size_for_region_aligned(rs.size(), min_pages));
-  }
-
+  const size_t page_size = ReservedSpace::actual_reserved_page_size(rs);
   const size_t granularity = os::vm_allocation_granularity();
   const size_t c_size = align_up(committed_size, page_size);
+  assert(c_size <= rs.size(), "alignment made committed size to large");
 
-  os::trace_page_sizes(_name, committed_size, rs.size(), page_size,
+  os::trace_page_sizes(_name, c_size, rs.size(), page_size,
                        rs.base(), rs.size());
   if (!_memory.initialize(rs, c_size)) {
     return false;


### PR DESCRIPTION
When adding a code heap the page size used with the underlying mapping is traced using `os::trace_page_sizes`. The old code tried to estimate the page-size based on the size, but the mapping has already been done so it is better to check the passed in `ReservedSpace`. Today we don't record the page size in the ReservedSpace, but we have a helper to do a good estimate: `ReservedSpace::actual_reserved_page_size()`. The proposal is to use this function.

When changing this I also realized that the traced min-size used un-aligned value while the actual `initialize`-call correctly uses the aligned size. Changed so that we also use the aligned size for tracing.

I'm currently doing some more work in this area and while I haven't added a specific test for this issue I have created a test I plan to integrate separately when a few more needed changes have gone in. The test is Linux-only and validates the output from `os::trace_page_sizes` against the information in `/proc/self/smaps`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261029](https://bugs.openjdk.java.net/browse/JDK-8261029): Code heap page sizes not traced correctly using os::trace_page_sizes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2481/head:pull/2481`
`$ git checkout pull/2481`
