### PR TITLE
8261661: gc/stress/TestReclaimStringsLeaksMemory.java fails because Reserved memory size is too big

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,9 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestReclaimStringsLeaksMemory {
 
-    // The amount of memory in kB reserved in the "Symbol" category that indicates a memory leak for
+    // The amount of memory in B reserved in the "Symbol" category that indicates a memory leak for
     // this test.
-    public static final int ReservedThreshold = 70000;
+    public static final int ReservedThreshold = 70000000;
 
     public static void main(String[] args) throws Exception {
         ArrayList<String> baseargs = new ArrayList<>(Arrays.asList("-Xms256M",
@@ -77,7 +77,7 @@ public class TestReclaimStringsLeaksMemory {
         }
 
         int reserved = Integer.parseInt(m.group(1));
-        Asserts.assertLT(reserved, ReservedThreshold, "Reserved memory size is " + reserved + "KB which is greater than or equal to " + ReservedThreshold + "KB indicating a memory leak");
+        Asserts.assertLT(reserved, ReservedThreshold, "Reserved memory size is " + reserved + "B which is greater than or equal to " + ReservedThreshold + "B indicating a memory leak");
 
         output.shouldHaveExitValue(0);
     }


### PR DESCRIPTION
A trivial fix to adjust a test to work with the fix from:

https://bugs.openjdk.java.net/browse/JDK-8261297 NMT: Final report should use scale 1

The idea for the fix came from @albertnetymk. Thanks!
The failure reproduces on my local MBP13 and does not reproduce
with this fix in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261661](https://bugs.openjdk.java.net/browse/JDK-8261661): gc/stress/TestReclaimStringsLeaksMemory.java fails because Reserved memory size is too big


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Contributors
 * Albert Mingkun Yang `<ayang@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2557/head:pull/2557`
`$ git checkout pull/2557`
