### PR TITLE
4841153: java.awt.geom.Rectangle2D.add(double,double) documented incorrectly

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/Rectangle2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Rectangle2D.java
@@ -794,7 +794,7 @@ public abstract class Rectangle2D extends RectangularShape {
      * {@code true}. The {@code contains} method does not
      * return {@code true} for points on the right or bottom
      * edges of a rectangle. Therefore, if the added point falls on
-     * the left or bottom edge of the enlarged rectangle,
+     * the right or bottom edge of the enlarged rectangle,
      * {@code contains} returns {@code false} for that point.
      * @param newx the X coordinate of the new point
      * @param newy the Y coordinate of the new point
@@ -820,7 +820,7 @@ public abstract class Rectangle2D extends RectangularShape {
      * {@code true}. The {@code contains}
      * method does not return {@code true} for points on the right
      * or bottom edges of a rectangle. Therefore, if the added point falls
-     * on the left or bottom edge of the enlarged rectangle,
+     * on the right or bottom edge of the enlarged rectangle,
      * {@code contains} returns {@code false} for that point.
      * @param     pt the new {@code Point2D} to add to this
      * {@code Rectangle2D}.


### PR DESCRIPTION
Fix a typo in Rectangle2D.add(double, double) and add(Point2D pt). It has already been fixed in Rectangle.add(int, int) https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/java/awt/Rectangle.java#L921

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-4841153](https://bugs.openjdk.java.net/browse/JDK-4841153): java.awt.geom.Rectangle2D.add(double,double) documented incorrectly


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2508/head:pull/2508`
`$ git checkout pull/2508`
