### PR TITLE
8261502: ECDHKeyAgreement no longer works with alternate impl of ECPrivateKey interface

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -25,21 +25,34 @@
 
 package sun.security.ec;
 
-import java.math.*;
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
-import java.util.Optional;
-
-import javax.crypto.*;
-import javax.crypto.spec.*;
-
+import sun.security.ec.point.AffinePoint;
+import sun.security.ec.point.Point;
 import sun.security.util.ArrayUtil;
 import sun.security.util.CurveDB;
-import sun.security.util.ECUtil;
 import sun.security.util.NamedCurve;
-import sun.security.util.math.*;
-import sun.security.ec.point.*;
+import sun.security.util.math.ImmutableIntegerModuloP;
+import sun.security.util.math.IntegerFieldModuloP;
+import sun.security.util.math.MutableIntegerModuloP;
+import sun.security.util.math.SmallValue;
+
+import javax.crypto.KeyAgreementSpi;
+import javax.crypto.SecretKey;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.ProviderException;
+import java.security.SecureRandom;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.EllipticCurve;
+import java.util.Optional;
 
 /**
  * KeyAgreement implementation for ECDH.
@@ -127,7 +140,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     }
 
     /*
-     * Check whether a public key is valid. Throw ProviderException
+     * Check whether a public key is valid. Throw exception
      * if it is not valid or could not be validated.
      */
     private static void validate(ECOperations ops, ECPublicKey key)
@@ -236,8 +249,6 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         }
         byte[] sArr = privImpl.getArrayS();
 
-        // to match the native implementation, validate the public key here
-        // and throw ProviderException if it is invalid
         validate(ops, pubKey);
 
         IntegerFieldModuloP field = ops.getField();

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,10 +226,14 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
             return Optional.empty();
         }
         ECOperations ops = opsOpt.get();
-        if (! (priv instanceof ECPrivateKeyImpl)) {
+        ECPrivateKeyImpl privImpl;
+        if (priv instanceof ECPrivateKeyImpl) {
+            privImpl = (ECPrivateKeyImpl) priv;
+        } else if (priv instanceof ECPrivateKey) {
+            privImpl = new ECPrivateKeyImpl(priv.getEncoded());
+        } else {
             return Optional.empty();
         }
-        ECPrivateKeyImpl privImpl = (ECPrivateKeyImpl) priv;
         byte[] sArr = privImpl.getArrayS();
 
         // to match the native implementation, validate the public key here

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -174,7 +174,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         try {
             resultOpt = deriveKeyImpl(privateKey, publicKey);
         } catch (Exception e) {
-            throw new IllegalStateException(e);
+            throw new ProviderException(e);
         }
         if (resultOpt.isEmpty()) {
             NamedCurve nc = CurveDB.lookup(publicKey.getParams());

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8238911
+ * @summary Check that ECPrivateKey's that are not ECPrivateKeyImpl can use
+ * ECDHKeyAgreement
+ */
+
+import javax.crypto.KeyAgreement;
+import java.math.BigInteger;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+
+public class ECKeyCheck {
+
+    public static final void main(String args[]) throws Exception {
+        ECGenParameterSpec spec = new ECGenParameterSpec("secp256r1");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(spec);
+
+        ECPrivateKey privKey = (ECPrivateKey) kpg.generateKeyPair().getPrivate();
+        ECPublicKey pubKey = (ECPublicKey) kpg.generateKeyPair().getPublic();
+        generateECDHSecret(privKey, pubKey);
+        generateECDHSecret(new newPrivateKeyImpl(privKey), pubKey);
+    }
+
+    private static byte[] generateECDHSecret(ECPrivateKey privKey,
+        ECPublicKey pubKey) throws Exception {
+        KeyAgreement ka = KeyAgreement.getInstance("ECDH");
+        ka.init(privKey);
+        ka.doPhase(pubKey, true);
+        return ka.generateSecret();
+    }
+
+    // Test ECPrivateKey class
+    private static class newPrivateKeyImpl implements ECPrivateKey {
+        private ECPrivateKey p;
+
+        newPrivateKeyImpl(ECPrivateKey p) {
+            this.p = p;
+        }
+
+        public BigInteger getS() {
+            return p.getS();
+        }
+
+        public byte[] getEncoded() {
+            return p.getEncoded();
+        }
+
+        public String getFormat() {
+            return p.getFormat();
+        }
+
+        public String getAlgorithm() {
+            return p.getAlgorithm();
+        }
+
+        public ECParameterSpec getParams() {
+            return p.getParams();
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I need a code review of this fix that should allow ECPrivateKey interface objects to be used with generateSecret().  This bug was hidden by the native EC library, that now is gone.  There are some changes to Exceptions that overlapped with this fix.  I chose to include them here.  All exceptions still throw ProviderException as they previously had, but the exceptions are wrapping InvalidKeyException.

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261502](https://bugs.openjdk.java.net/browse/JDK-8261502): ECDHKeyAgreement no longer works with alternate impl of ECPrivateKey interface


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2533/head:pull/2533`
`$ git checkout pull/2533`
