### PR TITLE
JDK-8260925: HttpsURLConnection does not work  with other JSSE provider.

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -451,7 +451,9 @@ final class HttpsClient extends HttpClient
                 if (!(serverSocket instanceof SSLSocket)) {
                     s = (SSLSocket)factory.createSocket(serverSocket,
                                                         host, port, true);
-                }
+                } else {
+		    s = (SSLSocket)serverSocket;
+		}
             } catch (IOException ex) {
                 // If we fail to connect through the tunnel, try it
                 // locally, as a last resort.  If this doesn't work,

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -453,6 +453,9 @@ final class HttpsClient extends HttpClient
                                                         host, port, true);
                 } else {
 		    s = (SSLSocket)serverSocket;
+                   if (s instanceof SSLSocketImpl) {
+                       ((SSLSocketImpl)s).setHost(host);
+                   }
 		}
             } catch (IOException ex) {
                 // If we fail to connect through the tunnel, try it
@@ -563,7 +566,9 @@ final class HttpsClient extends HttpClient
                     // will do the spoof checks in SSLSocket.
                     SSLParameters paramaters = s.getSSLParameters();
                     paramaters.setEndpointIdentificationAlgorithm("HTTPS");
-                    paramaters.setServerNames(List.of(new SNIHostName(host)));
+                    if (!(s instanceof SSLSocketImpl)) {
+                        paramaters.setServerNames(List.of(new SNIHostName(host)));
+                    }
                     s.setSSLParameters(paramaters);
 
                     needToCheckSpoofing = false;

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -566,7 +566,7 @@ final class HttpsClient extends HttpClient
                     // will do the spoof checks in SSLSocket.
                     SSLParameters paramaters = s.getSSLParameters();
                     paramaters.setEndpointIdentificationAlgorithm("HTTPS");
- 		    paramaters.setServerNames(Collections.singletonList(new SNIHostName(host)));
+                    paramaters.setServerNames(Collections.singletonList(new SNIHostName(host)));
                     s.setSSLParameters(paramaters);
 
                     needToCheckSpoofing = false;

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -452,11 +452,11 @@ final class HttpsClient extends HttpClient
                     s = (SSLSocket)factory.createSocket(serverSocket,
                                                         host, port, true);
                 } else {
-		    s = (SSLSocket)serverSocket;
-                   if (s instanceof SSLSocketImpl) {
-                       ((SSLSocketImpl)s).setHost(host);
-                   }
-		}
+	            s = (SSLSocket)serverSocket;
+                    if (s instanceof SSLSocketImpl) {
+                        ((SSLSocketImpl)s).setHost(host);
+                    }
+                }
             } catch (IOException ex) {
                 // If we fail to connect through the tunnel, try it
                 // locally, as a last resort.  If this doesn't work,

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -451,11 +451,6 @@ final class HttpsClient extends HttpClient
                 if (!(serverSocket instanceof SSLSocket)) {
                     s = (SSLSocket)factory.createSocket(serverSocket,
                                                         host, port, true);
-                } else {
-                    s = (SSLSocket)serverSocket;
-                    if (s instanceof SSLSocketImpl) {
-                        ((SSLSocketImpl)s).setHost(host);
-                    }
                 }
             } catch (IOException ex) {
                 // If we fail to connect through the tunnel, try it

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -39,6 +39,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.Principal;
 import java.security.cert.*;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -565,6 +566,7 @@ final class HttpsClient extends HttpClient
                     // will do the spoof checks in SSLSocket.
                     SSLParameters paramaters = s.getSSLParameters();
                     paramaters.setEndpointIdentificationAlgorithm("HTTPS");
+ 		    paramaters.setServerNames(Collections.singletonList(new SNIHostName(host)));
                     s.setSSLParameters(paramaters);
 
                     needToCheckSpoofing = false;

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -452,7 +452,7 @@ final class HttpsClient extends HttpClient
                     s = (SSLSocket)factory.createSocket(serverSocket,
                                                         host, port, true);
                 } else {
-	            s = (SSLSocket)serverSocket;
+                    s = (SSLSocket)serverSocket;
                     if (s instanceof SSLSocketImpl) {
                         ((SSLSocketImpl)s).setHost(host);
                     }
@@ -566,6 +566,7 @@ final class HttpsClient extends HttpClient
                     // will do the spoof checks in SSLSocket.
                     SSLParameters paramaters = s.getSSLParameters();
                     paramaters.setEndpointIdentificationAlgorithm("HTTPS");
+                    // host has been set previously for SSLSocketImpl
                     if (!(s instanceof SSLSocketImpl)) {
                         paramaters.setServerNames(List.of(new SNIHostName(host)));
                     }

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -39,7 +39,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.Principal;
 import java.security.cert.*;
-import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -566,7 +566,7 @@ final class HttpsClient extends HttpClient
                     // will do the spoof checks in SSLSocket.
                     SSLParameters paramaters = s.getSSLParameters();
                     paramaters.setEndpointIdentificationAlgorithm("HTTPS");
-                    paramaters.setServerNames(Collections.singletonList(new SNIHostName(host)));
+                    paramaters.setServerNames(List.of(new SNIHostName(host)));
                     s.setSSLParameters(paramaters);
 
                     needToCheckSpoofing = false;


### PR DESCRIPTION
HttpsURLConnection, works with SunJSSE provider but does not work with other JSSE provider. In case of SunJSSE , HttpsURLConnection set the host name as follows

s = (SSLSocket)serverSocket;
   if (s instanceof SSLSocketImpl) {
          ((SSLSocketImpl)s).setHost(host);
   } 

But in case of other providers(BouncyCastleProvider )  host will not get set and "java.security.cert.CertificateException: No subject alternative name found matching IP address" exception will be thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260925](https://bugs.openjdk.java.net/browse/JDK-8260925): HttpsURLConnection does not work  with other JSSE provider.


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2583/head:pull/2583`
`$ git checkout pull/2583`
