### PR TITLE
8261355: No data buffering in SunPKCS11 Cipher encryption when the underlying mechanism has no padding

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -626,10 +626,10 @@ final class P11Cipher extends CipherSpi {
                 }
                 newPadBufferLen = inLen & (blockSize - 1);
                 if (!encrypt && newPadBufferLen == 0) {
-                    // While decrypting with implUpdate, the current encrypted block
-                    // is always held in a buffer. If it's the last one (unknown
+                    // While decrypting with implUpdate, the last encrypted block
+                    // is always held in a buffer. If it's the final one (unknown
                     // at this point), it may contain padding bytes and need further
-                    // processing. In implDoFinal (where we know it's the last one)
+                    // processing. In implDoFinal (where we know it's the final one)
                     // the buffer is decrypted, unpadded and returned.
                     newPadBufferLen = padBuffer.length;
                 }
@@ -734,10 +734,10 @@ final class P11Cipher extends CipherSpi {
                 }
                 newPadBufferLen = inLen & (blockSize - 1);
                 if (!encrypt && newPadBufferLen == 0) {
-                    // While decrypting with implUpdate, the current encrypted block
-                    // is always held in a buffer. If it's the last one (unknown
+                    // While decrypting with implUpdate, the last encrypted block
+                    // is always held in a buffer. If it's the final one (unknown
                     // at this point), it may contain padding bytes and need further
-                    // processing. In implDoFinal (where we know it's the last one)
+                    // processing. In implDoFinal (where we know it's the final one)
                     // the buffer is decrypted, unpadded and returned.
                     newPadBufferLen = padBuffer.length;
                 }

--- a/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8261355
+ * @library /test/lib ..
+ * @run main/othervm EncryptionPadding
+ */
+
+import java.nio.ByteBuffer;
+import java.security.Provider;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+
+public class EncryptionPadding extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new EncryptionPadding(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+
+        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding", p);
+        cipher.init(Cipher.ENCRYPT_MODE,
+                new SecretKeySpec(new byte[16], "AES"));
+
+        cipher.update(new byte[1], 0, 1);
+        cipher.update(ByteBuffer.allocate(1), ByteBuffer.allocate(16));
+
+        System.out.println("TEST PASS - OK");
+    }
+}

--- a/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
@@ -65,7 +65,7 @@ public class EncryptionPadding extends PKCS11Test {
         Arrays.fill(plainText, (byte)(inputSize & 0xFF));
         ByteBuffer cipherText =
                 ByteBuffer.allocate(((inputSize / 16 ) + 1) * 16);
-        byte[] tmp = new byte[16];
+        byte[] tmp;
 
         Cipher sunPKCS11cipher = Cipher.getInstance(transformation, p);
         sunPKCS11cipher.init(Cipher.ENCRYPT_MODE, key);
@@ -74,8 +74,9 @@ public class EncryptionPadding extends PKCS11Test {
             if (!isByteBuffer) {
                 tmp = sunPKCS11cipher.update(plainText, i * 16,
                         updateLength);
-                if (tmp != null)
+                if (tmp != null) {
                     cipherText.put(tmp);
+                }
             } else {
                 ByteBuffer bb = ByteBuffer.allocate(updateLength);
                 bb.put(plainText, i * 16, updateLength);
@@ -83,9 +84,14 @@ public class EncryptionPadding extends PKCS11Test {
                 sunPKCS11cipher.update(bb, cipherText);
             }
         }
-        tmp = sunPKCS11cipher.doFinal();
-        if (tmp != null)
-            cipherText.put(tmp);
+        if (!isByteBuffer) {
+            tmp = sunPKCS11cipher.doFinal();
+            if (tmp != null) {
+                cipherText.put(tmp);
+            }
+        } else {
+            sunPKCS11cipher.doFinal(ByteBuffer.allocate(0), cipherText);
+        }
 
         Cipher sunJCECipher = Cipher.getInstance(transformation, "SunJCE");
         sunJCECipher.init(Cipher.DECRYPT_MODE, key);


### PR DESCRIPTION
Hi,

I'd like to propose a fix for JDK-8261355 [1].

The scheme used for holding data and padding while performing encryption operations is almost the same than the existing one for decryption. The only difference is that encryption does not require a block-sized buffer to be always held because there is no need, upon an update call, to determine which bytes are real output for the caller and which are padding -as it's required for decryption-. I added a couple of comments in implUpdate to explain this.

No regressions observed in jdk/sun/security/pkcs11.

Thanks,
Martin.-

--
[1] - https://bugs.openjdk.java.net/browse/JDK-8261355

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261355](https://bugs.openjdk.java.net/browse/JDK-8261355): No data buffering in SunPKCS11 Cipher encryption when the underlying mechanism has no padding


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2510/head:pull/2510` \
`$ git checkout pull/2510`

Update a local copy of the PR: \
`$ git checkout pull/2510` \
`$ git pull https://git.openjdk.java.net/jdk pull/2510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2510`

View PR using the GUI difftool: \
`$ git pr show -t 2510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2510.diff">https://git.openjdk.java.net/jdk/pull/2510.diff</a>

</details>
