### PR TITLE
8261702:  ClhsdbFindPC can fail due to PointerFinder incorrectly thinking an address is in a .so

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -82,17 +82,6 @@ public class PointerFinder {
         }
     }
 
-    // Check if address is a native (C++) symbol
-    JVMDebugger dbg = VM.getVM().getDebugger();
-    CDebugger cdbg = dbg.getCDebugger();
-    if (cdbg != null) {
-        loc.loadObject = cdbg.loadObjectContainingPC(a);
-        if (loc.loadObject != null) {
-            loc.nativeSymbol = loc.loadObject.closestSymbolToPC(a);
-            return loc;
-        }
-    }
-
     // Check if address is in the java heap.
     CollectedHeap heap = VM.getVM().getUniverse().heap();
     if (heap instanceof GenCollectedHeap) {
@@ -196,6 +185,19 @@ public class PointerFinder {
           return loc;
         }
       }
+    }
+
+    // Check if address is a native (C++) symbol. Do this last because we don't always
+    // do a good job of computing if an address is actually within a native lib, and sometimes
+    // an address outside of a lib will be found as inside.
+    JVMDebugger dbg = VM.getVM().getDebugger();
+    CDebugger cdbg = dbg.getCDebugger();
+    if (cdbg != null) {
+        loc.loadObject = cdbg.loadObjectContainingPC(a);
+        if (loc.loadObject != null) {
+            loc.nativeSymbol = loc.loadObject.closestSymbolToPC(a);
+            return loc;
+        }
     }
 
     // Fall through; have to return it anyway.


### PR DESCRIPTION
See bug description for details. The fix is simple and just a matter of moving some code to avoid incorrectly thinking an address is in a .so when it is in some other area of VM memory that occurs just after the last .so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261702](https://bugs.openjdk.java.net/browse/JDK-8261702): ClhsdbFindPC can fail due to PointerFinder incorrectly thinking an address is in a .so


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2562/head:pull/2562`
`$ git checkout pull/2562`
