### PR TITLE
JDK-8261609: remove remnants of XML-driven builders

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -107,16 +107,6 @@ public abstract class BaseConfiguration {
     public TagletManager tagletManager;
 
     /**
-     * The path to the builder XML input file.
-     */
-    public String builderXMLPath;
-
-    /**
-     * The default path to the builder XML.
-     */
-    public static final String DEFAULT_BUILDER_XML = "resources/doclet.xml";
-
-    /**
      * The meta tag keywords instance.
      */
     public MetaKeywords metakeywords;
@@ -605,18 +595,6 @@ public abstract class BaseConfiguration {
      * @return the {@link WriterFactory} for the doclet.
      */
     public abstract WriterFactory getWriterFactory();
-
-    /**
-     * Return the input stream to the builder XML.
-     *
-     * @return the input steam to the builder XML.
-     * @throws DocFileIOException when the given XML file cannot be found or opened.
-     */
-    public InputStream getBuilderXML() throws DocFileIOException {
-        return builderXMLPath == null ?
-                BaseConfiguration.class.getResourceAsStream(DEFAULT_BUILDER_XML) :
-                DocFile.createFileForInput(this, builderXMLPath).openInputStream();
-    }
 
     /**
      * Return the Locale for this document.


### PR DESCRIPTION
Small change to remove some long-dead code, related to a long-dead feature to configure the generated output by means of XML files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261609](https://bugs.openjdk.java.net/browse/JDK-8261609): remove remnants of XML-driven builders


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2534/head:pull/2534`
`$ git checkout pull/2534`
