### PR TITLE
8261098: Add clhsdb "findsym" command

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -68,7 +68,7 @@ class AutoJavaString {
 public:
   // check env->ExceptionOccurred() after ctor
   AutoJavaString(JNIEnv* env, jstring str)
-    : m_env(env), m_str(str), m_buf(env->GetStringUTFChars(str, NULL)) {
+    : m_env(env), m_str(str), m_buf(str == NULL ? NULL : env->GetStringUTFChars(str, NULL)) {
   }
 
   ~AutoJavaString() {
@@ -347,8 +347,8 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_l
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   // Note, objectName is ignored, and may in fact be NULL.
   // lookup_symbol will always search all objects/libs
-  //AutoJavaString objectName_cstr(env, objectName);
-  //CHECK_EXCEPTION_(0);
+  AutoJavaString objectName_cstr(env, objectName);
+  CHECK_EXCEPTION_(0);
   AutoJavaString symbolName_cstr(env, symbolName);
   CHECK_EXCEPTION_(0);
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2020, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -345,12 +345,14 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_l
   jlong addr;
   jboolean isCopy;
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
-  AutoJavaString objectName_cstr(env, objectName);
-  CHECK_EXCEPTION_(0);
+  // Note, objectName is ignored, and may in fact be NULL.
+  // lookup_symbol will always search all objects/libs
+  //AutoJavaString objectName_cstr(env, objectName);
+  //CHECK_EXCEPTION_(0);
   AutoJavaString symbolName_cstr(env, symbolName);
   CHECK_EXCEPTION_(0);
 
-  addr = (jlong) lookup_symbol(ph, objectName_cstr, symbolName_cstr);
+  addr = (jlong) lookup_symbol(ph, NULL, symbolName_cstr);
   return addr;
 }
 

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ class AutoJavaString {
 public:
   // check env->ExceptionOccurred() after ctor
   AutoJavaString(JNIEnv* env, jstring str)
-    : m_env(env), m_str(str), m_buf(env->GetStringUTFChars(str, nullptr)) {
+    : m_env(env), m_str(str), m_buf(str == nullptr ? nullptr : env->GetStringUTFChars(str, nullptr)) {
   }
 
   ~AutoJavaString() {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -82,6 +82,7 @@ public class ClhsdbFindPC {
 
     private static void testFindPC(boolean withXcomp, boolean withCore) throws Exception {
         try {
+            String linesep = System.getProperty("line.separator");
             String segvAddress = null;
             List<String> cmds = null;
             String cmdStr = null;
@@ -218,7 +219,7 @@ public class ClhsdbFindPC {
             String examineOutput = runTest(withCore, cmds, null);
             // Extract <value>.
             parts = examineOutput.split(tid + ": ");
-            String value = parts[1];
+            String value = parts[1].split(linesep)[0];
             // Use findpc on <value>. The output should look something like:
             //    Address 0x00007fed86f610b8: vtable for JavaThread + 0x10
             cmdStr = "findpc " + value;
@@ -229,11 +230,33 @@ public class ClhsdbFindPC {
             } else if (Platform.isOSX()) {
                 if (withCore) {
                     expStrMap.put(cmdStr, List.of("__ZTV10JavaThread"));
-                } else { // symbol lookups not supported with OSX live process
+                } else { // address -> symbol lookups not supported with OSX live process
                     expStrMap.put(cmdStr, List.of("In unknown location"));
                 }
             } else {
                 expStrMap.put(cmdStr, List.of("vtable for JavaThread"));
+            }
+            runTest(withCore, cmds, expStrMap);
+
+            // Run "findsym MaxJNILocalCapacity". The output should look something like:
+            //   0x00007eff8e1a0da0: <jdk-dir>/lib/server/libjvm.so + 0x1d81da0
+            String symbol = "MaxJNILocalCapacity";
+            cmds = List.of("findsym " + symbol);
+            String findsymOutput = runTest(withCore, cmds, null);
+            // Run findpc on the result of "findsym MaxJNILocalCapacity". The output
+            // should look something like:
+            //   Address 0x00007eff8e1a0da0: MaxJNILocalCapacity
+            parts = findsymOutput.split("findsym " + symbol + linesep);
+            parts = parts[1].split(":");
+            String findsymAddress = parts[0].split(linesep)[0];
+            cmdStr = "findpc " + findsymAddress;
+            cmds = List.of(cmdStr);
+            expStrMap = new HashMap<>();
+            if (Platform.isOSX() && !withCore) {
+                // address -> symbol lookups not supported with OSX live process
+                expStrMap.put(cmdStr, List.of("Address " + findsymAddress + ": In unknown location"));
+            } else {
+                expStrMap.put(cmdStr, List.of("Address " + findsymAddress + ": .*" + symbol));
             }
             runTest(withCore, cmds, expStrMap);
         } catch (SkippedException se) {


### PR DESCRIPTION
Add "findsym" to clhsdb. See the CR and CSR for details. The [CSR](https://bugs.openjdk.java.net/browse/JDK-8261101) still needs a reviewer.

There is a fix in LinuxDebuggerLocal_lookupByName0() to allow passing in NULL for the dso name. This is allowed, and in fact even not null it gets ignored. It is needed by the new findsym support in order for the following to work, which passes in null for the dso name:

`    Address addr = VM.getVM().getDebugger().lookup(null, symbol);`

There is one other somewhat unrelated fix in the test:

```
 -            String value = parts[1];
 +           String value = parts[1].split(linesep)[0];
```

This is suppose to capture just the value at the specified address, but it also captures the newline and some text after. The result if that when `findpc <value>` is executed, it also executes another command or two of garbage commands after that, which produce errors. They were not impacting the test, but were noticeable in the log. I first noticed it when similar code in the new part of the test had the same issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261098](https://bugs.openjdk.java.net/browse/JDK-8261098): Add clhsdb "findsym" command


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2567/head:pull/2567`
`$ git checkout pull/2567`
