### PR TITLE
JDK-8261548: ProblemList runtime/NMT/CheckForProperDetailStackTrace.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -85,6 +85,7 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
+runtime/NMT/CheckForProperDetailStackTrace.java 8261520 generic-all
 runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 containers/docker/TestJFRWithJMX.java 8256417 linux-5.4.17-2011.5.3.el8uek.x86_64
 


### PR DESCRIPTION
Trivial, Urgent.
JDK-8261302 broke this test, and I try to find the best solution. 
Since it causes a lot of noise, I'd like to add it to the problem list for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261548](https://bugs.openjdk.java.net/browse/JDK-8261548): ProblemList runtime/NMT/CheckForProperDetailStackTrace.java


### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.java.net/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2521/head:pull/2521`
`$ git checkout pull/2521`
