### PR TITLE
8261600: NMT: Relax memory order for updating MemoryCounter and fix racy updating of peak values

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -30,6 +30,36 @@
 
 size_t MallocMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
 
+#ifdef ASSERT
+void MemoryCounter::update_peak_count(size_t count) {
+  size_t peak_cnt = peak_count();
+  while (peak_cnt < count) {
+    size_t old_cnt = Atomic::cmpxchg(&_peak_count, peak_cnt, count, memory_order_relaxed);
+    if (old_cnt != peak_cnt) {
+      peak_cnt = old_cnt;
+    }
+  }
+}
+
+void MemoryCounter::update_peak_size(size_t sz) {
+  size_t peak_sz = peak_size();
+  while (peak_sz < sz) {
+    size_t old_sz = Atomic::cmpxchg(&_peak_size, peak_sz, sz, memory_order_relaxed);
+    if (old_sz != peak_sz) {
+      peak_sz = old_sz;
+    }
+  }
+}
+
+size_t MemoryCounter::peak_count() const {
+  return Atomic::load(&_peak_count);
+}
+
+size_t MemoryCounter::peak_size() const {
+  return Atomic::load(&_peak_size);
+}
+#endif
+
 // Total malloc'd memory amount
 size_t MallocMemorySnapshot::total() const {
   size_t amount = 0;

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -43,8 +43,8 @@ class MemoryCounter {
   volatile size_t   _count;
   volatile size_t   _size;
 
-  DEBUG_ONLY(size_t   _peak_count;)
-  DEBUG_ONLY(size_t   _peak_size; )
+  DEBUG_ONLY(volatile size_t   _peak_count;)
+  DEBUG_ONLY(volatile size_t   _peak_size; )
 
  public:
   MemoryCounter() : _count(0), _size(0) {
@@ -53,36 +53,40 @@ class MemoryCounter {
   }
 
   inline void allocate(size_t sz) {
-    Atomic::inc(&_count);
+    size_t cnt = Atomic::add(&_count, size_t(1), memory_order_relaxed);
     if (sz > 0) {
-      Atomic::add(&_size, sz);
-      DEBUG_ONLY(_peak_size = MAX2(_peak_size, _size));
+      size_t sum = Atomic::add(&_size, sz, memory_order_relaxed);
+      DEBUG_ONLY(update_peak_size(sum);)
     }
-    DEBUG_ONLY(_peak_count = MAX2(_peak_count, _count);)
+    DEBUG_ONLY(update_peak_count(cnt);)
   }
 
   inline void deallocate(size_t sz) {
-    assert(_count > 0, "Nothing allocated yet");
-    assert(_size >= sz, "deallocation > allocated");
-    Atomic::dec(&_count);
+    assert(count() > 0, "Nothing allocated yet");
+    assert(size() >= sz, "deallocation > allocated");
+    Atomic::dec(&_count, memory_order_relaxed);
     if (sz > 0) {
-      Atomic::sub(&_size, sz);
+      Atomic::sub(&_size, sz, memory_order_relaxed);
     }
   }
 
   inline void resize(ssize_t sz) {
     if (sz != 0) {
-      assert(sz >= 0 || _size >= size_t(-sz), "Must be");
-      Atomic::add(&_size, size_t(sz));
-      DEBUG_ONLY(_peak_size = MAX2(_size, _peak_size);)
+      assert(sz >= 0 || size() >= size_t(-sz), "Must be");
+      size_t sum = Atomic::add(&_size, size_t(sz), memory_order_relaxed);
+      DEBUG_ONLY(update_peak_size(sum);)
     }
   }
 
-  inline size_t count() const { return _count; }
-  inline size_t size()  const { return _size;  }
-  DEBUG_ONLY(inline size_t peak_count() const { return _peak_count; })
-  DEBUG_ONLY(inline size_t peak_size()  const { return _peak_size; })
+  inline size_t count() const { return Atomic::load(&_count); }
+  inline size_t size()  const { return Atomic::load(&_size);  }
 
+#ifdef ASSERT
+  void update_peak_count(size_t cnt);
+  void update_peak_size(size_t sz);
+  size_t peak_count() const;
+  size_t peak_size()  const;
+#endif // ASSERT
 };
 
 /*


### PR DESCRIPTION
Currently, MemoryCounter is updated with default memory_order_conservative, it is too strong for updating a counter.

Also, updating peak values with regular assignment, which is racy and broken.

- [x] hotspot_nmt on Linux x86_64 and aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261600](https://bugs.openjdk.java.net/browse/JDK-8261600): NMT: Relax memory order for updating MemoryCounter and fix racy updating of peak values


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2527/head:pull/2527`
`$ git checkout pull/2527`
