### PR TITLE
8242032: G1 region remembered sets may contain non-coarse level PRTs for already coarsened regions

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -146,7 +146,7 @@ void OtherRegionsTable::add_reference(OopOrNarrowOopStar from, uint tid) {
   if (prt == NULL) {
     MutexLocker x(_m, Mutex::_no_safepoint_check_flag);
 
-    // Make sure region hasn't been coarsened by another thread.
+    // Rechecking if the region is coarsened, while holding the lock.
     if (is_region_coarsened(from_hrm_ind)) {
       assert(contains_reference(from), "We just found " PTR_FORMAT " in the Coarse table", p2i(from));
       return;

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -146,7 +146,7 @@ void OtherRegionsTable::add_reference(OopOrNarrowOopStar from, uint tid) {
   if (prt == NULL) {
     MutexLocker x(_m, Mutex::_no_safepoint_check_flag);
 
-    // Make sure region hasn't been coarsened by other thread.
+    // Make sure region hasn't been coarsened by another thread.
     if (is_region_coarsened(from_hrm_ind)) {
       assert(contains_reference(from), "We just found " PTR_FORMAT " in the Coarse table", p2i(from));
       return;


### PR DESCRIPTION
This fix adds a check for coarsened region in mutex guarded section, when adding a reference to a remembered set.

Haven't been able to produce a testcase -- please advice on how to, or if not necessary.

**Testing:**
* hs-tier, hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242032](https://bugs.openjdk.java.net/browse/JDK-8242032): G1 region remembered sets may contain non-coarse level PRTs for already coarsened regions


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 7398c89b2c1e6a660451088615dd0ddfe0257903
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2545/head:pull/2545`
`$ git checkout pull/2545`
