### PR TITLE
8261660: AArch64: Race condition in stub code generation for LSE Atomics

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6772,7 +6772,9 @@ class StubGenerator: public StubCodeGenerator {
 
 #ifdef LINUX
 
+#if 0  // JDK-8261660: disabled for now.
     generate_atomic_entry_points();
+#endif
 
 #endif // LINUX
 


### PR DESCRIPTION
Temporary fix for race condition.

There's a narrow race condition in the code which generates LSE Atomic stubs and enables them for use by the runtime. DIsable LSE stub generation for now. 

/cc hotspot

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261660](https://bugs.openjdk.java.net/browse/JDK-8261660): AArch64: Race condition in stub code generation for LSE Atomics


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2553/head:pull/2553`
`$ git checkout pull/2553`
