### PR TITLE
JDK-8261499: Simplify HTML for javadoc links

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -44,12 +44,12 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.EXECUTABLE_MEMBER_PARAM;
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER;
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW;
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER_TYPE_PARAMS;
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.RECEIVER_TYPE;
-import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.THROWS_TYPE;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.EXECUTABLE_MEMBER_PARAM;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER_TYPE_PARAMS;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.RECEIVER_TYPE;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.THROWS_TYPE;
 
 /**
  * Print method and constructor info.
@@ -77,7 +77,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      * @return the type parameters.
      */
     protected Content getTypeParameters(ExecutableElement member) {
-        LinkInfoImpl linkInfo = new LinkInfoImpl(configuration, MEMBER_TYPE_PARAMS, member);
+        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration, MEMBER_TYPE_PARAMS, member);
         return writer.getTypeParameterLinks(linkInfo);
     }
 
@@ -108,8 +108,8 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      * @param tdSummary the content tree to which the link will be added
      */
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement te, Element member,
-            Content tdSummary) {
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement te, Element member,
+                                  Content tdSummary) {
         ExecutableElement ee = (ExecutableElement)member;
         Content memberLink = writer.getDocLink(context, te, ee, name(ee), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
@@ -126,7 +126,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content linksTree) {
-        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member), null));
+        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member)));
     }
 
     /**
@@ -139,7 +139,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     protected void addParam(ExecutableElement member, VariableElement param, TypeMirror paramType,
             boolean isVarArg, Content tree) {
-        Content link = writer.getLink(new LinkInfoImpl(configuration, EXECUTABLE_MEMBER_PARAM,
+        Content link = writer.getLink(new HtmlLinkInfo(configuration, EXECUTABLE_MEMBER_PARAM,
                 paramType).varargs(isVarArg));
         tree.add(link);
         if(name(param).length() > 0) {
@@ -158,7 +158,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      * @param tree the content tree to which the information will be added.
      */
     protected void addReceiver(ExecutableElement member, TypeMirror rcvrType, Content tree) {
-        var info = new LinkInfoImpl(configuration, RECEIVER_TYPE, rcvrType);
+        var info = new HtmlLinkInfo(configuration, RECEIVER_TYPE, rcvrType);
         info.linkToSelf = false;
         tree.add(writer.getLink(info));
         tree.add(Entity.NO_BREAK_SPACE);
@@ -289,7 +289,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                 htmlTree.add(",");
                 htmlTree.add(DocletConstants.NL);
             }
-            Content link = writer.getLink(new LinkInfoImpl(configuration, THROWS_TYPE, t));
+            Content link = writer.getLink(new HtmlLinkInfo(configuration, THROWS_TYPE, t));
             htmlTree.add(link);
         }
         return htmlTree;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -96,7 +96,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         content.add(signature);
 
         return writer.getDocLink(MEMBER_DEPRECATED_PREVIEW, utils.getEnclosingTypeElement(member),
-                member, content, false);
+                member, content, null, false);
     }
 
     /**
@@ -111,8 +111,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement te, Element member,
             Content tdSummary) {
         ExecutableElement ee = (ExecutableElement)member;
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, te, ee, name(ee)));
+        Content memberLink = writer.getDocLink(context, te, ee, name(ee), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
         addParameters(ee, code);
         tdSummary.add(code);
@@ -127,7 +126,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content linksTree) {
-        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member)));
+        linksTree.add(writer.getDocLink(MEMBER, te, member, name(member), null));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -147,7 +147,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
      * @param tdSummary   the content tree to which the link will be added
      */
     protected void addSummaryLink(TypeElement typeElement, Element member, Content tdSummary) {
-        addSummaryLink(LinkInfoImpl.Kind.MEMBER, typeElement, member, tdSummary);
+        addSummaryLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member, tdSummary);
     }
 
     /**
@@ -158,8 +158,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
      * @param member      the member to be documented
      * @param tdSummary   the content tree to which the summary link will be added
      */
-    protected abstract void addSummaryLink(LinkInfoImpl.Kind context,
-            TypeElement typeElement, Element member, Content tdSummary);
+    protected abstract void addSummaryLink(HtmlLinkInfo.Kind context,
+                                           TypeElement typeElement, Element member, Content tdSummary);
 
     /**
      * Adds the inherited summary link for the member.
@@ -210,8 +210,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
                 }
             }
             code.add(
-                    writer.getLink(new LinkInfoImpl(configuration,
-                            LinkInfoImpl.Kind.SUMMARY_RETURN_TYPE, type)));
+                    writer.getLink(new HtmlLinkInfo(configuration,
+                            HtmlLinkInfo.Kind.SUMMARY_RETURN_TYPE, type)));
         }
         tdSummaryType.add(code);
     }
@@ -336,8 +336,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
                 typeContent.add(name);
             }
             addSummaryLink(utils.isClass(element) || utils.isInterface(element)
-                    ? LinkInfoImpl.Kind.CLASS_USE
-                    : LinkInfoImpl.Kind.MEMBER,
+                    ? HtmlLinkInfo.Kind.CLASS_USE
+                    : HtmlLinkInfo.Kind.MEMBER,
                     te, element, typeContent);
             Content desc = new ContentBuilder();
             writer.addSummaryLinkComment(this, element, desc);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
                         } else {
                             contentTree.add(", ");
                         }
-                        addPreQualifiedClassLink(LinkInfoImpl.Kind.TREE, intf, contentTree);
+                        addPreQualifiedClassLink(HtmlLinkInfo.Kind.TREE, intf, contentTree);
                     }
                 }
             }
@@ -171,6 +171,6 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
      * @param contentTree the content tree to which the information will be added
      */
     protected void addPartialInfo(TypeElement typeElement, Content contentTree) {
-        addPreQualifiedStrongClassLink(LinkInfoImpl.Kind.TREE, typeElement, contentTree);
+        addPreQualifiedStrongClassLink(HtmlLinkInfo.Kind.TREE, typeElement, contentTree);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -151,8 +151,8 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
      */
     protected void addTableRow(Table table, TypeElement klass) {
         List<Content> rowContents = new ArrayList<>();
-        Content classLink = getLink(new LinkInfoImpl(
-                configuration, LinkInfoImpl.Kind.INDEX, klass));
+        Content classLink = getLink(new HtmlLinkInfo(
+                configuration, HtmlLinkInfo.Kind.INDEX, klass));
         ContentBuilder description = new ContentBuilder();
         Set<ElementFlag> flags = utils.elementFlags(klass);
         if (flags.contains(ElementFlag.PREVIEW)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
@@ -184,8 +184,8 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     }
 
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
-            Content tdSummary) {
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element member,
+                                  Content tdSummary) {
         Content memberLink = writer.getDocLink(context, utils.getEnclosingTypeElement(member), member,
                 name(member), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
@@ -206,7 +206,7 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
     }
 
     protected Comment selectComment(Comment c1, Comment c2) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeRequiredMemberWriterImpl.java
@@ -186,8 +186,8 @@ public class AnnotationTypeRequiredMemberWriterImpl extends AbstractMemberWriter
     @Override
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, member, name(member)));
+        Content memberLink = writer.getDocLink(context, utils.getEnclosingTypeElement(member), member,
+                name(member), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -252,8 +252,8 @@ public class ClassUseWriter extends SubWriterHolderWriter {
     protected void addPackageList(Content contentTree) {
         Content caption = contents.getContent(
                 "doclet.ClassUse_Packages.that.use.0",
-                getLink(new LinkInfoImpl(configuration,
-                        LinkInfoImpl.Kind.CLASS_USE_HEADER, typeElement)));
+                getLink(new HtmlLinkInfo(configuration,
+                        HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)));
         Table table = new Table(HtmlStyle.summaryTable)
                 .setCaption(caption)
                 .setHeader(getPackageTableHeader())
@@ -277,8 +277,8 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         }
         Content caption = contents.getContent(
                 "doclet.ClassUse_PackageAnnotation",
-                getLink(new LinkInfoImpl(configuration,
-                        LinkInfoImpl.Kind.CLASS_USE_HEADER, typeElement)));
+                getLink(new HtmlLinkInfo(configuration,
+                        HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)));
 
         Table table = new Table(HtmlStyle.summaryTable)
                 .setCaption(caption)
@@ -304,7 +304,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             HtmlTree htmlTree = HtmlTree.SECTION(HtmlStyle.detail)
                     .setId(htmlIds.forPackage(pkg));
             Content link = contents.getContent("doclet.ClassUse_Uses.of.0.in.1",
-                    getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.CLASS_USE_HEADER,
+                    getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.CLASS_USE_HEADER,
                             typeElement)),
                     getPackageLink(pkg, utils.getPackageName(pkg)));
             Content heading = HtmlTree.HEADING(Headings.TypeUse.SUMMARY_HEADING, link);
@@ -337,8 +337,8 @@ public class ClassUseWriter extends SubWriterHolderWriter {
      * @param contentTree the content tree to which the class use information will be added
      */
     protected void addClassUse(PackageElement pkg, Content contentTree) {
-        Content classLink = getLink(new LinkInfoImpl(configuration,
-            LinkInfoImpl.Kind.CLASS_USE_HEADER, typeElement));
+        Content classLink = getLink(new HtmlLinkInfo(configuration,
+            HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement));
         Content pkgLink = getPackageLink(pkg, utils.getPackageName(pkg));
         classSubWriter.addUseInfo(pkgToClassAnnotations.get(pkg),
                 contents.getContent("doclet.ClassUse_Annotation", classLink,
@@ -437,8 +437,8 @@ public class ClassUseWriter extends SubWriterHolderWriter {
     protected Navigation getNavBar(PageMode pageMode, Element element) {
         Content mdleLinkContent = getModuleLink(utils.elementUtils.getModuleOf(typeElement),
                 contents.moduleLabel);
-        Content classLinkContent = getLink(new LinkInfoImpl(
-                configuration, LinkInfoImpl.Kind.CLASS_USE_HEADER, typeElement)
+        Content classLinkContent = getLink(new HtmlLinkInfo(
+                configuration, HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)
                 .label(resources.getText("doclet.Class"))
                 .skipPreview(true));
         return super.getNavBar(pageMode, element)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -127,8 +127,8 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             pkgNameDiv.add(pkgNameContent);
             div.add(pkgNameDiv);
         }
-        LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
-                LinkInfoImpl.Kind.CLASS_HEADER, typeElement);
+        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
+                HtmlLinkInfo.Kind.CLASS_HEADER, typeElement);
         //Let's not link to ourselves in the header.
         linkInfo.linkToSelf = false;
         Content heading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
@@ -267,7 +267,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         Content content = new ContentBuilder();
         if (type.equals(typeElement.asType())) {
             Content typeParameters = getTypeParameterLinks(
-                    new LinkInfoImpl(configuration, LinkInfoImpl.Kind.TREE,
+                    new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.TREE,
                     typeElement));
             if (configuration.shouldExcludeQualifier(utils.containingPackage(typeElement).toString())) {
                 content.add(utils.asTypeElement(type).getSimpleName());
@@ -277,8 +277,8 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                 content.add(typeParameters);
             }
         } else {
-            Content link = getLink(new LinkInfoImpl(configuration,
-                    LinkInfoImpl.Kind.CLASS_TREE_PARENT, type)
+            Content link = getLink(new HtmlLinkInfo(configuration,
+                    HtmlLinkInfo.Kind.CLASS_TREE_PARENT, type)
                     .label(configuration.getClassName(utils.asTypeElement(type))));
             content.add(link);
         }
@@ -316,7 +316,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (!subclasses.isEmpty()) {
                 HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
                 dl.add(HtmlTree.DT(contents.subclassesLabel));
-                dl.add(HtmlTree.DD(getClassLinks(LinkInfoImpl.Kind.SUBCLASSES, subclasses)));
+                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUBCLASSES, subclasses)));
                 classInfoTree.add(dl);
             }
         }
@@ -329,7 +329,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (!subInterfaces.isEmpty()) {
                 Content dl = HtmlTree.DL(HtmlStyle.notes);
                 dl.add(HtmlTree.DT(contents.subinterfacesLabel));
-                dl.add(HtmlTree.DD(getClassLinks(LinkInfoImpl.Kind.SUBINTERFACES, subInterfaces)));
+                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUBINTERFACES, subInterfaces)));
                 classInfoTree.add(dl);
             }
         }
@@ -349,7 +349,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (!implcl.isEmpty()) {
             HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.implementingClassesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_CLASSES, implcl)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.IMPLEMENTED_CLASSES, implcl)));
             classInfoTree.add(dl);
         }
     }
@@ -361,7 +361,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (utils.isClass(typeElement) && !interfaces.isEmpty()) {
             HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.allImplementedInterfacesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(LinkInfoImpl.Kind.IMPLEMENTED_INTERFACES, interfaces)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.IMPLEMENTED_INTERFACES, interfaces)));
             classInfoTree.add(dl);
         }
     }
@@ -375,7 +375,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (utils.isInterface(typeElement) && !interfaces.isEmpty()) {
             HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.allSuperinterfacesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(LinkInfoImpl.Kind.SUPER_INTERFACES, interfaces)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUPER_INTERFACES, interfaces)));
             classInfoTree.add(dl);
         }
     }
@@ -393,8 +393,8 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                         ? contents.enclosingInterfaceLabel
                         : contents.enclosingClassLabel));
                 Content dd = new HtmlTree(TagName.DD);
-                dd.add(getLink(new LinkInfoImpl(configuration,
-                        LinkInfoImpl.Kind.CLASS, e)));
+                dd.add(getLink(new HtmlLinkInfo(configuration,
+                        HtmlLinkInfo.Kind.CLASS, e)));
                 dl.add(dd);
                 classInfoTree.add(dl);
                 return null;
@@ -450,7 +450,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
      * @param list the list of classes
      * @return a content tree for the class list
      */
-    private Content getClassLinks(LinkInfoImpl.Kind context, Collection<?> list) {
+    private Content getClassLinks(HtmlLinkInfo.Kind context, Collection<?> list) {
         Content content = new ContentBuilder();
         boolean isFirst = true;
         for (Object type : list) {
@@ -463,11 +463,11 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             // TODO: should we simply split this method up to avoid instanceof ?
             if (type instanceof TypeElement) {
                 Content link = getLink(
-                        new LinkInfoImpl(configuration, context, (TypeElement)(type)));
+                        new HtmlLinkInfo(configuration, context, (TypeElement)(type)));
                 content.add(HtmlTree.CODE(link));
             } else {
                 Content link = getLink(
-                        new LinkInfoImpl(configuration, context, ((TypeMirror)type)));
+                        new HtmlLinkInfo(configuration, context, ((TypeMirror)type)));
                 content.add(HtmlTree.CODE(link));
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -184,8 +184,8 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
 
         //generate links backward only to public classes.
         Content classlink = (utils.isPublic(typeElement) || utils.isProtected(typeElement)) ?
-            getLink(new LinkInfoImpl(configuration,
-                    LinkInfoImpl.Kind.CONSTANT_SUMMARY, typeElement)) :
+            getLink(new HtmlLinkInfo(configuration,
+                    HtmlLinkInfo.Kind.CONSTANT_SUMMARY, typeElement)) :
             new StringContent(utils.getFullyQualifiedName(typeElement));
 
         PackageElement enclosingPackage  = utils.containingPackage(typeElement);
@@ -222,8 +222,8 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
             code.add(modifier);
             code.add(Entity.NO_BREAK_SPACE);
         }
-        Content type = getLink(new LinkInfoImpl(configuration,
-                LinkInfoImpl.Kind.CONSTANT_SUMMARY, member.asType()));
+        Content type = getLink(new HtmlLinkInfo(configuration,
+                HtmlLinkInfo.Kind.CONSTANT_SUMMARY, member.asType()));
         code.add(type);
         typeContent.add(code);
         return typeContent;
@@ -236,7 +236,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
      * @return the name column of the constant table row
      */
     private Content getNameColumn(VariableElement member) {
-        Content nameContent = getDocLink(LinkInfoImpl.Kind.CONSTANT_SUMMARY,
+        Content nameContent = getDocLink(HtmlLinkInfo.Kind.CONSTANT_SUMMARY,
                 member, member.getSimpleName());
         return HtmlTree.CODE(nameContent);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -157,8 +157,8 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     }
 
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
-            Content tdSummary) {
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element member,
+                                  Content tdSummary) {
         Content memberLink = writer.getDocLink(context, utils.getEnclosingTypeElement(member), member,
                 name(member), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
@@ -177,7 +177,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -159,8 +159,8 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, member, name(member)));
+        Content memberLink = writer.getDocLink(context, utils.getEnclosingTypeElement(member), member,
+                name(member), HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -161,7 +161,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -181,8 +181,8 @@ public class FieldWriterImpl extends AbstractMemberWriter
     }
 
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
-            Content tdSummary) {
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element member,
+                                  Content tdSummary) {
         Content memberLink = writer.getDocLink(context, typeElement , member, name(member),
                 HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
@@ -192,7 +192,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         linksTree.add(
-                writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member, name(member), null));
+                writer.getDocLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member, name(member)));
     }
 
     @Override
