### PR TITLE
8261230: GC tracing of page sizes are wrong in a few places

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1497,8 +1497,8 @@ G1RegionToSpaceMapper* G1CollectedHeap::create_aux_memory_mapper(const char* des
 
   os::trace_page_sizes_for_requested_size(description,
                                           size,
-                                          preferred_page_size,
                                           page_size,
+                                          preferred_page_size,
                                           rs.base(),
                                           rs.size());
 

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -50,7 +50,8 @@ ParMarkBitMap::initialize(MemRegion covered_region)
   const size_t rs_align = page_sz == (size_t) os::vm_page_size() ? 0 :
     MAX2(page_sz, granularity);
   ReservedSpace rs(_reserved_byte_size, rs_align, rs_align > 0);
-  os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes, page_sz,
+  const size_t used_page_sz = ReservedSpace::actual_reserved_page_size(rs);
+  os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes, used_page_sz,
                        rs.base(), rs.size());
 
   MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -172,11 +172,12 @@ ReservedHeapSpace GenCollectedHeap::allocate(size_t alignment) {
          SIZE_FORMAT, total_reserved, alignment);
 
   ReservedHeapSpace heap_rs = Universe::reserve_heap(total_reserved, alignment);
+  size_t used_page_size = ReservedSpace::actual_reserved_page_size(heap_rs);
 
   os::trace_page_sizes("Heap",
                        MinHeapSize,
                        total_reserved,
-                       alignment,
+                       used_page_size,
                        heap_rs.base(),
                        heap_rs.size());
 

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -49,16 +49,31 @@ public class TestLargePageUseForAuxMemory {
     static long smallPageSize;
     static long allocGranularity;
 
-    static boolean checkLargePagesEnabled(OutputAnalyzer output) {
+    static boolean largePagesEnabled(OutputAnalyzer output) {
+        // The gc+init logging includes information about large pages.
         String lp = output.firstMatch("Large Page Support: (\\w*)", 1);
         return lp != null && lp.equals("Enabled");
     }
 
-    static void checkSize(OutputAnalyzer output, long expectedSize, String pattern) {
-        // First check if there is a large page failure associated with
-        // the data structure being checked.
+    static boolean largePagesAllocationFailure(OutputAnalyzer output, String pattern) {
+        // Check if there is a large page failure associated with the data  structure
+        // being checked. In case of a large page allocation failure the output will
+        // include logs like this for the affected data structure:
+        // [0.048s][debug][gc,heap,coops] Reserve regular memory without large pages
+        // [0.048s][info ][pagesize     ] Next Bitmap: ... page_size=4K ...
+        //
+        // The pattern passed in should match the second line.
         String failureMatch = output.firstMatch("Reserve regular memory without large pages\\n.*" + pattern, 1);
         if (failureMatch != null) {
+            return true;
+        }
+        return false;
+    }
+
+    static void checkSize(OutputAnalyzer output, long expectedSize, String pattern) {
+        // First check the output for any large page allocation failure associated with
+        // the checked data structure. If we detect a failure then expect small pages.
+        if (largePagesAllocationFailure(output, pattern)) {
             // This should only happen when we are expecting large pages
             if (expectedSize == smallPageSize) {
                 throw new RuntimeException("Expected small page size when large page failure was detected");
@@ -105,9 +120,8 @@ public class TestLargePageUseForAuxMemory {
                                                    "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        // Only expect large page size if no large page allocation failures
-        // are present in the log.
-        if (checkLargePagesEnabled(output)) {
+        // Only expect large page size if large pages are enabled.
+        if (largePagesEnabled(output)) {
             checkSmallTables(output, (cardsShouldUseLargePages ? largePageSize : smallPageSize));
             checkBitmaps(output, (bitmapShouldUseLargePages ? largePageSize : smallPageSize));
         } else {


### PR DESCRIPTION
The usage of `os::trace_page_sizes()` and friends are wrongly assuming that we always get the page size requested and needs to be updated. This is done by using the helper `ReservedSpace::actual_reserved_page_size()` instead of blindly trusting we get what we ask for. I have plans for the future to get rid of this helper and instead record the page size used in the `ReservedSpace`, but for now the helper is good enough. 

In G1 we used the helper but switched the order of the page size and the alignment parameter, which in turn helped the test to pass since the alignment will match the page size we expect in the test. The test had to be improved to recognize mapping failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261230](https://bugs.openjdk.java.net/browse/JDK-8261230): GC tracing of page sizes are wrong in a few places


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 76faa2e43f3d4f127374b9b7ed8e5e892da131f5


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2486/head:pull/2486`
`$ git checkout pull/2486`
