### PR TITLE
8260416: Remove unused method ReferenceProcessor::is_mt_processing_set_up()

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -769,10 +769,6 @@ void ReferenceProcessor::balance_queues(DiscoveredList ref_lists[])
 #endif
 }
 
-bool ReferenceProcessor::is_mt_processing_set_up(AbstractRefProcTaskExecutor* task_executor) const {
-  return task_executor != NULL && _processing_is_mt;
-}
-
 void ReferenceProcessor::process_soft_ref_reconsider(BoolObjectClosure* is_alive,
                                                      OopClosure* keep_alive,
                                                      VoidClosure* complete_gc,
@@ -782,7 +778,6 @@ void ReferenceProcessor::process_soft_ref_reconsider(BoolObjectClosure* is_alive
 
   size_t const num_soft_refs = total_count(_discoveredSoftRefs);
   phase_times->set_ref_discovered(REF_SOFT, num_soft_refs);
-
   phase_times->set_processing_is_mt(_processing_is_mt);
 
   if (num_soft_refs == 0) {

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -371,8 +371,6 @@ private:
 
   bool is_subject_to_discovery(oop const obj) const;
 
-  bool is_mt_processing_set_up(AbstractRefProcTaskExecutor* task_executor) const;
-
 public:
   // Default parameters give you a vanilla reference processor.
   ReferenceProcessor(BoolObjectClosure* is_subject_to_discovery,


### PR DESCRIPTION
Code is not used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260416](https://bugs.openjdk.java.net/browse/JDK-8260416): Remove unused method ReferenceProcessor::is_mt_processing_set_up()


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2591/head:pull/2591`
`$ git checkout pull/2591`
