### PR TITLE
8261675: ObjectValue::set_visited(bool) sets _visited false

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -159,11 +159,11 @@ void ObjectValue::read_object(DebugInfoReadStream* stream) {
 }
 
 void ObjectValue::write_on(DebugInfoWriteStream* stream) {
-  if (_visited) {
+  if (is_visited()) {
     stream->write_int(OBJECT_ID_CODE);
     stream->write_int(_id);
   } else {
-    _visited = true;
+    set_visited(true);
     stream->write_int(is_auto_box() ? AUTO_BOX_OBJECT_CODE : OBJECT_CODE);
     stream->write_int(_id);
     _klass->write_on(stream);

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -149,7 +149,7 @@ class ObjectValue: public ScopeValue {
   bool                        is_visited() const        { return _visited; }
 
   void                        set_value(oop value);
-  void                        set_visited(bool visited) { _visited = false; }
+  void                        set_visited(bool visited) { _visited = visited; }
 
   // Serialization of debugging information
   void read_object(DebugInfoReadStream* stream);


### PR DESCRIPTION
The setter is error-prone. it unconditionally sets _visited false.
this patch stores the argument to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261675](https://bugs.openjdk.java.net/browse/JDK-8261675): ObjectValue::set_visited(bool) sets _visited false


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2560/head:pull/2560`
`$ git checkout pull/2560`
