### PR TITLE
8261621: Delegate Unicode history from JLS to j.l.Character

### DIFF
--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,42 @@ import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
  * <a href="http://www.unicode.org">http://www.unicode.org</a>.
  * <p>
  * Character information is based on the Unicode Standard, version 13.0.
- *
+ * <p>
+ * The Java platform has supported different versions of the Unicode
+ * Standard over time. Upgrades to newer versions of the Unicode Standard
+ * occurred in the following Java releases, each indicating the new version:
+ * <p>
+ * <table class="striped">
+ * <caption style="display:none">Shows Java releases and supported Unicode versions</caption>
+ * <thead>
+ * <tr><th scope="col">Java release</th>
+ *     <th scope="col">Unicode version</th></tr>
+ * </thead>
+ * <tbody>
+ * <tr><td>Java SE 15</td>
+ *     <td>Unicode 13.0</td></tr>
+ * <tr><td>Java SE 13</td>
+ *     <td>Unicode 12.1</td></tr>
+ * <tr><td>Java SE 12</td>
+ *     <td>Unicode 11.0</td></tr>
+ * <tr><td>Java SE 11</td>
+ *     <td>Unicode 10.0</td></tr>
+ * <tr><td>Java SE 9</td>
+ *     <td>Unicode 8.0</td></tr>
+ * <tr><td>Java SE 8</td>
+ *     <td>Unicode 6.2</td></tr>
+ * <tr><td>Java SE 7</td>
+ *     <td>Unicode 6.0</td></tr>
+ * <tr><td>Java SE 5.0</td>
+ *     <td>Unicode 4.0</td></tr>
+ * <tr><td>Java SE 1.4</td>
+ *     <td>Unicode 3.0</td></tr>
+ * <tr><td>JDK 1.1</td>
+ *     <td>Unicode 2.0</td></tr>
+ * <tr><td>JDK 1.0.2</td>
+ *     <td>Unicode 1.1.5</td></tr>
+ * </tbody>
+ * </table>
  * <h2><a id="unicode">Unicode Character Representations</a></h2>
  *
  * <p>The {@code char} data type (and therefore the value that a

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -98,6 +98,8 @@ import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
  *     <td>Unicode 1.1.5</td></tr>
  * </tbody>
  * </table>
+ * Variations from these base Unicode versions, such as recognized appendixes,
+ * are documented elsewhere.
  * <h2><a id="unicode">Unicode Character Representations</a></h2>
  *
  * <p>The {@code char} data type (and therefore the value that a

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -67,7 +67,6 @@ import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
  * The Java platform has supported different versions of the Unicode
  * Standard over time. Upgrades to newer versions of the Unicode Standard
  * occurred in the following Java releases, each indicating the new version:
- * <p>
  * <table class="striped">
  * <caption style="display:none">Shows Java releases and supported Unicode versions</caption>
  * <thead>


### PR DESCRIPTION
Please review this doc fix to j.l.Character, which now includes the table of the history of supported Unicode versions. A corresponding CSR will be filed accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261621](https://bugs.openjdk.java.net/browse/JDK-8261621): Delegate Unicode history from JLS to j.l.Character


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 5560a4cf96ae4816b4bf912bb8a40a64ea56e76d
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to b026b5eb63a3ccddf3faacbc65f0e0b69d78ac79
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to b94b41c8e0c34cb3f520dbcf72d01019c0467f5d
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2538/head:pull/2538`
`$ git checkout pull/2538`
