### PR TITLE
8261308: C2: assert(inner->is_valid_counted_loop(T_INT) && inner->is_strip_mined()) failed: OuterStripMinedLoop should have been removed

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -124,7 +124,8 @@ void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase) {
     jlong limit_con = (stride_con > 0) ? limit_type->_hi : limit_type->_lo;
     int stride_m = stride_con - (stride_con > 0 ? 1 : -1);
     jlong trip_count = (limit_con - init_con + stride_m)/stride_con;
-    if (trip_count > 0 && (julong)trip_count < (julong)max_juint) {
+    trip_count = MAX2(trip_count, (jlong)1);
+    if (trip_count < (jlong)max_juint) {
       if (init_n->is_Con() && limit_n->is_Con()) {
         // Set exact trip count.
         cl->set_exact_trip_count((uint)trip_count);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -124,6 +124,8 @@ void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase) {
     jlong limit_con = (stride_con > 0) ? limit_type->_hi : limit_type->_lo;
     int stride_m = stride_con - (stride_con > 0 ? 1 : -1);
     jlong trip_count = (limit_con - init_con + stride_m)/stride_con;
+    // The loop body is always executed at least once even if init >= limit (for stride_con > 0) or
+    // init <= limit (for stride_con < 0).
     trip_count = MAX2(trip_count, (jlong)1);
     if (trip_count < (jlong)max_juint) {
       if (init_n->is_Con() && limit_n->is_Con()) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopZeroIter.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopZeroIter.java
@@ -55,7 +55,7 @@ public class TestCountedLoopZeroIter {
     while (++i19 < 173);
     System.out.println();
   }
-    
+
   public static void main(String[] strArr) {
       for (int i = 0; i < 10; i++) {
         test();

--- a/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopZeroIter.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopZeroIter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8261308
+ * @summary C2: assert(inner->is_valid_counted_loop(T_INT) && inner->is_strip_mined()) failed: OuterStripMinedLoop should have been removed
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestCountedLoopZeroIter TestCountedLoopZeroIter
+ *
+ */
+
+
+public class TestCountedLoopZeroIter {
+  static int N = 400;
+  static boolean b;
+  static long lArrFld[] = new long[N];
+  static int iArrFld[] = new int[N];
+
+  static void test() {
+    int i19 = 9, i21 = 8;
+    long l1;
+    do
+      if (!b) {
+        iArrFld[1] /= l1 = 1;
+        do {
+          int i22 = 1;
+          do {
+            iArrFld[0] = (int)l1;
+            iArrFld[i22 - 1] = i21;
+          } while (++i22 < 1);
+          lArrFld[1] = i21;
+        } while (++l1 < 145);
+      }
+    while (++i19 < 173);
+    System.out.println();
+  }
+    
+  public static void main(String[] strArr) {
+      for (int i = 0; i < 10; i++) {
+        test();
+     }
+  }
+}


### PR DESCRIPTION
The inner counted loop of the test case starts at 1 and stops at 1 so
runs for one iteration. A counted loop is created for it. The iv Phi
is found to be the constant 1 and its type is set by:

l->phi()->as_Phi()->set_type(l->phi()->Value(&_igvn));

in PhaseIdealLoop::is_counted_loop() but it's not replaced by the
constant 1 yet so the counted loop's shape is preserved.

IdealLoopTree::do_one_iteration_loop() runs but doesn't optimize the
loop because the trip count is not set to 1. The loop contains a range
check and range check elimination is applied. That causes the loop
exit test to be adjusted with a MinI(..) expression. When IGVN runs
next, the phi is replaced with 1 but because the exit test was
changed, IGVN can't prove it always fails. So the loop is not removed
which causes the assert failure as loop opts progress.

The fix I propose is for IdealLoopTree::do_one_iteration_loop() to
remove the 1 iteration loop. The reason it doesn't happen is that
IdealLoopTree::compute_trip_count() doesn't set the trip count because
it finds a zero trip count: limit - init = 1 - 1 = 0. All loops, once
entered execute at least once. So I think, it's safe to set the trip
count to 1 in those cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261308](https://bugs.openjdk.java.net/browse/JDK-8261308): C2: assert(inner->is_valid_counted_loop(T_INT) && inner->is_strip_mined()) failed: OuterStripMinedLoop should have been removed


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to 5f9ac283a95c5ee03448fe7744cf416420914c2b
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 5f9ac283a95c5ee03448fe7744cf416420914c2b


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2529/head:pull/2529`
`$ git checkout pull/2529`
