### PR TITLE
8261753: Test java/lang/System/OsVersionTest.java still failing on BigSur patch versions after JDK-8253702

### DIFF
--- a/test/jdk/java/lang/System/OsVersionTest.java
+++ b/test/jdk/java/lang/System/OsVersionTest.java
@@ -53,14 +53,9 @@ public class OsVersionTest {
             String swVersOutput = output.getOutput().trim();
             if (!osVersion.equals(swVersOutput)) {
                 // This section can be removed if minimum build SDK is xcode 12+
-                String[] swVersParts = swVersOutput.split("\\.");
-                String[] osVersParts = osVersion.split("\\.");
-                if (swVersParts.length >= 2 &&
-                    osVersParts.length >= 2 &&
-                    swVersParts[0].equals(osVersParts[0]) &&
-                    swVersParts[1].equals(osVersParts[1])) {
-                        throw new SkippedException("MacOS version only matches in parts, this is expected when " +
-                                                   "JDK was built with Xcode < 12 and MacOS version patch is > 0");
+                if (swVersOutput.startsWith(osVersion)) {
+                    throw new SkippedException("MacOS version only matches in parts, this is expected when " +
+                                               "JDK was built with Xcode < 12 and MacOS version patch is > 0");
                 }
                 throw new Error(osVersion + " != " + swVersOutput);
             }

--- a/test/jdk/java/lang/System/OsVersionTest.java
+++ b/test/jdk/java/lang/System/OsVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2021, SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/System/OsVersionTest.java
+++ b/test/jdk/java/lang/System/OsVersionTest.java
@@ -24,6 +24,7 @@
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 
 /*
  * @test
@@ -49,8 +50,19 @@ public class OsVersionTest {
         }
         else if (Platform.isOSX()) {
             OutputAnalyzer output = ProcessTools.executeProcess("sw_vers", "-productVersion");
-            if (!osVersion.equals(output.getOutput().trim())) {
-                throw new Error(osVersion + " != " + output.getOutput().trim());
+            String swVersOutput = output.getOutput().trim();
+            if (!osVersion.equals(swVersOutput)) {
+                // This section can be removed if minimum build SDK is xcode 12+
+                String[] swVersParts = swVersOutput.split("\\.");
+                String[] osVersParts = osVersion.split("\\.");
+                if (swVersParts.length >= 2 &&
+                    osVersParts.length >= 2 &&
+                    swVersParts[0].equals(osVersParts[0]) &&
+                    swVersParts[1].equals(osVersParts[1])) {
+                        throw new SkippedException("MacOS version only matches in parts, this is expected when " +
+                                                   "JDK was built with Xcode < 12 and MacOS version patch is > 0");
+                }
+                throw new Error(osVersion + " != " + swVersOutput);
             }
         }
         else if (Platform.isAix()) {


### PR DESCRIPTION
After the fix for JDK-8253702, the test java/lang/System/OsVersionTest.java still fails on BigSur versions that have a patch version (> 1), e.g. on macOS Big Sur 11.2.1, and where the JDK was built with xcode < 12.

java.lang.Error: 11.2 != 11.2.1

This is a proposal to relax the test and throw a SkippedException in such cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261753](https://bugs.openjdk.java.net/browse/JDK-8261753): Test java/lang/System/OsVersionTest.java still failing on BigSur patch versions after JDK-8253702


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to f06114c95fca72f690cde54eedba13b594f6289d


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2576/head:pull/2576`
`$ git checkout pull/2576`
