### PR TITLE
8253702: BigSur version number reported as 10.16, should be 11.nn

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -247,7 +247,7 @@ void setOSNameAndVersion(java_props_t *sprops) {
         [invoke getReturnValue:&osVer];
 
         NSString *nsVerStr;
-        // Copy out the char* if running on version other than pre-10.16 Mac OS (10.16 == 11.x)
+        // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
         if (!((long)osVer.majorVersion == 10 &&
                    (long)osVer.minorVersion >= 16)) {
             if (osVer.patchVersion == 0) { // Omit trailing ".0"

--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,15 +247,34 @@ void setOSNameAndVersion(java_props_t *sprops) {
         [invoke getReturnValue:&osVer];
 
         NSString *nsVerStr;
-        if (osVer.patchVersion == 0) { // Omit trailing ".0"
-            nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
-                    (long)osVer.majorVersion, (long)osVer.minorVersion];
-        } else {
-            nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
-                    (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+        // Copy out the char* if running on version other than pre-10.16 Mac OS (10.16 == 11.x)
+        if (!((long)osVer.majorVersion == 10 &&
+                   (long)osVer.minorVersion >= 16)) {
+            if (osVer.patchVersion == 0) { // Omit trailing ".0"
+                nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
+                        (long)osVer.majorVersion, (long)osVer.minorVersion];
+            } else {
+                nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
+                        (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+            }
+            // Copy out the char*
+            osVersionCStr = strdup([nsVerStr UTF8String]);
+        } else if (getenv("SYSTEM_VERSION_COMPAT") == NULL) {
+            // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
+            // AKA 11.x; compute the version number from the letter in the ProductBuildVersion
+            NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
+                             @"/System/Library/CoreServices/SystemVersion.plist"];
+            if (version != NULL) {
+                NSString *nsBuildVerStr = [version objectForKey : @"ProductBuildVersion"];
+                if (nsBuildVerStr != NULL && nsBuildVerStr.length >= 3) {
+                    int letter = [nsBuildVerStr characterAtIndex:2];
+                    if (letter >= 'B' && letter <= 'Z') {
+                        int vers = letter - 'A' - 1;
+                        asprintf(&osVersionCStr, "11.%d", vers);
+                    }
+                }
+            }
         }
-        // Copy out the char*
-        osVersionCStr = strdup([nsVerStr UTF8String]);
     }
     // Fallback if running on pre-10.9 Mac OS
     if (osVersionCStr == NULL) {

--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -248,8 +248,9 @@ void setOSNameAndVersion(java_props_t *sprops) {
 
         NSString *nsVerStr;
         // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
-        if (!((long)osVer.majorVersion == 10 &&
-                   (long)osVer.minorVersion >= 16)) {
+        // or explicitly requesting version compatibility
+        if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
+                (getenv("SYSTEM_VERSION_COMPAT") != NULL)) {
             if (osVer.patchVersion == 0) { // Omit trailing ".0"
                 nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
                         (long)osVer.majorVersion, (long)osVer.minorVersion];
@@ -259,7 +260,7 @@ void setOSNameAndVersion(java_props_t *sprops) {
             }
             // Copy out the char*
             osVersionCStr = strdup([nsVerStr UTF8String]);
-        } else if (getenv("SYSTEM_VERSION_COMPAT") == NULL) {
+        } else {
             // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
             // AKA 11.x; compute the version number from the letter in the ProductBuildVersion
             NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :


### PR DESCRIPTION
On Mac Os X, the OSVersionTest detected a difference in the version number reported in the os.version property
and the version number provided by `sw_vers -productVersion`.

When the java runtime is built with XCode 11.3, the os.version is reported as 10.16
though the current version numbering is 11.nnn.  

The workaround is to derive the os.version number from the ProductBuildVersion.
When the toolchain is updated to XCode 12.nnn it can be removed.
The workaround is enabled only when the environment variable SYSTEM_VERSION_COMPAT is unset.  
When the SYSTEM_VERSION_COMPAT is set in the environment the version number is reported as reported by Mac OS X.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253702](https://bugs.openjdk.java.net/browse/JDK-8253702): BigSur version number reported as 10.16, should be 11.nn


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2530/head:pull/2530`
`$ git checkout pull/2530`
