### PR TITLE
8261505: Test test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java killed by Linux OOM Killer

### DIFF
--- a/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
+++ b/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
@@ -26,7 +26,7 @@ package gc.parallel;
 /**
  * @test TestDynShrinkHeap
  * @bug 8016479
- * @requires vm.gc.Parallel
+ * @requires vm.gc.Parallel & os.maxMemory > 1G
  * @summary Verify that the heap shrinks after full GC according to the current values of the Min/MaxHeapFreeRatio flags
  * @modules java.base/jdk.internal.misc
  * @modules jdk.management


### PR DESCRIPTION
On memory constrained devices, the test might get killed by the linux kernel OOM Killer.

Executing the test with the JTreg test harness makes the test fail and get killed by the OOM Killer.
Executing the test manually, by using the JTreg provided "rerun" command line, the test succeeds.
This happened on a Raspberry PI 2, which has only 1G of memory available.

I added an "os.maxMemory" requirement, so the test gets skipped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261505](https://bugs.openjdk.java.net/browse/JDK-8261505): Test test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java killed by Linux OOM Killer


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2507/head:pull/2507`
`$ git checkout pull/2507`
