### PR TITLE
8261692:  Bugs in clhsdb history support

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbHistory.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbHistory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Utils;
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8190198
+ * @bug 8217612
+ * @bug 8217845
+ * @summary Test clhsdb command line history support
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run main/othervm ClhsdbHistory
+ */
+
+public class ClhsdbHistory {
+
+    public static void testHistory() throws Exception {
+        System.out.println("Starting ClhsdbHistory basic test");
+
+        LingeredApp theApp = null;
+        try {
+            ClhsdbLauncher test = new ClhsdbLauncher();
+            theApp = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+
+            List<String> cmds = List.of(
+                    "echo true",
+                    "assert false",
+                    "!!",                 // !! repeats previous command
+                    "versioncheck !$",    // !$ is last argument from previous command
+                    "assert foo bar baz",
+                    "versioncheck !*",    // !* is all arguments from previous command
+                    "versioncheck !$ !$", // !$ !$ should result in "baz baz"
+                    "assert maybe never",
+                    "!!- !*",             // !!- is the previous command, minus the last arg
+                    "!echo",              // match previous echo command, with args
+                    "assert \\!foo",      // quote the ! so it is not used for command history expansion
+                    "!10",                // match the 10th command in the history, with args
+                    "history");
+
+            // Unfortunately we can't create a map table that maps the clhsdb commands above
+            // to the expected output because the commands as you see them above won't be in
+            // the output. Instead their expanded forms will. So instead we just rely on
+            // the history output looking as expected.
+            Map<String, List<String>> expStrMap = new HashMap<>();
+            expStrMap.put("history", List.of(
+                "0 echo true",    // issued by ClhsdbLauncher
+                "1 verbose true", // issued by ClhsdbLauncher
+                "2 echo true",
+                "3 assert false",
+                "4 assert false",
+                "5 versioncheck false",
+                "6 assert foo bar baz",
+                "7 versioncheck foo bar baz",
+                "8 versioncheck baz baz",
+                "9 assert maybe never",
+                "10 assert maybe maybe never",
+                "11 echo true",
+                "12 assert !foo",
+                "13 assert maybe maybe never",
+                "14 history"));
+
+            test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            LingeredApp.stopApp(theApp);
+        }
+        System.out.println("Test PASSED");
+    }
+
+    public static void main(String[] args) throws Exception {
+        testHistory();
+    }
+}


### PR DESCRIPTION
See the CR for a description of the 3 issues fixed. There's also a new test added. I'll explain the fix related to quoting the '!' here since it's not that obvious how it works.

There's a complex pattern called `historyPattern` that is used to find various uses of ! to do expansion of commands and arguments in the history

    static Pattern historyPattern = Pattern.compile("([\\\\]?)((!\\*)|(!\\$)|(!!-?)|(!-?[0-9][0-9]*)|(![a-zA-Z][^ ]*))");

I added the `([\\\\]?)` part to handle allowing a '!' to be quoted with a backslash so it will just be treated as a '!' instead of being used for history expansion. This part of the pattern basically says match 1 backslash if present. Yes, you need 4 backslashes to do this. javac will reduce it to two, and then the pattern compilation reduces it down to just one backslash (not to be used for quoting).

The above pattern for searching for the backslash before a '!' is in the first pattern grouping, and the part that matches on the '!' and what follows is in the 2nd pattern grouping. Thus the code I added checks if the first pattern grouping matches something (and at most it will match just one backslash), and if so then we eat it and don't treat the '!' that follows as a history expansion:

                    if (m.group(1).length() != 0) {
                        // This means we matched a `\` before the '!'. Don't do any history
                        // expansion in this case. Just capture what matched after the `\`.
                        result.append(m.group(2));
                        continue;
                    }

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261692](https://bugs.openjdk.java.net/browse/JDK-8261692): Bugs in clhsdb history support


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2565/head:pull/2565`
`$ git checkout pull/2565`
