### PR TITLE
JDK-8261593: Do not use NULL pointer as write buffer parameter in jfrEmergencyDump.cpp write_repository_files

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -369,9 +369,10 @@ static void write_emergency_dump_file(const RepositoryIterator& iterator) {
   if (copy_block == NULL) {
     log_error(jfr, system)("Unable to malloc memory during jfr emergency dump");
     log_error(jfr, system)("Unable to write jfr emergency dump file");
+  } else {
+    write_repository_files(iterator, copy_block, block_size);
+    os::free(copy_block);
   }
-  write_repository_files(iterator, copy_block, block_size);
-  os::free(copy_block);
 }
 
 void JfrEmergencyDump::on_vm_error(const char* repository_path) {


### PR DESCRIPTION
In jfrEmergencyDump.cpp write_repository_files, potentially (when malloc fails) a NULL pointer is passed as second (buffer) parameter to os::write .
This is unwanted, see also the Sonar finding :

https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=cpp&open=AXck7_SvBBG2CXpcnJEx&resolved=false&severities=CRITICAL&types=BUG

bytes_written += (int64_t)os::write(emergency_fd, copy_block, bytes_read - bytes_written);

Sonar reports here : "Null pointer passed as read buffer "copy_block" in call to "write""

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261593](https://bugs.openjdk.java.net/browse/JDK-8261593): Do not use NULL pointer as write buffer parameter in jfrEmergencyDump.cpp write_repository_files


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2525/head:pull/2525`
`$ git checkout pull/2525`
