### PR TITLE
8260415: Remove unused class ReferenceProcessorMTProcMutator

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -601,28 +601,6 @@ class ReferenceProcessorAtomicMutator: StackObj {
   }
 };
 
-
-// A utility class to temporarily change the MT processing
-// disposition of the given ReferenceProcessor instance
-// in the scope that contains it.
-class ReferenceProcessorMTProcMutator: StackObj {
- private:
-  ReferenceProcessor* _rp;
-  bool  _saved_mt;
-
- public:
-  ReferenceProcessorMTProcMutator(ReferenceProcessor* rp,
-                                  bool mt):
-    _rp(rp) {
-    _saved_mt = _rp->processing_is_mt();
-    _rp->set_mt_processing(mt);
-  }
-
-  ~ReferenceProcessorMTProcMutator() {
-    _rp->set_mt_processing(_saved_mt);
-  }
-};
-
 // This class is an interface used to implement task execution for the
 // reference processing.
 class AbstractRefProcTaskExecutor {


### PR DESCRIPTION
ReferenceProcessorMTProcMutator is not used. ReferenceProcessorMTDiscoveryMutator seems to do the same and is still being used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260415](https://bugs.openjdk.java.net/browse/JDK-8260415): Remove unused class ReferenceProcessorMTProcMutator


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2578/head:pull/2578`
`$ git checkout pull/2578`
