### PR TITLE
8261496: Shenandoah: reconsider pacing updates memory ordering

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -100,7 +100,7 @@ void ShenandoahControlThread::run_service() {
     bool implicit_gc_requested = _gc_requested.is_set() && !is_explicit_gc(_requested_gc_cause);
 
     // This control loop iteration have seen this much allocations.
-    size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0);
+    size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
 
     // Check if we have seen a new target for soft max heap size.
     bool soft_max_changed = check_soft_max_changed();
@@ -595,7 +595,7 @@ void ShenandoahControlThread::notify_heap_changed() {
 
 void ShenandoahControlThread::pacing_notify_alloc(size_t words) {
   assert(ShenandoahPacing, "should only call when pacing is enabled");
-  Atomic::add(&_allocs_seen, words);
+  Atomic::add(&_allocs_seen, words, memory_order_relaxed);
 }
 
 void ShenandoahControlThread::set_forced_counters_update(bool value) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
@@ -53,13 +53,13 @@ inline void ShenandoahPacer::report_internal(size_t words) {
 inline void ShenandoahPacer::report_progress_internal(size_t words) {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
   STATIC_ASSERT(sizeof(size_t) <= sizeof(intptr_t));
-  Atomic::add(&_progress, (intptr_t)words);
+  Atomic::add(&_progress, (intptr_t)words, memory_order_relaxed);
 }
 
 inline void ShenandoahPacer::add_budget(size_t words) {
   STATIC_ASSERT(sizeof(size_t) <= sizeof(intptr_t));
   intptr_t inc = (intptr_t) words;
-  intptr_t new_budget = Atomic::add(&_budget, inc);
+  intptr_t new_budget = Atomic::add(&_budget, inc, memory_order_relaxed);
 
   // Was the budget replenished beyond zero? Then all pacing claims
   // are satisfied, notify the waiters. Avoid taking any locks here,


### PR DESCRIPTION
Shenandoah pacer uses atomic operations to update budget, progress, allocations seen. Hotspot's default for atomic operations is memory_order_conservative, which emits two-way memory fences around the CASes at least on AArch64 and PPC64.

This is excessive for pacing, as we do not piggyback memory effects on it. All pacing updates can use "relaxed".

Additional testing:
 - [x] Linux x86_64 hotspot_gc_shenandoah
 - [x] Linux AArch64 hotspot_gc_shenandoah
 - [x] Linux AArch64 tier1 with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261496](https://bugs.openjdk.java.net/browse/JDK-8261496): Shenandoah: reconsider pacing updates memory ordering


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2501/head:pull/2501`
`$ git checkout pull/2501`
