### PR TITLE
8261522: [PPC64] AES intrinsics write beyond the destination array

### DIFF
--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2628,7 +2628,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ li              (fifteen, 15);
 
-    // load unaligned from[0-15] to vsRet
+    // load unaligned from[0-15] to vRet
     __ lvx             (vRet, from);
     __ lvx             (vTmp1, fifteen, from);
     __ lvsl            (fromPerm, from);
@@ -2836,7 +2836,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ li              (fifteen, 15);
 
-    // load unaligned from[0-15] to vsRet
+    // load unaligned from[0-15] to vRet
     __ lvx             (vRet, from);
     __ lvx             (vTmp1, fifteen, from);
     __ lvsl            (fromPerm, from);

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2763,27 +2763,24 @@ class StubGenerator: public StubCodeGenerator {
     __ vcipher         (vRet, vRet, vKey1);
     __ vcipherlast     (vRet, vRet, vKey2);
 
+#ifdef VM_LITTLE_ENDIAN
+    // Swap Bytes
+    // toPerm = 0x0F0E0D0C0B0A09080706050403020100
+    __ li(temp, 0);
+    __ vspltisb(vTmp1, 0xf);
+    __ lvsl(vTmp2, temp);
+    __ vxor(toPerm, vTmp1, vTmp2);
+
+    __ vperm(vRet, vRet, vRet, toPerm);
+#endif
+
     // store result (unaligned)
-#ifdef VM_LITTLE_ENDIAN
-    __ lvsl            (toPerm, to);
-#else
-    __ lvsr            (toPerm, to);
-#endif
-    __ vspltisb        (vTmp3, -1);
-    __ vspltisb        (vTmp4, 0);
-    __ lvx             (vTmp1, to);
-    __ lvx             (vTmp2, fifteen, to);
-#ifdef VM_LITTLE_ENDIAN
-    __ vperm           (vTmp3, vTmp3, vTmp4, toPerm); // generate select mask
-    __ vxor            (toPerm, toPerm, fSplt);       // swap bytes
-#else
-    __ vperm           (vTmp3, vTmp4, vTmp3, toPerm); // generate select mask
-#endif
-    __ vperm           (vTmp4, vRet, vRet, toPerm);   // rotate data
-    __ vsel            (vTmp2, vTmp4, vTmp2, vTmp3);
-    __ vsel            (vTmp1, vTmp1, vTmp4, vTmp3);
-    __ stvx            (vTmp2, fifteen, to);          // store this one first (may alias)
-    __ stvx            (vTmp1, to);
+    Register lo = temp, hi = fifteen; // Reuse
+    __ vsldoi          (vTmp1, vRet, vRet, 8);
+    __ mfvrd           (hi, vRet);
+    __ mfvrd           (lo, vTmp1);
+    __ std             (hi, 0 LITTLE_ENDIAN_ONLY(+ 8), to);
+    __ std             (lo, 0 BIG_ENDIAN_ONLY(+ 8), to);
 
     __ blr();
      return start;
@@ -3000,27 +2997,24 @@ class StubGenerator: public StubCodeGenerator {
     __ vncipher        (vRet, vRet, vKey4);
     __ vncipherlast    (vRet, vRet, vKey5);
 
+#ifdef VM_LITTLE_ENDIAN
+    // Swap Bytes
+    // toPerm = 0x0F0E0D0C0B0A09080706050403020100
+    __ li(temp, 0);
+    __ vspltisb(vTmp1, 0xf);
+    __ lvsl(vTmp2, temp);
+    __ vxor(toPerm, vTmp1, vTmp2);
+
+    __ vperm(vRet, vRet, vRet, toPerm);
+#endif
+
     // store result (unaligned)
-#ifdef VM_LITTLE_ENDIAN
-    __ lvsl            (toPerm, to);
-#else
-    __ lvsr            (toPerm, to);
-#endif
-    __ vspltisb        (vTmp3, -1);
-    __ vspltisb        (vTmp4, 0);
-    __ lvx             (vTmp1, to);
-    __ lvx             (vTmp2, fifteen, to);
-#ifdef VM_LITTLE_ENDIAN
-    __ vperm           (vTmp3, vTmp3, vTmp4, toPerm); // generate select mask
-    __ vxor            (toPerm, toPerm, fSplt);       // swap bytes
-#else
-    __ vperm           (vTmp3, vTmp4, vTmp3, toPerm); // generate select mask
-#endif
-    __ vperm           (vTmp4, vRet, vRet, toPerm);   // rotate data
-    __ vsel            (vTmp2, vTmp4, vTmp2, vTmp3);
-    __ vsel            (vTmp1, vTmp1, vTmp4, vTmp3);
-    __ stvx            (vTmp2, fifteen, to);          // store this one first (may alias)
-    __ stvx            (vTmp1, to);
+    Register lo = temp, hi = fifteen; // Reuse
+    __ vsldoi          (vTmp1, vRet, vRet, 8);
+    __ mfvrd           (hi, vRet);
+    __ mfvrd           (lo, vTmp1);
+    __ std             (hi, 0 LITTLE_ENDIAN_ONLY(+ 8), to);
+    __ std             (lo, 0 BIG_ENDIAN_ONLY(+ 8), to);
 
     __ blr();
      return start;


### PR DESCRIPTION
I'd like to replace the read-modify-write implementation from aescrypt_encryptBlock / aescrypt_decryptBlock stubs. It can cause severe problems (see bug description).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261522](https://bugs.openjdk.java.net/browse/JDK-8261522): [PPC64] AES intrinsics write beyond the destination array


### Reviewers
 * @jrziviani (no known github.com user name / role) ⚠️ Review applies to 725dd8c7c29da7cbf30cab0d1fe7fb085d7edf12
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to 725dd8c7c29da7cbf30cab0d1fe7fb085d7edf12


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2514/head:pull/2514`
`$ git checkout pull/2514`
