### PR TITLE
8252399: Update mapMulti documentation to use type test pattern instead of instanceof once JEP 375 exits preview

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -386,8 +386,8 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * <pre>{@code
      *     Stream<Number> numbers = ... ;
      *     List<Integer> integers = numbers.<Integer>mapMulti((number, consumer) -> {
-     *             if (number instanceof Integer)
-     *                 consumer.accept((Integer) number);
+     *             if (number instanceof Integer i)
+     *                 consumer.accept(i);
      *         })
      *         .collect(Collectors.toList());
      * }</pre>
@@ -397,8 +397,8 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * <pre>{@code
      * class C {
      *     static void expandIterable(Object e, Consumer<Object> c) {
-     *         if (e instanceof Iterable) {
-     *             for (Object ie: (Iterable<?>) e) {
+     *         if (e instanceof Iterable elements) {
+     *             for (Object ie : elements) {
      *                 expandIterable(ie, c);
      *             }
      *         } else if (e != null) {

--- a/test/jdk/java/util/stream/examples/JavadocExamples.java
+++ b/test/jdk/java/util/stream/examples/JavadocExamples.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/*
+ * THE CONTENTS OF THIS FILE HAVE TO BE IN SYNC WITH THE EXAMPLES USED IN THE
+ * JAVADOC.
+ *
+ * @test
+ * @compile JavadocExamples.java
+ * @summary Checks to ensure example code displayed in the API documentation of
+ *  java/util/Stream compiles correctly.
+ */
+public class JavadocExamples {
+
+    public void fromMapMulti() {
+        // Number/Integer Example
+        Stream<Number> numbers = Stream.of(1, 2, 3.0);
+        List<Integer> integers = numbers.<Integer>mapMulti((number, consumer) -> {
+                    if (number instanceof Integer i)
+                        consumer.accept(i);
+                })
+                .collect(Collectors.toList());
+
+        // Expand Iterable Example
+        Consumer<Object> c = null;
+        Object e = List.of(1, 2, 3);
+        if (e instanceof Iterable elements) {
+            for (Object ie : elements) {
+                expandIterable(ie, c);
+            }
+        } else if (e != null) {
+            c.accept(e);
+        }
+    }
+    private void expandIterable(Object o, Consumer<Object> c) { }
+}
+
+
+
+


### PR DESCRIPTION
Hi,

Could someone please review my changeset for JDK-8252399: 'Update mapMulti documentation to use type test pattern instead of instanceof once JEP 375 exits preview' ?

This change updates the example code displayed in the API documentation for mapMulti to use the type test pattern introduced in [JEP375](https://openjdk.java.net/jeps/375).

Kind regards,
Patrick