### PR TITLE
8261472: BasicConstraintsExtension::toString shows "PathLen:2147483647" if there is no pathLenConstraint

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,10 +171,17 @@ implements CertAttrSet<String> {
       * Return user readable form of extension.
       */
      public String toString() {
+         String pathLenAsString;
+         if (pathLen < 0) {
+             pathLenAsString = " undefined";
+         } else if (pathLen == Integer.MAX_VALUE) {
+             pathLenAsString = " no limit";
+         } else {
+             pathLenAsString = String.valueOf(pathLen);
+         }
          return super.toString() +
              "BasicConstraints:[\n  CA:" + ca +
-             "\n  PathLen:" +
-             ((pathLen >= 0) ? String.valueOf(pathLen) : " undefined") +
+             "\n  PathLen:" + pathLenAsString +
              "\n]\n";
      }
 


### PR DESCRIPTION
Print out "no limit" instead. This is the words RFC 5280 uses: "Where pathLenConstraint does not appear, no limit is imposed".

No regression test. Trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261472](https://bugs.openjdk.java.net/browse/JDK-8261472): BasicConstraintsExtension::toString shows "PathLen:2147483647" if there is no pathLenConstraint


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2493/head:pull/2493`
`$ git checkout pull/2493`