@@ -203,7 +203,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -183,8 +183,8 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, typeElement , member, name(member)));
+        Content memberLink = writer.getDocLink(context, typeElement , member, name(member),
+                HtmlStyle.memberNameLink);
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }
@@ -192,7 +192,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         linksTree.add(
-                writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member, name(member)));
+                writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member, name(member), null));
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -750,8 +750,8 @@ public class HtmlDocletWriter {
      *
      * @return the link for the given class.
      */
-    public Content getLink(LinkInfoImpl linkInfo) {
-        LinkFactoryImpl factory = new LinkFactoryImpl(this);
+    public Content getLink(HtmlLinkInfo linkInfo) {
+        HtmlLinkFactory factory = new HtmlLinkFactory(this);
         return factory.getLink(linkInfo);
     }
 
@@ -761,8 +761,8 @@ public class HtmlDocletWriter {
      * @param linkInfo the information about the link.
      * @return the type for the given class.
      */
-    public Content getTypeParameterLinks(LinkInfoImpl linkInfo) {
-        LinkFactoryImpl factory = new LinkFactoryImpl(this);
+    public Content getTypeParameterLinks(HtmlLinkInfo linkInfo) {
+        HtmlLinkFactory factory = new HtmlLinkFactory(this);
         return factory.getTypeParameterLinks(linkInfo);
     }
 
@@ -830,9 +830,9 @@ public class HtmlDocletWriter {
      * @param element to link to
      * @return a content tree for the link
      */
-    public Content getQualifiedClassLink(LinkInfoImpl.Kind context, Element element) {
-        LinkInfoImpl linkInfoImpl = new LinkInfoImpl(configuration, context, (TypeElement)element);
-        return getLink(linkInfoImpl.label(utils.getFullyQualifiedName(element)));
+    public Content getQualifiedClassLink(HtmlLinkInfo.Kind context, Element element) {
+        HtmlLinkInfo htmlLinkInfo = new HtmlLinkInfo(configuration, context, (TypeElement)element);
+        return getLink(htmlLinkInfo.label(utils.getFullyQualifiedName(element)));
     }
 
     /**
@@ -842,7 +842,7 @@ public class HtmlDocletWriter {
      * @param typeElement to link to
      * @param contentTree the content tree to which the link will be added
      */
-    public void addPreQualifiedClassLink(LinkInfoImpl.Kind context, TypeElement typeElement, Content contentTree) {
+    public void addPreQualifiedClassLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Content contentTree) {
         addPreQualifiedClassLink(context, typeElement, null, contentTree);
     }
 
@@ -854,13 +854,13 @@ public class HtmlDocletWriter {
      * @param typeElement the class to link to.
      * @return the link with the package portion of the label in plain text.
      */
-    public Content getPreQualifiedClassLink(LinkInfoImpl.Kind context, TypeElement typeElement) {
+    public Content getPreQualifiedClassLink(HtmlLinkInfo.Kind context, TypeElement typeElement) {
         ContentBuilder classlink = new ContentBuilder();
         PackageElement pkg = utils.containingPackage(typeElement);
         if (pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
             classlink.add(getEnclosingPackageName(typeElement));
         }
-        classlink.add(getLink(new LinkInfoImpl(configuration,
+        classlink.add(getLink(new HtmlLinkInfo(configuration,
                 context, typeElement).label(utils.getSimpleName(typeElement))));
         return classlink;
     }
@@ -875,13 +875,13 @@ public class HtmlDocletWriter {
      * @param style optional style for the link
      * @param contentTree the content tree to which the link with be added
      */
-    public void addPreQualifiedClassLink(LinkInfoImpl.Kind context,
-            TypeElement typeElement, HtmlStyle style, Content contentTree) {
+    public void addPreQualifiedClassLink(HtmlLinkInfo.Kind context,
+                                         TypeElement typeElement, HtmlStyle style, Content contentTree) {
         PackageElement pkg = utils.containingPackage(typeElement);
         if(pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
             contentTree.add(getEnclosingPackageName(typeElement));
         }
-        LinkInfoImpl linkinfo = new LinkInfoImpl(configuration, context, typeElement)
+        HtmlLinkInfo linkinfo = new HtmlLinkInfo(configuration, context, typeElement)
                 .label(utils.getSimpleName(typeElement))
                 .style(style);
         Content link = getLink(linkinfo);
@@ -917,7 +917,7 @@ public class HtmlDocletWriter {
      * @param typeElement the class to link to
      * @param contentTree the content tree to which the link with be added
      */
-    public void addPreQualifiedStrongClassLink(LinkInfoImpl.Kind context, TypeElement typeElement, Content contentTree) {
+    public void addPreQualifiedStrongClassLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Content contentTree) {
         addPreQualifiedClassLink(context, typeElement, HtmlStyle.typeNameLink, contentTree);
     }
 
@@ -929,9 +929,25 @@ public class HtmlDocletWriter {
      * @param label the label for the link
      * @return a content tree for the element link
      */
-    public Content getDocLink(LinkInfoImpl.Kind context, Element element, CharSequence label) {
+    public Content getDocLink(HtmlLinkInfo.Kind context, Element element, CharSequence label) {
         return getDocLink(context, utils.getEnclosingTypeElement(element), element,
                 new StringContent(label), null, false);
+    }
+
+    /**
+     * Return the link for the given member.
+     *
+     * @param context the id of the context where the link will be printed.
+     * @param typeElement the typeElement that we should link to. This is not
+     *            not necessarily the type containing element since we may be
+     *            inheriting comments.
+     * @param element the member being linked to.
+     * @param label the label for the link.
+     * @return the link for the given member.
+     */
+    public Content getDocLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element element,
+                              CharSequence label) {
+        return getDocLink(context, typeElement, element, new StringContent(label), null, false);
     }
 
     /**
@@ -946,7 +962,7 @@ public class HtmlDocletWriter {
      * @param style optional style for the link.
      * @return the link for the given member.
      */
-    public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
+    public Content getDocLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element element,
                               CharSequence label, HtmlStyle style) {
         return getDocLink(context, typeElement, element, new StringContent(label), style, false);
     }
@@ -962,7 +978,7 @@ public class HtmlDocletWriter {
      * @param label the label for the link.
      * @return the link for the given member.
      */
-    public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
+    public Content getDocLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element element,
                               CharSequence label, boolean isProperty) {
         return getDocLink(context, typeElement, element, new StringContent(label), null, isProperty);
     }
@@ -980,8 +996,8 @@ public class HtmlDocletWriter {
      * @param isProperty true if the element parameter is a JavaFX property.
      * @return the link for the given member.
      */
-    public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            Content label, HtmlStyle style, boolean isProperty) {
+    public Content getDocLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element element,
+                              Content label, HtmlStyle style, boolean isProperty) {
         if (!utils.isLinkable(typeElement, element)) {
             return label;
         }
@@ -989,7 +1005,7 @@ public class HtmlDocletWriter {
         if (utils.isExecutableElement(element)) {
             ExecutableElement ee = (ExecutableElement)element;
             HtmlId id = isProperty ? htmlIds.forProperty(ee) : htmlIds.forMember(ee);
-            return getLink(new LinkInfoImpl(configuration, context, typeElement)
+            return getLink(new HtmlLinkInfo(configuration, context, typeElement)
                 .label(label)
                 .where(id.name())
                 .style(style)
@@ -997,7 +1013,7 @@ public class HtmlDocletWriter {
         }
 
         if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
-            return getLink(new LinkInfoImpl(configuration, context, typeElement)
+            return getLink(new HtmlLinkInfo(configuration, context, typeElement)
                 .label(label)
                 .where(element.getSimpleName().toString())
                 .style(style)
@@ -1074,12 +1090,12 @@ public class HtmlDocletWriter {
                     TypeMirror refType = ch.getReferencedType(see);
                     if (refType != null) {
                         return plainOrCode(isLinkPlain, getLink(
-                                new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, refType)));
+                                new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, refType)));
                     }
                 }
                 label = plainOrCode(isLinkPlain, new StringContent(utils.getSimpleName(refClass)));
             }
-            return getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, refClass)
+            return getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, refClass)
                     .label(label));
         } else if (refMem == null) {
             // Must be a member reference since refClass is not null and refMemName is not null.
@@ -1135,7 +1151,7 @@ public class HtmlDocletWriter {
 
             text = plainOrCode(kind == LINK_PLAIN, new StringContent(refMemName));
 
-            return getDocLink(LinkInfoImpl.Kind.SEE_TAG, containing,
+            return getDocLink(HtmlLinkInfo.Kind.SEE_TAG, containing,
                     refMem, (label.isEmpty() ? text: label), null, false);
         }
     }
@@ -1755,8 +1771,8 @@ public class HtmlDocletWriter {
             }
             annotation = new ContentBuilder();
             isAnnotationDocumented = false;
-            LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
-                                                     LinkInfoImpl.Kind.ANNOTATION, annotationElement);
+            HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
+                                                     HtmlLinkInfo.Kind.ANNOTATION, annotationElement);
             Map<? extends ExecutableElement, ? extends AnnotationValue> pairs = aDesc.getElementValues();
             // If the annotation is synthesized, do not print the container.
             if (utils.configuration.workArounds.isSynthesized(aDesc)) {
@@ -1831,7 +1847,7 @@ public class HtmlDocletWriter {
      * @param map annotation type element to annotation value pairs
      * @param linkBreak if true, add new line between each member value
      */
-    private void addAnnotations(TypeElement annotationDoc, LinkInfoImpl linkInfo,
+    private void addAnnotations(TypeElement annotationDoc, HtmlLinkInfo linkInfo,
                                 ContentBuilder annotation,
                                 Map<? extends ExecutableElement, ? extends AnnotationValue> map,
                                 boolean linkBreak) {
@@ -1858,7 +1874,7 @@ public class HtmlDocletWriter {
                 }
                 String simpleName = element.getSimpleName().toString();
                 if (multipleValues || !"value".equals(simpleName)) { // Omit "value=" where unnecessary
-                    annotation.add(getDocLink(LinkInfoImpl.Kind.ANNOTATION, element, simpleName));
+                    annotation.add(getDocLink(HtmlLinkInfo.Kind.ANNOTATION, element, simpleName));
                     annotation.add("=");
                 }
                 AnnotationValue annotationValue = map.get(element);
@@ -1947,8 +1963,8 @@ public class HtmlDocletWriter {
                 return new SimpleTypeVisitor9<Content, Void>() {
                     @Override
                     public Content visitDeclared(DeclaredType t, Void p) {
-                        LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
-                                LinkInfoImpl.Kind.ANNOTATION, t);
+                        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
+                                HtmlLinkInfo.Kind.ANNOTATION, t);
                         String name = utils.isIncluded(t.asElement())
                                 ? t.asElement().getSimpleName().toString()
                                 : utils.getFullyQualifiedName(t.asElement());
@@ -1972,7 +1988,7 @@ public class HtmlDocletWriter {
             }
             @Override
             public Content visitEnumConstant(VariableElement c, Void p) {
-                return getDocLink(LinkInfoImpl.Kind.ANNOTATION, c, c.getSimpleName());
+                return getDocLink(HtmlLinkInfo.Kind.ANNOTATION, c, c.getSimpleName());
             }
             @Override
             public Content visitArray(List<? extends AnnotationValue> vals, Void p) {
@@ -2260,7 +2276,7 @@ public class HtmlDocletWriter {
         elements.stream()
                 .sorted((te1, te2) -> te1.getSimpleName().toString().compareTo(te2.getSimpleName().toString()))
                 .distinct()
-                .map(te -> getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.CLASS, te).label(HtmlTree.CODE(new StringContent(te.getSimpleName()))).skipPreview(true)))
+                .map(te -> getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.CLASS, te).label(HtmlTree.CODE(new StringContent(te.getSimpleName()))).skipPreview(true)))
                 .forEach(c -> {
                     links.add(sep[0]);
                     links.add(c);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -775,12 +775,12 @@ public class HtmlDocletWriter {
      * @param refMemName the name of the member being referenced.  This should
      * be null or empty string if no member is being referenced.
      * @param label the label for the external link.
-     * @param strong true if the link should be strong.
+     * @param style optional style for the link.
      * @param code true if the label should be code font.
      * @return the link
      */
     public Content getCrossClassLink(TypeElement classElement, String refMemName,
-                                    Content label, boolean strong, boolean code) {
+                                    Content label, HtmlStyle style, boolean code) {
         if (classElement != null) {
             String className = utils.getSimpleName(classElement);
             PackageElement packageElement = utils.containingPackage(classElement);
@@ -798,8 +798,7 @@ public class HtmlDocletWriter {
                 DocLink link = configuration.extern.getExternalLink(packageElement, pathToRoot,
                                 className + ".html", refMemName);
                 return links.createLink(link,
-                    (label == null) || label.isEmpty() ? defaultLabel : label,
-                    strong,
+                    (label == null) || label.isEmpty() ? defaultLabel : label, style,
                     resources.getText("doclet.Href_Class_Or_Interface_Title",
                         utils.getPackageName(packageElement)), true);
             }
@@ -844,7 +843,7 @@ public class HtmlDocletWriter {
      * @param contentTree the content tree to which the link will be added
      */
     public void addPreQualifiedClassLink(LinkInfoImpl.Kind context, TypeElement typeElement, Content contentTree) {
-        addPreQualifiedClassLink(context, typeElement, false, contentTree);
+        addPreQualifiedClassLink(context, typeElement, null, contentTree);
     }
 
     /**
@@ -873,18 +872,18 @@ public class HtmlDocletWriter {
      *
      * @param context the id of the context where the link will be added
      * @param typeElement the class to link to
-     * @param isStrong true if the link should be strong
+     * @param style optional style for the link
      * @param contentTree the content tree to which the link with be added
      */
     public void addPreQualifiedClassLink(LinkInfoImpl.Kind context,
-            TypeElement typeElement, boolean isStrong, Content contentTree) {
+            TypeElement typeElement, HtmlStyle style, Content contentTree) {
         PackageElement pkg = utils.containingPackage(typeElement);
         if(pkg != null && ! configuration.shouldExcludeQualifier(pkg.getSimpleName().toString())) {
             contentTree.add(getEnclosingPackageName(typeElement));
         }
         LinkInfoImpl linkinfo = new LinkInfoImpl(configuration, context, typeElement)
                 .label(utils.getSimpleName(typeElement))
-                .strong(isStrong);
+                .style(style);
         Content link = getLink(linkinfo);
         contentTree.add(link);
     }
@@ -919,7 +918,7 @@ public class HtmlDocletWriter {
      * @param contentTree the content tree to which the link with be added
      */
     public void addPreQualifiedStrongClassLink(LinkInfoImpl.Kind context, TypeElement typeElement, Content contentTree) {
-        addPreQualifiedClassLink(context, typeElement, true, contentTree);
+        addPreQualifiedClassLink(context, typeElement, HtmlStyle.typeNameLink, contentTree);
     }
 
     /**
@@ -932,7 +931,7 @@ public class HtmlDocletWriter {
      */
     public Content getDocLink(LinkInfoImpl.Kind context, Element element, CharSequence label) {
         return getDocLink(context, utils.getEnclosingTypeElement(element), element,
-                new StringContent(label), false);
+                new StringContent(label),null, false);
     }
 
     /**
@@ -944,11 +943,12 @@ public class HtmlDocletWriter {
      *            inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
+     * @param style optional style for the link.
      * @return the link for the given member.
      */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-                              CharSequence label) {
-        return getDocLink(context, typeElement, element, label, false);
+                              CharSequence label, HtmlStyle style) {
+        return getDocLink(context, typeElement, element, new StringContent(label), style, false);
     }
 
     /**
@@ -964,7 +964,7 @@ public class HtmlDocletWriter {
      */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
                               CharSequence label, boolean isProperty) {
-        return getDocLink(context, typeElement, element, new StringContent(label), isProperty);
+        return getDocLink(context, typeElement, element, new StringContent(label), null, isProperty);
     }
 
     /**
@@ -976,11 +976,12 @@ public class HtmlDocletWriter {
      *            inheriting comments.
      * @param element the member being linked to.
      * @param label the label for the link.
+     * @param style optional style to use for the link.
      * @param isProperty true if the element parameter is a JavaFX property.
      * @return the link for the given member.
      */
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
-            Content label, boolean isProperty) {
+            Content label, HtmlStyle style, boolean isProperty) {
         if (!utils.isLinkable(typeElement, element)) {
             return label;
         }
@@ -991,6 +992,7 @@ public class HtmlDocletWriter {
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(id.name())
+                .style(style)
                 .targetMember(element));
         }
 
@@ -998,6 +1000,7 @@ public class HtmlDocletWriter {
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(element.getSimpleName().toString())
+                .style(style)
                 .targetMember(element));
         }
 
@@ -1133,7 +1136,7 @@ public class HtmlDocletWriter {
             text = plainOrCode(kind == LINK_PLAIN, new StringContent(refMemName));
 
             return getDocLink(LinkInfoImpl.Kind.SEE_TAG, containing,
-                    refMem, (label.isEmpty() ? text: label), false);
+                    refMem, (label.isEmpty() ? text: label), null, false);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -931,7 +931,7 @@ public class HtmlDocletWriter {
      */
     public Content getDocLink(LinkInfoImpl.Kind context, Element element, CharSequence label) {
         return getDocLink(context, utils.getEnclosingTypeElement(element), element,
-                new StringContent(label),null, false);
+                new StringContent(label), null, false);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -57,12 +57,12 @@ import jdk.javadoc.internal.doclets.toolkit.util.links.LinkInfo;
  *  This code and its internal interfaces are subject to change or
  *  deletion without notice.</b>
  */
-public class LinkFactoryImpl extends LinkFactory {
+public class HtmlLinkFactory extends LinkFactory {
 
     private final HtmlDocletWriter m_writer;
     private final DocPaths docPaths;
 
-    public LinkFactoryImpl(HtmlDocletWriter writer) {
+    public HtmlLinkFactory(HtmlDocletWriter writer) {
         super(writer.configuration.utils);
         m_writer = writer;
         docPaths = writer.configuration.docPaths;
@@ -76,7 +76,7 @@ public class LinkFactoryImpl extends LinkFactory {
     @Override
     protected Content getClassLink(LinkInfo linkInfo) {
         BaseConfiguration configuration = m_writer.configuration;
-        LinkInfoImpl classLinkInfo = (LinkInfoImpl) linkInfo;
+        HtmlLinkInfo classLinkInfo = (HtmlLinkInfo) linkInfo;
         TypeElement typeElement = classLinkInfo.typeElement;
         // Create a tool tip if we are linking to a class or interface.  Don't
         // create one if we are linking to a member.
@@ -94,7 +94,7 @@ public class LinkFactoryImpl extends LinkFactory {
         if (!hasWhere && showPreview) {
             flags = utils.elementFlags(typeElement);
             target = typeElement;
-        } else if ((classLinkInfo.context == LinkInfoImpl.Kind.SEE_TAG || classLinkInfo.context == LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW) &&
+        } else if ((classLinkInfo.context == HtmlLinkInfo.Kind.SEE_TAG || classLinkInfo.context == HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW) &&
                    classLinkInfo.targetMember != null && showPreview) {
             flags = utils.elementFlags(classLinkInfo.targetMember);
             target = classLinkInfo.targetMember;
@@ -172,7 +172,7 @@ public class LinkFactoryImpl extends LinkFactory {
                 if (many) {
                     links.add(",");
                     links.add(Entity.ZERO_WIDTH_SPACE);
-                    if (((LinkInfoImpl) linkInfo).getContext() == LinkInfoImpl.Kind.MEMBER_TYPE_PARAMS) {
+                    if (((HtmlLinkInfo) linkInfo).getContext() == HtmlLinkInfo.Kind.MEMBER_TYPE_PARAMS) {
                         links.add(DocletConstants.NL);
                     }
                 }
@@ -192,8 +192,8 @@ public class LinkFactoryImpl extends LinkFactory {
      * @return the link
      */
     protected Content getTypeParameterLink(LinkInfo linkInfo, TypeMirror typeParam) {
-        LinkInfoImpl typeLinkInfo = new LinkInfoImpl(m_writer.configuration,
-                ((LinkInfoImpl) linkInfo).getContext(), typeParam).skipPreview(true);
+        HtmlLinkInfo typeLinkInfo = new HtmlLinkInfo(m_writer.configuration,
+                ((HtmlLinkInfo) linkInfo).getContext(), typeParam).skipPreview(true);
         typeLinkInfo.excludeTypeBounds = linkInfo.excludeTypeBounds;
         typeLinkInfo.excludeTypeParameterLinks = linkInfo.excludeTypeParameterLinks;
         typeLinkInfo.linkToSelf = linkInfo.linkToSelf;
@@ -209,7 +209,7 @@ public class LinkFactoryImpl extends LinkFactory {
         } else if (utils.isTypeVariable(linkInfo.type)) {
             // TODO: use the context for now, and special case for Receiver_Types,
             // which takes the default case.
-            switch (((LinkInfoImpl)linkInfo).context) {
+            switch (((HtmlLinkInfo)linkInfo).context) {
                 case MEMBER_TYPE_PARAMS:
                 case EXECUTABLE_MEMBER_PARAM:
                 case CLASS_SIGNATURE:
@@ -271,7 +271,7 @@ public class LinkFactoryImpl extends LinkFactory {
      *
      * @param linkInfo the information about the link.
      */
-    private DocPath getPath(LinkInfoImpl linkInfo) {
+    private DocPath getPath(HtmlLinkInfo linkInfo) {
         return m_writer.pathToRoot.resolve(docPaths.forClass(linkInfo.typeElement));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -44,7 +44,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.links.LinkInfo;
  *  This code and its internal interfaces are subject to change or
  *  deletion without notice.</b>
  */
-public class LinkInfoImpl extends LinkInfo {
+public class HtmlLinkInfo extends LinkInfo {
 
     public enum Kind {
         DEFAULT,
@@ -256,7 +256,7 @@ public class LinkInfoImpl extends LinkInfo {
      * @param context    the context of the link.
      * @param ee   the member to link to.
      */
-    public LinkInfoImpl(HtmlConfiguration configuration, Kind context, ExecutableElement ee) {
+    public HtmlLinkInfo(HtmlConfiguration configuration, Kind context, ExecutableElement ee) {
         this.configuration = configuration;
         this.utils = configuration.utils;
         this.executableElement = ee;
@@ -275,7 +275,7 @@ public class LinkInfoImpl extends LinkInfo {
      * @param context    the context of the link.
      * @param typeElement   the class to link to.
      */
-    public LinkInfoImpl(HtmlConfiguration configuration, Kind context, TypeElement typeElement) {
+    public HtmlLinkInfo(HtmlConfiguration configuration, Kind context, TypeElement typeElement) {
         this.configuration = configuration;
         this.utils = configuration.utils;
         this.typeElement = typeElement;
@@ -289,7 +289,7 @@ public class LinkInfoImpl extends LinkInfo {
      * @param context    the context of the link.
      * @param type       the class to link to.
      */
-    public LinkInfoImpl(HtmlConfiguration configuration, Kind context, TypeMirror type) {
+    public HtmlLinkInfo(HtmlConfiguration configuration, Kind context, TypeMirror type) {
         this.configuration = configuration;
         this.utils = configuration.utils;
         this.type = type;
@@ -300,7 +300,7 @@ public class LinkInfoImpl extends LinkInfo {
      * Set the label for the link.
      * @param label plain-text label for the link
      */
-    public LinkInfoImpl label(CharSequence label) {
+    public HtmlLinkInfo label(CharSequence label) {
         this.label = new StringContent(label);
         return this;
     }
@@ -308,7 +308,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Set the label for the link.
      */
-    public LinkInfoImpl label(Content label) {
+    public HtmlLinkInfo label(Content label) {
         this.label = label;
         return this;
     }
@@ -316,7 +316,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Sets the style to be used for the link.
      */
-    public LinkInfoImpl style(HtmlStyle style) {
+    public HtmlLinkInfo style(HtmlStyle style) {
         this.style = style;
         return this;
     }
@@ -324,7 +324,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Set whether or not this is a link to a varargs parameter.
      */
-    public LinkInfoImpl varargs(boolean varargs) {
+    public HtmlLinkInfo varargs(boolean varargs) {
         this.isVarArg = varargs;
         return this;
     }
@@ -332,7 +332,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Set the fragment specifier for the link.
      */
-    public LinkInfoImpl where(String where) {
+    public HtmlLinkInfo where(String where) {
         this.where = where;
         return this;
     }
@@ -340,7 +340,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Set the member this link points to (if any).
      */
-    public LinkInfoImpl targetMember(Element el) {
+    public HtmlLinkInfo targetMember(Element el) {
         this.targetMember = el;
         return this;
     }
@@ -348,7 +348,7 @@ public class LinkInfoImpl extends LinkInfo {
     /**
      * Set whether or not the preview flags should be skipped for this link.
      */
-    public LinkInfoImpl skipPreview(boolean skipPreview) {
+    public HtmlLinkInfo skipPreview(boolean skipPreview) {
         this.skipPreview = skipPreview;
         return this;
     }
@@ -436,7 +436,7 @@ public class LinkInfoImpl extends LinkInfo {
 
     @Override
     public String toString() {
-        return "LinkInfoImpl{" +
+        return "HtmlLinkInfo{" +
                 "context=" + context +
                 ", where=" + where +
                 ", style=" + style +

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import javax.lang.model.type.TypeMirror;
 import com.sun.source.doctree.DocTree;
 
 import com.sun.source.doctree.SerialTree;
-import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
@@ -42,7 +41,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.RawHtml;
 import jdk.javadoc.internal.doclets.formats.html.markup.StringContent;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.SerializedFormWriter;
-import jdk.javadoc.internal.doclets.toolkit.taglets.TagletWriter;
 import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 
 /**
@@ -121,8 +119,8 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         if (fieldType == null) {
             pre.add(fieldTypeStr);
         } else {
-            Content fieldContent = writer.getLink(new LinkInfoImpl(
-                    configuration, LinkInfoImpl.Kind.SERIAL_MEMBER, fieldType));
+            Content fieldContent = writer.getLink(new HtmlLinkInfo(
+                    configuration, HtmlLinkInfo.Kind.SERIAL_MEMBER, fieldType));
             pre.add(fieldContent);
         }
         pre.add(fieldDimensions + " ");
@@ -136,8 +134,8 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         Content heading = HtmlTree.HEADING(TagName.H5, nameContent);
         contentTree.add(heading);
         Content pre = new HtmlTree(TagName.PRE);
-        Content fieldContent = writer.getLink(new LinkInfoImpl(
-                configuration, LinkInfoImpl.Kind.SERIAL_MEMBER, fieldType));
+        Content fieldContent = writer.getLink(new HtmlLinkInfo(
+                configuration, HtmlLinkInfo.Kind.SERIAL_MEMBER, fieldType));
         pre.add(fieldContent);
         pre.add(" ");
         pre.add(fieldName);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -214,8 +214,8 @@ public class IndexWriter extends HtmlDocletWriter {
             case RECORD:
             case ANNOTATION_TYPE:
             case INTERFACE:
-                dt = HtmlTree.DT(getLink(new LinkInfoImpl(configuration,
-                        LinkInfoImpl.Kind.INDEX, (TypeElement) element).style(HtmlStyle.typeNameLink)));
+                dt = HtmlTree.DT(getLink(new HtmlLinkInfo(configuration,
+                        HtmlLinkInfo.Kind.INDEX, (TypeElement) element).style(HtmlStyle.typeNameLink)));
                 dt.add(" - ");
                 addClassInfo((TypeElement) element, dt);
                 break;
@@ -225,7 +225,7 @@ public class IndexWriter extends HtmlDocletWriter {
             case FIELD:
             case ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
-                dt = HtmlTree.DT(getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element,
+                dt = HtmlTree.DT(getDocLink(HtmlLinkInfo.Kind.INDEX, containingType, element,
                                 label, HtmlStyle.memberNameLink));
                 dt.add(" - ");
                 addMemberDesc(element, containingType, dt);
@@ -338,7 +338,7 @@ public class IndexWriter extends HtmlDocletWriter {
             default -> throw new IllegalArgumentException(member.getKind().toString());
         };
         contentTree.add(contents.getContent(resource, kindName)).add(" ");
-        addPreQualifiedClassLink(LinkInfoImpl.Kind.INDEX, enclosing,
+        addPreQualifiedClassLink(HtmlLinkInfo.Kind.INDEX, enclosing,
                 null, contentTree);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -215,7 +215,7 @@ public class IndexWriter extends HtmlDocletWriter {
             case ANNOTATION_TYPE:
             case INTERFACE:
                 dt = HtmlTree.DT(getLink(new LinkInfoImpl(configuration,
-                        LinkInfoImpl.Kind.INDEX, (TypeElement) element).strong(true)));
+                        LinkInfoImpl.Kind.INDEX, (TypeElement) element).style(HtmlStyle.typeNameLink)));
                 dt.add(" - ");
                 addClassInfo((TypeElement) element, dt);
                 break;
@@ -225,9 +225,8 @@ public class IndexWriter extends HtmlDocletWriter {
             case FIELD:
             case ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
-                dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                        getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element,
-                                new StringContent(label), false)));
+                dt = HtmlTree.DT(getDocLink(LinkInfoImpl.Kind.INDEX, containingType, element,
+                                label, HtmlStyle.memberNameLink));
                 dt.add(" - ");
                 addMemberDesc(element, containingType, dt);
                 break;
@@ -340,7 +339,7 @@ public class IndexWriter extends HtmlDocletWriter {
         };
         contentTree.add(contents.getContent(resource, kindName)).add(" ");
         addPreQualifiedClassLink(LinkInfoImpl.Kind.INDEX, enclosing,
-                false, contentTree);
+                null, contentTree);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -268,7 +268,7 @@ public class IndexWriter extends HtmlDocletWriter {
         String itemPath = pathToRoot.isEmpty() ? "" : pathToRoot.getPath() + "/";
         itemPath += item.getUrl();
         HtmlTree labelLink = HtmlTree.A(itemPath, new StringContent(item.getLabel()));
-        Content dt = HtmlTree.DT(HtmlTree.SPAN(HtmlStyle.searchTagLink, labelLink));
+        Content dt = HtmlTree.DT(labelLink.setStyle(HtmlStyle.searchTagLink));
         dt.add(" - ");
         dt.add(contents.getContent("doclet.Search_tag_in", item.getHolder()));
         dlTree.add(dt);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -112,7 +112,7 @@ public class LinkFactoryImpl extends LinkFactory {
                         link.add(m_writer.links.createLink(
                                 filename.fragment(classLinkInfo.where),
                                 label,
-                                classLinkInfo.isStrong,
+                                classLinkInfo.style,
                                 title));
                         if (flags.contains(ElementFlag.PREVIEW)) {
                             link.add(HtmlTree.SUP(m_writer.links.createLink(
@@ -125,7 +125,7 @@ public class LinkFactoryImpl extends LinkFactory {
         } else {
             Content crossLink = m_writer.getCrossClassLink(
                 typeElement, classLinkInfo.where,
-                label, classLinkInfo.isStrong, true);
+                label, classLinkInfo.style, true);
             if (crossLink != null) {
                 link.add(crossLink);
                 if (flags.contains(ElementFlag.PREVIEW)) {
@@ -133,7 +133,7 @@ public class LinkFactoryImpl extends LinkFactory {
                         typeElement,
                         m_writer.htmlIds.forPreviewSection(target).name(),
                         m_writer.contents.previewMark,
-                        false, false)));
+                        null, false)));
                 }
                 return link;
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -31,6 +31,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
+import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.StringContent;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
@@ -241,6 +242,11 @@ public class LinkInfoImpl extends LinkInfo {
      */
     public Element targetMember;
 
+    /**
+     * Optional style for the link.
+     */
+    public HtmlStyle style = null;
+
     public final Utils utils;
 
     /**
@@ -308,10 +314,10 @@ public class LinkInfoImpl extends LinkInfo {
     }
 
     /**
-     * Set whether or not the link should be strong.
+     * Sets the style to be used for the link.
      */
-    public LinkInfoImpl strong(boolean strong) {
-        this.isStrong = strong;
+    public LinkInfoImpl style(HtmlStyle style) {
+        this.style = style;
         return this;
     }
 
@@ -433,6 +439,7 @@ public class LinkInfoImpl extends LinkInfo {
         return "LinkInfoImpl{" +
                 "context=" + context +
                 ", where=" + where +
+                ", style=" + style +
                 super.toString() + '}';
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -150,12 +150,11 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                 writer.addInlineComment(method, methodDocTree);
             } else {
                 Content link =
-                        writer.getDocLink(LinkInfoImpl.Kind.EXECUTABLE_ELEMENT_COPY,
+                        writer.getDocLink(HtmlLinkInfo.Kind.EXECUTABLE_ELEMENT_COPY,
                         holder, method,
                         utils.isIncluded(holder)
                                 ? utils.getSimpleName(holder)
-                                : utils.getFullyQualifiedName(holder),
-                        null);
+                                : utils.getFullyQualifiedName(holder));
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)
@@ -214,7 +213,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -270,22 +269,22 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
         if (method != null) {
             Contents contents = writer.contents;
             Content label;
-            LinkInfoImpl.Kind context;
+            HtmlLinkInfo.Kind context;
             if (utils.isAbstract(holder) && utils.isAbstract(method)){
                 //Abstract method is implemented from abstract class,
                 //not overridden
                 label = contents.specifiedByLabel;
-                context = LinkInfoImpl.Kind.METHOD_SPECIFIED_BY;
+                context = HtmlLinkInfo.Kind.METHOD_SPECIFIED_BY;
             } else {
                 label = contents.overridesLabel;
-                context = LinkInfoImpl.Kind.METHOD_OVERRIDES;
+                context = HtmlLinkInfo.Kind.METHOD_OVERRIDES;
             }
             dl.add(HtmlTree.DT(label));
             Content overriddenTypeLink =
-                    writer.getLink(new LinkInfoImpl(writer.configuration, context, overriddenType));
+                    writer.getLink(new HtmlLinkInfo(writer.configuration, context, overriddenType));
             Content codeOverriddenTypeLink = HtmlTree.CODE(overriddenTypeLink);
             Content methlink = writer.getLink(
-                    new LinkInfoImpl(writer.configuration, LinkInfoImpl.Kind.MEMBER, holder)
+                    new HtmlLinkInfo(writer.configuration, HtmlLinkInfo.Kind.MEMBER, holder)
                             .where(writer.htmlIds.forMember(method).name())
                             .label(method.getSimpleName()));
             Content codeMethLink = HtmlTree.CODE(methlink);
@@ -322,12 +321,12 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
         for (ExecutableElement implementedMeth : implementedMethods) {
             TypeMirror intfac = vmt.getImplementedMethodHolder(method, implementedMeth);
             intfac = utils.getDeclaredType(utils.getEnclosingTypeElement(method), intfac);
-            Content intfaclink = writer.getLink(new LinkInfoImpl(
-                    writer.configuration, LinkInfoImpl.Kind.METHOD_SPECIFIED_BY, intfac));
+            Content intfaclink = writer.getLink(new HtmlLinkInfo(
+                    writer.configuration, HtmlLinkInfo.Kind.METHOD_SPECIFIED_BY, intfac));
             Content codeIntfacLink = HtmlTree.CODE(intfaclink);
             dl.add(HtmlTree.DT(contents.specifiedByLabel));
             Content methlink = writer.getDocLink(
-                    LinkInfoImpl.Kind.MEMBER, implementedMeth,
+                    HtmlLinkInfo.Kind.MEMBER, implementedMeth,
                     implementedMeth.getSimpleName());
             Content codeMethLink = HtmlTree.CODE(methlink);
             Content dd = HtmlTree.DD(codeMethLink);
@@ -348,7 +347,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     protected Content getReturnType(ExecutableElement method) {
         TypeMirror type = utils.getReturnType(typeElement, method);
         if (type != null) {
-            return writer.getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.RETURN_TYPE, type));
+            return writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RETURN_TYPE, type));
         }
         return new ContentBuilder();
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -154,7 +154,8 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                         holder, method,
                         utils.isIncluded(holder)
                                 ? utils.getSimpleName(holder)
-                                : utils.getFullyQualifiedName(holder));
+                                : utils.getFullyQualifiedName(holder),
+                        null);
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -726,7 +726,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             if (!displayServiceDirective(t, usesTrees)) {
                 continue;
             }
-            typeLinkContent = getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.PACKAGE, t));
+            typeLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, t));
             Content summary = new ContentBuilder();
             if (display(usesTrees)) {
                 description = usesTrees.get(t);
@@ -756,7 +756,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 continue;
             }
             implSet = entry.getValue();
-            Content srvLinkContent = getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.PACKAGE, srv));
+            Content srvLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, srv));
             Content desc = new ContentBuilder();
             if (display(providesTrees)) {
                 description = providesTrees.get(srv);
@@ -776,7 +776,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 String sep = "";
                 for (TypeElement impl : implSet) {
                     desc.add(sep);
-                    desc.add(getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.PACKAGE, impl)));
+                    desc.add(getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, impl)));
                     sep = ", ";
                 }
                 desc.add(")");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -101,7 +101,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
 
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
-        Content classLink = writer.getPreQualifiedClassLink(LinkInfoImpl.Kind.MEMBER, typeElement);
+        Content classLink = writer.getPreQualifiedClassLink(HtmlLinkInfo.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isInterface(typeElement)
@@ -120,9 +120,9 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     }
 
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
-            Content tdSummary) {
-        Content memberLink = writer.getLink(new LinkInfoImpl(configuration, context, (TypeElement)member)
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element member,
+                                  Content tdSummary) {
+        Content memberLink = writer.getLink(new HtmlLinkInfo(configuration, context, (TypeElement)member)
                 .style(HtmlStyle.typeNameLink));
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
@@ -131,7 +131,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         linksTree.add(
-                writer.getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.MEMBER,
+                writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                         (TypeElement)member)));
     }
 
@@ -142,6 +142,6 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
 
     @Override
     protected Content getSummaryLink(Element member) {
-        return writer.getQualifiedClassLink(LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW, member);
+        return writer.getQualifiedClassLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -122,8 +122,8 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     @Override
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getLink(new LinkInfoImpl(configuration, context, (TypeElement)member)));
+        Content memberLink = writer.getLink(new LinkInfoImpl(configuration, context, (TypeElement)member)
+                .style(HtmlStyle.typeNameLink));
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -213,8 +213,8 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 if (!utils.isCoreClass(klass) || !configuration.isGeneratedDoc(klass)) {
                     continue;
                 }
-                Content classLink = getLink(new LinkInfoImpl(
-                        configuration, LinkInfoImpl.Kind.PACKAGE, klass));
+                Content classLink = getLink(new HtmlLinkInfo(
+                        configuration, HtmlLinkInfo.Kind.PACKAGE, klass));
                 ContentBuilder description = new ContentBuilder();
                 addPreviewSummary(klass, description);
                 if (utils.isDeprecated(klass)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -112,11 +112,10 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                 writer.addInlineComment(property, propertyDocTree);
             } else {
                 Content link =
-                        writer.getDocLink(LinkInfoImpl.Kind.PROPERTY_COPY,
+                        writer.getDocLink(HtmlLinkInfo.Kind.PROPERTY_COPY,
                         holder, property,
                         utils.isIncluded(holder)
-                                ? holder.getSimpleName() : holder.getQualifiedName(),
-                        null);
+                                ? holder.getSimpleName() : holder.getQualifiedName());
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)
@@ -168,7 +167,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content inheritedTree) {
         Content classLink = writer.getPreQualifiedClassLink(
-                LinkInfoImpl.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.MEMBER, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = new StringContent(utils.isClass(typeElement)
@@ -188,8 +187,8 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     }
 
     @Override
-    protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
-            Content tdSummary) {
+    protected void addSummaryLink(HtmlLinkInfo.Kind context, TypeElement typeElement, Element member,
+                                  Content tdSummary) {
         Content memberLink = writer.getDocLink(context, typeElement,
                 member,
                 new StringContent(utils.getPropertyLabel(name(member))),
@@ -203,7 +202,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content linksTree) {
         String mname = name(member);
-        Content content = writer.getDocLink(LinkInfoImpl.Kind.MEMBER, typeElement, member,
+        Content content = writer.getDocLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member,
                 utils.isProperty(mname) ? utils.getPropertyName(mname) : mname, true);
         linksTree.add(content);
     }
@@ -215,7 +214,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
 
     @Override
     protected Content getSummaryLink(Element member) {
-        return writer.getDocLink(LinkInfoImpl.Kind.MEMBER_DEPRECATED_PREVIEW, member,
+        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member,
                 utils.getFullyQualifiedName(member));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -115,7 +115,8 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                         writer.getDocLink(LinkInfoImpl.Kind.PROPERTY_COPY,
                         holder, property,
                         utils.isIncluded(holder)
-                                ? holder.getSimpleName() : holder.getQualifiedName());
+                                ? holder.getSimpleName() : holder.getQualifiedName(),
+                        null);
                 Content codeLink = HtmlTree.CODE(link);
                 Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
                         utils.isClass(holder)
@@ -189,11 +190,11 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     protected void addSummaryLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element member,
             Content tdSummary) {
-        Content memberLink = HtmlTree.SPAN(HtmlStyle.memberNameLink,
-                writer.getDocLink(context, typeElement,
+        Content memberLink = writer.getDocLink(context, typeElement,
                 member,
-                utils.getPropertyLabel(name(member)),
-                true));
+                new StringContent(utils.getPropertyLabel(name(member))),
+                HtmlStyle.memberNameLink,
+                true);
 
         Content code = HtmlTree.CODE(memberLink);
         tdSummary.add(code);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -149,13 +149,13 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
     @Override
     public Content getClassHeader(TypeElement typeElement) {
         Content classLink = (isVisibleClass(typeElement))
-                ? getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, typeElement)
+                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, typeElement)
                         .label(configuration.getClassName(typeElement)))
                 : new StringContent(utils.getFullyQualifiedName(typeElement));
         Content section = HtmlTree.SECTION(HtmlStyle.serializedClassDetails)
                 .setId(htmlIds.forClass(typeElement));
         Content superClassLink = typeElement.getSuperclass() != null
-                ? getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.SERIALIZED_FORM,
+                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SERIALIZED_FORM,
                         typeElement.getSuperclass()))
                 : null;
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -97,8 +97,8 @@ public class Signatures {
             } else {
                 nameSpan.addStyle(HtmlStyle.typeNameLabel).add(className);
             }
-            LinkInfoImpl linkInfo = new LinkInfoImpl(configuration,
-                    LinkInfoImpl.Kind.CLASS_SIGNATURE, typeElement);
+            HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
+                    HtmlLinkInfo.Kind.CLASS_SIGNATURE, typeElement);
             //Let's not link to ourselves in the signature.
             linkInfo.linkToSelf = false;
             nameSpan.add(classWriter.getTypeParameterLinks(linkInfo));
@@ -115,8 +115,8 @@ public class Signatures {
                     if (superclass != null) {
                         content.add(DocletConstants.NL);
                         extendsImplements.add("extends ");
-                        Content link = classWriter.getLink(new LinkInfoImpl(configuration,
-                                LinkInfoImpl.Kind.CLASS_SIGNATURE_PARENT_NAME,
+                        Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                                HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
                                 superclass));
                         extendsImplements.add(link);
                     }
@@ -136,8 +136,8 @@ public class Signatures {
                         } else {
                             extendsImplements.add(", ");
                         }
-                        Content link = classWriter.getLink(new LinkInfoImpl(configuration,
-                                LinkInfoImpl.Kind.CLASS_SIGNATURE_PARENT_NAME,
+                        Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                                HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
                                 type));
                         extendsImplements.add(link);
                     }
@@ -166,8 +166,8 @@ public class Signatures {
                     } else {
                         permitsSpan.add(", ");
                     }
-                    Content link = classWriter.getLink(new LinkInfoImpl(configuration,
-                            LinkInfoImpl.Kind.PERMITTED_SUBCLASSES,
+                    Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                            HtmlLinkInfo.Kind.PERMITTED_SUBCLASSES,
                             type));
                     permitsSpan.add(link);
                 }
@@ -190,7 +190,7 @@ public class Signatures {
                 content.add(sep);
                 classWriter.getAnnotations(e.getAnnotationMirrors(), false)
                         .forEach(a -> { content.add(a).add(" "); });
-                Content link = classWriter.getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.RECORD_COMPONENT,
+                Content link = classWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RECORD_COMPONENT,
                         e.asType()));
                 content.add(link);
                 content.add(Entity.NO_BREAK_SPACE);
@@ -265,7 +265,7 @@ public class Signatures {
          * @return this instance
          */
         MemberSignature setType(TypeMirror type) {
-            this.returnType = memberWriter.writer.getLink(new LinkInfoImpl(memberWriter.configuration, LinkInfoImpl.Kind.MEMBER, type));
+            this.returnType = memberWriter.writer.getLink(new HtmlLinkInfo(memberWriter.configuration, HtmlLinkInfo.Kind.MEMBER, type));
             return this;
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -319,14 +319,14 @@ public class TagletWriterImpl extends TagletWriter {
         Element exception = ch.getException(throwsTag);
         Content excName;
         if (substituteType != null) {
-           excName = htmlWriter.getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.MEMBER,
+           excName = htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                    substituteType));
         } else if (exception == null) {
             excName = new RawHtml(ch.getExceptionName(throwsTag).toString());
         } else if (exception.asType() == null) {
             excName = new RawHtml(utils.getFullyQualifiedName(exception));
         } else {
-            LinkInfoImpl link = new LinkInfoImpl(configuration, LinkInfoImpl.Kind.MEMBER,
+            HtmlLinkInfo link = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                                                  exception.asType());
             link.excludeTypeBounds = true;
             excName = htmlWriter.getLink(link);
@@ -345,14 +345,14 @@ public class TagletWriterImpl extends TagletWriter {
     @Override
     public Content throwsTagOutput(TypeMirror throwsType) {
         HtmlTree result = HtmlTree.DD(HtmlTree.CODE(htmlWriter.getLink(
-                new LinkInfoImpl(configuration, LinkInfoImpl.Kind.MEMBER, throwsType))));
+                new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER, throwsType))));
         return result;
     }
 
     @Override
     public Content valueTagOutput(VariableElement field, String constantVal, boolean includeLink) {
         return includeLink
-                ? htmlWriter.getDocLink(LinkInfoImpl.Kind.VALUE_TAG, field, constantVal)
+                ? htmlWriter.getDocLink(HtmlLinkInfo.Kind.VALUE_TAG, field, constantVal)
                 : new StringContent(constantVal);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
@@ -101,12 +101,11 @@ public class Links {
 
     /**
      * Creates a link of the form {@code <a href="path" title="title">label</a>}.
-     * If {@code strong} is set, the label will be wrapped in
-     *      {@code <span style="typeNameLink">...</span>}.
+     * If {@code style} is not null, it will be added as {@code class="style"} to the link.
      *
      * @param path      the path for the link
      * @param label     the content for the link
-     * @param style     optional style for the link
+     * @param style     the style for the link, or null
      * @param title     the title for the link
      * @return a content tree for the link
      */
@@ -155,12 +154,11 @@ public class Links {
 
     /**
      * Creates a link of the form {@code <a href="link" title="title" >label</a>}.
-     * If {@code strong} is set, the label will be wrapped in
-     *      {@code <span style="typeNameLink">...</span>}.
+     * If {@code style} is not null, it will be added as {@code class="style"} to the link.
      *
      * @param link      the details for the link
      * @param label     the content for the link
-     * @param style    whether to wrap the {@code label} in a SPAN element
+     * @param style     the style for the link, or null
      * @param title     the title for the link
      * @return a content tree for the link
      */
@@ -171,12 +169,11 @@ public class Links {
 
     /**
      * Creates a link of the form {@code <a href="link" title="title">label</a>}.
-     * If {@code strong} is set, the label will be wrapped in
-     *      {@code <span style="typeNameLink">...</span>}.
+     * If {@code style} is not null, it will be added as {@code class="style"} to the link.
      *
      * @param link       the details for the link
      * @param label      the content for the link
-     * @param style      optional style for the link
+     * @param style      the style for the link, or null
      * @param title      the title for the link
      * @param isExternal is the link external to the generated documentation
      * @return a content tree for the link

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Links.java
@@ -85,7 +85,7 @@ public class Links {
      * @return a content tree for the link
      */
     public Content createLink(DocPath path, String label) {
-        return createLink(path, new StringContent(label), false, "");
+        return createLink(path, new StringContent(label), null, "");
     }
 
     /**
@@ -106,12 +106,12 @@ public class Links {
      *
      * @param path      the path for the link
      * @param label     the content for the link
-     * @param strong    whether to wrap the {@code label} in a SPAN element
+     * @param style     optional style for the link
      * @param title     the title for the link
      * @return a content tree for the link
      */
-    public Content createLink(DocPath path, Content label, boolean strong, String title) {
-        return createLink(new DocLink(path), label, strong, title);
+    public Content createLink(DocPath path, Content label, HtmlStyle style, String title) {
+        return createLink(new DocLink(path), label, style, title);
     }
 
     /**
@@ -160,13 +160,13 @@ public class Links {
      *
      * @param link      the details for the link
      * @param label     the content for the link
-     * @param strong    whether to wrap the {@code label} in a SPAN element
+     * @param style    whether to wrap the {@code label} in a SPAN element
      * @param title     the title for the link
      * @return a content tree for the link
      */
-    public Content createLink(DocLink link, Content label, boolean strong,
+    public Content createLink(DocLink link, Content label, HtmlStyle style,
                               String title) {
-        return createLink(link, label, strong, title, false);
+        return createLink(link, label, style, title, false);
     }
 
     /**
@@ -176,23 +176,23 @@ public class Links {
      *
      * @param link       the details for the link
      * @param label      the content for the link
-     * @param strong     whether to wrap the {@code label} in a SPAN element
+     * @param style      optional style for the link
      * @param title      the title for the link
      * @param isExternal is the link external to the generated documentation
      * @return a content tree for the link
      */
-    public Content createLink(DocLink link, Content label, boolean strong,
+    public Content createLink(DocLink link, Content label, HtmlStyle style,
                               String title, boolean isExternal) {
-        Content body = label;
-        if (strong) {
-            body = HtmlTree.SPAN(HtmlStyle.typeNameLink, body);
+        HtmlTree l = HtmlTree.A(link.relativizeAgainst(file).toString(), label);
+        if (style != null) {
+            l.setStyle(style);
         }
-        HtmlTree l = HtmlTree.A(link.relativizeAgainst(file).toString(), body);
         if (title != null && title.length() != 0) {
             l.put(HtmlAttr.TITLE, title);
         }
         if (isExternal) {
-            l.setStyle(HtmlStyle.externalLink);
+            // Use addStyle as external links might have an explicit style set above as well.
+            l.addStyle(HtmlStyle.externalLink);
         }
         return l;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -70,11 +70,6 @@ public abstract class LinkInfo {
     public Content label;
 
     /**
-     * True if the link should be strong.
-     */
-    public boolean isStrong = false;
-
-    /**
      * True if we should exclude the type bounds for the type parameter.
      */
     public boolean excludeTypeBounds = false;
@@ -146,7 +141,6 @@ public abstract class LinkInfo {
                 ", type=" + type +
                 ", isVarArg=" + isVarArg +
                 ", label=" + label +
-                ", isStrong=" + isStrong +
                 ", excludeTypeBounds=" + excludeTypeBounds +
                 ", excludeTypeParameterLinks=" + excludeTypeParameterLinks +
                 ", linkToSelf=" + linkToSelf + '}';

--- a/test/langtools/jdk/javadoc/doclet/testAnchorNames/TestAnchorNames.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnchorNames/TestAnchorNames.java
@@ -92,86 +92,86 @@ public class TestAnchorNames extends JavadocTester {
         // Test some fields
         checkOutput("pkg1/RegClass.html", true,
                 "<section class=\"detail\" id=\"_\">",
-                "<a href=\"#_\">",
+                "<a href=\"#_\" class=\"member-name-link\">",
                 "<section class=\"detail\" id=\"_$\">",
-                "<a href=\"#_$\">",
+                "<a href=\"#_$\" class=\"member-name-link\">",
                 "<section class=\"detail\" id=\"$_\">",
-                "<a href=\"#$_\">",
+                "<a href=\"#$_\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="$field">""",
-                "<a href=\"#$field\">",
+                "<a href=\"#$field\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="fieldInCla$$">""",
-                "<a href=\"#fieldInCla$$\">",
+                "<a href=\"#fieldInCla$$\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="S_$$$$$INT">""",
-                "<a href=\"#S_$$$$$INT\">",
+                "<a href=\"#S_$$$$$INT\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="method$$">""",
-                "<a href=\"#method$$\">");
+                "<a href=\"#method$$\" class=\"member-name-link\">");
 
         checkOutput("pkg1/DeprMemClass.html", true,
                 """
                     <section class="detail" id="_field_In_Class">""",
-                "<a href=\"#_field_In_Class\">");
+                "<a href=\"#_field_In_Class\" class=\"member-name-link\">");
 
         // Test constructor
         checkOutput("pkg1/RegClass.html", true,
                 """
                     <section class="detail" id="&lt;init&gt;(java.lang.String,int)">""",
                 """
-                    <a href="#%3Cinit%3E(java.lang.String,int)">""");
+                    <a href="#%3Cinit%3E(java.lang.String,int)" class="member-name-link">""");
 
         // Test some methods
         checkOutput("pkg1/RegClass.html", true,
                 """
                     <section class="detail" id="_methodInClass(java.lang.String)">""",
                 """
-                    <a href="#_methodInClass(java.lang.String)">""",
+                    <a href="#_methodInClass(java.lang.String)" class="member-name-link">""",
                 """
                     <section class="detail" id="method()">""",
-                "<a href=\"#method()\">",
+                "<a href=\"#method()\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="foo(java.util.Map)">""",
-                "<a href=\"#foo(java.util.Map)\">",
+                "<a href=\"#foo(java.util.Map)\" class=\"member-name-link\">",
                 """
                     <section class="detail" id="methodInCla$s(java.lang.String[])">""",
                 """
-                    <a href="#methodInCla$s(java.lang.String%5B%5D)">""",
+                    <a href="#methodInCla$s(java.lang.String%5B%5D)" class="member-name-link">""",
                 """
                     <section class="detail" id="_methodInClas$(java.lang.String,int)">""",
                 """
-                    <a href="#_methodInClas$(java.lang.String,int)">""",
+                    <a href="#_methodInClas$(java.lang.String,int)" class="member-name-link">""",
                 """
                     <section class="detail" id="methodD(pkg1.RegClass.$A)">""",
                 """
-                    <a href="#methodD(pkg1.RegClass.$A)">""",
+                    <a href="#methodD(pkg1.RegClass.$A)" class="member-name-link">""",
                 """
                     <section class="detail" id="methodD(pkg1.RegClass.D[])">""",
                 """
-                    <a href="#methodD(pkg1.RegClass.D%5B%5D)">""");
+                    <a href="#methodD(pkg1.RegClass.D%5B%5D)" class="member-name-link">""");
 
         checkOutput("pkg1/DeprMemClass.html", true,
                 """
                     <section class="detail" id="$method_In_Class()">""",
-                "<a href=\"#$method_In_Class()\">");
+                "<a href=\"#$method_In_Class()\" class=\"member-name-link\">");
 
         // Test enum
         checkOutput("pkg1/RegClass.Te$t_Enum.html", true,
                 """
                     <section class="detail" id="$FLD2">""",
-                "<a href=\"#$FLD2\">");
+                "<a href=\"#$FLD2\" class=\"member-name-link\">");
 
         // Test nested class
         checkOutput("pkg1/RegClass._NestedClas$.html", true,
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
-                "<a href=\"#%3Cinit%3E()\">");
+                "<a href=\"#%3Cinit%3E()\" class=\"member-name-link\">");
 
         // Test class use page
         checkOutput("pkg1/class-use/DeprMemClass.html", true,
                 """
-                    <a href="../RegClass.html#d____mc">""");
+                    <a href="../RegClass.html#d____mc" class="member-name-link">""");
 
         // Test deprecated list page
         checkOutput("deprecated-list.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
@@ -60,8 +60,8 @@ public class TestAnnotationTypes extends JavadocTester {
                 "<!-- =========== FIELD SUMMARY =========== -->",
                 "<h2>Field Summary</h2>",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="\
-                    #DEFAULT_NAME">DEFAULT_NAME</a></span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="#DEFAULT_NAME" class="memb\
+                    er-name-link">DEFAULT_NAME</a></code></div>""",
                 "<!-- ============ FIELD DETAIL =========== -->",
                 """
                     <section class="detail" id="DEFAULT_NAME">

--- a/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
@@ -56,13 +56,13 @@ public class TestClassLinks extends JavadocTester {
                 """
                     <code><a href="C2.html" title="class in p">C2</a></code>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E()">C1</a></span>()</code>""");
+                    <code><a href="#%3Cinit%3E()" class="member-name-link">C1</a>()</code>""");
 
         checkOutput("p/C2.html", true,
                 """
                     <code><a href="C3.html" title="class in p">C3</a></code>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E()">C2</a></span>()</code>""");
+                    <code><a href="#%3Cinit%3E()" class="member-name-link">C2</a>()</code>""");
 
         checkOutput("p/C3.html", true,
                 """
@@ -72,7 +72,7 @@ public class TestClassLinks extends JavadocTester {
                     /a>&lt;T&gt;</code>, <code><a href="IT2.html" title="interface in p">IT2</a>&lt;\
                     java.lang.String&gt;</code>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E()">C3</a></span>()</code>""");
+                    <code><a href="#%3Cinit%3E()" class="member-name-link">C3</a>()</code>""");
 
         checkOutput("p/I1.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testClassTree/TestClassTree.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassTree/TestClassTree.java
@@ -54,14 +54,14 @@ public class TestClassTree extends JavadocTester {
         checkOutput("pkg/package-tree.html", true,
                 """
                     <ul>
-                    <li class="circle">pkg.<a href="ParentClass.html" title="class in pkg"><span cla\
-                    ss="type-name-link">ParentClass</span></a>""",
+                    <li class="circle">pkg.<a href="ParentClass.html" class="type-name-link" title="\
+                    class in pkg">ParentClass</a>""",
                 """
                     <h2 title="Annotation Interface Hierarchy">Annotation Interface Hierarchy</h2>
                     <ul>
-                    <li class="circle">pkg.<a href="AnnotationType.html" title="annotation in pkg"><\
-                    span class="type-name-link">AnnotationType</span></a> (implements java.lang.anno\
-                    tation.Annotation)</li>
+                    <li class="circle">pkg.<a href="AnnotationType.html" class="type-name-link" titl\
+                    e="annotation in pkg">AnnotationType</a> (implements java.lang.annotation.Annota\
+                    tion)</li>
                     </ul>""",
                 """
                     <h2 title="Enum Class Hierarchy">Enum Class Hierarchy</h2>
@@ -71,7 +71,8 @@ public class TestClassTree extends JavadocTester {
                     <li class="circle">java.lang.Enum&lt;E&gt; (implements java.lang.Comparable&lt;T\
                     &gt;, java.lang.constant.Constable, java.io.Serializable)
                     <ul>
-                    <li class="circle">pkg.<a href="Coin.html" title="enum class in pkg"><span class="type-name-link">Coin</span></a></li>
+                    <li class="circle">pkg.<a href="Coin.html" class="type-name-link" title="enum cl\
+                    ass in pkg">Coin</a></li>
                     </ul>
                     </li>
                     </ul>
@@ -80,7 +81,7 @@ public class TestClassTree extends JavadocTester {
 
         checkOutput("pkg/package-tree.html", false,
                 """
-                    <li class="circle">class pkg.<a href=".ParentClass.html" title="class in pkg"><s\
-                    pan class="type-name-link">ParentClass</span></a></li>""");
+                    <li class="circle">class pkg.<a href=".ParentClass.html" class="type-name-link" \
+                    title="class in pkg">ParentClass</a></li>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
@@ -61,31 +61,31 @@ public class TestConstructors extends JavadocTester {
                     "#%3Cinit%3E(int)"><code>Outer(int)</code></a>, <a href="Outer.Inner.NestedInner\
                     .html#%3Cinit%3E(int)"><code>NestedInner(int)</code></a>""",
                 """
-                    <a href="#%3Cinit%3E()">Outer</a></span>()""",
+                    <a href="#%3Cinit%3E()" class="member-name-link">Outer</a>()""",
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)">Outer</a></span>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">Outer</a>&#8203;(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 
         checkOutput("pkg1/Outer.Inner.html", true,
                 """
-                    <a href="#%3Cinit%3E()">Inner</a></span>()""",
+                    <a href="#%3Cinit%3E()" class="member-name-link">Inner</a>()""",
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)">Inner</a></span>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">Inner</a>&#8203;(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 
         checkOutput("pkg1/Outer.Inner.NestedInner.html", true,
                 """
-                    <a href="#%3Cinit%3E()">NestedInner</a></span>()""",
+                    <a href="#%3Cinit%3E()" class="member-name-link">NestedInner</a>()""",
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)">NestedInner</a></span>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">NestedInner</a>&#8203;(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 

--- a/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
+++ b/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
@@ -68,10 +68,10 @@ public class TestEnumConstructor extends JavadocTester {
                 "Constructor Summary",
                 "Modifier", "Constructor",
                 "private", """
-                    <a href="#%3Cinit%3E(int)">TestEnum</a></span>&#8203;(int&nbsp;val)""");
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">TestEnum</a>&#8203;(int&nbsp;val)""");
         checkOutput("index-all.html", true,
                 """
-                    <a href="pkg/TestEnum.html#%3Cinit%3E(int)">TestEnum(int)</a>""");
+                    <a href="pkg/TestEnum.html#%3Cinit%3E(int)" class="member-name-link">TestEnum(int)</a>""");
 
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -572,7 +572,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("pkg1/C1.html", true,
                 """
                     <div class="col-first odd-row-color"><code><a href="../pkg2/C2.html" title="class in pkg2">C2</a></code></div>
-                    <div class="col-second odd-row-color"><code><span class="member-name-link"><a href="#field">field</a></span></code></div>
+                    <div class="col-second odd-row-color"><code><a href="#field" class="member-name-link">field</a></code></div>
                     <div class="col-last odd-row-color">
                     <div class="block">Test field for class.</div>
                     </div>""",
@@ -580,8 +580,8 @@ public class TestHtmlTableTags extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>void</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    ethod1(int,int)">method1</a></span>&#8203;(int&nbsp;a,
+                    tab2 method-summary-table-tab4"><code><a href="#method1(int,int)" class="member-\
+                    name-link">method1</a>&#8203;(int&nbsp;a,
                      int&nbsp;b)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
@@ -591,7 +591,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("pkg2/C2.html", true,
                 """
                     <div class="col-first even-row-color"><code><a href="../pkg1/C1.html" title="class in pkg1">C1</a></code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#field">field</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#field" class="member-name-link">field</a></code></div>
                     <div class="col-last even-row-color">
                     <div class="block">A test field.</div>
                     </div>""",
@@ -600,8 +600,8 @@ public class TestHtmlTableTags extends JavadocTester {
                     ab2 method-summary-table-tab4"><code><a href="../pkg1/C1.html" title="class in p\
                     kg1">C1</a></code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    ethod(pkg1.C1)">method</a></span>&#8203;(<a href="../pkg1/C1.html" title="class \
+                    tab2 method-summary-table-tab4"><code><a href="#method(pkg1.C1)" class="member-n\
+                    ame-link">method</a>&#8203;(<a href="../pkg1/C1.html" title="class \
                     in pkg1">C1</a>&nbsp;param)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
@@ -610,15 +610,15 @@ public class TestHtmlTableTags extends JavadocTester {
 
         checkOutput("pkg2/C2.ModalExclusionType.html", true,
                 """
-                    <div class="col-first odd-row-color"><code><span class="member-name-link"><a hre\
-                    f="#NO_EXCLUDE">NO_EXCLUDE</a></span></code></div>
+                    <div class="col-first odd-row-color"><code><a href="#NO_EXCLUDE" class="member-n\
+                    ame-link">NO_EXCLUDE</a></code></div>
                     <div class="col-last odd-row-color">
                     <div class="block">Test comment.</div>
                     </div>""");
 
         checkOutput("pkg2/C3.html", true,
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#value()">value</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#value()" class="member-name-link">value</a></code></div>
                     <div class="col-last even-row-color">
                     <div class="block">Comment.</div>
                     </div>""");
@@ -626,7 +626,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("pkg2/C4.html", true,
                 """
                     <div class="col-first even-row-color"><code>boolean</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#value()">value</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#value()" class="member-name-link">value</a></code></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""");
 
@@ -642,16 +642,15 @@ public class TestHtmlTableTags extends JavadocTester {
                 """
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
-                    code><span class="member-name-link"><a href="../../pkg1/C1.html#field">field</a>\
-                    </span></code></div>
+                    code><a href="../../pkg1/C1.html#field" class="member-name-link">field</a></code></div>
                     <div class="col-last even-row-color">
                     <div class="block">Test field for class.</div>
                     </div>""",
                 """
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
-                    code><span class="member-name-link"><a href="../../pkg1/C1.html#method(pkg2.C2)"\
-                    >method</a></span>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp\
+                    code><a href="../../pkg1/C1.html#method(pkg2.C2)" class="member-name-link">metho\
+                    d</a>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp\
                     ;param)</code></div>
                     <div class="col-last even-row-color">
                     <div class="block">Method thats does some processing.</div>
@@ -726,14 +725,14 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("pkg1/C1.html", true,
                 """
                     <div class="col-first odd-row-color"><code><a href="../pkg2/C2.html" title="class in pkg2">C2</a></code></div>
-                    <div class="col-second odd-row-color"><code><span class="member-name-link"><a href="#field">field</a></span></code></div>
+                    <div class="col-second odd-row-color"><code><a href="#field" class="member-name-link">field</a></code></div>
                     <div class="col-last odd-row-color"></div>""",
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>void</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    ethod1(int,int)">method1</a></span>&#8203;(int&nbsp;a,
+                    tab2 method-summary-table-tab4"><code><a href="#method1(int,int)" class="member-\
+                    name-link">method1</a>&#8203;(int&nbsp;a,
                      int&nbsp;b)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"></div>""");
@@ -741,34 +740,36 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("pkg2/C2.html", true,
                 """
                     <div class="col-first even-row-color"><code><a href="../pkg1/C1.html" title="class in pkg1">C1</a></code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#field">field</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#field" class="member-name-link">field</a></code></div>
                     <div class="col-last even-row-color"></div>""",
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code><a href="../pkg1/C1.html" title="class in p\
                     kg1">C1</a></code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    ethod(pkg1.C1)">method</a></span>&#8203;(<a href="../pkg1/C1.html" title="class \
-                    in pkg1">C1</a>&nbsp;param)</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#method(pkg1.C1)" class="member-n\
+                    ame-link">method</a>&#8203;(<a href="../pkg1/C1.html" title="class in pkg1">C1</\
+                    a>&nbsp;param)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"></div>""");
 
         checkOutput("pkg2/C2.ModalExclusionType.html", true,
                 """
-                    <div class="col-first odd-row-color"><code><span class="member-name-link"><a hre\
-                    f="#NO_EXCLUDE">NO_EXCLUDE</a></span></code></div>
+                    <div class="col-first odd-row-color"><code><a href="#NO_EXCLUDE" class="member-n\
+                    ame-link">NO_EXCLUDE</a></code></div>
                     <div class="col-last odd-row-color"></div>""");
 
         checkOutput("pkg2/C3.html", true,
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#value()">value</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#value()" class="member-na\
+                    me-link">value</a></code></div>
                     <div class="col-last even-row-color"></div>""");
 
         checkOutput("pkg2/C4.html", true,
                 """
                     <div class="col-first even-row-color"><code>boolean</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#value()">value</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#value()" class="member-na\
+                    me-link">value</a></code></div>
                     <div class="col-last even-row-color"></div>
                     </div>""");
 
@@ -782,15 +783,14 @@ public class TestHtmlTableTags extends JavadocTester {
                 """
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
-                    code><span class="member-name-link"><a href="../../pkg1/C1.html#field">field</a>\
-                    </span></code></div>
+                    code><a href="../../pkg1/C1.html#field" class="member-name-link">field</a></code\
+                    ></div>
                     <div class="col-last even-row-color"></div>""",
                 """
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
-                    code><span class="member-name-link"><a href="../../pkg1/C1.html#method(pkg2.C2)"\
-                    >method</a></span>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp\
-                    ;param)</code></div>
+                    code><a href="../../pkg1/C1.html#method(pkg2.C2)" class="member-name-link">metho\
+                    d</a>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp;param)</code></div>
                     <div class="col-last even-row-color"></div>""");
 
         // Package use documentation

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
@@ -76,6 +76,6 @@ public class TestIndex extends JavadocTester {
                     <dd>&nbsp;</dd>
                     </dl>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/Coin.html#Enum">Enum</a></span> - Search tag in enum class pkg.Coin</dt>""");
+                    <dt><a href="pkg/Coin.html#Enum" class="search-tag-link">Enum</a> - Search tag in enum class pkg.Coin</dt>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
@@ -52,28 +52,27 @@ public class TestIndex extends JavadocTester {
         //Test index-all.html
         checkOutput("index-all.html", true,
                 """
-                    <a href="pkg/C.html" title="class in pkg"><span class="type-name-link">C</span><\
-                    /a> - Class in <a href="pkg/package-summary.html">pkg</a>""",
+                    <a href="pkg/C.html" class="type-name-link" title="class in pkg">C</a> - Class i\
+                    n <a href="pkg/package-summary.html">pkg</a>""",
                 """
-                    <a href="pkg/Interface.html" title="interface in pkg"><span class="type-name-lin\
-                    k">Interface</span></a> - Interface in <a href="pkg/package-summary.html">pkg</a\
-                    >""",
+                    <a href="pkg/Interface.html" class="type-name-link" title="interface in pkg">Int\
+                    erface</a> - Interface in <a href="pkg/package-summary.html">pkg</a>""",
                 """
-                    <a href="pkg/AnnotationType.html" title="annotation in pkg"><span class="type-na\
-                    me-link">AnnotationType</span></a> - Annotation Interface in <a href="pkg/package-sum\
-                    mary.html">pkg</a>""",
+                    <a href="pkg/AnnotationType.html" class="type-name-link" title="annotation in pk\
+                    g">AnnotationType</a> - Annotation Interface in <a href="pkg/packag\
+                    e-summary.html">pkg</a>""",
                 """
-                    <a href="pkg/Coin.html" title="enum class in pkg"><span class="type-name-link">Coin</s\
-                    pan></a> - Enum Class in <a href="pkg/package-summary.html">pkg</a>""",
+                    <a href="pkg/Coin.html" class="type-name-link" title="enum class in pkg">Coin</a\
+                    > - Enum Class in <a href="pkg/package-summary.html">pkg</a>""",
                 """
                     Class in <a href="package-summary.html">&lt;Unnamed&gt;</a>""",
                 """
                     <dl class="index">
-                    <dt><span class="member-name-link"><a href="pkg/C.html#Java">Java</a></span> - S\
-                    tatic variable in class pkg.<a href="pkg/C.html" title="class in pkg">C</a></dt>
+                    <dt><a href="pkg/C.html#Java" class="member-name-link">Java</a> - Static variabl\
+                    e in class pkg.<a href="pkg/C.html" title="class in pkg">C</a></dt>
                     <dd>&nbsp;</dd>
-                    <dt><span class="member-name-link"><a href="pkg/C.html#JDK">JDK</a></span> - Sta\
-                    tic variable in class pkg.<a href="pkg/C.html" title="class in pkg">C</a></dt>
+                    <dt><a href="pkg/C.html#JDK" class="member-name-link">JDK</a> - Static variable \
+                    in class pkg.<a href="pkg/C.html" title="class in pkg">C</a></dt>
                     <dd>&nbsp;</dd>
                     </dl>""",
                 """

--- a/test/langtools/jdk/javadoc/doclet/testIndexInPackageFiles/TestIndexInPackageFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInPackageFiles/TestIndexInPackageFiles.java
@@ -112,15 +112,15 @@ public class TestIndexInPackageFiles extends JavadocTester {
 
         checkOutput("index-all.html", true,
             """
-                <span class="search-tag-link"><a href="p/q/package-summary.html#test.name.1">test.name.1</a></span>""",
+                <a href="p/q/package-summary.html#test.name.1" class="search-tag-link">test.name.1</a>""",
             """
-                <span class="search-tag-link"><a href="p/q/doc-files/extra.html#test.name.2">test.name.2</a></span>""",
+                <a href="p/q/doc-files/extra.html#test.name.2" class="search-tag-link">test.name.2</a>""",
             """
-                <span class="search-tag-link"><a href="index.html#test.name.3">test.name.3</a></span> - Search tag in Overview</dt>""",
+                <a href="index.html#test.name.3" class="search-tag-link">test.name.3</a> - Search tag in Overview</dt>""",
             """
-                <span class="search-tag-link"><a href="p/q/package-summary.html#test.property.1">test.property.1</a></span>""",
+                <a href="p/q/package-summary.html#test.property.1" class="search-tag-link">test.property.1</a>""",
             """
-                <span class="search-tag-link"><a href="p/q/doc-files/extra.html#test.property.2">test.property.2</a></span>""");
+                <a href="p/q/doc-files/extra.html#test.property.2" class="search-tag-link">test.property.2</a>""");
     }
 }
 

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -136,8 +136,8 @@ public class TestInterface extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab1 method-summary-table-tab4"><code>static void</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab1 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    ()">m</a></span>()</code></div>
+                    tab1 method-summary-table-tab4"><code><a href="#m()" class="member-name-link">m<\
+                    /a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b1 method-summary-table-tab4">
                     <div class="block">A hider method</div>

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -78,8 +78,10 @@ public class TestJavaFX extends JavadocTester {
                     <dl class="notes">
                     <dt>Property description:</dt>""",
                 """
-                    <div class="col-first odd-row-color"><code><a href="C.DoubleProperty.html" title="class in pkg1">C.DoubleProperty</a></code></div>
-                    <div class="col-second odd-row-color"><code><span class="member-name-link"><a href="#rateProperty">rate</a></span></code></div>
+                    <div class="col-first odd-row-color"><code><a href="C.DoubleProperty.html" title\
+                    ="class in pkg1">C.DoubleProperty</a></code></div>
+                    <div class="col-second odd-row-color"><code><a href="#rateProperty" class="membe\
+                    r-name-link">rate</a></code></div>
                     <div class="col-last odd-row-color">
                     <div class="block">Defines the direction/speed at which the <code>Timeline</code> is expected to
                      be played.</div>""",
@@ -90,11 +92,11 @@ public class TestJavaFX extends JavadocTester {
                 "<dt>Property description:</dt>",
                 """
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#setTes\
-                    tMethodProperty()">setTestMethodProperty</a></span>()</code></div>""",
+                    tab2 method-summary-table-tab4"><code><a href="#setTestMethodProperty()" class="\
+                    member-name-link">setTestMethodProperty</a>()</code></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="\
-                    #pausedProperty">paused</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#pausedProperty" class="me\
+                    mber-name-link">paused</a></code></div>
                     <div class="col-last even-row-color">
                     <div class="block">Defines if paused.</div>""",
                 """
@@ -320,32 +322,32 @@ public class TestJavaFX extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>&lt;T&gt;&nbsp;java.lang.Object</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#alphaP\
-                    roperty(java.util.List)">alphaProperty</a></span>&#8203;(java.util.List&lt;T&gt;\
-                    &nbsp;foo)</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#alphaProperty(java.util.List)" c\
+                    lass="member-name-link">alphaProperty</a>&#8203;(java.util.List&lt;T&gt;&nbsp;fo\
+                    o)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"><code>java.lang.Object</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#betaPr\
-                    operty()">betaProperty</a></span>()</code></div>
+                    ab2 method-summary-table-tab4"><code><a href="#betaProperty()" class="member-nam\
+                    e-link">betaProperty</a>()</code></div>
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code>java.util.List&lt;java.util.Set&lt;? super java.\
-                    lang.Object&gt;&gt;</code></div>
+                    ab2 method-summary-table-tab4"><code>java.util.List&lt;java.util.Set&lt;? super \
+                    java.lang.Object&gt;&gt;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#deltaP\
-                    roperty()">deltaProperty</a></span>()</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#deltaProperty()" class="member-n\
+                    ame-link">deltaProperty</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>java.util.List&lt;java.lang.String&gt;</code></d\
-                    iv>
+                    b2 method-summary-table-tab4"><code>java.util.List&lt;java.lang.String&gt;</code\
+                    ></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#gammaP\
-                    roperty()">gammaProperty</a></span>()</code></div>
+                    ab2 method-summary-table-tab4"><code><a href="#gammaProperty()" class="member-na\
+                    me-link">gammaProperty</a>()</code></div>
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">&nbsp;</div>"""
         );

--- a/test/langtools/jdk/javadoc/doclet/testLinksWithNoDeprecatedOption/TestLinksWithNoDeprecatedOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinksWithNoDeprecatedOption/TestLinksWithNoDeprecatedOption.java
@@ -74,20 +74,20 @@ public class TestLinksWithNoDeprecatedOption extends JavadocTester {
 
         checkOutput("pkg/class-use/A.html", true,
                 """
-                    <span class="member-name-link"><a href="../B.html#a2">a2</a></span>""");
+                    <a href="../B.html#a2" class="member-name-link">a2</a>""");
 
         //links for deprecated items will not be found
         checkOutput("pkg/class-use/A.html", false,
                 """
-                    <span class="member-name-link"><a href="../B.html#deprecatedField">deprecatedField</a></span>""");
+                    <a href="../B.html#deprecatedField" class="member-name-link">deprecatedField</a>""");
 
         checkOutput("pkg/class-use/A.html", false,
                 """
-                    <span class="member-name-link"><a href="../B.html#deprecatedMethod(pkg.A)">deprecatedMethod</a></span>""");
+                    <a href="../B.html#deprecatedMethod(pkg.A)" class="member-name-link">deprecatedMethod</a>""");
 
         checkOutput("pkg/class-use/A.html",false,
                 """
-                    <span class="member-name-link"><a href="../B.html#%3Cinit%3E(pkg.A)">B</a></span>""");
+                    <a href="../B.html#%3Cinit%3E(pkg.A)" class="member-name-link">B</a>""");
 
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -105,9 +105,9 @@ public class TestMemberInheritance extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab1 method-summary-table-tab4"><code>static java.time.Period</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab1 method-summary-table-tab4"><code><span class="member-name-link"><a href="#betwee\
-                    n(java.time.LocalDate,java.time.LocalDate)">between</a></span>&#8203;(java.time.\
-                    LocalDate&nbsp;startDateInclusive,
+                    tab1 method-summary-table-tab4"><code><a href="#between(java.time.LocalDate,java\
+                    .time.LocalDate)" class="member-name-link">between</a>&#8203;(java.time.LocalDat\
+                    e&nbsp;startDateInclusive,
                      java.time.LocalDate&nbsp;endDateExclusive)</code></div>""");
 
         checkOutput("pkg1/Implementer.html", false,
@@ -131,8 +131,8 @@ public class TestMemberInheritance extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-tab2 m\
                     ethod-summary-table-tab3"><code>protected abstract java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-tab2 \
-                    method-summary-table-tab3"><code><span class="member-name-link"><a href="#parent\
-                    Method(T)">parentMethod</a></span>&#8203;(java.lang.String&nbsp;t)</code></div>
+                    method-summary-table-tab3"><code><a href="#parentMethod(T)" class="member-name-link">\
+                    parentMethod</a>&#8203;(java.lang.String&nbsp;t)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-tab2 me\
                     thod-summary-table-tab3">
                     <div class="block">Returns some value with an inherited search tag.</div>
@@ -162,8 +162,8 @@ public class TestMemberInheritance extends JavadocTester {
         checkOutput("pkg2/DocumentedNonGenericChild.html", true,
                 """
                     <div class="col-first even-row-color"><code>java.lang.String</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="\
-                    #parentField">parentField</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#parentField" class="membe\
+                    r-name-link">parentField</a></code></div>
                     <div class="col-last even-row-color">
                     <div class="block">A field.</div>""",
                 """
@@ -180,31 +180,29 @@ public class TestMemberInheritance extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#method\
-                    (T)">method</a></span>&#8203;(java.lang.String&nbsp;t)</code></div>""",
+                    tab2 method-summary-table-tab4"><code><a href="#method(T)" class="member-name-li\
+                    nk">method</a>&#8203;(java.lang.String&nbsp;t)</code></div>""",
                 """
                     <section class="detail" id="method(T)">
                     <h3 id="method(java.lang.Object)">method</h3>
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="return-type">java.lang.String</span>&nbsp;<span class="element-name">method</span>\
-                    &#8203;<span class="parameters">(java.lang.String&nbsp;t)</span></div>
+                    lass="return-type">java.lang.String</span>&nbsp;<span class="element-name">metho\
+                    d</span>&#8203;<span class="parameters">(java.lang.String&nbsp;t)</span></div>
                     </section>""");
 
         checkOutput("index-all.html", true,
                 """
-                    <dt><span class="member-name-link"><a href="pkg2/DocumentedNonGenericChild.html#\
-                    parentField">parentField</a></span> - Variable in class pkg2.<a href="pkg2/Docum\
-                    entedNonGenericChild.html" title="class in pkg2">DocumentedNonGenericChild</a></\
-                    dt>
+                    <dt><a href="pkg2/DocumentedNonGenericChild.html#parentField" class="member-name\
+                    -link">parentField</a> - Variable in class pkg2.<a href="pkg2/DocumentedNonGener\
+                    icChild.html" title="class in pkg2">DocumentedNonGenericChild</a></dt>
                     <dd>
                     <div class="block">A field.</div>
                     </dd>
                     """,
                 """
-                    <dt><span class="member-name-link"><a href="pkg2/DocumentedNonGenericChild.html#\
-                    parentMethod(T)">parentMethod(String)</a></span> - Method in class pkg2.<a href=\
-                    "pkg2/DocumentedNonGenericChild.html" title="class in pkg2">DocumentedNonGeneric\
-                    Child</a></dt>
+                    <dt><a href="pkg2/DocumentedNonGenericChild.html#parentMethod(T)" class="member-\
+                    name-link">parentMethod(String)</a> - Method in class pkg2.<a href="pkg2/Documen\
+                    tedNonGenericChild.html" title="class in pkg2">DocumentedNonGenericChild</a></dt>
                     <dd>
                     <div class="block">Returns some value with an inherited search tag.</div>
                     </dd>""");
@@ -245,19 +243,17 @@ public class TestMemberInheritance extends JavadocTester {
 
         checkOutput("index-files/index-9.html", true,
                 """
-                    <dt><span class="member-name-link"><a href="../pkg2/DocumentedNonGenericChild.ht\
-                    ml#parentField">parentField</a></span> - Variable in class pkg2.<a href="../pkg2\
-                    /DocumentedNonGenericChild.html" title="class in pkg2">DocumentedNonGenericChild\
-                    </a></dt>
+                    <dt><a href="../pkg2/DocumentedNonGenericChild.html#parentField" class="member-n\
+                    ame-link">parentField</a> - Variable in class pkg2.<a href="../pkg2/DocumentedNo\
+                    nGenericChild.html" title="class in pkg2">DocumentedNonGenericChild</a></dt>
                     <dd>
                     <div class="block">A field.</div>
                     </dd>
                     """,
                 """
-                    <dt><span class="member-name-link"><a href="../pkg2/DocumentedNonGenericChild.ht\
-                    ml#parentMethod(T)">parentMethod(String)</a></span> - Method in class pkg2.<a hr\
-                    ef="../pkg2/DocumentedNonGenericChild.html" title="class in pkg2">DocumentedNonG\
-                    enericChild</a></dt>
+                    <dt><a href="../pkg2/DocumentedNonGenericChild.html#parentMethod(T)" class="memb\
+                    er-name-link">parentMethod(String)</a> - Method in class pkg2.<a href="../pkg2/D\
+                    ocumentedNonGenericChild.html" title="class in pkg2">DocumentedNonGenericChild</a></dt>
                     <dd>
                     <div class="block">Returns some value with an inherited search tag.</div>
                     </dd>""");

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -55,24 +55,23 @@ public class TestMemberSummary extends JavadocTester {
                 """
                     <code><a href="PublicChild.html" title="class in pkg">PublicChild</a></code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#return\
-                    TypeTest()">returnTypeTest</a></span>()</code></div>""",
+                    tab2 method-summary-table-tab4"><code><a href="#returnTypeTest()" class="member-\
+                    name-link">returnTypeTest</a>()</code></div>""",
                 // Check return type in member detail.
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type"><a href="PublicChild.html" title="class in pkg">PublicChild</\
                     a></span>&nbsp;<span class="element-name">returnTypeTest</span>()</div>""",
                 """
-                    <div class="col-constructor-name even-row-color"><code><span class="member-name-link"\
-                    ><a href="#%3Cinit%3E()">PublicChild</a></span>()</code></div>
+                    <div class="col-constructor-name even-row-color"><code><a href="#%3Cinit%3E()" c\
+                    lass="member-name-link">PublicChild</a>()</code></div>
                     <div class="col-last even-row-color">&nbsp;</div>""");
 
         checkOutput("pkg/PrivateParent.html", true,
                 """
                     <div class="col-first even-row-color"><code>private </code></div>
-                    <div class="col-constructor-name even-row-color"><code><span class="member-name-link"\
-                    ><a href="#%3Cinit%3E(int)">PrivateParent</a></span>&#8203;(int&nbsp;i)</code></\
-                    div>""");
+                    <div class="col-constructor-name even-row-color"><code><a href="#%3Cinit%3E(int)\
+                    " class="member-name-link">PrivateParent</a>&#8203;(int&nbsp;i)</code></div>""");
 
         // Legacy anchor dimensions (6290760)
         checkOutput("pkg2/A.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -848,20 +848,20 @@ public class TestModules extends JavadocTester {
                     </dl>""",
                 """
                     <dl class="index">
-                    <dt><span class="search-tag-link"><a href="moduleB/module-summary.html#search_wo\
-                    rd">search_word</a></span> - Search tag in module moduleB</dt>
+                    <dt><a href="moduleB/module-summary.html#search_word" class="search-tag-link">se\
+                    arch_word</a> - Search tag in module moduleB</dt>
                     <dd>&nbsp;</dd>
-                    <dt><span class="search-tag-link"><a href="moduleA/module-summary.html#searchphr\
-                    ase">search phrase</a></span> - Search tag in module moduleA</dt>
+                    <dt><a href="moduleA/module-summary.html#searchphrase" class="search-tag-link">s\
+                    earch phrase</a> - Search tag in module moduleA</dt>
                     <dd>with description</dd>
                     </dl>""");
         checkOutput("index-all.html", false,
                 """
-                    <dt><span class="search-tag-link"><a href="moduleA/module-summary.html#searchphr\
-                    ase">search phrase</a></span> - Search tag in module moduleA</dt>
+                    <dt><a href="moduleA/module-summary.html#searchphrase" class="search-tag-link">s\
+                    earch phrase</a> - Search tag in module moduleA</dt>
                     <dd>with description</dd>
-                    <dt><span class="search-tag-link"><a href="moduleA/module-summary.html#searchphr\
-                    ase">search phrase</a></span> - Search tag in module moduleA</dt>
+                    <dt><a href="moduleA/module-summary.html#searchphrase" class="search-tag-link">s\
+                    earch phrase</a></span> - Search tag in module moduleA</dt>
                     <dd>with description</dd>""");
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -76,7 +76,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 "<div class=\"caption\"><span>Enum Constants</span></div>",
                 // Detail for enum constant
                 """
-                    <span class="member-name-link"><a href="#Dime">Dime</a></span>""",
+                    <a href="#Dime" class="member-name-link">Dime</a>""",
                 // Automatically insert documentation for values() and valueOf().
                 "Returns an array containing the constants of this enum class,",
                 "Returns the enum constant of this class with the specified name",
@@ -142,14 +142,13 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 // Method that returns TypeParameters
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><a href="TypeParameters.html" title="type parame\
-                    ter in TypeParameters">E</a>[]</code></div>
+                    ab2 method-summary-table-tab4"><code><a href="TypeParameters.html" title="type p\
+                    arameter in TypeParameters">E</a>[]</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#method\
-                    ThatReturnsTypeParameterA(E%5B%5D)">methodThatReturnsTypeParameterA</a></span>&#\
-                    8203;(<a href="TypeParameters.html" title="type parameter in TypeParameters">E</\
-                    a>[]&nbsp;e)</code>""",
-                    """
+                    tab2 method-summary-table-tab4"><code><a href="#methodThatReturnsTypeParameterA(\
+                    E%5B%5D)" class="member-name-link">methodThatReturnsTypeParameterA</a>&#8203;(<a\
+                     href="TypeParameters.html" title="type parameter in TypeParameters">E</a>[]&nbsp;e)</code>""",
+                """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type"><a href="TypeParameters.html" title="type parameter in TypePa\
                     rameters">E</a>[]</span>&nbsp;<span class="element-name">methodThatReturnsTypeParameterA\
@@ -158,12 +157,12 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     """,
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code>&lt;T extends java.lang.Object &amp; java.lang.C\
-                    omparable&lt;? super T&gt;&gt;<br>T</code></div>
+                    ab2 method-summary-table-tab4"><code>&lt;T extends java.lang.Object &amp; java.l\
+                    ang.Comparable&lt;? super T&gt;&gt;<br>T</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#method\
-                    tThatReturnsTypeParametersB(java.util.Collection)">methodtThatReturnsTypeParamet\
-                    ersB</a></span>&#8203;(java.util.Collection&lt;? extends T&gt;&nbsp;coll)</code>""",
+                    tab2 method-summary-table-tab4"><code><a href="#methodtThatReturnsTypeParameters\
+                    B(java.util.Collection)" class="member-name-link">methodtThatReturnsTypeParamete\
+                    rsB</a>&#8203;(java.util.Collection&lt;? extends T&gt;&nbsp;coll)</code>""",
                 """
                     <div class="block">Returns TypeParameters</div>
                     """,
@@ -173,9 +172,9 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     b2 method-summary-table-tab4"><code>&lt;X extends java.lang.Throwable&gt;<br><a href\
                     ="TypeParameters.html" title="type parameter in TypeParameters">E</a></code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#orElse\
-                    Throw(java.util.function.Supplier)">orElseThrow</a></span>&#8203;(java.util.func\
-                    tion.Supplier&lt;? extends X&gt;&nbsp;exceptionSupplier)</code>"""
+                    ab2 method-summary-table-tab4"><code><a href="#orElseThrow(java.util.function.Su\
+                    pplier)" class="member-name-link">orElseThrow</a>&#8203;(java.util.function.Supp\
+                    lier&lt;? extends X&gt;&nbsp;exceptionSupplier)</code>"""
                 );
 
         checkOutput("pkg/Wildcards.html", true,
@@ -248,18 +247,18 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     arameters of type <a href="../Foo.html" title="class in pkg2">Foo</a></span></\
                     div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest1.html" title="class in pkg2">ClassUseTest1</a>&lt;T extends <a\
-                     href="../Foo.html" title="class in pkg2">Foo</a> &amp; <a href="../Foo2.html"\
-                     title="interface in pkg2">Foo2</a>&gt;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest1.html" cla\
+                    ss="type-name-link" title="class in pkg2">ClassUseTest1</a>&lt;T extends <a href\
+                    ="../Foo.html" title="class in pkg2">Foo</a> &amp; <a href="../Foo2.html" title=\
+                    "interface in pkg2">Foo2</a>&gt;</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../Foo.html" title="class in pkg2">Foo<\
                     /a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest1.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest1.html#metho\
-                    d(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>""",
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t1.</span><code><a href="../ClassUseTest1.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Fields in <a href="../package-summary.html">pkg2</a>\
                      with type parameters of type <a href="../Foo.html" title="class in pkg2">Foo</a\
@@ -287,18 +286,18 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     > with type parameters of type <a href="../Foo2.html" title="interface in pkg2"\
                     >Foo2</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest1.html" title="class in pkg2">ClassUseTest1</a>&lt;T extends <a\
-                     href="../Foo.html" title="class in pkg2">Foo</a> &amp; <a href="../Foo2.html"\
-                     title="interface in pkg2">Foo2</a>&gt;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest1.html" cla\
+                    ss="type-name-link" title="class in pkg2">ClassUseTest1</a>&lt;T extends <a href\
+                    ="../Foo.html" title="class in pkg2">Foo</a> &amp; <a href="../Foo2.html" title=\
+                    "interface in pkg2">Foo2</a>&gt;</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../Foo2.html" title="interface in pkg2"\
                     >Foo2</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest1.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest1.html#metho\
-                    d(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>"""
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t1.</span><code><a href="../ClassUseTest1.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>"""
         );
 
         // ClassUseTest2: <T extends ParamTest<Foo3>>
@@ -308,18 +307,18 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     > with type parameters of type <a href="../ParamTest.html" title="class in pkg2\
                     ">ParamTest</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest2.html" title="class in pkg2">ClassUseTest2</a>&lt;T extends <a\
-                     href="../ParamTest.html" title="class in pkg2">ParamTest</a>&lt;<a href="../Fo\
-                    o3.html" title="class in pkg2">Foo3</a>&gt;&gt;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest2.html" cl\
+                    ass="type-name-link" title="class in pkg2">ClassUseTest2</a>&lt;T extends <a hr\
+                    ef="../ParamTest.html" title="class in pkg2">ParamTest</a>&lt;<a href="../Foo3.\
+                    html" title="class in pkg2">Foo3</a>&gt;&gt;</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../ParamTest.html" title="class in pkg2\
                     ">ParamTest</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest2.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest2.html#metho\
-                    d(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>""",
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t2.</span><code><a href="../ClassUseTest2.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Fields in <a href="../package-summary.html">pkg2</a>\
                      declared as <a href="../ParamTest.html" title="class in pkg2">ParamTest</a></s\
@@ -346,18 +345,18 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     > with type parameters of type <a href="../Foo3.html" title="class in pkg2">Foo\
                     3</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest2.html" title="class in pkg2">ClassUseTest2</a>&lt;T extends <a\
-                     href="../ParamTest.html" title="class in pkg2">ParamTest</a>&lt;<a href="../Fo\
-                    o3.html" title="class in pkg2">Foo3</a>&gt;&gt;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest2.html" cl\
+                    ass="type-name-link" title="class in pkg2">ClassUseTest2</a>&lt;T extends <a hr\
+                    ef="../ParamTest.html" title="class in pkg2">ParamTest</a>&lt;<a href="../Foo3.\
+                    html" title="class in pkg2">Foo3</a>&gt;&gt;</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../Foo3.html" title="class in pkg2">Foo\
                     3</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest2.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest2.html#metho\
-                    d(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>""",
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t2.</span><code><a href="../ClassUseTest2.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > that return types with arguments of type <a href="../Foo3.html" title="class\
@@ -377,19 +376,19 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     > with type parameters of type <a href="../ParamTest2.html" title="class in pkg\
                     2">ParamTest2</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest3.html" title="class in pkg2">ClassUseTest3</a>&lt;T extends <a\
-                     href="../ParamTest2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.Li\
-                    st&lt;? extends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&g\
-                    t;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest3.html" cl\
+                    ass="type-name-link" title="class in pkg2">ClassUseTest3</a>&lt;T extends <a hr\
+                    ef="../ParamTest2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.List&\
+                    lt;? extends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&gt;<\
+                    /code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../ParamTest2.html" title="class in pkg\
                     2">ParamTest2</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest3.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest3.html#metho\
-                    d(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>""",
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t3.</span><code><a href="../ClassUseTest3.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
                 """
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest2.htm\
                     l" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends <a href=\
@@ -404,19 +403,19 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     > with type parameters of type <a href="../Foo4.html" title="class in pkg2">Foo\
                     4</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href=\
-                    "../ClassUseTest3.html" title="class in pkg2">ClassUseTest3</a>&lt;T extends <a\
-                     href="../ParamTest2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.Li\
-                    st&lt;? extends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&g\
-                    t;</span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="../ClassUseTest3.html" cl\
+                    ass="type-name-link" title="class in pkg2">ClassUseTest3</a>&lt;T extends <a hr\
+                    ef="../ParamTest2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.List&\
+                    lt;? extends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&gt;<\
+                    /code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../Foo4.html" title="class in pkg2">Foo\
                     4</a></span></div>""",
                 """
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest3.\
-                    </span><code><span class="member-name-link"><a href="../ClassUseTest3.html#met\
-                    hod(T)">method</a></span>&#8203;(T&nbsp;t)</code></div>""",
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t3.</span><code><a href="../ClassUseTest3.html#method(T)" class="member-name-lin\
+                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > that return types with arguments of type <a href="../Foo4.html" title="class\
@@ -436,10 +435,10 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="table-header col-second">Method</div>
                     <div class="table-header col-last">Description</div>
                     <div class="col-first even-row-color"><code>void</code></div>
-                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTest3.<\
-                    /span><code><span class="member-name-link"><a href="../ClassUseTest3.html#metho\
-                    d(java.util.Set)">method</a></span>&#8203;(java.util.Set&lt;<a href="../Foo4.ht\
-                    ml" title="class in pkg2">Foo4</a>&gt;&nbsp;p)</code></div>
+                    <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
+                    t3.</span><code><a href="../ClassUseTest3.html#method(java.util.Set)" class="mem\
+                    ber-name-link">method</a>&#8203;(java.util.Set&lt;<a href="../Foo4.html" title="\
+                    class in pkg2">Foo4</a>&gt;&nbsp;p)</code></div>
                     <div class="col-last even-row-color">&nbsp;</div>""",
                 """
                     <div class="caption"><span>Constructor parameters in <a href="../package-summary.html">pkg2<\
@@ -452,7 +451,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
         //=================================
         checkOutput("index-all.html", true,
                 """
-                    <span class="member-name-link"><a href="pkg2/Foo.html#method(java.util.Vector)">method(Vector&lt;Object&gt;)</a></span>"""
+                    <a href="pkg2/Foo.html#method(java.util.Vector)" class="member-name-link">method(Vector&lt;Object&gt;)</a>"""
         );
 
         // TODO: duplicate of previous case; left in delibarately for now to simplify comparison testing
@@ -461,7 +460,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
         //=================================
         checkOutput("index-all.html", true,
                 """
-                    <span class="member-name-link"><a href="pkg2/Foo.html#method(java.util.Vector)">method(Vector&lt;Object&gt;)</a></span>"""
+                    <a href="pkg2/Foo.html#method(java.util.Vector)" class="member-name-link">method(Vector&lt;Object&gt;)</a>"""
         );
 
     }

--- a/test/langtools/jdk/javadoc/doclet/testOrdering/TestOrdering.java
+++ b/test/langtools/jdk/javadoc/doclet/testOrdering/TestOrdering.java
@@ -397,78 +397,78 @@ public class TestOrdering extends JavadocTester {
             checkOrder("index-all.html", composeTestVectors());
             checkOrder("add0/add/package-tree.html",
                     """
-                        <a href="Add.add.html" title="enum class in add0.add">""",
+                        <a href="Add.add.html" class="type-name-link" title="enum class in add0.add">""",
                     """
-                        <a href="Add.ADD.html" title="enum class in add0.add">""");
+                        <a href="Add.ADD.html" class="type-name-link" title="enum class in add0.add">""");
             checkOrder("overview-tree.html",
                     """
-                        <a href="Add.add.html" title="enum class in &lt;Unnamed&gt;">""",
+                        <a href="Add.add.html" class="type-name-link" title="enum class in &lt;Unnamed&gt;">""",
                     """
-                        <a href="add0/Add.add.html" title="enum class in add0">""",
+                        <a href="add0/Add.add.html" class="type-name-link" title="enum class in add0">""",
                     """
-                        <a href="add0/add/Add.add.html" title="enum class in add0.add">""",
+                        <a href="add0/add/Add.add.html" class="type-name-link" title="enum class in add0.add">""",
                     """
-                        <a href="add0/add/add/Add.add.html" title="enum class in add0.add.add">""",
+                        <a href="add0/add/add/Add.add.html" class="type-name-link" title="enum class in add0.add.add">""",
                     """
-                        <a href="add0/add/add/add/Add.add.html" title="enum class in add0.add.add.add">""",
+                        <a href="add0/add/add/add/Add.add.html" class="type-name-link" title="enum class in add0.add.add.add">""",
                     """
-                        <a href="add1/Add.add.html" title="enum class in add1">""",
+                        <a href="add1/Add.add.html" class="type-name-link" title="enum class in add1">""",
                     """
-                        <a href="add1/add/Add.add.html" title="enum class in add1.add">""",
+                        <a href="add1/add/Add.add.html" class="type-name-link" title="enum class in add1.add">""",
                     """
-                        <a href="add1/add/add/Add.add.html" title="enum class in add1.add.add">""",
+                        <a href="add1/add/add/Add.add.html" class="type-name-link" title="enum class in add1.add.add">""",
                     """
-                        <a href="add1/add/add/add/Add.add.html" title="enum class in add1.add.add.add">""",
+                        <a href="add1/add/add/add/Add.add.html" class="type-name-link" title="enum class in add1.add.add.add">""",
                     """
-                        <a href="add2/Add.add.html" title="enum class in add2">""",
+                        <a href="add2/Add.add.html" class="type-name-link" title="enum class in add2">""",
                     """
-                        <a href="add2/add/Add.add.html" title="enum class in add2.add">""",
+                        <a href="add2/add/Add.add.html" class="type-name-link" title="enum class in add2.add">""",
                     """
-                        <a href="add2/add/add/Add.add.html" title="enum class in add2.add.add">""",
+                        <a href="add2/add/add/Add.add.html" class="type-name-link" title="enum class in add2.add.add">""",
                     """
-                        <a href="add2/add/add/add/Add.add.html" title="enum class in add2.add.add.add">""",
+                        <a href="add2/add/add/add/Add.add.html" class="type-name-link" title="enum class in add2.add.add.add">""",
                     """
-                        <a href="add3/Add.add.html" title="enum class in add3">""",
+                        <a href="add3/Add.add.html" class="type-name-link" title="enum class in add3">""",
                     """
-                        <a href="add3/add/Add.add.html" title="enum class in add3.add">""",
+                        <a href="add3/add/Add.add.html" class="type-name-link" title="enum class in add3.add">""",
                     """
-                        <a href="add3/add/add/Add.add.html" title="enum class in add3.add.add">""",
+                        <a href="add3/add/add/Add.add.html" class="type-name-link" title="enum class in add3.add.add">""",
                     """
-                        <a href="add3/add/add/add/Add.add.html" title="enum class in add3.add.add.add">""",
+                        <a href="add3/add/add/add/Add.add.html" class="type-name-link" title="enum class in add3.add.add.add">""",
                     """
-                        <a href="Add.ADD.html" title="enum class in &lt;Unnamed&gt;">""",
+                        <a href="Add.ADD.html" class="type-name-link" title="enum class in &lt;Unnamed&gt;">""",
                     """
-                        <a href="add0/Add.ADD.html" title="enum class in add0">""",
+                        <a href="add0/Add.ADD.html" class="type-name-link" title="enum class in add0">""",
                     """
-                        <a href="add0/add/Add.ADD.html" title="enum class in add0.add">""",
+                        <a href="add0/add/Add.ADD.html" class="type-name-link" title="enum class in add0.add">""",
                     """
-                        <a href="add0/add/add/Add.ADD.html" title="enum class in add0.add.add">""",
+                        <a href="add0/add/add/Add.ADD.html" class="type-name-link" title="enum class in add0.add.add">""",
                     """
-                        <a href="add0/add/add/add/Add.ADD.html" title="enum class in add0.add.add.add">""",
+                        <a href="add0/add/add/add/Add.ADD.html" class="type-name-link" title="enum class in add0.add.add.add">""",
                     """
-                        <a href="add1/Add.ADD.html" title="enum class in add1">""",
+                        <a href="add1/Add.ADD.html" class="type-name-link" title="enum class in add1">""",
                     """
-                        <a href="add1/add/Add.ADD.html" title="enum class in add1.add">""",
+                        <a href="add1/add/Add.ADD.html" class="type-name-link" title="enum class in add1.add">""",
                     """
-                        <a href="add1/add/add/Add.ADD.html" title="enum class in add1.add.add">""",
+                        <a href="add1/add/add/Add.ADD.html" class="type-name-link" title="enum class in add1.add.add">""",
                     """
-                        <a href="add1/add/add/add/Add.ADD.html" title="enum class in add1.add.add.add">""",
+                        <a href="add1/add/add/add/Add.ADD.html" class="type-name-link" title="enum class in add1.add.add.add">""",
                     """
-                        <a href="add2/Add.ADD.html" title="enum class in add2">""",
+                        <a href="add2/Add.ADD.html" class="type-name-link" title="enum class in add2">""",
                     """
-                        <a href="add2/add/Add.ADD.html" title="enum class in add2.add">""",
+                        <a href="add2/add/Add.ADD.html" class="type-name-link" title="enum class in add2.add">""",
                     """
-                        <a href="add2/add/add/Add.ADD.html" title="enum class in add2.add.add">""",
+                        <a href="add2/add/add/Add.ADD.html" class="type-name-link" title="enum class in add2.add.add">""",
                     """
-                        <a href="add2/add/add/add/Add.ADD.html" title="enum class in add2.add.add.add">""",
+                        <a href="add2/add/add/add/Add.ADD.html" class="type-name-link" title="enum class in add2.add.add.add">""",
                     """
-                        <a href="add3/Add.ADD.html" title="enum class in add3">""",
+                        <a href="add3/Add.ADD.html" class="type-name-link" title="enum class in add3">""",
                     """
-                        <a href="add3/add/Add.ADD.html" title="enum class in add3.add">""",
+                        <a href="add3/add/Add.ADD.html" class="type-name-link" title="enum class in add3.add">""",
                     """
-                        <a href="add3/add/add/Add.ADD.html" title="enum class in add3.add.add">""",
+                        <a href="add3/add/add/Add.ADD.html" class="type-name-link" title="enum class in add3.add.add">""",
                     """
-                        <a href="add3/add/add/add/Add.ADD.html" title="enum class in add3.add.add.add">""");
+                        <a href="add3/add/add/add/Add.ADD.html" class="type-name-link" title="enum class in add3.add.add.add">""");
         }
 
         void emitFile(String pkgname, String clsname, ListOrder order) throws IOException {
@@ -557,18 +557,15 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("index-all.html",
                     "something</a> - package something</dt>",
-                    "something</span></a> - Class in",
-                    "something</span></a> - Enum Class in",
-                    "something</span></a> - Interface in",
-                    "something</span></a> - Annotation Interface in",
-                    "something</a></span> - Variable in class",
-                    "something()</a></span> - Constructor",
-                    """
-                        something()</a></span> - Method in class a.<a href="a/A.html\"""",
-                    """
-                        something()</a></span> - Method in class a.<a href="a/something.html\"""",
-                    """
-                        something()</a></span> - Method in class something.<a href="something/J.html\"""");
+                    "something</a> - Class in",
+                    "something</a> - Enum Class in",
+                    "something</a> - Interface in",
+                    "something</a> - Annotation Interface in",
+                    "something</a> - Variable in class",
+                    "something()</a> - Constructor",
+                    "something()</a> - Method in class a.<a href=\"a/A.html\"",
+                    "something()</a> - Method in class a.<a href=\"a/something.html\"",
+                    "something()</a> - Method in class something.<a href=\"something/J.html\"");
         }
     }
 
@@ -601,10 +598,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/AnnoOptionalTest.html",
                     "<h2>Optional Element Summary</h2>",
-                    "<a href=\"#four()\">four</a>",
-                    "<a href=\"#one()\">one</a>",
-                    "<a href=\"#three()\">three</a>",
-                    "<a href=\"#two()\">two</a>",
+                    "<a href=\"#four()\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#one()\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#three()\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#two()\" class=\"member-name-link\">two</a>",
                     "<h2>Element Details</h2>",
                     "<h3>one</h3>",
                     "<h3>two</h3>",
@@ -613,10 +610,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/AnnoRequiredTest.html",
                     "<h2>Required Element Summary</h2>",
-                    "<a href=\"#four()\">four</a>",
-                    "<a href=\"#one()\">one</a>",
-                    "<a href=\"#three()\">three</a>",
-                    "<a href=\"#two()\">two</a>",
+                    "<a href=\"#four()\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#one()\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#three()\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#two()\" class=\"member-name-link\">two</a>",
                     "<h2>Element Details</h2>",
                     "<h3>one</h3>",
                     "<h3>two</h3>",
@@ -643,10 +640,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/EnumTest.html",
                     "<h2>Enum Constant Summary</h2>",
-                    "<a href=\"#FOUR\">FOUR</a>",
-                    "<a href=\"#ONE\">ONE</a>",
-                    "<a href=\"#THREE\">THREE</a>",
-                    "<a href=\"#TWO\">TWO</a>",
+                    "<a href=\"#FOUR\" class=\"member-name-link\">FOUR</a>",
+                    "<a href=\"#ONE\" class=\"member-name-link\">ONE</a>",
+                    "<a href=\"#THREE\" class=\"member-name-link\">THREE</a>",
+                    "<a href=\"#TWO\" class=\"member-name-link\">TWO</a>",
                     "<h2>Enum Constant Details</h2>",
                     "<h3>ONE</h3>",
                     "<h3>TWO</h3>",
@@ -655,10 +652,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/FieldTest.html",
                     "<h2>Field Summary</h2>",
-                    "<a href=\"#four\">four</a>",
-                    "<a href=\"#one\">one</a>",
-                    "<a href=\"#three\">three</a>",
-                    "<a href=\"#two\">two</a>",
+                    "<a href=\"#four\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#one\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#three\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#two\" class=\"member-name-link\">two</a>",
                     "<h2>Field Details</h2>",
                     "<h3>one</h3>",
                     "<h3>two</h3>",
@@ -667,10 +664,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/IntfTest.html",
                     "<h2>Method Summary</h2>",
-                    "<a href=\"#four()\">four</a>",
-                    "<a href=\"#one()\">one</a>",
-                    "<a href=\"#three()\">three</a>",
-                    "<a href=\"#two()\">two</a>",
+                    "<a href=\"#four()\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#one()\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#three()\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#two()\" class=\"member-name-link\">two</a>",
                     "<h2>Method Details</h2>",
                     "<h3>one</h3>",
                     "<h3>two</h3>",
@@ -679,10 +676,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/MethodTest.html",
                     "<h2>Method Summary</h2>",
-                    "<a href=\"#four()\">four</a>",
-                    "<a href=\"#one()\">one</a>",
-                    "<a href=\"#three()\">three</a>",
-                    "<a href=\"#two()\">two</a>",
+                    "<a href=\"#four()\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#one()\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#three()\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#two()\" class=\"member-name-link\">two</a>",
                     "<h2>Method Details</h2>",
                     "<h3>one</h3>",
                     "<h3>two</h3>",
@@ -691,11 +688,10 @@ public class TestOrdering extends JavadocTester {
 
             checkOrder("pkg5/PropertyTest.html",
                     "<h2>Property Summary</h2>",
-                    "<a href=\"#fourProperty\">four</a>",
-                    "<a href=\"#oneProperty\">one</a>",
-                    """
-                        <a href="#threeProperty">three</a>""",
-                    "<a href=\"#twoProperty\">two</a>",
+                    "<a href=\"#fourProperty\" class=\"member-name-link\">four</a>",
+                    "<a href=\"#oneProperty\" class=\"member-name-link\">one</a>",
+                    "<a href=\"#threeProperty\" class=\"member-name-link\">three</a>",
+                    "<a href=\"#twoProperty\" class=\"member-name-link\">two</a>",
                     "<h2>Property Details</h2>",
                     "<h3>oneProperty</h3>",
                     "<h3>twoProperty</h3>",

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -104,12 +104,12 @@ public class TestOverrideMethods  extends JavadocTester {
                 // Check method summary
                 "Method Summary",
                 "void",
-                "#m1()\">m1",
+                "#m1()\" class=\"member-name-link\">m1",
                 "A modified method",
 
                 "void",
                 """
-                    #m4(java.lang.String,java.lang.String)">m4""",
+                    #m4(java.lang.String,java.lang.String)" class="member-name-link">m4""",
                 "java.lang.String&nbsp;k,",
                 "java.lang.String",
                 "&nbsp;v)",
@@ -239,8 +239,8 @@ public class TestOverrideMethods  extends JavadocTester {
 
                 // Check Method Summary
                 "Method Summary",
-                "#m()\">m",
-                "#n()\">n",
+                "#m()\" class=\"member-name-link\">m",
+                "#n()\" class=\"member-name-link\">n",
 
                 // Check footnotes
                 """
@@ -265,45 +265,46 @@ public class TestOverrideMethods  extends JavadocTester {
                 """
                     <h2 class="title" id="I:M">M</h2>""",
                 """
-                    <a href="pkg5/Interfaces.C.html#m()">m()""",
+                    <a href="pkg5/Interfaces.C.html#m()" class="member-name-link">m()""",
                 """
-                    <a href="pkg5/Interfaces.D.html#m()">m()</a>""",
+                    <a href="pkg5/Interfaces.D.html#m()" class="member-name-link">m()</a>""",
                 """
-                    <a href="pkg5/Classes.GP.html#m0()">m0()""",
+                    <a href="pkg5/Classes.GP.html#m0()" class="member-name-link">m0()""",
                 """
-                    <a href="pkg5/Interfaces.A.html#m0()">m0()</a>""",
+                    <a href="pkg5/Interfaces.A.html#m0()" class="member-name-link">m0()</a>""",
                 """
-                    <a href="pkg5/Classes.C.html#m1()">m1()</a>""",
+                    <a href="pkg5/Classes.C.html#m1()" class="member-name-link">m1()</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m1()">m1()</a>""",
+                    <a href="pkg5/Classes.P.html#m1()" class="member-name-link">m1()</a>""",
                 """
-                    <a href="pkg5/Interfaces.A.html#m1()">m1()</a>""",
+                    <a href="pkg5/Interfaces.A.html#m1()" class="member-name-link">m1()</a>""",
                 """
-                    <a href="pkg5/Interfaces.B.html#m1()">m1()</a>""",
+                    <a href="pkg5/Interfaces.B.html#m1()" class="member-name-link">m1()</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m2()">m2()</a>""",
+                    <a href="pkg5/Classes.P.html#m2()" class="member-name-link">m2()</a>""",
                 """
-                    <a href="pkg5/Interfaces.A.html#m2()">m2()</a>""",
+                    <a href="pkg5/Interfaces.A.html#m2()" class="member-name-link">m2()</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m3()">m3()</a>""",
+                    <a href="pkg5/Classes.P.html#m3()" class="member-name-link">m3()</a>""",
                 """
-                    <a href="pkg5/Interfaces.A.html#m3()">m3()</a>""",
+                    <a href="pkg5/Interfaces.A.html#m3()" class="member-name-link">m3()</a>""",
                 """
-                    <a href="pkg5/Interfaces.B.html#m3()">m3()</a>""",
+                    <a href="pkg5/Interfaces.B.html#m3()" class="member-name-link">m3()</a>""",
                 """
-                    <a href="pkg5/Classes.C.html#m4(java.lang.String,java.lang.String)">m4(String, String)</a>""",
+                    <a href="pkg5/Classes.C.html#m4(java.lang.String,java.lang.String)" class="membe\
+                    r-name-link">m4(String, String)</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m4(K,V)">m4(K, V)</a>""",
+                    <a href="pkg5/Classes.P.html#m4(K,V)" class="member-name-link">m4(K, V)</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m5()">m5()</a>""",
+                    <a href="pkg5/Classes.P.html#m5()" class="member-name-link">m5()</a>""",
                 """
-                    <a href="pkg5/Classes.C.html#m6()">m6()</a>""",
+                    <a href="pkg5/Classes.C.html#m6()" class="member-name-link">m6()</a>""",
                 """
-                    <a href="pkg5/Classes.P.html#m6()">m6()</a>""",
+                    <a href="pkg5/Classes.P.html#m6()" class="member-name-link">m6()</a>""",
                 """
-                    <a href="pkg5/Classes.C.html#m7()">m7()</a>""",
+                    <a href="pkg5/Classes.C.html#m7()" class="member-name-link">m7()</a>""",
                 """
-                    <a href="pkg5/Classes.GP.html#m7()">m7()</a>""",
+                    <a href="pkg5/Classes.GP.html#m7()" class="member-name-link">m7()</a>""",
                 "Returns the enum constant of this class with the specified name.",
                 """
                     Returns an array containing the constants of this enum class, in
@@ -321,8 +322,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m2()">\
-                    m2</a></span>()</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#m2()" class="member-name-link">\
+                    m2</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
                     <div class="block">This is Base::m2.</div>
@@ -330,8 +331,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"><code>void</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m4\
-                    ()">m4</a></span>()</code></div>
+                    ab2 method-summary-table-tab4"><code><a href="#m4()" class="member-name-link">m4\
+                    </a>()</code></div>
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">
                     <div class="block">This is Base::m4.</div>
@@ -339,8 +340,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>java.lang.Object</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    5()">m5</a></span>()</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#m5()" class="member-name-link">m\
+                    5</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
                     <div class="block">This is Base::m5.</div>
@@ -348,8 +349,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"><code>java.lang.Object</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m6\
-                    ()">m6</a></span>()</code></div>
+                    ab2 method-summary-table-tab4"><code><a href="#m6()" class="member-name-link">m6\
+                    </a>()</code></div>
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">
                     <div class="block">This is Base::m6.</div>
@@ -357,8 +358,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>java.lang.Object</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#m\
-                    7()">m7</a></span>()</code></div>
+                    tab2 method-summary-table-tab4"><code><a href="#m7()" class="member-name-link">m\
+                    7</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
                     <div class="block">This is Base::m7.</div>
@@ -366,8 +367,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab3"><code>abstract java.lang.Object</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab3"><code><span class="member-name-link"><a href="#m8\
-                    ()">m8</a></span>()</code></div>
+                    ab2 method-summary-table-tab3"><code><a href="#m8()" class="member-name-link">m8\
+                    </a>()</code></div>
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab3">
                     <div class="block">This is Base::m8.</div>

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -61,10 +61,10 @@ public class TestPrivateClasses extends JavadocTester {
         checkOutput("pkg/PublicChild.html", true,
                 // Field inheritence from non-public superclass.
                 """
-                    <a href="#fieldInheritedFromParent">fieldInheritedFromParent</a>""",
+                    <a href="#fieldInheritedFromParent" class="member-name-link">fieldInheritedFromParent</a>""",
                 // Method inheritance from non-public superclass.
                 """
-                    <a href="#methodInheritedFromParent(int)">methodInheritedFromParent</a>""",
+                    <a href="#methodInheritedFromParent(int)" class="member-name-link">methodInheritedFromParent</a>""",
                 // private class does not show up in tree
                 """
                     <div class="inheritance" title="Inheritance Tree">java.lang.Object
@@ -113,10 +113,10 @@ public class TestPrivateClasses extends JavadocTester {
         checkOutput("pkg/PublicInterface.html", true,
                 // Field inheritance from non-public superinterface.
                 """
-                    <a href="#fieldInheritedFromInterface">fieldInheritedFromInterface</a>""",
+                    <a href="#fieldInheritedFromInterface" class="member-name-link">fieldInheritedFromInterface</a>""",
                 // Method inheritance from non-public superinterface.
                 """
-                    <a href="#methodInterface(int)">methodInterface</a>""",
+                    <a href="#methodInterface(int)" class="member-name-link">methodInterface</a>""",
                 //Make sure implemented interfaces from private superclass are inherited
                 """
                     <dl class="notes">
@@ -217,7 +217,7 @@ public class TestPrivateClasses extends JavadocTester {
 
         checkOutput("pkg/PrivateInterface.html", true,
                 """
-                    <a href="#methodInterface(int)">methodInterface</a>"""
+                    <a href="#methodInterface(int)" class="member-name-link">methodInterface</a>"""
         );
 
         checkOutput("pkg2/C.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
+++ b/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
@@ -80,8 +80,8 @@ public class TestProperty extends JavadocTester {
                     <div class="col-first even-row-color"><code><a href="ObjectProperty.html" title="clas\
                     s in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">MyObj<\
                     /a>[]&gt;</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="\
-                    #badProperty">bad</a></span></code></div>
+                    <div class="col-second even-row-color"><code><a href="#badProperty" class="membe\
+                    r-name-link">bad</a></code></div>
                     <div class="col-last even-row-color">""",
 
                 // tab classes should be used in the method table
@@ -91,8 +91,8 @@ public class TestProperty extends JavadocTester {
                     g">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">MyObj</a>[]&g\
                     t;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#badPro\
-                    perty()">badProperty</a></span>()</code></div>"""
+                    tab2 method-summary-table-tab4"><code><a href="#badProperty()" class="member-nam\
+                    e-link">badProperty</a>()</code></div>"""
         );
 
         checkOutput("pkg/MyClassT.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -77,7 +77,7 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     <span class="modifiers">public record </span><span class="element-name type-name-label">R</span>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E(int)">R</a></span>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     <span class="modifiers">public record </span><span class="element-name type-name-label">R</span>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E(int)">R</a></span>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     <span class="modifiers">public record </span><span class="element-name type-name-label">R</span>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E()">R</a></span>()</code>""");
+                    <code><a href="#%3Cinit%3E()" class="member-name-link">R</a>()</code>""");
     }
 
     @Test
@@ -149,7 +149,7 @@ public class TestRecordTypes extends JavadocTester {
                     <dd><code><span id="param-r1">r1</span></code> - This is a component.</dd>
                     </dl>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E(int)">R</a></span>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -182,7 +182,7 @@ public class TestRecordTypes extends JavadocTester {
                     <dd><code><span id="param-r1">r1</span></code> - This is a component.</dd>
                     </dl>""",
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E(int)">R</a></span>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -207,22 +207,22 @@ public class TestRecordTypes extends JavadocTester {
         checkOrder("p/R.html",
                 """
                     <section class="constructor-summary" id="constructor.summary">""",
-                "<a href=\"#%3Cinit%3E(int)\">R</a>",
+                "<a href=\"#%3Cinit%3E(int)\" class=\"member-name-link\">R</a>",
                 "Creates an instance of a <code>R</code> record class.",
                 """
                     <section class="method-summary" id="method.summary">""",
                 """
-                    <a href="#equals(java.lang.Object)">equals</a>""",
+                    <a href="#equals(java.lang.Object)" class="member-name-link">equals</a>""",
                 """
                     Indicates whether some other object is "equal to" this one.""",
                 """
-                    <a href="#hashCode()">hashCode</a>""",
+                    <a href="#hashCode()" class="member-name-link">hashCode</a>""",
                 "Returns a hash code value for this object.",
-                "<a href=\"#r1()\">r1</a>",
+                "<a href=\"#r1()\" class=\"member-name-link\">r1</a>",
                 """
                     Returns the value of the <a href="#param-r1"><code>r1</code></a> record component.""",
                 """
-                    <a href="#toString()">toString</a>""",
+                    <a href="#toString()" class="member-name-link">toString</a>""",
                 "Returns a string representation of this record class.",
                 "Method Details",
                 """
@@ -270,22 +270,22 @@ public class TestRecordTypes extends JavadocTester {
         checkOrder("p/R.html",
                 """
                     <section class="constructor-summary" id="constructor.summary">""",
-                "<a href=\"#%3Cinit%3E(int)\">R</a>",
+                "<a href=\"#%3Cinit%3E(int)\" class=\"member-name-link\">R</a>",
                 "Creates an instance of a <code>R</code> record class.",
                 """
                     <section class="method-summary" id="method.summary">""",
                 """
-                    <a href="#equals(java.lang.Object)">equals</a>""",
+                    <a href="#equals(java.lang.Object)" class="member-name-link">equals</a>""",
                 """
                     Indicates whether some other object is "equal to" this one.""",
                 """
-                    <a href="#hashCode()">hashCode</a>""",
+                    <a href="#hashCode()" class="member-name-link">hashCode</a>""",
                 "Returns a hash code value for this object.",
-                "<a href=\"#r1()\">r1</a>",
+                "<a href=\"#r1()\" class=\"member-name-link\">r1</a>",
                 """
                     Returns the value of the <a href="#param-r1"><code>r1</code></a> record component.""",
                 """
-                    <a href="#toString()">toString</a>""",
+                    <a href="#toString()" class="member-name-link">toString</a>""",
                 "Returns a string representation of this record class.",
                 "Method Details",
                 """
@@ -372,20 +372,20 @@ public class TestRecordTypes extends JavadocTester {
         checkOrder("p/R.html",
                 """
                     <section class="constructor-summary" id="constructor.summary">""",
-                "<a href=\"#%3Cinit%3E(int)\">R</a>",
+                "<a href=\"#%3Cinit%3E(int)\" class=\"member-name-link\">R</a>",
                 "User constructor.",
                 """
                     <section class="method-summary" id="method.summary">""",
                 """
-                    <a href="#equals(java.lang.Object)">equals</a>""",
+                    <a href="#equals(java.lang.Object)" class="member-name-link">equals</a>""",
                 "User equals.",
                 """
-                    <a href="#hashCode()">hashCode</a>""",
+                    <a href="#hashCode()" class="member-name-link">hashCode</a>""",
                 "User hashCode.",
-                "<a href=\"#r1()\">r1</a>",
+                "<a href=\"#r1()\" class=\"member-name-link\">r1</a>",
                 "User accessor.",
                 """
-                    <a href="#toString()">toString</a>""",
+                    <a href="#toString()" class="member-name-link">toString</a>""",
                 "User toString."
         );
     }

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -486,15 +486,17 @@ public class TestSearch extends JavadocTester {
                     <dt><span class="search-tag-link"><a href="pkg/AnotherClass.html#quoted">quoted<\
                     /a></span> - Search tag in pkg.AnotherClass.CONSTANT1</dt>""",
                 """
-                    <dt><span class="member-name-link"><a href="pkg2/TestEnum.html#ONE">ONE</a></spa\
-                    n> - Enum constant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</a></dt>""",
+                    <dt><a href="pkg2/TestEnum.html#ONE" class="member-name-link">ONE</a> - Enum con\
+                    stant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2"\
+                    >TestEnum</a></dt>""",
                 """
-                    <dt><span class="member-name-link"><a href="pkg2/TestEnum.html#THREE">THREE</a><\
-                    /span> - Enum constant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</a></dt\
-                    >""",
+                    <dt><a href="pkg2/TestEnum.html#THREE" class="member-name-link">THREE</a> - Enum\
+                     constant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in p\
+                    kg2">TestEnum</a></dt>""",
                 """
-                    <dt><span class="member-name-link"><a href="pkg2/TestEnum.html#TWO">TWO</a></spa\
-                    n> - Enum constant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</a></dt>""");
+                    <dt><a href="pkg2/TestEnum.html#TWO" class="member-name-link">TWO</a> - Enum con\
+                    stant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2"\
+                    >TestEnum</a></dt>""");
         checkOutput("index-all.html", true,
                 """
                     <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
@@ -574,18 +576,18 @@ public class TestSearch extends JavadocTester {
                     ed</a></span> - Search tag in pkg.AnotherClass.CONSTANT1</dt>""");
         checkOutput("index-files/index-9.html", true,
                 """
-                    <dt><span class="member-name-link"><a href="../pkg2/TestEnum.html#ONE">ONE</a></\
-                    span> - Enum constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</a></\
-                    dt>""");
+                    <dt><a href="../pkg2/TestEnum.html#ONE" class="member-name-link">ONE</a> - Enum \
+                    constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum class in\
+                     pkg2">TestEnum</a></dt>""");
         checkOutput("index-files/index-14.html", true,
                 """
-                    <dt><span class="member-name-link"><a href="../pkg2/TestEnum.html#THREE">THREE</\
-                    a></span> - Enum constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</\
-                    a></dt>""",
+                    <dt><a href="../pkg2/TestEnum.html#THREE" class="member-name-link">THREE</a> - E\
+                    num constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum clas\
+                    s in pkg2">TestEnum</a></dt>""",
                 """
-                    <dt><span class="member-name-link"><a href="../pkg2/TestEnum.html#TWO">TWO</a></\
-                    span> - Enum constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum class in pkg2">TestEnum</a></\
-                    dt>""");
+                    <dt><a href="../pkg2/TestEnum.html#TWO" class="member-name-link">TWO</a> - Enum \
+                    constant in enum class pkg2.<a href="../pkg2/TestEnum.html" title="enum class in\
+                     pkg2">TestEnum</a></dt>""");
     }
 
     void checkIndexNoComment() {

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -433,58 +433,57 @@ public class TestSearch extends JavadocTester {
         // Test for search tags markup in index file.
         checkOutput("index-all.html", expectedOutput,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#phrasewithsp\
-                    aces">phrase with spaces</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#phrasewithspaces" class="search-tag-link">\
+                    phrase with spaces</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#pkg">pkg</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#pkg" class="search-tag-link">pkg</a> - Sea\
+                    rch tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#pkg2.5">pkg2\
-                    .5</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#pkg2.5" class="search-tag-link">pkg2.5</a>\
+                     - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#r">r</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#r" class="search-tag-link">r</a> - Search \
+                    tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#searchphrase">sear\
-                    ch phrase</a></span> - Search tag in class pkg1.RegClass</dt>""",
+                    <dt><a href="pkg1/RegClass.html#searchphrase" class="search-tag-link">search phr\
+                    ase</a> - Search tag in class pkg1.RegClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#SearchWordWithDesc\
-                    ription">SearchWordWithDescription</a></span> - Search tag in pkg1.RegClass.CONS\
-                    TANT_FIELD_1</dt>""",
+                    <dt><a href="pkg1/RegClass.html#SearchWordWithDescription" class="search-tag-lin\
+                    k">SearchWordWithDescription</a> - Search tag in pkg1.RegClass.CONSTANT_FIELD_1<\
+                    /dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestAnnotationType.html#searchph\
-                    rasewithdescdeprecated">search phrase with desc deprecated</a></span> - Search t\
-                    ag in annotation interface pkg2.TestAnnotationType</dt>""",
+                    <dt><a href="pkg2/TestAnnotationType.html#searchph\
+                    rasewithdescdeprecated" class="search-tag-link">search phrase with desc deprecat\
+                    ed</a> - Search tag in annotation interface pkg2.TestAnnotationType</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestClass.html#SearchTagDeprecat\
-                    edClass">SearchTagDeprecatedClass</a></span> - Search tag in class pkg2.TestClas\
-                    s</dt>""",
+                    <dt><a href="pkg2/TestClass.html#SearchTagDeprecatedClass" class="search-tag-lin\
+                    k">SearchTagDeprecatedClass</a> - Search tag in class pkg2.TestClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestEnum.html#searchphrasedeprec\
-                    ated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</dt>""",
+                    <dt><a href="pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-link">\
+                    search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestEnum.html#searchphrasedeprec\
-                    ated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</dt>""",
+                    <dt><a href="pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-link">\
+                    search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>""",
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>""",
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#SingleWord">\
-                    SingleWord</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#SingleWord" class="search-tag-link">Single\
+                    Word</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/AnotherClass.ModalExclusionType.h\
-                    tml#nested%7B@indexnested_tag_test%7D">nested {@index nested_tag_test}</a></span\
-                    > - Search tag in pkg.AnotherClass.ModalExclusionType.NO_EXCLUDE</dt>""",
+                    <dt><a href="pkg/AnotherClass.ModalExclusionType.html#nested%7B@indexnested_tag_\
+                    test%7D" class="search-tag-link">nested {@index nested_tag_test}</a> - Search ta\
+                    g in pkg.AnotherClass.ModalExclusionType.NO_EXCLUDE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/AnotherClass.ModalExclusionType.html#""" + html_span_see_span + """
-                    ">html &lt;span&gt; see &lt;/span&gt;</a></span> - Search tag in pkg.AnotherClas\
-                    s.ModalExclusionType.APPLICATION_EXCLUDE</dt>""",
+                    <dt><a href="pkg/AnotherClass.ModalExclusionType.html#""" + html_span_see_span + """
+                    " class="search-tag-link">html &lt;span&gt; see &lt;/span&gt;</a> - Search tag i\
+                    n pkg.AnotherClass.ModalExclusionType.APPLICATION_EXCLUDE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/AnotherClass.html#quoted">quoted<\
-                    /a></span> - Search tag in pkg.AnotherClass.CONSTANT1</dt>""",
+                    <dt><a href="pkg/AnotherClass.html#quoted" class="search-tag-link">quoted</a> - \
+                    Search tag in pkg.AnotherClass.CONSTANT1</dt>""",
                 """
                     <dt><a href="pkg2/TestEnum.html#ONE" class="member-name-link">ONE</a> - Enum con\
                     stant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2"\
@@ -511,69 +510,65 @@ public class TestSearch extends JavadocTester {
         // Test for search tags markup in split index file.
         checkOutput("index-files/index-13.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg1/RegClass.html#searchphrase">s\
-                    earch phrase</a></span> - Search tag in class pkg1.RegClass</dt>""",
+                    <dt><a href="../pkg1/RegClass.html#searchphrase" class="search-tag-link">search \
+                    phrase</a> - Search tag in class pkg1.RegClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg1/RegClass.html#SearchWordWithD\
-                    escription">SearchWordWithDescription</a></span> - Search tag in pkg1.RegClass.C\
-                    ONSTANT_FIELD_1</dt>""",
+                    <dt><a href="../pkg1/RegClass.html#SearchWordWithDescription" class="search-tag-\
+                    link">SearchWordWithDescription</a> - Search tag in pkg1.RegClass.CONSTANT_FIELD\
+                    _1</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestAnnotationType.html#searc\
-                    hphrasewithdescdeprecated">search phrase with desc deprecated</a></span> - Searc\
-                    h tag in annotation interface pkg2.TestAnnotationType</dt>""",
+                    <dt><a href="../pkg2/TestAnnotationType.html#searchphrasewithdescdeprecated" cla\
+                    ss="search-tag-link">search phrase with desc deprecated</a> - Search tag in anno\
+                    tation interface pkg2.TestAnnotationType</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestClass.html#SearchTagDepre\
-                    catedClass">SearchTagDeprecatedClass</a></span> - Search tag in class pkg2.TestC\
-                    lass</dt>""",
+                    <dt><a href="../pkg2/TestClass.html#SearchTagDeprecatedClass" class="search-tag-\
+                    link">SearchTagDeprecatedClass</a> - Search tag in class pkg2.TestClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestEnum.html#searchphrasedep\
-                    recated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</\
-                    dt>""",
+                    <dt><a href="../pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-lin\
+                    k">search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestEnum.html#searchphrasedep\
-                    recated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</\
-                    dt>""",
+                    <dt><a href="../pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-lin\
+                    k">search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestError.html#SearchTagDepre\
-                    catedMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError\
-                    .TestError()</dt>""",
+                    <dt><a href="../pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag\
+                    -link">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestError.html#SearchTagDepre\
-                    catedMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError\
-                    .TestError()</dt>""",
+                    <dt><a href="../pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag\
+                    -link">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/package-summary.html#SingleWor\
-                    d">SingleWord</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="../pkg/package-summary.html#SingleWord" class="search-tag-link">Sin\
+                    gleWord</a> - Search tag in package pkg</dt>""",
                 """
                     <br><a href="../allclasses-index.html">All&nbsp;Classes</a><span class="vertical\
                     -separator">|</span><a href="../allpackages-index.html">All&nbsp;Packages</a>""");
         checkOutput("index-files/index-10.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/package-summary.html#phrasewit\
-                    hspaces">phrase with spaces</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="../pkg/package-summary.html#phrasewithspaces" class="search-tag-lin\
+                    k">phrase with spaces</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/package-summary.html#pkg">pkg<\
-                    /a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="../pkg/package-summary.html#pkg" class="search-tag-link">pkg</a> - \
+                    Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/package-summary.html#pkg2.5">p\
-                    kg2.5</a></span> - Search tag in package pkg</dt>""");
+                    <dt><a href="../pkg/package-summary.html#pkg2.5" class="search-tag-link">pkg2.5<\
+                    /a> - Search tag in package pkg</dt>""");
         checkOutput("index-files/index-12.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/package-summary.html#r">r</a></span> - Search tag in package pkg</dt>""");
+                    <dt><a href="../pkg/package-summary.html#r" class="search-tag-link">r</a> - Sear\
+                    ch tag in package pkg</dt>""");
         checkOutput("index-files/index-8.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/AnotherClass.ModalExclusionTyp\
-                    e.html#nested%7B@indexnested_tag_test%7D">nested {@index nested_tag_test}</a></s\
-                    pan> - Search tag in pkg.AnotherClass.ModalExclusionType.NO_EXCLUDE</dt>""");
+                    <dt><a href="../pkg/AnotherClass.ModalExclusionType.html#nested%7B@indexnested_t\
+                    ag_test%7D" class="search-tag-link">nested {@index nested_tag_test}</a> - Search\
+                     tag in pkg.AnotherClass.ModalExclusionType.NO_EXCLUDE</dt>""");
         checkOutput("index-files/index-5.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/AnotherClass.ModalExclusionTyp\
-                    e.html#html%3Cspan%3Esee%3C/span%3E">html &lt;span&gt; see &lt;/span&gt;</a></sp\
-                    an> - Search tag in pkg.AnotherClass.ModalExclusionType.APPLICATION_EXCLUDE</dt>""");
+                    <dt><a href="../pkg/AnotherClass.ModalExclusionType.html#html%3Cspan%3Esee%3C/sp\
+                    an%3E" class="search-tag-link">html &lt;span&gt; see &lt;/span&gt;</a> - Search \
+                    tag in pkg.AnotherClass.ModalExclusionType.APPLICATION_EXCLUDE</dt>""");
         checkOutput("index-files/index-11.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg/AnotherClass.html#quoted">quot\
-                    ed</a></span> - Search tag in pkg.AnotherClass.CONSTANT1</dt>""");
+                    <dt><a href="../pkg/AnotherClass.html#quoted" class="search-tag-link">quoted</a>\
+                     - Search tag in pkg.AnotherClass.CONSTANT1</dt>""");
         checkOutput("index-files/index-9.html", true,
                 """
                     <dt><a href="../pkg2/TestEnum.html#ONE" class="member-name-link">ONE</a> - Enum \
@@ -594,81 +589,75 @@ public class TestSearch extends JavadocTester {
         // Test for search tags markup in index file when javadoc is executed with -nocomment.
         checkOutput("index-all.html", false,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#phrasewithsp\
-                    aces">phrase with spaces</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#phrasewithspaces" class="search-tag-link">\
+                    phrase with spaces</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#pkg">pkg</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#pkg" class="search-tag-link">pkg</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#pkg2.5">pkg2\
-                    .5</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#pkg2.5" class="search-tag-link">pkg2.5</a>\
+                     - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#r">r</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#r" class="search-tag-link">r</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#searchphrase">sear\
-                    ch phrase</a></span> - Search tag in class pkg1.RegClass</dt>""",
+                    <dt><a href="pkg1/RegClass.html#searchphrase" class="search-tag-link">search phr\
+                    ase</a> - Search tag in class pkg1.RegClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#SearchWordWithDesc\
-                    ription">SearchWordWithDescription</a></span> - Search tag in pkg1.RegClass.CONS\
-                    TANT_FIELD_1</dt>""",
+                    <dt><a href="pkg1/RegClass.html#SearchWordWithDescription" class="search-tag-lin\
+                    k">SearchWordWithDescription</a> - Search tag in pkg1.RegClass.CONSTANT_FIELD_1</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestAnnotationType.html#searchph\
-                    rasewithdescdeprecated">search phrase with desc deprecated</a></span> - Search t\
-                    ag in annotation interface pkg2.TestAnnotationType</dt>""",
+                    <dt><a href="pkg2/TestAnnotationType.html#searchphrasewithdescdeprecated" class=\
+                    "search-tag-link">search phrase with desc deprecated</a> - Search tag in annotat\
+                    ion interface pkg2.TestAnnotationType</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestClass.html#SearchTagDeprecat\
-                    edClass">SearchTagDeprecatedClass</a></span> - Search tag in class pkg2.TestClas\
-                    s</dt>""",
+                    <dt><a href="pkg2/TestClass.html#SearchTagDeprecatedClass" class="search-tag-lin\
+                    k">SearchTagDeprecatedClass</a> - Search tag in class pkg2.TestClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#SingleWord">\
-                    SingleWord</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#SingleWord" class="search-tag-link">Single\
+                    Word</a> - Search tag in package pkg</dt>""",
                 """
                     <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
-                    TagDeprecatedClass">SearchTagDeprecatedClass</span></div>""",
+                    TagDeprecatedClass">SearchTagDeprecatedClass</div>""",
                 """
                     <div class="deprecation-comment">error_test3 passes. Search tag for
                      method <span id="SearchTagDeprecatedMethod">SearchTagDeprecatedMethod</span></div>""");
         checkOutput("index-all.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestEnum.html#searchphrasedeprec\
-                    ated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</dt>""",
+                    <dt><a href="pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-link">\
+                    search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>""");
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""");
     }
 
     void checkIndexNoDeprecated() {
         // Test for search tags markup in index file when javadoc is executed using -nodeprecated.
         checkOutput("index-all.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#phrasewithsp\
-                    aces">phrase with spaces</a></span> - Search tag in package pkg</dt>""",
+                    <dt><a href="pkg/package-summary.html#phrasewithspaces" class="search-tag-link">\
+                    phrase with spaces</a> - Search tag in package pkg</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#searchphrase">sear\
-                    ch phrase</a></span> - Search tag in class pkg1.RegClass</dt>""",
+                    <dt><a href="pkg1/RegClass.html#searchphrase" class="search-tag-link">search phr\
+                    ase</a> - Search tag in class pkg1.RegClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg1/RegClass.html#SearchWordWithDesc\
-                    ription">SearchWordWithDescription</a></span> - Search tag in pkg1.RegClass.CONS\
-                    TANT_FIELD_1</dt>""",
+                    <dt><a href="pkg1/RegClass.html#SearchWordWithDescription" class="search-tag-lin\
+                    k">SearchWordWithDescription</a> - Search tag in pkg1.RegClass.CONSTANT_FIELD_1</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg/package-summary.html#SingleWord">\
-                    SingleWord</a></span> - Search tag in package pkg</dt>""");
+                    <dt><a href="pkg/package-summary.html#SingleWord" class="search-tag-link">Single\
+                    Word</a> - Search tag in package pkg</dt>""");
         checkOutput("index-all.html", false,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestAnnotationType.html#searchph\
-                    rasewithdescdeprecated">search phrase with desc deprecated</a></span> - Search t\
-                    ag in annotation interface pkg2.TestAnnotationType</dt>""",
+                    <dt><a href="pkg2/TestAnnotationType.html#searchphrasewithdescdeprecated" class=\
+                    "search-tag-link">search phrase with desc deprecated</a> - Search tag in annotat\
+                    ion interface pkg2.TestAnnotationType</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestClass.html#SearchTagDeprecat\
-                    edClass">SearchTagDeprecatedClass</a></span> - Search tag in class pkg2.TestClas\
-                    s</dt>""",
+                    <dt><a href="pkg2/TestClass.html#SearchTagDeprecatedClass" class="search-tag-lin\
+                    k">SearchTagDeprecatedClass</a> - Search tag in class pkg2.TestClass</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestEnum.html#searchphrasedeprec\
-                    ated">search phrase deprecated</a></span> - Search tag in pkg2.TestEnum.ONE</dt>""",
+                    <dt><a href="pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-link">\
+                    search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>""",
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
                 """
                     <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
                     TagDeprecatedClass">SearchTagDeprecatedClass</span></div>""",
@@ -779,19 +768,16 @@ public class TestSearch extends JavadocTester {
         // Test for search tags duplication in index file.
         checkOutput("index-all.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>""");
         checkOutput("index-all.html", false,
                 """
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>
-                    <dt><span class="search-tag-link"><a href="pkg2/TestError.html#SearchTagDeprecat\
-                    edMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError.Te\
-                    stError()</dt>
+                    <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>""");
     }
 
@@ -799,19 +785,16 @@ public class TestSearch extends JavadocTester {
         // Test for search tags duplication in index file.
         checkOutput("index-files/index-13.html", true,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestError.html#SearchTagDepre\
-                    catedMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError\
-                    .TestError()</dt>
+                    <dt><a href="../pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag\
+                    -link">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>""");
         checkOutput("index-files/index-13.html", false,
                 """
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestError.html#SearchTagDepre\
-                    catedMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError\
-                    .TestError()</dt>
+                    <dt><a href="../pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag\
+                    -link">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>
-                    <dt><span class="search-tag-link"><a href="../pkg2/TestError.html#SearchTagDepre\
-                    catedMethod">SearchTagDeprecatedMethod</a></span> - Search tag in pkg2.TestError\
-                    .TestError()</dt>
+                    <dt><a href="../pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag\
+                    -link">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>
                     <dd>with description</dd>""");
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
@@ -50,33 +50,33 @@ public class TestSummaryTag extends JavadocTester {
         checkOutput("index-all.html", true,
             """
                 <dl class="index">
-                <dt><span class="member-name-link"><a href="p1/A.html#m()">m()</a></span> - Meth\
-                od in class p1.<a href="p1/A.html" title="class in p1">A</a></dt>
+                <dt><a href="p1/A.html#m()" class="member-name-link">m()</a> - Method in class p1.<a\
+                 href="p1/A.html" title="class in p1">A</a></dt>
                 <dd>
                 <div class="block">First sentence</div>
                 </dd>
-                <dt><span class="member-name-link"><a href="p1/B.html#m()">m()</a></span> - Meth\
-                od in class p1.<a href="p1/B.html" title="class in p1">B</a></dt>
+                <dt><a href="p1/B.html#m()" class="member-name-link">m()</a> - Method in class p1.<a\
+                 href="p1/B.html" title="class in p1">B</a></dt>
                 <dd>
                 <div class="block">First sentence</div>
                 </dd>
-                <dt><span class="member-name-link"><a href="p1/A.html#m1()">m1()</a></span> - Me\
-                thod in class p1.<a href="p1/A.html" title="class in p1">A</a></dt>
+                <dt><a href="p1/A.html#m1()" class="member-name-link">m1()</a> - Method in class p1.\
+                <a href="p1/A.html" title="class in p1">A</a></dt>
                 <dd>
                 <div class="block"> First sentence </div>
                 </dd>
-                <dt><span class="member-name-link"><a href="p1/A.html#m2()">m2()</a></span> - Me\
-                thod in class p1.<a href="p1/A.html" title="class in p1">A</a></dt>
+                <dt><a href="p1/A.html#m2()" class="member-name-link">m2()</a> - Method in class p1.\
+                <a href="p1/A.html" title="class in p1">A</a></dt>
                 <dd>
                 <div class="block">Some html &lt;foo&gt; &nbsp; codes</div>
                 </dd>
-                <dt><span class="member-name-link"><a href="p1/A.html#m3()">m3()</a></span> - Me\
-                thod in class p1.<a href="p1/A.html" title="class in p1">A</a></dt>
+                <dt><a href="p1/A.html#m3()" class="member-name-link">m3()</a> - Method in class p1.\
+                <a href="p1/A.html" title="class in p1">A</a></dt>
                 <dd>
                 <div class="block">First sentence </div>
                 </dd>
-                <dt><span class="member-name-link"><a href="p1/A.html#m4()">m4()</a></span> - Me\
-                thod in class p1.<a href="p1/A.html" title="class in p1">A</a></dt>
+                <dt><a href="p1/A.html#m4()" class="member-name-link">m4()</a> - Method in class p1.\
+                <a href="p1/A.html" title="class in p1">A</a></dt>
                 <dd>
                 <div class="block">First sentence i.e. the first sentence</div>
                 </dd>

--- a/test/langtools/jdk/javadoc/doclet/testSystemPropertyTaglet/TestSystemPropertyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testSystemPropertyTaglet/TestSystemPropertyTaglet.java
@@ -165,102 +165,102 @@ public class TestSystemPropertyTaglet extends JavadocTester {
                    """
                        <h2 class="title" id="I:T">T</h2>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyAnnotation.html#\
-                       test.property">test.property</a></span> - Search tag in annotation interface mypackag\
+                       <dt><a href="mymodule/mypackage/MyAnnotation.html#\
+                       test.property" class="search-tag-link">test.property</a> - Search tag in annotation interface mypackag\
                        e.MyAnnotation</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property">test.property</a></span> - Search tag in class mypackage.MyClass</dt>
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property" class="search-tag-link">test.property</a> - Search tag in class mypackage.MyClass</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyEnum.html#test.p\
-                       roperty">test.property</a></span> - Search tag in enum class mypackage.MyEnum</dt>
+                       <dt><a href="mymodule/mypackage/MyEnum.html#test.p\
+                       roperty" class="search-tag-link">test.property</a> - Search tag in enum class mypackage.MyEnum</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyError.html#test.\
-                       property">test.property</a></span> - Search tag in error mypackage.MyError</dt>
+                       <dt><a href="mymodule/mypackage/MyError.html#test.\
+                       property" class="search-tag-link">test.property</a> - Search tag in error mypackage.MyError</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyException.html#t\
-                       est.property">test.property</a></span> - Search tag in exception mypackage.MyExc\
+                       <dt><a href="mymodule/mypackage/MyException.html#t\
+                       est.property" class="search-tag-link">test.property</a> - Search tag in exception mypackage.MyExc\
                        eption</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyInterface.html#t\
-                       est.property">test.property</a></span> - Search tag in interface mypackage.MyInt\
+                       <dt><a href="mymodule/mypackage/MyInterface.html#t\
+                       est.property" class="search-tag-link">test.property</a> - Search tag in interface mypackage.MyInt\
                        erface</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/module-summary.html#test.pro\
-                       perty">test.property</a></span> - Search tag in module mymodule</dt>
+                       <dt><a href="mymodule/module-summary.html#test.pro\
+                       perty" class="search-tag-link">test.property</a> - Search tag in module mymodule</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyAnnotation.html#\
-                       test.property-1">test.property</a></span> - Search tag in mypackage.MyAnnotation\
+                       <dt><a href="mymodule/mypackage/MyAnnotation.html#\
+                       test.property-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyAnnotation\
                        .value()</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property-2">test.property</a></span> - Search tag in mypackage.MyClass.INT_CONST\
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property-2" class="search-tag-link">test.property</a> - Search tag in mypackage.MyClass.INT_CONST\
                        ANT</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property-3">test.property</a></span> - Search tag in mypackage.MyClass.MyClass()\
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property-3" class="search-tag-link">test.property</a> - Search tag in mypackage.MyClass.MyClass()\
                        </dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property-1">test.property</a></span> - Search tag in mypackage.MyClass.intField<\
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyClass.intField<\
                        /dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property-5">test.property</a></span> - Search tag in mypackage.MyClass.run()</dt\
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property-5" class="search-tag-link">test.property</a> - Search tag in mypackage.MyClass.run()</dt\
                        >
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyClass.html#test.\
-                       property-4">test.property</a></span> - Search tag in mypackage.MyClass.value()</\
+                       <dt><a href="mymodule/mypackage/MyClass.html#test.\
+                       property-4" class="search-tag-link">test.property</a> - Search tag in mypackage.MyClass.value()</\
                        dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyEnum.html#test.p\
-                       roperty-1">test.property</a></span> - Search tag in mypackage.MyEnum.X</dt>
+                       <dt><a href="mymodule/mypackage/MyEnum.html#test.p\
+                       roperty-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyEnum.X</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyEnum.html#test.p\
-                       roperty-2">test.property</a></span> - Search tag in mypackage.MyEnum.m()</dt>
+                       <dt><a href="mymodule/mypackage/MyEnum.html#test.p\
+                       roperty-2" class="search-tag-link">test.property</a> - Search tag in mypackage.MyEnum.m()</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyError.html#test.\
-                       property-1">test.property</a></span> - Search tag in mypackage.MyError.MyError()\
+                       <dt><a href="mymodule/mypackage/MyError.html#test.\
+                       property-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyError.MyError()\
                        </dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyException.html#t\
-                       est.property-1">test.property</a></span> - Search tag in mypackage.MyException.M\
+                       <dt><a href="mymodule/mypackage/MyException.html#t\
+                       est.property-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyException.M\
                        yException()</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyInterface.html#t\
-                       est.property-1">test.property</a></span> - Search tag in mypackage.MyInterface.I\
+                       <dt><a href="mymodule/mypackage/MyInterface.html#t\
+                       est.property-1" class="search-tag-link">test.property</a> - Search tag in mypackage.MyInterface.I\
                        NT_CONSTANT</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyInterface.html#t\
-                       est.property-2">test.property</a></span> - Search tag in mypackage.MyInterface.m\
+                       <dt><a href="mymodule/mypackage/MyInterface.html#t\
+                       est.property-2" class="search-tag-link">test.property</a> - Search tag in mypackage.MyInterface.m\
                        ()</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/MyInterface.html#t\
-                       est.property-3">test.property</a></span> - Search tag in mypackage.MyInterface.m\
+                       <dt><a href="mymodule/mypackage/MyInterface.html#t\
+                       est.property-3" class="search-tag-link">test.property</a> - Search tag in mypackage.MyInterface.m\
                        (String...)</dt>
                        <dd>System Property</dd>""",
                    """
-                       <dt><span class="search-tag-link"><a href="mymodule/mypackage/package-summary.ht\
-                       ml#test.property">test.property</a></span> - Search tag in package mypackage</dt\
+                       <dt><a href="mymodule/mypackage/package-summary.ht\
+                       ml#test.property" class="search-tag-link">test.property</a> - Search tag in package mypackage</dt\
                        >
                        <dd>System Property</dd>""",
                    "");

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -536,8 +536,8 @@ public class TestTypeAnnotations extends JavadocTester {
 
         checkOutput("typeannos/RepeatingOnConstructor.Inner.html", true,
                 """
-                    <code><span class="member-name-link"><a href="#%3Cinit%3E(java.lang.String,java.\
-                    lang.String...)">Inner</a></span>&#8203;(java.lang.String&nbsp;parameter,
+                    <code><a href="#%3Cinit%3E(java.lang.String,java.lang.String...)" class="member-\
+                    name-link">Inner</a>&#8203;(java.lang.String&nbsp;parameter,
                      java.lang.String <a href="RepTypeUseA.html" title="annotation in typeannos">@Rep\
                     TypeUseA</a> <a href="RepTypeUseA.html" title="annotation in typeannos">@RepType\
                     UseA</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeUseB\
@@ -568,7 +568,8 @@ public class TestTypeAnnotations extends JavadocTester {
         checkOutput("typeannos/RepeatingOnField.html", true,
                 """
                     <div class="col-first even-row-color"><code>(package private) java.lang.Integer</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#i1">i1</a></span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="#i1" class="member-name-li\
+                    nk">i1</a></code></div>""",
 
                 """
                     <div class="col-first odd-row-color"><code>(package private) <a href="RepTypeUseA.ht\
@@ -576,8 +577,8 @@ public class TestTypeAnnotations extends JavadocTester {
                      title="annotation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" tit\
                     le="annotation in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="\
                     annotation in typeannos">@RepTypeUseB</a> java.lang.Integer</code></div>
-                    <div class="col-second odd-row-color"><code><span class="member-name-link"><a href="\
-                    #i2">i2</a></span></code></div>
+                    <div class="col-second odd-row-color"><code><a href="\
+                    #i2" class="member-name-link">i2</a></code></div>
                     <div class="col-last odd-row-color">&nbsp;</div>""",
 
                 """
@@ -586,7 +587,8 @@ public class TestTypeAnnotations extends JavadocTester {
                      title="annotation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" tit\
                     le="annotation in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="\
                     annotation in typeannos">@RepTypeUseB</a> java.lang.Integer</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#i3">i3</a></span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="#i3" class="member-name-li\
+                    nk">i3</a></code></div>""",
 
                 """
                     <div class="col-first odd-row-color"><code>(package private) <a href="RepAllContexts\
@@ -595,7 +597,8 @@ public class TestTypeAnnotations extends JavadocTester {
                     ContextsB.html" title="annotation in typeannos">@RepAllContextsB</a> <a href="Re\
                     pAllContextsB.html" title="annotation in typeannos">@RepAllContextsB</a> java.la\
                     ng.Integer</code></div>
-                    <div class="col-second odd-row-color"><code><span class="member-name-link"><a href="#i4">i4</a></span></code></div>""",
+                    <div class="col-second odd-row-color"><code><a href="#i4" class="member-name-lin\
+                    k">i4</a></code></div>""",
 
                 """
                     <div class="col-first even-row-color"><code>(package private) java.lang.String <a hre\
@@ -607,7 +610,8 @@ public class TestTypeAnnotations extends JavadocTester {
                     ml" title="annotation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html"\
                      title="annotation in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" tit\
                     le="annotation in typeannos">@RepTypeUseB</a> []</code></div>
-                    <div class="col-second even-row-color"><code><span class="member-name-link"><a href="#sa">sa</a></span></code></div>""",
+                    <div class="col-second even-row-color"><code><a href="#sa" class="member-name-li\
+                    nk">sa</a></code></div>""",
 
                 """
                     <div class="member-signature"><span class="annotations"><a href="RepFieldA.html"\
@@ -669,8 +673,8 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <code>(package private) java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#t\
-                    est1()">test1</a></span>()</code>""",
+                    tab2 method-summary-table-tab4"><code><a href="#t\
+                    est1()" class="member-name-link">test1</a>()</code>""",
 
                 """
                     <code>(package private) <a href="RepTypeUseA.html" title="annotation in typeanno\
@@ -679,8 +683,8 @@ public class TestTypeAnnotations extends JavadocTester {
                     ypeUseB</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeU\
                     seB</a> java.lang.String</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#te\
-                    st2()">test2</a></span>()</code>""",
+                    ab2 method-summary-table-tab4"><code><a href="#te\
+                    st2()" class="member-name-link">test2</a>()</code>""",
 
                 """
                     <code>(package private) <a href="RepTypeUseA.html" title="annotation in typeanno\
@@ -689,8 +693,8 @@ public class TestTypeAnnotations extends JavadocTester {
                     ypeUseB</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeU\
                     seB</a> java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#t\
-                    est3()">test3</a></span>()</code>""",
+                    tab2 method-summary-table-tab4"><code><a href="#t\
+                    est3()" class="member-name-link">test3</a>()</code>""",
 
                 """
                     <code>(package private) <a href="RepAllContextsA.html" title="annotation in type\
@@ -699,12 +703,12 @@ public class TestTypeAnnotations extends JavadocTester {
                     n in typeannos">@RepAllContextsB</a> <a href="RepAllContextsB.html" title="annot\
                     ation in typeannos">@RepAllContextsB</a> java.lang.String</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#te\
-                    st4()">test4</a></span>()</code>""",
+                    ab2 method-summary-table-tab4"><code><a href="#te\
+                    st4()" class="member-name-link">test4</a>()</code>""",
 
                 """
-                    <code><span class="member-name-link"><a href="#test5(java.lang.String,java.lang.\
-                    String...)">test5</a></span>&#8203;(java.lang.String&nbsp;parameter,
+                    <code><a href="#test5(java.lang.String,java.lang.\
+                    String...)" class="member-name-link">test5</a>&#8203;(java.lang.String&nbsp;parameter,
                      java.lang.String <a href="RepTypeUseA.html" title="annotation in typeannos">@Re\
                     pTypeUseA</a> <a href="RepTypeUseA.html" title="annotation in typeannos">@RepTyp\
                     eUseA</a> <a href="RepTypeUseB.html" title="annotation in typeannos">@RepTypeUse\
@@ -777,15 +781,15 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <code>(package private) &lt;T&gt;&nbsp;java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#g\
-                    enericMethod(T)">genericMethod</a></span>&#8203;(T&nbsp;t)</code>""",
+                    tab2 method-summary-table-tab4"><code><a href="#genericMethod(T)" class="member-\
+                    name-link">genericMethod</a>&#8203;(T&nbsp;t)</code>""",
 
                 """
                     <code>(package private) &lt;T&gt;&nbsp;java.lang.String</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#generi\
-                    cMethod2(T)">genericMethod2</a></span>&#8203;(<a href="RepTypeUseA.html" title="\
-                    annotation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="anno\
+                    ab2 method-summary-table-tab4"><code><a href="#genericMethod2(T)" class="member-\
+                    name-link">genericMethod2</a>&#8203;(<a href="RepTypeUseA.html" title="annotatio\
+                    n in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="anno\
                     tation in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotati\
                     on in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation i\
                     n typeannos">@RepTypeUseB</a> T&nbsp;t)</code>""",
@@ -793,8 +797,8 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <code>(package private) java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
-                    tab2 method-summary-table-tab4"><code><span class="member-name-link"><a href="#t\
-                    est()">test</a></span>()</code>""",
+                    tab2 method-summary-table-tab4"><code><a href="#test()" class="member-name-link"\
+                    >test</a>()</code>""",
 
                 """
                     <span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">test</\

--- a/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
@@ -66,10 +66,10 @@ public class TestTypeParameters extends JavadocTester {
 
         checkOutput("pkg/class-use/Foo4.html", true,
                 """
-                    <a href="../ClassUseTest3.html" title="class in pkg">ClassUseTest3</a>&lt;T exte\
-                    nds <a href="../ParamTest2.html" title="class in pkg">ParamTest2</a>&lt;java.uti\
-                    l.List&lt;? extends <a href="../Foo4.html" title="class in pkg">Foo4</a>&gt;&gt;\
-                    &gt;""");
+                    <a href="../ClassUseTest3.html" class="type-name-link" title="class in pkg">Clas\
+                    sUseTest3</a>&lt;T extends <a href="../ParamTest2.html" title="class in pkg">Par\
+                    amTest2</a>&lt;java.util.List&lt;? extends <a href="../Foo4.html" title="class i\
+                    n pkg">Foo4</a>&gt;&gt;&gt;""");
 
         // Nested type parameters
         checkOutput("pkg/C.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
@@ -83,7 +83,7 @@ public class TestUseOption extends JavadocTester {
         );
         checkOutput("pkg1/class-use/UsedClass.html", true,
           """
-              <a href="../C1.html#methodInC1ReturningType()">methodInC1ReturningType</a>"""
+              <a href="../C1.html#methodInC1ReturningType()" class="member-name-link">methodInC1ReturningType</a>"""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
           """
@@ -100,7 +100,7 @@ public class TestUseOption extends JavadocTester {
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
            """
-               <a href="../AnAbstract.html" title="class in pkg1">AnAbstract</a>"""
+               <a href="../AnAbstract.html" class="type-name-link" title="class in pkg1">AnAbstract</a>"""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             "../C10.html#withReturningTypeParameters()"
@@ -114,15 +114,15 @@ public class TestUseOption extends JavadocTester {
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             """
-                <a href="../C10.html#addAll(pkg1.UsedInterface...)">addAll</a>"""
+                <a href="../C10.html#addAll(pkg1.UsedInterface...)" class="member-name-link">addAll</a>"""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             """
-                <a href="../C10.html#create(pkg1.UsedInterfaceA,pkg1.UsedInterface,java.lang.String)">"""
+                <a href="../C10.html#create(pkg1.UsedInterfaceA,pkg1.UsedInterface,java.lang.String)" class="member-name-link">"""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             """
-                <a href="../C10.html#withTypeParametersOfType(java.lang.Class)">withTypeParametersOfType</a>"""
+                <a href="../C10.html#withTypeParametersOfType(java.lang.Class)" class="member-name-link">withTypeParametersOfType</a>"""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             """
@@ -130,8 +130,8 @@ public class TestUseOption extends JavadocTester {
                 nterface</a> in <a href="../package-summary.html">pkg1""",
             """
                 <div class="col-first even-row-color"><code>interface&nbsp;</code></div>
-                <div class="col-second even-row-color"><code><span class="member-name-link"><a href="\
-                ../SubInterface.html" title="interface in pkg1">SubInterface</a>&lt;T&gt;</span>\
+                <div class="col-second even-row-color"><code><a href="\
+                ../SubInterface.html" class="type-name-link" title="interface in pkg1">SubInterface</a>&lt;T&gt;\
                 </code></div>"""
         );
         checkOutput("pkg1/class-use/UsedThrowable.html", true,
@@ -141,8 +141,8 @@ public class TestUseOption extends JavadocTester {
             """
                 <div class="col-first even-row-color"><code>void</code></div>
                 <div class="col-second even-row-color"><span class="type-name-label">C1.</span><code>\
-                <span class="member-name-link"><a href="../C1.html#methodInC1ThrowsThrowable()">\
-                methodInC1ThrowsThrowable</a></span>()</code></div>"""
+                <a href="../C1.html#methodInC1ThrowsThrowable()" class="member-name-link">\
+                methodInC1ThrowsThrowable</a>()</code></div>"""
         );
     }
 
@@ -183,12 +183,12 @@ public class TestUseOption extends JavadocTester {
         checkExit(Exit.OK);
         checkUnique("unique/class-use/UseMe.html",
                 """
-                    <a href="../C1.html#umethod1(unique.UseMe,unique.UseMe%5B%5D)">""",
+                    <a href="../C1.html#umethod1(unique.UseMe,unique.UseMe%5B%5D)" class="member-name-link">""",
                 """
-                    <a href="../C1.html#umethod2(unique.UseMe,unique.UseMe)">""",
+                    <a href="../C1.html#umethod2(unique.UseMe,unique.UseMe)" class="member-name-link">""",
                 """
-                    <a href="../C1.html#umethod3(unique.UseMe,unique.UseMe)">""",
+                    <a href="../C1.html#umethod3(unique.UseMe,unique.UseMe)" class="member-name-link">""",
                 """
-                    <a href="../C1.html#%3Cinit%3E(unique.UseMe,unique.UseMe)">""");
+                    <a href="../C1.html#%3Cinit%3E(unique.UseMe,unique.UseMe)" class="member-name-link">""");
     }
 }


### PR DESCRIPTION
This change gets rid of `<span>` elements used in conjunction with HTML links whose only purpose is to apply a CSS class to the link. Instead, the CSS class attribute is applied directly to the link's `<a href="...">` element. 

There  are three CSS styles for links previously used with embedded or embedding `<span>` elements:

 - `type-name-link`, which was applied to a `<span>` element inside the link. This was generated by passing `true` as argument for the `strong` parameter in various get*Link methods. 
 - `member-name-link` and `search-tag-link`, which were applied to a `<span>` element wrapping the link.

I could find no visual changes in the generated documentation with one exception:

[Class and interface links in the second column of "Uses" page tables][1] were previously wrapped in a `<span class="member-name-link">` element causing the whole class name (including non-linked parts such as type parameters) to be displayed with a bold font. With this change, the `type-name-link` style is applied only to the active link, leaving non-linked parts such as type parameters with normal font-weight. 

[1]: https://download.java.net/java/early_access/jdk17/docs/api/java.base/java/util/class-use/Map.html#java.util

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261499](https://bugs.openjdk.java.net/browse/JDK-8261499): Simplify HTML for javadoc links


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 875fb7dafe1c3b13b09a8fdf982b025c7373b38d


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2516/head:pull/2516`
`$ git checkout pull/2516`
