### PR TITLE
JDK-8260858: Implementation specific property xsltcIsStandalone for XSLTC Serializer

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -20,6 +20,7 @@
 
 package com.sun.org.apache.xml.internal.serializer;
 
+import com.sun.org.apache.xerces.internal.impl.Constants;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 import jdk.xml.internal.SecuritySupport;
@@ -70,7 +71,7 @@ import jdk.xml.internal.SecuritySupport;
  * @see SerializerFactory
  * @see Method
  * @see Serializer
- * @LastModified: Mar 2019
+ * @LastModified: Feb 2021
  */
 public final class OutputPropertiesFactory
 {
@@ -186,6 +187,13 @@ public final class OutputPropertiesFactory
      */
     public static final String ORACLE_IS_STANDALONE = "http://www.oracle.com/xml/is-standalone";
 
+    // standardized property, refer to the definition in java.xml module-info
+    public static final String JDK_IS_STANDALONE = Constants.ORACLE_JAXP_PROPERTY_PREFIX +
+            "xsltcIsStandalone";
+
+    // Corresponding System property
+    public static final String SP_IS_STANDALONE = "jdk.xml.xsltcIsStandalone";
+
     //************************************************************
     //*  PRIVATE CONSTANTS
     //************************************************************
@@ -212,7 +220,8 @@ public final class OutputPropertiesFactory
         "media-type",
         "{http://xml.apache.org/xalan}indent-amount",
         "{http://xml.apache.org/xalan}content-handler",
-        "{http://xml.apache.org/xalan}entities"
+        "{http://xml.apache.org/xalan}entities",
+        JDK_IS_STANDALONE
     };
 
     private static final String[] PROP_XML_VALUE = {
@@ -225,7 +234,8 @@ public final class OutputPropertiesFactory
         "text/xml",
         "0",
         "com.sun.org.apache.xml.internal.serializer.ToXMLStream",
-        "com/sun/org/apache/xml/internal/serializer/XMLEntities"
+        "com/sun/org/apache/xml/internal/serializer/XMLEntities",
+        "no"
     };
 
     private static final String[] PROP_HTML = {

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
@@ -494,7 +494,7 @@ abstract public class ToStream extends SerializerBase {
                     setIndentAmount(Integer.parseInt(val));
                 } else if (OutputKeys.INDENT.equals(name)) {
                     m_doIndent = val.endsWith("yes");
-                } else if ((DOMConstants.S_JDK_PROPERTIES_NS + DOMConstants.S_IS_STANDALONE)
+                } else if ((DOMConstants.NS_IS_STANDALONE)
                         .equals(name)) {
                     m_isStandalone = val.endsWith("yes");
                 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -49,7 +49,7 @@ import org.xml.sax.SAXException;
  *
  * This class is not a public API, it is public because it is used within Xalan.
  * @xsl.usage internal
- * @LastModified: Aug 2019
+ * @LastModified: Feb 2021
  */
 public final class ToUnknownStream extends SerializerBase
 {
@@ -655,6 +655,11 @@ public final class ToUnknownStream extends SerializerBase
         m_handler.setStandalone(standalone);
     }
 
+    @Override
+    public void setIsStandalone(boolean isStandalone) {
+       super.setIsStandalone(isStandalone);
+       m_handler.setIsStandalone(isStandalone);
+    }
     /**
      * Pass the call on to the underlying handler
      * @see org.xml.sax.ext.DeclHandler#attributeDecl(String, String, String, String, String)

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
@@ -358,10 +358,7 @@ final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
         fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL, "no");
 
         // JDK specific property isStandalone
-        String p = SecuritySupport.getSystemProperty(DOMConstants.SP_IS_STANDALONE);
-        if (p == null || p.isEmpty()) {
-            p = SecuritySupport.readJAXPProperty(DOMConstants.SP_IS_STANDALONE);
-        }
+        String p = SecuritySupport.getJAXPSystemProperty(DOMConstants.SP_IS_STANDALONE);
         // the system property is true only if it is "true" and false otherwise
         if (p != null && p.equals("true")) {
             fFeatures |= IS_STANDALONE;

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -174,6 +174,13 @@
  * {@code factory.setAttribute(name, value);}
  * </td>
  * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XSLTCSerializer">XSLTC Serializer</th>
+ * <td>XSLTC Serializer</td>
+ * <td>
+ * {@code Transformer transformer = TransformerFactory.newInstance().newTransformer();}<br>
+ * {@code transformer.setOutputProperty(name, value);}
+ * </td>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="DOMLS">DOMLS</th>
@@ -230,6 +237,28 @@
  * <td><a href="#DOMLS">DOMLS</a></td>
  * <td>17</td>
  * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XSLTCISSTANDALONE">xsltcIsStandalone</th>
+ * <td>indicates that the <a href="#XSLTCSerializer">XSLTC serializer</a> should
+ * treat the output as a standalone document. The property can be used to ensure
+ * a newline is written after the XML declaration. Unlike the property
+ * {@link javax.xml.transform.OutputKeys#OMIT_XML_DECLARATION OMIT_XML_DECLARATION},
+ * this property does not have an effect on whether an XML declaration should be
+ * written out.
+ * <p>
+ * This property behaves similar to that for <a href="#DOMLS">DOMLS</a> above,
+ * except that it is for the <a href="#XSLTCSerializer">XSLTC Serializer</a>
+ * and its value is a String.
+ * </td>
+ * <td>yes</td>
+ * <td>yes</td>
+ * <td>String</td>
+ * <th id="Value" scope="row" style="font-weight:normal">yes/no</th>
+ * <th id="Default" scope="row" style="font-weight:normal">no</th>
+ * <td>No</td>
+ * <td><a href="#XSLTCSerializer">XSLTC Serializer</a></td>
+ * <td>17</td>
+ * </tr>
  * </tbody>
  * </table>
  * <p>
@@ -241,8 +270,12 @@
  *
  * <p>
  * <b>[3]</b> The value must be exactly as listed in this table, case-sensitive.
- * The value type for the corresponding System Property is String. For boolean
- * type, the system property is true only if it is "true" and false otherwise.
+ * The value of the corresponding System Property is the String representation of
+ * the property value. If the type is boolean, the system property is true only
+ * if it is "true"; If the type is String, the system property is true only if
+ * it is exactly the same string representing the positive value (e.g. "yes" for
+ * {@code xsltcIsStandalone}); The system property is false otherwise.
+ *
  * <p>
  * <b>[4]</b> A value "yes" indicates the property is a Security Property. Refer
  * to the <a href="#ScopeAndOrder">Scope and Order</a> on how secure processing

--- a/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
@@ -20,9 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
 package common.prettyprint;
 
+import java.io.ByteArrayInputStream;
 import static jaxp.library.JAXPTestUtilities.clearSystemProperty;
 import static jaxp.library.JAXPTestUtilities.setSystemProperty;
 
@@ -66,7 +66,7 @@ import org.xml.sax.SAXException;
 
 /*
  * @test
- * @bug 6439439 8087303 8174025 8223291 8249867 8261209
+ * @bug 6439439 8087303 8174025 8223291 8249867 8261209 8260858
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true common.prettyprint.PrettyPrintTest
  * @run testng/othervm common.prettyprint.PrettyPrintTest
@@ -74,10 +74,15 @@ import org.xml.sax.SAXException;
  */
 @Listeners({jaxp.library.FilePolicy.class})
 public class PrettyPrintTest {
+
     private static final String DOM_FORMAT_PRETTY_PRINT = "format-pretty-print";
-    private static final String JDK_IS_STANDALONE =
-            "http://www.oracle.com/xml/jaxp/properties/isStandalone";
+    private static final String JDK_IS_STANDALONE
+            = "http://www.oracle.com/xml/jaxp/properties/isStandalone";
     private static final String SP_JDK_IS_STANDALONE = "jdk.xml.isStandalone";
+    private static final String XSLTC_IS_STANDALONE
+            = "http://www.oracle.com/xml/jaxp/properties/xsltcIsStandalone";
+    private static final String SP_XSLTC_IS_STANDALONE = "jdk.xml.xsltcIsStandalone";
+
     // pretty-print=true, isStandalone=true, linebreak added after header
     private static final String XML_LB
             = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sometag/>\n";
@@ -87,19 +92,32 @@ public class PrettyPrintTest {
     // pretty-print=false, isStandalone=true, linebreak added after header
     private static final String XML_PPFALSE_LB
             = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sometag/>";
+
+    private static final String XSL = "<?xml version=\"1.0\"?>\n"
+            + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n"
+            + "\n"
+            + "<!--Identity template, copies all content into the output -->\n"
+            + "    <xsl:template match=\"@*|node()\">\n"
+            + "        <xsl:copy>\n"
+            + "            <xsl:apply-templates select=\"@*|node()\"/>\n"
+            + "        </xsl:copy>\n"
+            + "    </xsl:template>\n"
+            + "\n"
+            + "</xsl:stylesheet>";
+
     /*
      * test CDATA, elements only, text and element, xml:space property, mixed
      * node types.
      */
     @DataProvider(name = "xml-data")
     public Object[][] xmlData() throws Exception {
-        return new Object[][] {
-                { "xmltest1.xml", "xmltest1.out" },
-                { "xmltest2.xml", "xmltest2.out" },
-                { "xmltest3.xml", "xmltest3.out" },
-                { "xmltest4.xml", "xmltest4.out" },
-                { "xmltest6.xml", "xmltest6.out" },
-                { "xmltest8.xml", "xmltest8.out" } };
+        return new Object[][]{
+            {"xmltest1.xml", "xmltest1.out"},
+            {"xmltest2.xml", "xmltest2.out"},
+            {"xmltest3.xml", "xmltest3.out"},
+            {"xmltest4.xml", "xmltest4.out"},
+            {"xmltest6.xml", "xmltest6.out"},
+            {"xmltest8.xml", "xmltest8.out"}};
     }
 
     /*
@@ -111,16 +129,38 @@ public class PrettyPrintTest {
     Object[][] getData() throws Exception {
         return new Object[][]{
             // pretty-print = true
-            {true, false, true, true, XML_LB},       //set System property = true
+            {true, false, true, true, XML_LB}, //set System property = true
+
             {true, false, true, false, XML_PPTRUE_NOLB}, //set System property = false
-            {true, true, false, true, XML_LB},       //set property = true
+            {true, true, false, true, XML_LB}, //set property = true
             {true, true, false, false, XML_PPTRUE_NOLB}, //set property = false
             {true, false, false, false, XML_PPTRUE_NOLB},//default
 
             // pretty-print = false
             {false, false, true, true, XML_PPFALSE_LB}, //System property = true
-            {false, true, false, true, XML_PPFALSE_LB}, //set property = true
+            {false, true, false, true, XML_PPFALSE_LB} //set property = true
+        };
+    }
 
+    /*
+     * Bug: 8249867 8260858
+     * DataProvider: for testing the xsltcIsStandalone property
+     * Data columns: xsl, pretty-print, property, system property, value, expected result
+     */
+    @DataProvider(name = "dataWithTemplate")
+    Object[][] getDataWTemplate() throws Exception {
+        return new Object[][]{
+            // pretty-print = true
+            {XSL, true, false, true, true, XML_LB}, //set System property = true
+
+            {XSL, true, false, true, false, XML_PPTRUE_NOLB}, //set System property = false
+            {XSL, true, true, false, true, XML_LB}, //set property = true
+            {XSL, true, true, false, false, XML_PPTRUE_NOLB}, //set property = false
+            {XSL, true, false, false, false, XML_PPTRUE_NOLB},//default
+
+            // pretty-print = false
+            {XSL, false, false, true, true, XML_PPFALSE_LB}, //System property = true
+            {XSL, false, true, false, true, XML_PPFALSE_LB} //set property = true
         };
     }
 
@@ -136,8 +176,34 @@ public class PrettyPrintTest {
             {"true", true},
             {"false", false},
             {"yes", false},
-            {"", false},
+            {"", false}
         };
+    }
+
+    /*
+     * Bug: 8260858
+     * Verifies the use of the new property "xsltcIsStandalone" and the
+     * corresponding System property "jdk.xml.xsltcIsStandalone".
+     */
+    @Test(dataProvider = "setting")
+    public void testIsStandalone_XSLTC(boolean pretty, boolean p, boolean sp,
+            boolean val, String expected)
+            throws Exception {
+        String result = transform(null, expected, false, pretty, p, sp, val);
+        Assert.assertEquals(result, expected);
+    }
+
+    /*
+     * Bug: 8260858
+     * Samiliar to testIsStandalone_XSLTC, except that the transformer is created
+     * from a template.
+     */
+    @Test(dataProvider = "dataWithTemplate")
+    public void testIsStandalone_Template(String xsl, boolean pretty, boolean p,
+            boolean sp, boolean val, String expected)
+            throws Exception {
+        String result = transform(xsl, expected, false, pretty, p, sp, val);
+        Assert.assertEquals(result, expected);
     }
 
     /*
@@ -157,7 +223,7 @@ public class PrettyPrintTest {
             setSystemProperty(SP_JDK_IS_STANDALONE, Boolean.toString(val));
         }
         Document document = getDocument();
-        DOMImplementationLS impl = (DOMImplementationLS)document.getImplementation();
+        DOMImplementationLS impl = (DOMImplementationLS) document.getImplementation();
         LSSerializer ser = impl.createLSSerializer();
         DOMConfiguration config = ser.getDomConfig();
         if (pretty) {
@@ -265,9 +331,9 @@ public class PrettyPrintTest {
      */
     @DataProvider(name = "xml-data-whitespace-ls")
     public Object[][] whitespaceLS() throws Exception {
-        return new Object[][] {
-                { "xmltest5.xml", "xmltest5ls.out" },
-                { "xmltest7.xml", "xmltest7ls.out" } };
+        return new Object[][]{
+            {"xmltest5.xml", "xmltest5ls.out"},
+            {"xmltest7.xml", "xmltest7ls.out"}};
     }
 
     /*
@@ -294,9 +360,9 @@ public class PrettyPrintTest {
      */
     @DataProvider(name = "xml-data-whitespace-xslt")
     public Object[][] whitespaceXSLT() throws Exception {
-        return new Object[][] {
-                { "xmltest5.xml", "xmltest5xslt.out" },
-                { "xmltest7.xml", "xmltest7xslt.out" } };
+        return new Object[][]{
+            {"xmltest5.xml", "xmltest5xslt.out"},
+            {"xmltest7.xml", "xmltest7xslt.out"}};
     }
 
     /*
@@ -324,15 +390,15 @@ public class PrettyPrintTest {
      */
     @DataProvider(name = "html-data")
     public Object[][] htmlData() throws Exception {
-        return new Object[][] {
-            { "htmltest1.xml", "htmltest1.out" },
-            { "htmltest2.xml", "htmltest2.out" },
-            { "htmltest3.xml", "htmltest3.out" },
-            { "htmltest4.xml", "htmltest4.out" },
-            { "htmltest5.xml", "htmltest5.out" },
-            { "htmltest6.xml", "htmltest6.out" },
+        return new Object[][]{
+            {"htmltest1.xml", "htmltest1.out"},
+            {"htmltest2.xml", "htmltest2.out"},
+            {"htmltest3.xml", "htmltest3.out"},
+            {"htmltest4.xml", "htmltest4.out"},
+            {"htmltest5.xml", "htmltest5.out"},
+            {"htmltest6.xml", "htmltest6.out"},
             /* @bug 8174025, test whitespace between inline elements */
-            { "htmltest7.xml", "htmltest7.out" } };
+            {"htmltest7.xml", "htmltest7.out"}};
     }
 
     /*
@@ -366,9 +432,9 @@ public class PrettyPrintTest {
      */
     @Test
     public void testDisableOutputEscaping() throws Exception {
-        final String xsl ="generate-catalog.xsl";
-        final String xml ="simple-entity-resolver-config.xml";
-        final String expectedOutput ="simple-entity-resolver-config-transformed.xml";
+        final String xsl = "generate-catalog.xsl";
+        final String xml = "simple-entity-resolver-config.xml";
+        final String expectedOutput = "simple-entity-resolver-config-transformed.xml";
         TransformerFactory factory = TransformerFactory.newInstance();
         Transformer transformer = factory.newTemplates(
                 new StreamSource(new StringReader(read(xsl)))).newTransformer();
@@ -388,25 +454,25 @@ public class PrettyPrintTest {
         final String XML_DOCUMENT = "<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n"
                 + "<hello>before child element<child><children/><children/></child>"
                 + "after child element</hello>";
-        /**JDK-8035467
-         * no newline in default output
+        /**
+         * JDK-8035467 no newline in default output
          */
-        final String XML_DOCUMENT_DEFAULT_PRINT =
-                "<?xml version=\"1.0\" encoding=\"UTF-16\"?>"
+        final String XML_DOCUMENT_DEFAULT_PRINT
+                = "<?xml version=\"1.0\" encoding=\"UTF-16\"?>"
                 + "<hello>"
                 + "before child element"
                 + "<child><children/><children/></child>"
                 + "after child element</hello>";
 
-        final String XML_DOCUMENT_PRETTY_PRINT =
-                "<?xml version=\"1.0\" encoding=\"UTF-16\"?><hello>\n" +
-                "    before child element\n" +
-                "    <child>\n" +
-                "        <children/>\n" +
-                "        <children/>\n" +
-                "    </child>\n" +
-                "    after child element\n" +
-                "</hello>\n";
+        final String XML_DOCUMENT_PRETTY_PRINT
+                = "<?xml version=\"1.0\" encoding=\"UTF-16\"?><hello>\n"
+                + "    before child element\n"
+                + "    <child>\n"
+                + "        <children/>\n"
+                + "        <children/>\n"
+                + "    </child>\n"
+                + "    after child element\n"
+                + "</hello>\n";
 
         // it all begins with a Document
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -443,12 +509,12 @@ public class PrettyPrintTest {
         DOMConfiguration domConfiguration = lsSerializer.getDomConfig();
 
         // query current configuration
-        Boolean defaultFormatPrettyPrint =
-                (Boolean) domConfiguration.getParameter(DOM_FORMAT_PRETTY_PRINT);
-        Boolean canSetFormatPrettyPrintFalse =
-                (Boolean) domConfiguration.canSetParameter(DOM_FORMAT_PRETTY_PRINT, Boolean.FALSE);
-        Boolean canSetFormatPrettyPrintTrue =
-                (Boolean) domConfiguration.canSetParameter(DOM_FORMAT_PRETTY_PRINT, Boolean.TRUE);
+        Boolean defaultFormatPrettyPrint
+                = (Boolean) domConfiguration.getParameter(DOM_FORMAT_PRETTY_PRINT);
+        Boolean canSetFormatPrettyPrintFalse
+                = (Boolean) domConfiguration.canSetParameter(DOM_FORMAT_PRETTY_PRINT, Boolean.FALSE);
+        Boolean canSetFormatPrettyPrintTrue
+                = (Boolean) domConfiguration.canSetParameter(DOM_FORMAT_PRETTY_PRINT, Boolean.TRUE);
 
         System.out.println(DOM_FORMAT_PRETTY_PRINT + " default/can set false/can set true = "
                 + defaultFormatPrettyPrint + "/"
@@ -501,8 +567,8 @@ public class PrettyPrintTest {
 
     private String serializerWrite(Node xml, boolean pretty) throws Exception {
         DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
-        DOMImplementationLS domImplementation =
-                (DOMImplementationLS) registry.getDOMImplementation("LS");
+        DOMImplementationLS domImplementation
+                = (DOMImplementationLS) registry.getDOMImplementation("LS");
         StringWriter writer = new StringWriter();
         LSOutput formattedOutput = domImplementation.createLSOutput();
         formattedOutput.setCharacterStream(writer);
@@ -517,6 +583,14 @@ public class PrettyPrintTest {
         Transformer transformer = getTransformer(false, pretty);
         StringWriter writer = new StringWriter();
         transformer.transform(new DOMSource(xml), new StreamResult(writer));
+        return writer.toString();
+    }
+
+    private String transform(String xsl, String xml, boolean omit, boolean pretty, boolean p, boolean sp, boolean standalone)
+            throws Exception {
+        Transformer transformer = getTransformer(xsl, false, omit, pretty, p, sp, standalone);
+        StringWriter writer = new StringWriter();
+        transformer.transform(new StreamSource(new StringReader(xml)), new StreamResult(writer));
         return writer.toString();
     }
 
@@ -589,12 +663,41 @@ public class PrettyPrintTest {
     }
 
     private Transformer getTransformer(boolean html, boolean pretty) throws Exception {
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        return getTransformer(null, html, true, pretty, false, false, false);
+    }
+
+    private Transformer getTransformer(String xsl) throws Exception {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        if (xsl == null) {
+            return tf.newTransformer();
+        }
+
+        return tf.newTemplates(
+                new StreamSource(new ByteArrayInputStream(xsl.getBytes())))
+                .newTransformer();
+    }
+
+    private Transformer getTransformer(String xsl, boolean html, boolean omit,
+            boolean pretty, boolean p, boolean sp, boolean standalone)
+            throws Exception {
+        if (sp) {
+            setSystemProperty(SP_XSLTC_IS_STANDALONE, standalone ? "yes" : "no");
+        }
+        Transformer transformer = getTransformer(xsl);
         transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-        if (html)
+        if (omit) {
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        }
+        if (html) {
             transformer.setOutputProperty(OutputKeys.METHOD, "html");
+        }
         transformer.setOutputProperty(OutputKeys.INDENT, pretty ? "yes" : "no");
+        if (p && !sp) {
+            transformer.setOutputProperty(XSLTC_IS_STANDALONE, standalone ? "yes" : "no");
+        }
+        if (sp) {
+            clearSystemProperty(SP_XSLTC_IS_STANDALONE);
+        }
         return transformer;
     }
 
@@ -616,7 +719,7 @@ public class PrettyPrintTest {
 
     private DOMImplementationLS getImpl() throws Exception {
         Document document = getDocument();
-        return (DOMImplementationLS)document.getImplementation();
+        return (DOMImplementationLS) document.getImplementation();
     }
 
     private DOMConfiguration getConfig() throws Exception {


### PR DESCRIPTION
Adds a property similar to 'isStandalone' in JDK-8249867.

Please note that the test received an auto-format. The material changes were the two tests marked with bug id 8260858 and related data and methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260858](https://bugs.openjdk.java.net/browse/JDK-8260858): Implementation specific property xsltcIsStandalone for XSLTC Serializer


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2559/head:pull/2559`
`$ git checkout pull/2559`
