### PR TITLE
8261655: [PPC64] Build broken after JDK-8260941

### DIFF
--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
@@ -43,6 +43,8 @@
 
 void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr,
                                                                     Register count, Register preserve) {
+  CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(BarrierSet::barrier_set());
+  CardTable* ct = ctbs->card_table();
   assert_different_registers(addr, count, R0);
 
   Label Lskip_loop, Lstore_loop;


### PR DESCRIPTION
We have to add back `CardTable* ct = ctbs->card_table();` after it was removed with JDK-8260941.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261655](https://bugs.openjdk.java.net/browse/JDK-8261655): [PPC64] Build broken after JDK-8260941


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2548/head:pull/2548`
`$ git checkout pull/2548`
