### PR TITLE
8261534: Test sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java fails on platforms where no nsslib artifacts are defined

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
@@ -71,6 +71,7 @@ public class IllegalPackageAccess extends PKCS11Test {
 
     @Override
     public void main(Provider p) throws Exception {
+        Policy.setPolicy(null);
         Policy.setPolicy(new MyPolicy());
         System.setSecurityManager(new SecurityManager());
 


### PR DESCRIPTION
Fix exception in test sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java:

java.security.AccessControlException: access denied ("java.security.SecurityPermission" "removeProvider.SUN")
at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
at java.base/java.security.AccessController.checkPermission(AccessController.java:1036)
at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:408)
at java.base/java.lang.SecurityManager.checkSecurityAccess(SecurityManager.java:1521)
at java.base/java.security.Security.check(Security.java:832)
at java.base/java.security.Security.removeProvider(Security.java:444)
at IllegalPackageAccess.main(IllegalPackageAccess.java:81)
at PKCS11Test.premain(PKCS11Test.java:171)
at PKCS11Test.testNSS(PKCS11Test.java:568)
at PKCS11Test.main(PKCS11Test.java:207)
at IllegalPackageAccess.main(IllegalPackageAccess.java:69)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:566)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:831)

Root cause is that the test materializes and installs a policy by [obtaining the current policy](https://github.com/openjdk/jdk/blob/4be2173478bd1e84946bd903b350ce466bddb36b/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java#L46). At the time it [tries to remove a provider](https://github.com/openjdk/jdk/blob/4be2173478bd1e84946bd903b350ce466bddb36b/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java#L80), the materialized policy is used for an access check, due to some intricacies of the [java.security.Policy implementation](https://github.com/openjdk/jdk/blob/4be2173478bd1e84946bd903b350ce466bddb36b/src/java.base/share/classes/java/security/Policy.java#L293). This policy does not allow the removal of a provider.
On platforms where the test runs through [PKCS11Test::fetchNssLib](https://github.com/openjdk/jdk/blob/4be2173478bd1e84946bd903b350ce466bddb36b/test/jdk/sun/security/pkcs11/PKCS11Test.java#L859), the default policy is reset  which makes the test work. But if we don't pass there, the test fails.

The fix is to unconditionally call Policy.setPolicy(null); in IllegalPackageAccess before installing MyPolicy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261534](https://bugs.openjdk.java.net/browse/JDK-8261534): Test sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java fails on platforms where no nsslib artifacts are defined


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2518/head:pull/2518`
`$ git checkout pull/2518`
