### PR TITLE
JDK-8261623: reference to javac internals in Extern class

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -198,6 +198,17 @@ public class WorkArounds {
         return elementUtils.getTypeElement(className);
     }
 
+
+    // TODO: The following should be replaced by a new method such as Elements.isAutomaticModule
+    public boolean isAutomaticModule(ModuleElement me) {
+        if (me == null) {
+            return false;
+        } else {
+            ModuleSymbol msym = (ModuleSymbol) me;
+            return (msym.flags() & Flags.AUTOMATIC_MODULE) != 0;
+        }
+    }
+
     // TODO:  need to re-implement this using j.l.m. correctly!, this has
     //        implications on testInterface, the note here is that javac's supertype
     //        does the right thing returning Parameters in scope.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -200,6 +200,7 @@ public class WorkArounds {
 
 
     // TODO: The following should be replaced by a new method such as Elements.isAutomaticModule
+    // see JDK-8261625
     public boolean isAutomaticModule(ModuleElement me) {
         if (me == null) {
             return false;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
@@ -47,8 +47,6 @@ import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.DocumentationTool;
 
-import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import jdk.javadoc.doclet.Reporter;
 import jdk.javadoc.internal.doclets.toolkit.AbstractDoclet;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
@@ -573,7 +571,7 @@ public class Extern {
                 return DocletConstants.DEFAULT_ELEMENT_NAME;
             } else if (moduleName == null) {
                 // suppress the warning message in the case of automatic modules
-                if (!isAutomaticModule(me) && issueWarning) {
+                if (!configuration.workArounds.isAutomaticModule(me) && issueWarning) {
                     configuration.getReporter().print(Kind.WARNING,
                             resources.getText("doclet.linkMismatch_ModuleLinkedtoPackage", path));
                 }
@@ -582,16 +580,6 @@ public class Extern {
             }
         }
         return moduleName == null ? DocletConstants.DEFAULT_ELEMENT_NAME : moduleName;
-    }
-
-    // The following should be replaced by a new method such as Elements.isAutomaticModule
-    private boolean isAutomaticModule(ModuleElement me) {
-        if (me == null) {
-            return false;
-        } else {
-            ModuleSymbol msym = (ModuleSymbol) me;
-            return (msym.flags() & Flags.AUTOMATIC_MODULE) != 0;
-        }
     }
 
     public boolean isUrl (String urlCandidate) {


### PR DESCRIPTION
Trivial patch to move some code that accesses javac-internals into the `WorkArounds` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261623](https://bugs.openjdk.java.net/browse/JDK-8261623): reference to javac internals in Extern class


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2537/head:pull/2537`
`$ git checkout pull/2537`
