### PR TITLE
8261606: Surprising behavior of step over in String switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3885,7 +3885,9 @@ public class Lower extends TreeTranslator {
 
                 stmtList.append(switch2);
 
-                return make.Block(0L, stmtList.toList());
+                JCBlock res = make.Block(0L, stmtList.toList());
+                res.endpos = TreeInfo.endPos(tree);
+                return res;
             } else {
                 JCSwitchExpression switch2 = make.SwitchExpression(make.Ident(dollar_tmp), lb.toList());
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2821,6 +2821,7 @@ public class JavacParser implements Parser {
             accept(LBRACE);
             List<JCCase> cases = switchBlockStatementGroups();
             JCSwitch t = to(F.at(pos).Switch(selector, cases));
+            t.endpos = token.endPos;
             accept(RBRACE);
             return t;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -1246,6 +1246,8 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     public static class JCSwitch extends JCStatement implements SwitchTree {
         public JCExpression selector;
         public List<JCCase> cases;
+        /** Position of closing brace, optional. */
+        public int endpos = Position.NOPOS;
         protected JCSwitch(JCExpression selector, List<JCCase> cases) {
             this.selector = selector;
             this.cases = cases;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -427,6 +427,9 @@ public class TreeInfo {
             JCTry t = (JCTry) tree;
             return endPos((t.finalizer != null) ? t.finalizer
                           : (t.catchers.nonEmpty() ? t.catchers.last().body : t.body));
+        } else if (tree.hasTag(SWITCH) &&
+                   ((JCSwitch) tree).endpos != Position.NOPOS) {
+            return ((JCSwitch) tree).endpos;
         } else if (tree.hasTag(SWITCH_EXPRESSION) &&
                    ((JCSwitchExpression) tree).endpos != Position.NOPOS) {
             return ((JCSwitchExpression) tree).endpos;

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/StringSwitchBreaks.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/StringSwitchBreaks.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8261606
+ * @summary Tests a line number table attribute for language constructions in different containers.
+ * @library /tools/lib /tools/javac/lib ../lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox InMemoryFileManager TestBase
+ * @build LineNumberTestBase TestCase
+ * @run main StringSwitchBreaks
+ */
+
+import java.util.List;
+
+public class StringSwitchBreaks extends LineNumberTestBase {
+    public static void main(String[] args) throws Exception {
+        new StringSwitchBreaks().test();
+    }
+
+    public void test() throws Exception {
+        test(List.of(TEST_CASE));
+    }
+
+    private static final TestCase[] TEST_CASE = new TestCase[] {
+        new TestCase("""
+                     public class StringSwitchBreaks {                     // 1
+                         private void test(String s) {                     // 2
+                             if (s != null) {                              // 3
+                                 switch (s) {                              // 4
+                                     case "a":                             // 5
+                                         System.out.println("a");          // 6
+                                         break;                            // 7
+                                     default:                              // 8
+                                         System.out.println("default");    // 9
+                                 }                                         //10
+                             } else {                                      //11
+                                 System.out.println("null");               //12
+                             }                                             //13
+                         }                                                 //14
+                     }                                                     //15
+                     """,
+                     List.of(1, 3, 4, 6, 7, 9, 10, 12, 14),
+                     "StringSwitchBreaks")
+    };
+
+}


### PR DESCRIPTION
Consider code like:
```
public class Test {
    public static void main(String... args) {
        new Test().test("a");
    }
    private void test(String s) {
        if (s != null) {
            switch (s) {
                case "a":
                    System.out.println("a"); //breakpoint here, and continue with step-over
                    break;
                default:
                    System.out.println("default"); //the program counter will be shown here eventually
            }
        } else {
            System.out.println("null");
        }
    }
} 
```

Placing breakpoint at the marked line (with `System.out.println("a");`), running debugger and performing step-over, the execution eventually is shown to stop at the line with `System.out.println("default");`.

The reason for this is (roughly) because the switch-over-string is desugared into a block, but that block does not have an end position set. So the LineNumberTable point for the closing bracket of the block is not generated, and hence the last previous point is used, which is the last line of the last case (branch) of the switch.

The proposal is to set the end position for the synthetic block generated for the switch-over-string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261606](https://bugs.openjdk.java.net/browse/JDK-8261606): Surprising behavior of step over in String switch


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2569/head:pull/2569`
`$ git checkout pull/2569`
