### PR TITLE
8261493: Shenandoah: reconsider bitmap access memory ordering

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkBitMap.hpp
@@ -82,8 +82,6 @@ private:
     return map() + to_words_align_down(bit);
   }
 
-  static inline const bm_word_t load_word_ordered(const volatile bm_word_t* const addr, atomic_memory_order memory_order);
-
   bool at(idx_t index) const {
     verify_index(index);
     return (*word_addr(index) & bit_mask(index)) != 0;


### PR DESCRIPTION
Shenandoah currently uses its own marking bitmap (added by JDK-8254315). It accesses the marking bitmap with "acquire" for reads and "conservative" for updates. Hotspot's default for atomic operations is memory_order_conservative, which emits two-way memory fences around the CASes at least on AArch64 and PPC64.

I think both are actually excessive for marking bitmap accesses: we do not piggyback object updates on it, the atomics there are only to guarantee the access atomicity and CAS updates to bits.  It seems "relaxed" is enough for marking bitmap accesses.

Sample run with "compact" (frequent GC cycles) on SPECjvm2008:compiler.sunflow on AArch64:

```
# Baseline
# Baseline
[146.028s][info][gc,stats] Concurrent Marking =   50.315 s (a =   258024 us) (n =   195) (lvls, us =    31836,   230469,   273438,   306641,   464255)
[141.458s][info][gc,stats] Concurrent Marking =   47.819 s (a =   242737 us) (n =   197) (lvls, us =    42773,   197266,   267578,   287109,   433948)
[144.108s][info][gc,stats] Concurrent Marking =   49.806 s (a =   250283 us) (n =   199) (lvls, us =    32227,   201172,   267578,   296875,   448549)

# Patched
[144.238s][info][gc,stats] Concurrent Marking =   46.627 s (a =   220981 us) (n =   211) (lvls, us =    24414,   197266,   238281,   259766,   345112)
[138.406s][info][gc,stats] Concurrent Marking =   45.022 s (a =   227383 us) (n =   198) (lvls, us =    20508,   205078,   244141,   271484,   427658)
[140.950s][info][gc,stats] Concurrent Marking =   45.073 s (a =   222036 us) (n =   203) (lvls, us =    21680,   181641,   240234,   265625,   375750)
```

Average time goes down, total marking time goes down.

Additional testing:
 - [x] Linux x86_64 `hotspot_gc_shenandoah`
 - [x] Linux AArch64 `hotspot_gc_shenandoah`
 - [x] Linux AArch64 `tier1` with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261493](https://bugs.openjdk.java.net/browse/JDK-8261493): Shenandoah: reconsider bitmap access memory ordering


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2497/head:pull/2497`
`$ git checkout pull/2497`
