### PR TITLE
8261481: Cannot read Kerberos settings in dynamic store on macOS Big Sur

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -167,17 +167,16 @@ public class Config {
 
         String osVersion = GetPropertyAction.privilegedGetProperty("os.version");
         String[] fragments = osVersion.split("\\.");
-
-        // sanity check the "10." part of the version
-        if (!fragments[0].equals("10")) return false;
         if (fragments.length < 2) return false;
 
-        // check if Mac OS X 10.7(.y)
+        // check if Mac OS X 10.7(.y) or higher
         try {
+            int majorVers = Integer.parseInt(fragments[0]);
             int minorVers = Integer.parseInt(fragments[1]);
-            if (minorVers >= 7) return true;
+            if (majorVers > 10) return true;
+            if (majorVers == 10 && minorVers >= 7) return true;
         } catch (NumberFormatException e) {
-            // was not an integer
+            // were not integers
         }
 
         return false;


### PR DESCRIPTION
Accept macOS 11.x as well.

No new regression test. This can be approved by running the existing test test/sun/security/krb5/config/native/TestDynamicStore.java on Big Sur.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261481](https://bugs.openjdk.java.net/browse/JDK-8261481): Cannot read Kerberos settings in dynamic store on macOS Big Sur


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2492/head:pull/2492`
`$ git checkout pull/2492`
