### PR TITLE
8261504: Shenandoah: reconsider ShenandoahJavaThreadsIterator::claim memory ordering

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -46,7 +46,7 @@ ShenandoahJavaThreadsIterator::ShenandoahJavaThreadsIterator(ShenandoahPhaseTimi
 }
 
 uint ShenandoahJavaThreadsIterator::claim() {
-  return Atomic::fetch_and_add(&_claimed, _stride);
+  return Atomic::fetch_and_add(&_claimed, _stride, memory_order_relaxed);
 }
 
 void ShenandoahJavaThreadsIterator::threads_do(ThreadClosure* cl, uint worker_id) {


### PR DESCRIPTION
JDK-8256298 added the thread iterator for thread roots, and I don't think we need the Hotspot's default memory_order_conservative, which emits two-way memory fences around the CASes at least on AArch64 and PPC64. The simple "relaxed" should do.

Additional testing:
 - [x] Linux x86_64 hotspot_gc_shenandoah
 - [x] Linux AArch64 hotspot_gc_shenandoah
 - [x] Linux AArch64 tier1 with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261504](https://bugs.openjdk.java.net/browse/JDK-8261504): Shenandoah: reconsider ShenandoahJavaThreadsIterator::claim memory ordering


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2506/head:pull/2506`
`$ git checkout pull/2506`
