### PR TITLE
JDK-8261422: Adjust problematic String.format calls in jdk/internal/util/Preconditions.java outOfBoundsMessage

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Preconditions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,13 +203,13 @@ public class Preconditions {
         // Switch to default if fewer or more arguments than required are supplied
         switch ((args.size() != argSize) ? "" : checkKind) {
             case "checkIndex":
-                return String.format("Index %d out of bounds for length %d",
+                return String.format("Index %s out of bounds for length %s",
                                      args.get(0), args.get(1));
             case "checkFromToIndex":
-                return String.format("Range [%d, %d) out of bounds for length %d",
+                return String.format("Range [%s, %s) out of bounds for length %s",
                                      args.get(0), args.get(1), args.get(2));
             case "checkFromIndexSize":
-                return String.format("Range [%d, %<d + %d) out of bounds for length %d",
+                return String.format("Range [%s, %<s + %s) out of bounds for length %s",
                                      args.get(0), args.get(1), args.get(2));
             default:
                 return String.format("Range check failed: %s %s", checkKind, args);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261422](https://bugs.openjdk.java.net/browse/JDK-8261422): Adjust problematic String.format calls in jdk/internal/util/Preconditions.java outOfBoundsMessage


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2483/head:pull/2483`
`$ git checkout pull/2483`
