### PR TITLE
8261533: Java_sun_font_CFont_getCascadeList leaks memory according to Xcode

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -544,6 +544,7 @@ JNIEXPORT void JNICALL
 Java_sun_font_CFont_getCascadeList
     (JNIEnv *env, jclass cls, jlong awtFontPtr, jobject arrayListOfString)
 {
+JNI_COCOA_ENTER(env);
     jclass alc = (*env)->FindClass(env, "java/util/ArrayList");
     if (alc == NULL) return;
     jmethodID addMID = (*env)->GetMethodID(env, alc, "add", "(Ljava/lang/Object;)Z");
@@ -553,13 +554,15 @@ Java_sun_font_CFont_getCascadeList
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(awtFontPtr);
     NSFont* nsFont = awtFont->fFont;
     CTFontRef font = (CTFontRef)nsFont;
-    CFStringRef base = CTFontCopyFullName(font);
     CFArrayRef codes = CFLocaleCopyISOLanguageCodes();
 
 #ifdef DEBUG
+    CFStringRef base = CTFontCopyFullName(font);
     NSLog(@"BaseFont is : %@", (NSString*)base);
+    CFRelease(base);
 #endif
     CFArrayRef fds = CTFontCopyDefaultCascadeListForLanguages(font, codes);
+    CFRelease(codes);
     CFIndex cnt = CFArrayGetCount(fds);
     for (i=0; i<cnt; i++) {
         CTFontDescriptorRef ref = CFArrayGetValueAtIndex(fds, i);
@@ -569,10 +572,14 @@ Java_sun_font_CFont_getCascadeList
         NSLog(@"Font is : %@", (NSString*)fontname);
 #endif
         jstring jFontName = (jstring)NSStringToJavaString(env, fontname);
+        CFRelease(fontname);
         (*env)->CallBooleanMethod(env, arrayListOfString, addMID, jFontName);
         if ((*env)->ExceptionOccurred(env)) {
+            CFRelease(fds);
             return;
         }
         (*env)->DeleteLocalRef(env, jFontName);
     }
+    CFRelease(fds);
+JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
The various CF*Copy* functions called here need a matching CFRelease

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261533](https://bugs.openjdk.java.net/browse/JDK-8261533): Java_sun_font_CFont_getCascadeList leaks memory according to Xcode


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2532/head:pull/2532`
`$ git checkout pull/2532`
