### PR TITLE
6323374: (coll) Optimize Collections.unmodifiable* and synchronized*

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1008,6 +1008,7 @@ public class Collections {
      * The returned collection will be serializable if the specified collection
      * is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param  <T> the class of the objects in the collection
      * @param  c the collection for which an unmodifiable view is to be
      *         returned.
@@ -1120,6 +1121,7 @@ public class Collections {
      * The returned set will be serializable if the specified set
      * is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param  <T> the class of the objects in the set
      * @param  s the set for which an unmodifiable view is to be returned.
      * @return an unmodifiable view of the specified set.
@@ -1156,6 +1158,7 @@ public class Collections {
      * The returned sorted set will be serializable if the specified sorted set
      * is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param  <T> the class of the objects in the set
      * @param s the sorted set for which an unmodifiable view is to be
      *        returned.
@@ -1208,6 +1211,7 @@ public class Collections {
      * The returned navigable set will be serializable if the specified
      * navigable set is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param  <T> the class of the objects in the set
      * @param s the navigable set for which an unmodifiable view is to be
      *        returned
@@ -1303,6 +1307,7 @@ public class Collections {
      * is serializable. Similarly, the returned list will implement
      * {@link RandomAccess} if the specified list does.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param  <T> the class of the objects in the list
      * @param  list the list for which an unmodifiable view is to be returned.
      * @return an unmodifiable view of the specified list.
@@ -1457,6 +1462,7 @@ public class Collections {
      * The returned map will be serializable if the specified map
      * is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param <K> the class of the map keys
      * @param <V> the class of the map values
      * @param  m the map for which an unmodifiable view is to be returned.
@@ -1818,6 +1824,7 @@ public class Collections {
      * The returned sorted map will be serializable if the specified sorted map
      * is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param <K> the class of the map keys
      * @param <V> the class of the map values
      * @param m the sorted map for which an unmodifiable view is to be
@@ -1867,6 +1874,7 @@ public class Collections {
      * The returned navigable map will be serializable if the specified
      * navigable map is serializable.
      *
+     * @implNote This method may return its argument if the argument is already unmodifiable.
      * @param <K> the class of the map keys
      * @param <V> the class of the map values
      * @param m the navigable map for which an unmodifiable view is to be

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1015,7 +1015,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Collection<T> unmodifiableCollection(Collection<? extends T> c) {
-        if(c.getClass() == UnmodifiableCollection.class) {
+        if (c.getClass() == UnmodifiableCollection.class) {
             return (Collection<T>) c;
         }
         return new UnmodifiableCollection<>(c);
@@ -1126,7 +1126,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
-        if(s.getClass() == UnmodifiableSet.class ||
+        if (s.getClass() == UnmodifiableSet.class ||
            s.getClass() == ImmutableCollections.Set12.class ||
            s.getClass() == ImmutableCollections.SetN.class) {
             return (Set<T>) s;
@@ -1164,7 +1164,7 @@ public class Collections {
      * @return an unmodifiable view of the specified sorted set.
      */
     public static <T> SortedSet<T> unmodifiableSortedSet(SortedSet<T> s) {
-        if(s.getClass() == UnmodifiableSortedSet.class) {
+        if (s.getClass() == UnmodifiableSortedSet.class) {
             return s;
         }
         return new UnmodifiableSortedSet<>(s);
@@ -1217,7 +1217,7 @@ public class Collections {
      * @since 1.8
      */
     public static <T> NavigableSet<T> unmodifiableNavigableSet(NavigableSet<T> s) {
-        if(s.getClass() == UnmodifiableNavigableSet.class) {
+        if (s.getClass() == UnmodifiableNavigableSet.class) {
             return s;
         }
         return new UnmodifiableNavigableSet<>(s);
@@ -1469,7 +1469,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
-        if(m.getClass() == UnmodifiableMap.class ||
+        if (m.getClass() == UnmodifiableMap.class ||
            m.getClass() == ImmutableCollections.Map1.class ||
            m.getClass() == ImmutableCollections.MapN.class) {
             return (Map<K,V>) m;
@@ -1833,7 +1833,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> SortedMap<K,V> unmodifiableSortedMap(SortedMap<K, ? extends V> m) {
-        if(m.getClass() == UnmodifiableSortedMap.class) {
+        if (m.getClass() == UnmodifiableSortedMap.class) {
             return (SortedMap<K,V>) m;
         }
         return new UnmodifiableSortedMap<>(m);
@@ -1883,7 +1883,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> NavigableMap<K,V> unmodifiableNavigableMap(NavigableMap<K, ? extends V> m) {
-        if(m.getClass() == UnmodifiableNavigableMap.class) {
+        if (m.getClass() == UnmodifiableNavigableMap.class) {
             return (NavigableMap<K,V>) m;
         }
         return new UnmodifiableNavigableMap<>(m);

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1128,7 +1128,9 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
-        if (s.getClass() == UnmodifiableSet.class) {
+        if (s.getClass() == UnmodifiableSet.class ||
+            s.getClass() == UnmodifiableSortedSet.class ||
+            s.getClass() == UnmodifiableNavigableSet.class) {
             return (Set<T>) s;
         }
         return new UnmodifiableSet<>(s);
@@ -1165,7 +1167,8 @@ public class Collections {
      * @return an unmodifiable view of the specified sorted set.
      */
     public static <T> SortedSet<T> unmodifiableSortedSet(SortedSet<T> s) {
-        if (s.getClass() == UnmodifiableSortedSet.class) {
+        if (s.getClass() == UnmodifiableSortedSet.class ||
+            s.getClass() == UnmodifiableNavigableSet.class) {
             return s;
         }
         return new UnmodifiableSortedSet<>(s);
@@ -1470,7 +1473,9 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
-        if (m.getClass() == UnmodifiableMap.class) {
+        if (m.getClass() == UnmodifiableMap.class ||
+            m.getClass() == UnmodifiableSortedMap.class ||
+            m.getClass() == UnmodifiableNavigableMap.class) {
             return (Map<K,V>) m;
         }
         return new UnmodifiableMap<>(m);
@@ -1833,7 +1838,8 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> SortedMap<K,V> unmodifiableSortedMap(SortedMap<K, ? extends V> m) {
-        if (m.getClass() == UnmodifiableSortedMap.class) {
+        if (m.getClass() == UnmodifiableSortedMap.class ||
+            m.getClass() == UnmodifiableNavigableMap.class) {
             return (SortedMap<K,V>) m;
         }
         return new UnmodifiableSortedMap<>(m);

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1128,9 +1128,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
-        if (s.getClass() == UnmodifiableSet.class ||
-            s.getClass() == UnmodifiableSortedSet.class ||
-            s.getClass() == UnmodifiableNavigableSet.class) {
+        if (s.getClass() == UnmodifiableSet.class) {
             return (Set<T>) s;
         }
         return new UnmodifiableSet<>(s);
@@ -1167,8 +1165,7 @@ public class Collections {
      * @return an unmodifiable view of the specified sorted set.
      */
     public static <T> SortedSet<T> unmodifiableSortedSet(SortedSet<T> s) {
-        if (s.getClass() == UnmodifiableSortedSet.class ||
-            s.getClass() == UnmodifiableNavigableSet.class) {
+        if (s.getClass() == UnmodifiableSortedSet.class) {
             return s;
         }
         return new UnmodifiableSortedSet<>(s);
@@ -1473,9 +1470,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
-        if (m.getClass() == UnmodifiableMap.class ||
-            m.getClass() == UnmodifiableSortedMap.class ||
-            m.getClass() == UnmodifiableNavigableMap.class) {
+        if (m.getClass() == UnmodifiableMap.class) {
             return (Map<K,V>) m;
         }
         return new UnmodifiableMap<>(m);
@@ -1838,8 +1833,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> SortedMap<K,V> unmodifiableSortedMap(SortedMap<K, ? extends V> m) {
-        if (m.getClass() == UnmodifiableSortedMap.class ||
-            m.getClass() == UnmodifiableNavigableMap.class) {
+        if (m.getClass() == UnmodifiableSortedMap.class) {
             return (SortedMap<K,V>) m;
         }
         return new UnmodifiableSortedMap<>(m);

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1126,9 +1126,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
-        if (s.getClass() == UnmodifiableSet.class ||
-           s.getClass() == ImmutableCollections.Set12.class ||
-           s.getClass() == ImmutableCollections.SetN.class) {
+        if (s.getClass() == UnmodifiableSet.class) {
             return (Set<T>) s;
         }
         return new UnmodifiableSet<>(s);
@@ -1311,10 +1309,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> List<T> unmodifiableList(List<? extends T> list) {
-        if (list.getClass() == UnmodifiableList.class || list.getClass() == UnmodifiableRandomAccessList.class ||
-            list.getClass() == ImmutableCollections.List12.class ||
-            list.getClass() == ImmutableCollections.ListN.class ||
-            list.getClass() == ImmutableCollections.SubList.class) {
+        if (list.getClass() == UnmodifiableList.class || list.getClass() == UnmodifiableRandomAccessList.class) {
            return (List<T>) list;
         }
 
@@ -1469,9 +1464,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
-        if (m.getClass() == UnmodifiableMap.class ||
-           m.getClass() == ImmutableCollections.Map1.class ||
-           m.getClass() == ImmutableCollections.MapN.class) {
+        if (m.getClass() == UnmodifiableMap.class) {
             return (Map<K,V>) m;
         }
         return new UnmodifiableMap<>(m);

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1128,6 +1128,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
+        // Not checking for subclasses because of heap pollution and information leakage.
         if (s.getClass() == UnmodifiableSet.class) {
             return (Set<T>) s;
         }
@@ -1165,6 +1166,7 @@ public class Collections {
      * @return an unmodifiable view of the specified sorted set.
      */
     public static <T> SortedSet<T> unmodifiableSortedSet(SortedSet<T> s) {
+        // Not checking for subclasses because of heap pollution and information leakage.
         if (s.getClass() == UnmodifiableSortedSet.class) {
             return s;
         }
@@ -1470,6 +1472,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
+        // Not checking for subclasses because of heap pollution and information leakage.
         if (m.getClass() == UnmodifiableMap.class) {
             return (Map<K,V>) m;
         }
@@ -1833,6 +1836,7 @@ public class Collections {
      */
     @SuppressWarnings("unchecked")
     public static <K,V> SortedMap<K,V> unmodifiableSortedMap(SortedMap<K, ? extends V> m) {
+        // Not checking for subclasses because of heap pollution and information leakage.
         if (m.getClass() == UnmodifiableSortedMap.class) {
             return (SortedMap<K,V>) m;
         }

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1013,7 +1013,11 @@ public class Collections {
      *         returned.
      * @return an unmodifiable view of the specified collection.
      */
+    @SuppressWarnings("unchecked")
     public static <T> Collection<T> unmodifiableCollection(Collection<? extends T> c) {
+        if(c.getClass() == UnmodifiableCollection.class) {
+            return (Collection<T>) c;
+        }
         return new UnmodifiableCollection<>(c);
     }
 
@@ -1120,7 +1124,13 @@ public class Collections {
      * @param  s the set for which an unmodifiable view is to be returned.
      * @return an unmodifiable view of the specified set.
      */
+    @SuppressWarnings("unchecked")
     public static <T> Set<T> unmodifiableSet(Set<? extends T> s) {
+        if(s.getClass() == UnmodifiableSet.class ||
+           s.getClass() == ImmutableCollections.Set12.class ||
+           s.getClass() == ImmutableCollections.SetN.class) {
+            return (Set<T>) s;
+        }
         return new UnmodifiableSet<>(s);
     }
 
@@ -1154,6 +1164,9 @@ public class Collections {
      * @return an unmodifiable view of the specified sorted set.
      */
     public static <T> SortedSet<T> unmodifiableSortedSet(SortedSet<T> s) {
+        if(s.getClass() == UnmodifiableSortedSet.class) {
+            return s;
+        }
         return new UnmodifiableSortedSet<>(s);
     }
 
@@ -1204,6 +1217,9 @@ public class Collections {
      * @since 1.8
      */
     public static <T> NavigableSet<T> unmodifiableNavigableSet(NavigableSet<T> s) {
+        if(s.getClass() == UnmodifiableNavigableSet.class) {
+            return s;
+        }
         return new UnmodifiableNavigableSet<>(s);
     }
 
@@ -1293,7 +1309,15 @@ public class Collections {
      * @param  list the list for which an unmodifiable view is to be returned.
      * @return an unmodifiable view of the specified list.
      */
+    @SuppressWarnings("unchecked")
     public static <T> List<T> unmodifiableList(List<? extends T> list) {
+        if (list.getClass() == UnmodifiableList.class || list.getClass() == UnmodifiableRandomAccessList.class ||
+            list.getClass() == ImmutableCollections.List12.class ||
+            list.getClass() == ImmutableCollections.ListN.class ||
+            list.getClass() == ImmutableCollections.SubList.class) {
+           return (List<T>) list;
+        }
+
         return (list instanceof RandomAccess ?
                 new UnmodifiableRandomAccessList<>(list) :
                 new UnmodifiableList<>(list));
@@ -1443,7 +1467,13 @@ public class Collections {
      * @param  m the map for which an unmodifiable view is to be returned.
      * @return an unmodifiable view of the specified map.
      */
+    @SuppressWarnings("unchecked")
     public static <K,V> Map<K,V> unmodifiableMap(Map<? extends K, ? extends V> m) {
+        if(m.getClass() == UnmodifiableMap.class ||
+           m.getClass() == ImmutableCollections.Map1.class ||
+           m.getClass() == ImmutableCollections.MapN.class) {
+            return (Map<K,V>) m;
+        }
         return new UnmodifiableMap<>(m);
     }
 
@@ -1801,7 +1831,11 @@ public class Collections {
      *        returned.
      * @return an unmodifiable view of the specified sorted map.
      */
+    @SuppressWarnings("unchecked")
     public static <K,V> SortedMap<K,V> unmodifiableSortedMap(SortedMap<K, ? extends V> m) {
+        if(m.getClass() == UnmodifiableSortedMap.class) {
+            return (SortedMap<K,V>) m;
+        }
         return new UnmodifiableSortedMap<>(m);
     }
 
@@ -1847,7 +1881,11 @@ public class Collections {
      * @return an unmodifiable view of the specified navigable map
      * @since 1.8
      */
+    @SuppressWarnings("unchecked")
     public static <K,V> NavigableMap<K,V> unmodifiableNavigableMap(NavigableMap<K, ? extends V> m) {
+        if(m.getClass() == UnmodifiableNavigableMap.class) {
+            return (NavigableMap<K,V>) m;
+        }
         return new UnmodifiableNavigableMap<>(m);
     }
 

--- a/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
+++ b/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
@@ -46,27 +46,19 @@ public class WrappedUnmodifiableCollections {
     static final Class<?> UNMODIFIABLESORTEDMAP;
     static final Class<?> UNMODIFIABLENAVIGABLEMAP;
     static final Class<?> UNMODIFIABLECOLLECTION;
-    static final Class<?> LIST12, LISTN, MAP1, MAPN, SET12, SETN, SUBLIST;
 
     static {
         try {
             UNMODIFIABLESET = Class.forName("java.util.Collections$UnmodifiableSet");
             UNMODIFIABLESORTEDSET = Class.forName("java.util.Collections$UnmodifiableSortedSet");
             UNMODIFIABLENAVIGABLESET = Class.forName("java.util.Collections$UnmodifiableNavigableSet");
-            SET12 = Class.forName("java.util.ImmutableCollections$Set12");
-            SETN = Class.forName("java.util.ImmutableCollections$SetN");
 
             UNMODIFIABLELIST = Class.forName("java.util.Collections$UnmodifiableList");
             UNMODIFIABLERANDOMACCESSLIST = Class.forName("java.util.Collections$UnmodifiableRandomAccessList");
-            LIST12 = Class.forName("java.util.ImmutableCollections$List12");
-            LISTN = Class.forName("java.util.ImmutableCollections$ListN");
-            SUBLIST = Class.forName("java.util.ImmutableCollections$SubList");
 
             UNMODIFIABLEMAP = Class.forName("java.util.Collections$UnmodifiableMap");
             UNMODIFIABLESORTEDMAP = Class.forName("java.util.Collections$UnmodifiableSortedMap");
             UNMODIFIABLENAVIGABLEMAP = Class.forName("java.util.Collections$UnmodifiableNavigableMap");
-            MAP1 = Class.forName("java.util.ImmutableCollections$Map1");
-            MAPN = Class.forName("java.util.ImmutableCollections$MapN");
 
             UNMODIFIABLECOLLECTION= Class.forName("java.util.Collections$UnmodifiableCollection");
 
@@ -79,28 +71,33 @@ public class WrappedUnmodifiableCollections {
 
     public void testUnmodifiableListsDontWrap() {
         List<Integer> list = List.of(1,2,3);
+        assertNotSame(list.getClass(), UNMODIFIABLERANDOMACCESSLIST);
         List<Integer> result = Collections.unmodifiableList(list);
-        assertSame(list, result);
+        assertSame(result.getClass(), UNMODIFIABLERANDOMACCESSLIST);
 
         //Empty List
         List<?> list2 = List.of();
+        assertNotSame(list2.getClass(), UNMODIFIABLERANDOMACCESSLIST);
         List<?> result2 = Collections.unmodifiableList(list2);
-        assertSame(list2, result2);
+        assertSame(result2.getClass(), UNMODIFIABLERANDOMACCESSLIST);
 
         //ImmutableCollections.List12
         List<?> list12 = List.of(1);
+        assertNotSame(list12.getClass(), UNMODIFIABLERANDOMACCESSLIST);
         List<?> result3 = Collections.unmodifiableList(list12);
-        assertSame(list12, result3);
+        assertSame(result3.getClass(), UNMODIFIABLERANDOMACCESSLIST);
 
         //ImmutableCollections.ListN
         List<?> listN = List.of(1,2,3,4,5,6);
+        assertNotSame(listN.getClass(), UNMODIFIABLERANDOMACCESSLIST);
         List<?> result4 = Collections.unmodifiableList(listN);
-        assertSame(listN, result4);
+        assertSame(result4.getClass(), UNMODIFIABLERANDOMACCESSLIST);
 
         //ImmutableCollections.Sublist
         List<?> subList = list.subList(0,1);
+        assertNotSame(subList.getClass(), UNMODIFIABLERANDOMACCESSLIST);
         List<?> subListResult = Collections.unmodifiableList(subList);
-        assertSame(subList, subListResult);
+        assertSame(subListResult.getClass(), UNMODIFIABLERANDOMACCESSLIST);
 
         //Collections.UnmodifiableList
         List<Integer> linkedList = new LinkedList<>();
@@ -178,15 +175,15 @@ public class WrappedUnmodifiableCollections {
 
         //SET12
         Set<Integer> set12 = Set.of(1,2);
+        assertNotSame(set12.getClass(), UNMODIFIABLESET);
         Set<Integer> reWrappedSet12 = Collections.unmodifiableSet(set12);
-        assertSame(reWrappedSet12.getClass(), SET12);
-        assertSame(set12, reWrappedSet12);
+        assertSame(reWrappedSet12.getClass(), UNMODIFIABLESET);
 
         //SETN
         Set<Integer> setN = Set.of(1,2,3,4,5,6);
+        assertNotSame(setN.getClass(), UNMODIFIABLESET);
         Set<Integer> reWrappedSetN = Collections.unmodifiableSet(setN);
-        assertSame(reWrappedSetN.getClass(), SETN);
-        assertSame(setN, reWrappedSetN);
+        assertSame(reWrappedSetN.getClass(), UNMODIFIABLESET);
 
 
     }
@@ -223,17 +220,17 @@ public class WrappedUnmodifiableCollections {
 
         //ImmutableCollections.Map1
         Map<Integer,Integer> map1 = Map.of(1,1);
-        assertSame(map1.getClass(), MAP1);
+        assertNotSame(map1.getClass(), UNMODIFIABLEMAP);
 
         Map<Integer,Integer> reWrappedMap1 = Collections.unmodifiableMap(map1);
-        assertSame(map1, reWrappedMap1);
+        assertSame(reWrappedMap1.getClass(), UNMODIFIABLEMAP);
 
         //ImmutableCollections.MapN
         Map<Integer,Integer> mapN = Map.of(1,1, 2, 2, 3, 3, 4, 4);
-        assertSame(mapN.getClass(), MAPN);
+        assertNotSame(mapN.getClass(), UNMODIFIABLEMAP);
 
         Map<Integer,Integer> reWrappedMapN = Collections.unmodifiableMap(mapN);
-        assertSame(mapN, reWrappedMapN);
+        assertSame(reWrappedMapN.getClass(), UNMODIFIABLEMAP);
 
 
 

--- a/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
+++ b/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6323374
+ * @run testng WrappedUnmodifiableCollections
+ */
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+
+@Test
+public class WrappedUnmodifiableCollections {
+
+    static final Class<?> UNMODIFIABLESET;
+    static final Class<?> UNMODIFIABLESORTEDSET;
+    static final Class<?> UNMODIFIABLENAVIGABLESET;
+    static final Class<?> UNMODIFIABLELIST;
+    static final Class<?> UNMODIFIABLERANDOMACCESSLIST;
+    static final Class<?> UNMODIFIABLEMAP;
+    static final Class<?> UNMODIFIABLESORTEDMAP;
+    static final Class<?> UNMODIFIABLENAVIGABLEMAP;
+    static final Class<?> UNMODIFIABLECOLLECTION;
+    static final Class<?> LIST12, LISTN, MAP1, MAPN, SET12, SETN, SUBLIST;
+
+    static {
+        try {
+            UNMODIFIABLESET = Class.forName("java.util.Collections$UnmodifiableSet");
+            UNMODIFIABLESORTEDSET = Class.forName("java.util.Collections$UnmodifiableSortedSet");
+            UNMODIFIABLENAVIGABLESET = Class.forName("java.util.Collections$UnmodifiableNavigableSet");
+            SET12 = Class.forName("java.util.ImmutableCollections$Set12");
+            SETN = Class.forName("java.util.ImmutableCollections$SetN");
+
+            UNMODIFIABLELIST = Class.forName("java.util.Collections$UnmodifiableList");
+            UNMODIFIABLERANDOMACCESSLIST = Class.forName("java.util.Collections$UnmodifiableRandomAccessList");
+            LIST12 = Class.forName("java.util.ImmutableCollections$List12");
+            LISTN = Class.forName("java.util.ImmutableCollections$ListN");
+            SUBLIST = Class.forName("java.util.ImmutableCollections$SubList");
+
+            UNMODIFIABLEMAP = Class.forName("java.util.Collections$UnmodifiableMap");
+            UNMODIFIABLESORTEDMAP = Class.forName("java.util.Collections$UnmodifiableSortedMap");
+            UNMODIFIABLENAVIGABLEMAP = Class.forName("java.util.Collections$UnmodifiableNavigableMap");
+            MAP1 = Class.forName("java.util.ImmutableCollections$Map1");
+            MAPN = Class.forName("java.util.ImmutableCollections$MapN");
+
+            UNMODIFIABLECOLLECTION= Class.forName("java.util.Collections$UnmodifiableCollection");
+
+
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Class Not found: " + e.getMessage());
+        }
+    }
+
+
+    public void testUnmodifiableListsDontWrap() {
+        List<Integer> list = List.of(1,2,3);
+        List<Integer> result = Collections.unmodifiableList(list);
+        assertSame(list, result);
+
+        //Empty List
+        List<?> list2 = List.of();
+        List<?> result2 = Collections.unmodifiableList(list2);
+        assertSame(list2, result2);
+
+        //ImmutableCollections.List12
+        List<?> list12 = List.of(1);
+        List<?> result3 = Collections.unmodifiableList(list12);
+        assertSame(list12, result3);
+
+        //ImmutableCollections.ListN
+        List<?> listN = List.of(1,2,3,4,5,6);
+        List<?> result4 = Collections.unmodifiableList(listN);
+        assertSame(listN, result4);
+
+        //ImmutableCollections.Sublist
+        List<?> subList = list.subList(0,1);
+        List<?> subListResult = Collections.unmodifiableList(subList);
+        assertSame(subList, subListResult);
+
+        //Collections.UnmodifiableList
+        List<Integer> linkedList = new LinkedList<>();
+        linkedList.add(1);
+        linkedList.add(2);
+        linkedList.add(3);
+        List<?> resultLinkedList = Collections.unmodifiableList(linkedList);
+        assertNotSame(linkedList, resultLinkedList);
+        assertSame(resultLinkedList.getClass(), UNMODIFIABLELIST);
+
+        List<?> rewrappedLinkedListAttempt = Collections.unmodifiableList(resultLinkedList);
+        assertSame(resultLinkedList, rewrappedLinkedListAttempt);
+
+        //Collections.UnmodifiableRandomAccessList
+        List<Integer> arrayList = new ArrayList<>();
+        linkedList.add(1);
+        linkedList.add(2);
+        linkedList.add(3);
+
+        List<?> resultArrayList = Collections.unmodifiableList(arrayList);
+        assertNotSame(arrayList, resultArrayList);
+        assertSame(resultArrayList.getClass(), UNMODIFIABLERANDOMACCESSLIST);
+
+        List<?> rewrappedLinkedListAttempt2 = Collections.unmodifiableList(resultLinkedList);
+        assertSame(resultLinkedList, rewrappedLinkedListAttempt2);
+
+    }
+
+
+    public void testUnmodifiableCollectionsDontWrap() {
+        List<Integer> list = new ArrayList<>();
+        list.add(1);
+        list.add(2);
+        list.add(3);
+
+        Collection<Integer> unmodifiableCollection = Collections.unmodifiableCollection(list);
+
+        assertSame(unmodifiableCollection.getClass(), UNMODIFIABLECOLLECTION);
+        Collection<?> unmodifiableCollection2 = Collections.unmodifiableCollection(unmodifiableCollection);
+
+        assertSame(UNMODIFIABLECOLLECTION, unmodifiableCollection2.getClass());
+        assertSame(unmodifiableCollection2, unmodifiableCollection);
+
+    }
+
+    public void testUnmodifiableSetsDontWrap() {
+
+        TreeSet<Integer> treeSet = new TreeSet<>();
+
+        //Collections.UnmodifiableSet
+        Set<Integer> unmodifiableSet = Collections.unmodifiableSet(treeSet);
+        assertSame(unmodifiableSet.getClass(), UNMODIFIABLESET);
+
+        Set<Integer> rewrappedUnmodifiableSet = Collections.unmodifiableSet(unmodifiableSet);
+        assertSame(rewrappedUnmodifiableSet.getClass(), UNMODIFIABLESET);
+        assertSame(rewrappedUnmodifiableSet, unmodifiableSet);
+
+        //Collections.UnmodifiableSortedSet
+        SortedSet<Integer> unmodifiableSortedSet = Collections.unmodifiableSortedSet(treeSet);
+        assertSame(unmodifiableSortedSet.getClass(), UNMODIFIABLESORTEDSET);
+
+
+        SortedSet<Integer> reWrappedUmodifiableSortedSet = Collections.unmodifiableSortedSet(unmodifiableSortedSet);
+        assertSame(reWrappedUmodifiableSortedSet.getClass(), UNMODIFIABLESORTEDSET);
+        assertSame(reWrappedUmodifiableSortedSet, unmodifiableSortedSet);
+
+        //Collections.UnmodifiableNavigableSet
+        NavigableSet<Integer> unmodifiableNavigableSet = Collections.unmodifiableNavigableSet(treeSet);
+        assertSame(unmodifiableNavigableSet.getClass(), UNMODIFIABLENAVIGABLESET);
+
+        NavigableSet<Integer> reWrappedUnmodifiableNavigableSet =
+                Collections.unmodifiableNavigableSet(unmodifiableNavigableSet);
+        assertSame(reWrappedUnmodifiableNavigableSet.getClass(), UNMODIFIABLENAVIGABLESET);
+        assertSame(reWrappedUnmodifiableNavigableSet, unmodifiableNavigableSet);
+
+        //SET12
+        Set<Integer> set12 = Set.of(1,2);
+        Set<Integer> reWrappedSet12 = Collections.unmodifiableSet(set12);
+        assertSame(reWrappedSet12.getClass(), SET12);
+        assertSame(set12, reWrappedSet12);
+
+        //SETN
+        Set<Integer> setN = Set.of(1,2,3,4,5,6);
+        Set<Integer> reWrappedSetN = Collections.unmodifiableSet(setN);
+        assertSame(reWrappedSetN.getClass(), SETN);
+        assertSame(setN, reWrappedSetN);
+
+
+    }
+
+    public void testUnmodifiableMapsDontWrap() {
+        TreeMap<Integer,Integer> treeMap = new TreeMap<>();
+        treeMap.put(1,1);
+        treeMap.put(2,2);
+        treeMap.put(3,3);
+
+        //Collections.UnModifiableMap
+        Map<Integer,Integer> unmodifiableMap = Collections.unmodifiableMap(treeMap);
+        assertSame(unmodifiableMap.getClass(), UNMODIFIABLEMAP);
+        assertNotSame(unmodifiableMap, treeMap);
+
+        Map<Integer,Integer> reWrappedUnmodifiableMap = Collections.unmodifiableMap(unmodifiableMap);
+        assertSame(reWrappedUnmodifiableMap, unmodifiableMap);
+
+        //Collections.UnModifiableSortedMap
+        SortedMap<Integer,Integer> unmodifiableSortedMap = Collections.unmodifiableSortedMap(treeMap);
+        assertSame(unmodifiableSortedMap.getClass(), UNMODIFIABLESORTEDMAP);
+        assertNotSame(unmodifiableSortedMap, treeMap);
+
+        Map<Integer,Integer> reWrappedUnmodifiableSortedMap = Collections.unmodifiableSortedMap(unmodifiableSortedMap);
+        assertSame(reWrappedUnmodifiableSortedMap, unmodifiableSortedMap);
+
+        //Collections.UnModifiableNavigableMap
+        NavigableMap<Integer,Integer> unmodifiableNavigableMap = Collections.unmodifiableNavigableMap(treeMap);
+        assertSame(unmodifiableNavigableMap.getClass(), UNMODIFIABLENAVIGABLEMAP);
+
+        NavigableMap<Integer,Integer> reWrappedUnmodifiableNavigableMap =
+                Collections.unmodifiableNavigableMap(unmodifiableNavigableMap);
+        assertSame(unmodifiableNavigableMap, reWrappedUnmodifiableNavigableMap);
+
+        //ImmutableCollections.Map1
+        Map<Integer,Integer> map1 = Map.of(1,1);
+        assertSame(map1.getClass(), MAP1);
+
+        Map<Integer,Integer> reWrappedMap1 = Collections.unmodifiableMap(map1);
+        assertSame(map1, reWrappedMap1);
+
+        //ImmutableCollections.MapN
+        Map<Integer,Integer> mapN = Map.of(1,1, 2, 2, 3, 3, 4, 4);
+        assertSame(mapN.getClass(), MAPN);
+
+        Map<Integer,Integer> reWrappedMapN = Collections.unmodifiableMap(mapN);
+        assertSame(mapN, reWrappedMapN);
+
+
+
+
+    }
+
+}

--- a/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
+++ b/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
@@ -43,12 +43,6 @@ public class WrappedUnmodifiableCollections {
         assertSame(collection1, collection2);
     }
 
-    private static <T, E extends T> void testDoesNotWrap(T collection, Function<T,E> wrapper) {
-        var collection2 = wrapper.apply(collection);
-        assertSame(collection, collection2);
-
-    }
-
     public void testUnmodifiableListsDontWrap() {
         List<List<?>> lists = List.of(List.of(), List.of(1,2,3), List.of(1),
                 List.of(1,2,3,4,5,6),
@@ -102,36 +96,6 @@ public class WrappedUnmodifiableCollections {
 
         //Collections.UnModifiableNavigableMap
         testWrapping((NavigableMap<?,?>) treeMap, Collections::unmodifiableNavigableMap);
-
-    }
-
-    public void testUnmodifiableSetSubclassesDontWrap() {
-        TreeSet<?> treeSet = new TreeSet<>();
-
-        var unmodifiableSortedSet = Collections.unmodifiableSortedSet(treeSet);
-        var unmodifiableNavigableSet = Collections.unmodifiableNavigableSet(treeSet);
-
-        //UnmodifiableSet subclasses
-        testDoesNotWrap((Set<?>) unmodifiableSortedSet, Collections::unmodifiableSet);
-        testDoesNotWrap((Set<?>) unmodifiableNavigableSet, Collections::unmodifiableSet);
-
-        //UnmodifiableSortedSet subclasses
-        testDoesNotWrap((SortedSet<?>) unmodifiableNavigableSet, Collections::unmodifiableSortedSet);
-
-    }
-
-    public void testUnmodifiableMapSublcassesDontWrap() {
-        TreeMap<?,?> treeMap = new TreeMap<>();
-
-        var unmodifiableSortedMap = Collections.unmodifiableSortedMap(treeMap);
-        var unmodifiableNavigableMap = Collections.unmodifiableNavigableMap(treeMap);
-
-        //UnmodifiableMap subclasses
-        testDoesNotWrap((Map<?,?>) unmodifiableSortedMap, Collections::unmodifiableMap);
-        testDoesNotWrap((Map<?,?>) unmodifiableNavigableMap, Collections::unmodifiableMap);
-
-        //UnmodifiableSortedMap subclasses
-        testDoesNotWrap((SortedMap<?,?>) unmodifiableNavigableMap, Collections::unmodifiableSortedMap);
 
     }
 

--- a/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
+++ b/test/jdk/java/util/Collections/WrappedUnmodifiableCollections.java
@@ -43,6 +43,12 @@ public class WrappedUnmodifiableCollections {
         assertSame(collection1, collection2);
     }
 
+    private static <T, E extends T> void testDoesNotWrap(T collection, Function<T,E> wrapper) {
+        var collection2 = wrapper.apply(collection);
+        assertSame(collection, collection2);
+
+    }
+
     public void testUnmodifiableListsDontWrap() {
         List<List<?>> lists = List.of(List.of(), List.of(1,2,3), List.of(1),
                 List.of(1,2,3,4,5,6),
@@ -96,6 +102,36 @@ public class WrappedUnmodifiableCollections {
 
         //Collections.UnModifiableNavigableMap
         testWrapping((NavigableMap<?,?>) treeMap, Collections::unmodifiableNavigableMap);
+
+    }
+
+    public void testUnmodifiableSetSubclassesDontWrap() {
+        TreeSet<?> treeSet = new TreeSet<>();
+
+        var unmodifiableSortedSet = Collections.unmodifiableSortedSet(treeSet);
+        var unmodifiableNavigableSet = Collections.unmodifiableNavigableSet(treeSet);
+
+        //UnmodifiableSet subclasses
+        testDoesNotWrap((Set<?>) unmodifiableSortedSet, Collections::unmodifiableSet);
+        testDoesNotWrap((Set<?>) unmodifiableNavigableSet, Collections::unmodifiableSet);
+
+        //UnmodifiableSortedSet subclasses
+        testDoesNotWrap((SortedSet<?>) unmodifiableNavigableSet, Collections::unmodifiableSortedSet);
+
+    }
+
+    public void testUnmodifiableMapSublcassesDontWrap() {
+        TreeMap<?,?> treeMap = new TreeMap<>();
+
+        var unmodifiableSortedMap = Collections.unmodifiableSortedMap(treeMap);
+        var unmodifiableNavigableMap = Collections.unmodifiableNavigableMap(treeMap);
+
+        //UnmodifiableMap subclasses
+        testDoesNotWrap((Map<?,?>) unmodifiableSortedMap, Collections::unmodifiableMap);
+        testDoesNotWrap((Map<?,?>) unmodifiableNavigableMap, Collections::unmodifiableMap);
+
+        //UnmodifiableSortedMap subclasses
+        testDoesNotWrap((SortedMap<?,?>) unmodifiableNavigableMap, Collections::unmodifiableSortedMap);
 
     }
 


### PR DESCRIPTION
Modify the `unmodifiable*` methods in `java.util.Collections` to be idempotent. That is, when given an immutable collection from `java.util.ImmutableCollections` or `java.util.Collections`, these methods will return the reference instead of creating a new immutable collection that wraps the existing one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6323374](https://bugs.openjdk.java.net/browse/JDK-6323374): (coll) Optimize Collections.unmodifiable* and synchronized*


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to ebdd0f85c5f878623abd6923376a2ffad7a29741
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 88127ed5ed61178c8145f3b74adcb0f983888826
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2596/head:pull/2596`
`$ git checkout pull/2596`
