### PR TITLE
8261585: Restore HandleArea used in Deoptimization::uncommon_trap

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2465,6 +2465,7 @@ Deoptimization::UnrollBlock* Deoptimization::uncommon_trap(JavaThread* thread, j
     // This enters VM and may safepoint
     uncommon_trap_inner(thread, trap_request);
   }
+  HandleMark hm(thread);
   return fetch_unroll_info_helper(thread, exec_mode);
 }
 

--- a/test/hotspot/jtreg/compiler/uncommontrap/UncommonTrapLeak.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/UncommonTrapLeak.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.ref.WeakReference;
+
+/*
+ * @test
+ * @bug 8260473
+ * @summary Handle leak might cause object not collected as expected
+ *
+ * @run main/othervm -XX:-Inline -XX:-TieredCompilation -XX:CompileCommand=compileonly,UncommonTrapLeak.foo
+ *                   -XX:CompileThreshold=100 -XX:-BackgroundCompilation UncommonTrapLeak
+ *
+ * @author Hui Shi
+ */
+public class UncommonTrapLeak {
+    static WeakReference<Object> ref = null;
+    static int val = 0;
+    public static void main(String args[]) {
+        for (int i = 0; i < 300; i++) {
+            val++;
+            foo(i);
+            System.gc();
+            if (ref.get() != null) {
+                throw new RuntimeException("Failed: referent not collected after trap " + ref.get());
+            }
+            if (i % 100 == 0) {
+                System.out.println(i);
+            }
+        }
+    }
+
+    static void foo(int i) {
+        Object o = new Object();
+        ref = new WeakReference<Object>(o);
+        if (val == 200) {
+            // trigger Deoptimization::uncommon_trap
+            if (o instanceof UncommonTrapLeak) {
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Add HandleMark in Deoptimization::uncommon_trap before Deoptimization::fetch_unroll_info_helper, avoid reference hold in HandleArea increase object lifetime. Then object lifetime will be consistent with/without uncommon trap.

For test case in commit, WeakReference is expected cleared after GC, but it fails with option "-XX:-Inline -XX:-TieredCompilation -XX:CompileCommand=compileonly,UncommonTrapLeak.foo -XX:CompileThreshold=100 -XX:-BackgroundCompilation". Reference's referent object is still alive after "foo" finish, because with uncommon trap, oops are recorded in HandleArea and HandleArea is not poped when uncommon trap process finish.

When Deoptimization::fetch_unroll_info_helper return, all oops in deoptimized frames are saved in Deoptimization::UnrollBlock or Thread data structure, HandleArea can be poped safely.
1. local and expression oops raw address is stored in vframeArrayElement _locals/_expressions as intptr
2. return value restore, raw oop recoreded in frame // (oop *)map->location(rax->as_VMReg());
3. exception object, raw oop recorded on Thread._exception_oop

In deoptimize blob entry, JRT_BLOCK_ENTRY(Deoptimization::fetch_unroll_info) has HandleMarkCleaner, HandleArea is restored after Deoptimization::fetch_unroll_info_helper finish. So it's also safe to add HandleMark in Deoptimization::uncommon_trap before fetch_unroll_info_helper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261585](https://bugs.openjdk.java.net/browse/JDK-8261585): Restore HandleArea used in Deoptimization::uncommon_trap


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2526/head:pull/2526`
`$ git checkout pull/2526`
