### PR TITLE
8252883: AccessDeniedException caused by delayed file deletion on Windows

### DIFF
--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * @test
+ * @bug 8252883
+ * @summary tests the handling of AccessDeniedException due to delay in Windows deletion.
+ * @modules java.logging/java.util.logging:open
+ * @run main/othervm FileHandlerAccessTest process 20
+ * @run main/othervm FileHandlerAccessTest thread 20
+ * @author evwhelan
+ */
+
+public class FileHandlerAccessTest {
+    public static void main(String[] args){
+        if (!(args.length == 2 || args.length == 1)) {
+            System.out.println("Usage error: expects java FileHandlerAccessTest [process/thread] <count>");
+            System.exit(1);
+        }
+        else if (args.length == 2) {
+            var type = args[0];
+            var count = Integer.parseInt(args[1]);
+
+            for (var i = 0; i < count; i++) {
+                System.out.println("Testing with arguments: type=" + type + ", count="+count);
+                if (type.equals("process")) {
+                    new Thread(FileHandlerAccessTest::accessProcess).start();
+                }
+                else if (type.equals("thread")) {
+                    new Thread(FileHandlerAccessTest::access).start();
+                }
+            }
+        }
+        else {
+            access();
+        }
+    }
+
+    private static void access(){
+        try {
+            var handler = new FileHandler("sample%g.log", 1048576, 2, true);
+            handler.publish(new LogRecord(Level.SEVERE, "TEST"));
+            handler.close();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void accessProcess() {
+        final var javaHome = System.getProperty("java.home");
+        var name = Thread.currentThread().getName();
+        BufferedReader bufferedReader = null;
+        Process childProcess = null;
+        final String className = new Object(){}.getClass().getEnclosingClass().getName();
+
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(javaHome + File.separator + "bin" + File.separator + "java", "-cp", ".", className, "doProcess");
+            processBuilder.redirectErrorStream(true);
+            childProcess = processBuilder.start();
+
+            bufferedReader = new BufferedReader(new InputStreamReader(childProcess.getInputStream()));
+            String line;
+            while((line = bufferedReader.readLine()) != null) {
+                System.out.println(name + "\t|" + line);
+            }
+            childProcess.waitFor();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+        finally {
+            if (childProcess != null){
+                childProcess.destroy();
+            }
+            if (bufferedReader != null){
+                try{
+                    bufferedReader.close();
+                }
+                catch(Exception ignored){}
+            }
+        }
+    }
+}

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -41,10 +41,8 @@ import java.util.logging.LogRecord;
 public class FileHandlerAccessTest {
     public static void main(String[] args) {
         if (!(args.length == 2 || args.length == 1)) {
-            System.out.println("Usage error: expects java FileHandlerAccessTest [process/thread] <count>");
-            return;
-        }
-        else if (args.length == 2) {
+            throw new IllegalArgumentException("Usage error: expects java FileHandlerAccessTest [process/thread] <count>");
+        } else if (args.length == 2) {
             var type = args[0];
             var count = Integer.parseInt(args[1]);
 
@@ -57,8 +55,7 @@ public class FileHandlerAccessTest {
                     new Thread(FileHandlerAccessTest::access).start();
                 }
             }
-        }
-        else {
+        } else {
             access();
         }
     }

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -25,6 +25,7 @@
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
@@ -41,10 +42,10 @@ import java.util.logging.LogRecord;
  */
 
 public class FileHandlerAccessTest {
-    public static void main(String[] args){
+    public static void main(String[] args) throws Exception {
         if (!(args.length == 2 || args.length == 1)) {
             System.out.println("Usage error: expects java FileHandlerAccessTest [process/thread] <count>");
-            System.exit(1);
+            return;
         }
         else if (args.length == 2) {
             var type = args[0];
@@ -65,14 +66,13 @@ public class FileHandlerAccessTest {
         }
     }
 
-    private static void access(){
+    private static void access() {
         try {
             var handler = new FileHandler("sample%g.log", 1048576, 2, true);
             handler.publish(new LogRecord(Level.SEVERE, "TEST"));
             handler.close();
-        }
-        catch(Exception e) {
-            e.printStackTrace();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -90,23 +90,20 @@ public class FileHandlerAccessTest {
 
             bufferedReader = new BufferedReader(new InputStreamReader(childProcess.getInputStream()));
             String line;
-            while((line = bufferedReader.readLine()) != null) {
+            while ((line = bufferedReader.readLine()) != null) {
                 System.out.println(name + "\t|" + line);
             }
             childProcess.waitFor();
-        }
-        catch(Exception e) {
-            e.printStackTrace();
-        }
-        finally {
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
             if (childProcess != null){
                 childProcess.destroy();
             }
             if (bufferedReader != null){
-                try{
+                try {
                     bufferedReader.close();
-                }
-                catch(Exception ignored){}
+                } catch (Exception ignored) {}
             }
         }
     }

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/logging/FileHandlerAccessTest.java
+++ b/test/jdk/java/util/logging/FileHandlerAccessTest.java
@@ -25,7 +25,6 @@
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
@@ -42,7 +41,7 @@ import java.util.logging.LogRecord;
  */
 
 public class FileHandlerAccessTest {
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         if (!(args.length == 2 || args.length == 1)) {
             System.out.println("Usage error: expects java FileHandlerAccessTest [process/thread] <count>");
             return;
@@ -93,14 +92,18 @@ public class FileHandlerAccessTest {
             while ((line = bufferedReader.readLine()) != null) {
                 System.out.println(name + "\t|" + line);
             }
-            childProcess.waitFor();
+
+            int exitCode = childProcess.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("An error occured in the child process.");
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            if (childProcess != null){
+            if (childProcess != null) {
                 childProcess.destroy();
             }
-            if (bufferedReader != null){
+            if (bufferedReader != null) {
                 try {
                     bufferedReader.close();
                 } catch (Exception ignored) {}


### PR DESCRIPTION
Hi,

Please review this fix for JDK-8252883. This handles the case when an AccessDeniedException is being thrown on Windows, due to a delay in deleting the lock file it is trying to write to.

This fix passes all testing.

Kind regards,
Evan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252883](https://bugs.openjdk.java.net/browse/JDK-8252883): AccessDeniedException caused by delayed file deletion on Windows


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * @vyommani (no known github.com user name / role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2572/head:pull/2572`
`$ git checkout pull/2572`
