### PR TITLE
8261309: Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/cardTableBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/cardTableBarrierSetAssembler_aarch64.cpp
@@ -46,7 +46,6 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 
   if (UseCondCardMark) {
     Label L_already_dirty;
-    __ membar(Assembler::StoreLoad);
     __ ldrb(rscratch2,  Address(obj, rscratch1));
     __ cbz(rscratch2, L_already_dirty);
     __ strb(zr, Address(obj, rscratch1));


### PR DESCRIPTION
Hi all,

  can I have reviews for this (tiny) change that removes the last (unconditional) StoreLoad memory barrier for Serial/Parallel GC that has apparently been forgotten to be made conditional on `CardTable::scanned_concurrently()` just removed in [JDK-8260941](https://bugs.openjdk.java.net/browse/JDK-8260941) ?

Thanks,
  Thomas

Testing: automatic compilation via github actions, but this is a quite straightforward removal of a single line...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261309](https://bugs.openjdk.java.net/browse/JDK-8261309): Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2541/head:pull/2541`
`$ git checkout pull/2541`
