### PR TITLE
8260291: The case instruction is not visible in dark mode

### DIFF
--- a/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
+++ b/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
@@ -101,7 +101,6 @@ public class TestJSpinnerPressUnpress {
         JTextArea instructionTextArea = new JTextArea();
         instructionTextArea.setText(INSTRUCTIONS);
         instructionTextArea.setEditable(false);
-        instructionTextArea.setBackground(Color.white);
 
         gbc.gridx = 0;
         gbc.gridy = 1;

--- a/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
+++ b/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8234733
+ * @bug 8234733 8260291
  * @summary Verify that JSpinner up/down button rendering is changed
  *           according to pressed state in GTKLookAndFeel
  * @run main/manual TestJSpinnerPressUnpress

--- a/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
+++ b/test/jdk/javax/swing/JSpinner/TestJSpinnerPressUnpress.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8234733 8260291
+ * @bug 8234733
  * @summary Verify that JSpinner up/down button rendering is changed
  *           according to pressed state in GTKLookAndFeel
  * @run main/manual TestJSpinnerPressUnpress


### PR DESCRIPTION
Please review a trivial test only fix.

This is a GTKL&F specific manual test and create an instruction panel containing JTextArea. The JTextArea background color is hardcoded as white color, which is causing issues on dark mode in Ubuntu 20.04 and Ubuntu 20.10 as the text color is also white. The fix is to remove the hardcoded white color as the JTextArea background color should be set by L&F and should not be hardcoded in test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260291](https://bugs.openjdk.java.net/browse/JDK-8260291): The case instruction is not visible in dark mode 


### Reviewers
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2564/head:pull/2564`
`$ git checkout pull/2564`
