### PR TITLE
8261711: Clhsdb "versioncheck true" throws NPE every time

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1157,7 +1157,7 @@ public class CommandProcessor {
                                 (System.getProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck") == null));
                 } else if (t.countTokens() == 1) {
                     if (Boolean.valueOf(t.nextToken()).booleanValue()) {
-                        System.setProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck", null);
+                        System.clearProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck");
                     } else {
                         System.setProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck", "true");
                     }


### PR DESCRIPTION
See CR for details. There's no test for `versioncheck`, and I don't think it's worth adding, especially for this trivial fix. Here's how I tested:
```
hsdb> versioncheck
versioncheck is true
hsdb> versioncheck false
hsdb> versioncheck
versioncheck is false
hsdb> versioncheck true
hsdb> versioncheck
versioncheck is true
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261711](https://bugs.openjdk.java.net/browse/JDK-8261711): Clhsdb "versioncheck true" throws NPE every time


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2566/head:pull/2566`
`$ git checkout pull/2566`
