### PR TITLE
8261607: SA attach is exceeding JNI Local Refs capacity

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2020, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -183,6 +183,8 @@ static void fillThreadsAndLoadObjects(JNIEnv* env, jobject this_obj, struct ps_p
     CHECK_EXCEPTION;
     env->CallBooleanMethod(threadList, listAdd_ID, thread);
     CHECK_EXCEPTION;
+    env->DeleteLocalRef(thread);
+    env->DeleteLocalRef(threadList);
   }
 
   // add load objects
@@ -205,6 +207,9 @@ static void fillThreadsAndLoadObjects(JNIEnv* env, jobject this_obj, struct ps_p
      CHECK_EXCEPTION;
      env->CallBooleanMethod(loadObjectList, listAdd_ID, loadObject);
      CHECK_EXCEPTION;
+     env->DeleteLocalRef(str);
+     env->DeleteLocalRef(loadObject);
+     env->DeleteLocalRef(loadObjectList);
   }
 }
 

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -965,6 +965,10 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__I(
     called from Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__Ljava_lang_String_2Ljava_lang_String_2 */
 static void fillLoadObjects(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) {
   int n = 0, i = 0;
+  jobject loadObjectList;
+
+  loadObjectList = (*env)->GetObjectField(env, this_obj, loadObjectList_ID);
+  CHECK_EXCEPTION;
 
   // add load objects
   n = get_num_libs(ph);
@@ -972,7 +976,6 @@ static void fillLoadObjects(JNIEnv* env, jobject this_obj, struct ps_prochandle*
      uintptr_t base;
      const char* name;
      jobject loadObject;
-     jobject loadObjectList;
      jstring nameString;
 
      base = get_lib_base(ph, i);
@@ -982,10 +985,10 @@ static void fillLoadObjects(JNIEnv* env, jobject this_obj, struct ps_prochandle*
      loadObject = (*env)->CallObjectMethod(env, this_obj, createLoadObject_ID,
                                             nameString, (jlong)0, (jlong)base);
      CHECK_EXCEPTION;
-     loadObjectList = (*env)->GetObjectField(env, this_obj, loadObjectList_ID);
-     CHECK_EXCEPTION;
      (*env)->CallBooleanMethod(env, loadObjectList, listAdd_ID, loadObject);
      CHECK_EXCEPTION;
+     (*env)->DeleteLocalRef(env, nameString);
+     (*env)->DeleteLocalRef(env, loadObject);
   }
 }
 

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -503,6 +503,7 @@ static bool addLoadObjects(JNIEnv* env, jobject obj) {
     env->CallVoidMethod(obj, addLoadObject_ID, strName, (jlong) params[u].Size,
                         (jlong) params[u].Base);
     CHECK_EXCEPTION_(false);
+    env->DeleteLocalRef(strName);
   }
 
   return true;
@@ -629,6 +630,7 @@ static bool addThreads(JNIEnv* env, jobject obj) {
 
     env->CallVoidMethod(obj, setThreadIntegerRegisterSet_ID, (jlong)ptrThreadIds[t], regs);
     CHECK_EXCEPTION_(false);
+    env->DeleteLocalRef(regs);
 
     ULONG sysId;
     COM_VERIFY_OK_(ptrIDebugSystemObjects->GetCurrentThreadSystemId(&sysId),

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -144,7 +144,7 @@ public class ClhsdbLauncher {
         System.out.println("Output: ");
         System.out.println(output);
 
-        // Make sure no -Xcheck:jni failures. WARNING: JNI local refs
+        // Make sure there are no -Xcheck:jni warnings.
         oa.shouldNotMatch("^WARNING: JNI local refs:.*$");
         oa.shouldNotMatch("^WARNING in native method:.*$");
         // This will detect most SA failures, including during the attach.

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,6 +144,9 @@ public class ClhsdbLauncher {
         System.out.println("Output: ");
         System.out.println(output);
 
+        // Make sure no -Xcheck:jni failures. WARNING: JNI local refs
+        oa.shouldNotMatch("^WARNING: JNI local refs:.*$");
+        oa.shouldNotMatch("^WARNING in native method:.*$");
         // This will detect most SA failures, including during the attach.
         oa.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
         // This will detect unexpected exceptions, like NPEs and asserts, that are caught

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -144,7 +144,7 @@ public class ClhsdbLauncher {
         System.out.println("Output: ");
         System.out.println(output);
 
-        // Make sure there are no -Xcheck:jni warnings.
+        // -Xcheck:jni might be set via TEST_VM_OPTS. Make sure there are no warnings.
         oa.shouldNotMatch("^WARNING: JNI local refs:.*$");
         oa.shouldNotMatch("^WARNING in native method:.*$");
         // This will detect most SA failures, including during the attach.


### PR DESCRIPTION
Delete some localrefs to avoid -Xcheck:jni warnings. See CR for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261607](https://bugs.openjdk.java.net/browse/JDK-8261607): SA attach is exceeding JNI Local Refs capacity


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2568/head:pull/2568`
`$ git checkout pull/2568`
