### PR TITLE
8261752: Multiple GC test are missing memory requirements

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
@@ -26,7 +26,7 @@ package gc.epsilon;
 /**
  * @test TestByteArrays
  * @key randomness
- * @requires vm.gc.Epsilon
+ * @requires vm.gc.Epsilon & os.maxMemory > 1G
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  * @library /test/lib
  *

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
@@ -26,7 +26,7 @@ package gc.epsilon;
 /**
  * @test TestElasticTLAB
  * @key randomness
- * @requires vm.gc.Epsilon
+ * @requires vm.gc.Epsilon & os.maxMemory > 1G
  * @summary Epsilon is able to work with/without elastic TLABs
  * @library /test/lib
  *

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
@@ -26,7 +26,7 @@ package gc.epsilon;
 /**
  * @test TestElasticTLABDecay
  * @key randomness
- * @requires vm.gc.Epsilon
+ * @requires vm.gc.Epsilon & os.maxMemory > 1G
  * @summary Epsilon is able to work with/without elastic TLABs
  * @library /test/lib
  *

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
@@ -26,7 +26,7 @@ package gc.epsilon;
 
 /**
  * @test TestMemoryPools
- * @requires vm.gc.Epsilon
+ * @requires vm.gc.Epsilon & os.maxMemory >= 2G
  * @summary Test JMX memory pools
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/g1/TestHumongousRemsetsMatch.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousRemsetsMatch.java
@@ -27,7 +27,7 @@ package gc.g1;
  * @test TestHumongousRemSetsMatch
  * @bug 8205426
  * @summary Test to make sure that humongous object remset states are in sync
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & os.maxMemory >= 2G
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -29,6 +29,7 @@
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires !(vm.graal.enabled & vm.compMode == "Xcomp")
+ * @requires os.maxMemory > 1G
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -44,6 +44,7 @@ import sun.hotspot.WhiteBox;
  *          java.management
  * @requires vm.gc != "Epsilon"
  * @requires vm.gc != "Z"
+ * @requires os.maxMemory >= 2G
  *
  * @compile TestMetaSpaceLog.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
I used systemd to figure out which memory requirement makes sense for which test:

```
$ systemd-run --user --scope -p MemoryMax=768M -p MemorySwapMax=0 /usr/bin/make TEST="..." test
```

Tests succeeding with `768M` of MemoryMax got a requirement of 1G, all others got 2G and succeeded with a MemoryMax of 1536M.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261752](https://bugs.openjdk.java.net/browse/JDK-8261752): Multiple GC test are missing memory requirements


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2575/head:pull/2575`
`$ git checkout pull/2575`
