### PR TITLE
JDK-8261601:  free memory in early return in Java_sun_nio_ch_sctp_SctpChannelImpl_receive0

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -475,6 +475,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_receive0
                 iov->iov_len = SCTP_NOTIFICATION_SIZE - rv;
                 if ((rv = recvmsg(fd, msg, flags)) < 0) {
                     handleSocketError(env, errno);
+                    free(newBuf);
                     return 0;
                 }
                 bufp = newBuf;


### PR DESCRIPTION
There seems to be an early return in Java_sun_nio_ch_sctp_SctpChannelImpl_receive0 that misses freeing memory.

Sonar reports :
https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=c&open=AXck8Cl0BBG2CXpcnjFu&resolved=false&severities=BLOCKER&types=BUG

Potential leak of memory pointed to by 'newBuf'
I adjusted  the early return and added freeing memory .


Btw. while  adjusting  Java_sun_nio_ch_sctp_SctpChannelImpl_receive0  , I started  to wonder what happens to the allocated memory in  the same file in handleSendFailed  (  if ((addressP = malloc(dataLength)) == NULL)   )   in early return cases  incl. the CHECK_NULL , is there some deallocation missing there too ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261601](https://bugs.openjdk.java.net/browse/JDK-8261601): free memory in early return in Java_sun_nio_ch_sctp_SctpChannelImpl_receive0


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2540/head:pull/2540`
`$ git checkout pull/2540`
