### PR TITLE
8261500: Shenandoah: reconsider region live data memory ordering

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -80,7 +80,7 @@ inline void ShenandoahHeapRegion::increase_live_data_gc_words(size_t s) {
 }
 
 inline void ShenandoahHeapRegion::internal_increase_live_data(size_t s) {
-  size_t new_live_data = Atomic::add(&_live_data, s);
+  size_t new_live_data = Atomic::add(&_live_data, s, memory_order_relaxed);
 #ifdef ASSERT
   size_t live_bytes = new_live_data * HeapWordSize;
   size_t used_bytes = used();
@@ -90,11 +90,11 @@ inline void ShenandoahHeapRegion::internal_increase_live_data(size_t s) {
 }
 
 inline void ShenandoahHeapRegion::clear_live_data() {
-  Atomic::release_store_fence(&_live_data, (size_t)0);
+  Atomic::store(&_live_data, (size_t)0);
 }
 
 inline size_t ShenandoahHeapRegion::get_live_data_words() const {
-  return Atomic::load_acquire(&_live_data);
+  return Atomic::load(&_live_data);
 }
 
 inline size_t ShenandoahHeapRegion::get_live_data_bytes() const {


### PR DESCRIPTION
Current Shenandoah region live data tracking uses default CAS updates to achieve atomicity of updates. Hotspot's default for atomic operations is memory_order_conservative, which emits two-way memory fences around the CASes at least on AArch64 and PPC64.

This seems to be excessive for live data tracking, and "relaxed" could be used instead. The only serious user of that data is collection set chooser, which runs at safepoint and so everything should be quiescent when that happens.

Additional testing:
 - [x] Linux x86_64 hotspot_gc_shenandoah
 - [x] Linux AArch64 hotspot_gc_shenandoah
 - [x] Linux AArch64 tier1 with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261500](https://bugs.openjdk.java.net/browse/JDK-8261500): Shenandoah: reconsider region live data memory ordering


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2503/head:pull/2503`
`$ git checkout pull/2503`
