### PR TITLE
8260414: Remove unused set_single_threaded_mode() method in task executor

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -245,11 +245,6 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(
     process_phantom_refs(is_alive, keep_alive, complete_gc, task_executor, phase_times);
   }
 
-  if (task_executor != NULL) {
-    // Record the work done by the parallel workers.
-    task_executor->set_single_threaded_mode();
-  }
-
   phase_times->set_total_time_ms((os::elapsedTime() - start_time) * 1000);
 
   return stats;

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -633,9 +633,6 @@ public:
 
   // Executes a task using worker threads.
   virtual void execute(ProcessTask& task, uint ergo_workers) = 0;
-
-  // Switch to single threaded mode.
-  virtual void set_single_threaded_mode() { };
 };
 
 // Abstract reference processing task to execute.


### PR DESCRIPTION
This code is not used any more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260414](https://bugs.openjdk.java.net/browse/JDK-8260414): Remove unused set_single_threaded_mode() method in task executor


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2558/head:pull/2558`
`$ git checkout pull/2558`
