### PR TITLE
8160720: [TEST_BUG] javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,6 @@ javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
-javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all

--- a/test/jdk/javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java
+++ b/test/jdk/javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java
@@ -40,7 +40,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
  * @bug 8015085 8079253
  * @summary Shortening via " ... " is broken for Strings containing a combining
  *          diaeresis.
- * @run main TestBadBreak
+ * @run main/othervm -Dsun.java2d.uiScale=1 TestBadBreak
  */
 public class TestBadBreak {
 
@@ -54,6 +54,7 @@ public class TestBadBreak {
         final BufferedImage bi1 = new BufferedImage(200, 90, TYPE_INT_ARGB);
         final BufferedImage bi2 = new BufferedImage(200, 90, TYPE_INT_ARGB);
         test(withCombiningDiaeresis, bi1);
+        robot.delay(1000);
         test(withoutCombiningDiaeresis, bi2);
         for (int x = 0; x < bi1.getWidth(); ++x) {
             for (int y = 0; y < bi1.getHeight(); ++y) {
@@ -83,11 +84,14 @@ public class TestBadBreak {
                 label.setOpaque(true);
                 frame.getContentPane().add(label);
                 frame.setBounds(200, 200, 200, 90);
+                frame.setUndecorated(true);
+                frame.setLocationRelativeTo(null);
             }
         });
         robot.waitForIdle();
         SwingUtilities.invokeAndWait(() -> frame.setVisible(true));
         robot.waitForIdle();
+        robot.delay(1000);
         SwingUtilities.invokeAndWait(frame::dispose);
         robot.waitForIdle();
     }


### PR DESCRIPTION
Test hardcodes bufferedimage and frame bounds so it does not capture correct size if scaling factor is used.
The solution is to always use the same uiscale=1, an updated test still can reproduce the JDK-8015085 issue without fix. Additionally, moved the frame to centre of screen for better mach5 stability.
Mach5 job running for several iterations on all platforms is ok. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8160720](https://bugs.openjdk.java.net/browse/JDK-8160720): [TEST_BUG] javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2502/head:pull/2502`
`$ git checkout pull/2502`
