### PR TITLE
8196301: java/awt/print/PrinterJob/Margins.java times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -272,8 +272,6 @@ java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8197796 ge
 java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java 8196300 windows-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
-java/awt/print/PrinterJob/Margins.java 8196301 windows-all,macosx-all
-java/awt/PrintJob/PrinterException.java 8196301 windows-all,macosx-all
 java/awt/Choice/PopupPosTest/PopupPosTest.java  8197811 windows-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all,linux-all
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all

--- a/test/jdk/java/awt/PrintJob/PrinterException.java
+++ b/test/jdk/java/awt/PrintJob/PrinterException.java
@@ -39,11 +39,11 @@ public class PrinterException {
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
         Thread t = new Thread (() -> {
-            robot.waitForIdle();
             robot.delay(2000);
             robot.keyPress(KeyEvent.VK_ESCAPE);
             robot.keyRelease(KeyEvent.VK_ESCAPE);
-           });
+            robot.waitForIdle();
+        });
         Toolkit tk = Toolkit.getDefaultToolkit();
         PrintJob pj = null;
 

--- a/test/jdk/java/awt/print/PrinterJob/Margins.java
+++ b/test/jdk/java/awt/print/PrinterJob/Margins.java
@@ -37,6 +37,8 @@ import java.awt.print.Printable;
 import java.awt.print.PageFormat;
 import java.awt.print.Paper;
 import java.awt.print.PrinterException;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Color;
@@ -47,28 +49,33 @@ public class Margins implements Printable {
 
     public static void main(String args[]) throws Exception {
         Robot robot = new Robot();
-        Thread t = new Thread (() -> {
-            robot.waitForIdle();
-            robot.delay(5000);
-            robot.keyPress(KeyEvent.VK_ENTER);
-            robot.keyRelease(KeyEvent.VK_ENTER);
-            robot.waitForIdle();
-            robot.delay(5000);
-            robot.keyPress(KeyEvent.VK_ENTER);
-            robot.keyRelease(KeyEvent.VK_ENTER);
-            robot.waitForIdle();
-            robot.delay(5000);
-            robot.keyPress(KeyEvent.VK_ENTER);
-            robot.keyRelease(KeyEvent.VK_ENTER);
-        });
-
         PrinterJob job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            System.out.println("No printers. Test cannot continue");
+            return;
+        }
+        PrintService psrv = PrintServiceLookup.lookupDefaultPrintService();
+        System.out.println("PrintService " + psrv.getName());
+        if (psrv.getName().contains("Print to PDF") ||
+            psrv.getName().contains("OneNote") ||
+            psrv.getName().contains("XPS Document Writer")) {
+            System.out.println("Please use real printer.");
+            System.out.println("Please avoid Microsoft Print to PDF or OneNote printer or XPS Writer");
+            return;
+        }
+
         PageFormat pageFormat = job.defaultPage();
         Paper paper = pageFormat.getPaper();
         double wid = paper.getWidth();
         double hgt = paper.getHeight();
         paper.setImageableArea(0, -10, wid, hgt);
-        t.start();
+
+        Thread t1 = new Thread(() -> {
+            robot.delay(2000);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+        });
+        t1.start();
 
         pageFormat = job.pageDialog(pageFormat);
         pageFormat.setPaper(paper);
@@ -79,6 +86,14 @@ public class Margins implements Printable {
         }
 
         paper.setImageableArea(0, 0, wid, hgt + 72);
+
+        Thread t2 = new Thread(() -> {
+            robot.delay(2000);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+        });
+        t2.start();
+
         pageFormat = job.pageDialog(pageFormat);
         pageFormat.setPaper(paper);
 
@@ -94,6 +109,14 @@ public class Margins implements Printable {
         hgt = paper.getHeight();
 
         paper.setImageableArea(0, -10, -wid, hgt);
+
+        Thread t3 = new Thread(() -> {
+            robot.delay(2000);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+        });
+        t3.start();
+
         pageFormat = job.pageDialog(pageFormat);
         pageFormat.setPaper(paper);
 

--- a/test/jdk/java/awt/print/PrinterJob/Margins.java
+++ b/test/jdk/java/awt/print/PrinterJob/Margins.java
@@ -56,13 +56,6 @@ public class Margins implements Printable {
         }
         PrintService psrv = PrintServiceLookup.lookupDefaultPrintService();
         System.out.println("PrintService " + psrv.getName());
-        if (psrv.getName().contains("Print to PDF") ||
-            psrv.getName().contains("OneNote") ||
-            psrv.getName().contains("XPS Document Writer")) {
-            System.out.println("Please use real printer.");
-            System.out.println("Please avoid Microsoft Print to PDF or OneNote printer or XPS Writer");
-            return;
-        }
 
         PageFormat pageFormat = job.defaultPage();
         Paper paper = pageFormat.getPaper();


### PR DESCRIPTION
This test was timing out in windows in mach5 nightly testing. Investigation reveals that 70% of the time, it is failing due to printer being chosen was Microsoft Print to PDF which opens up a File Save Dialog when "OK" was clicked in printer pagedialog. Since no user intervention is done to dismiss the modal filedialog, so subsequent pagedialog was not dismissed resulting in timeout.
Other times, it was found that "One Note" software printer was used as default printerservice which again, opens up a OneNote app which again gets focus and obscure pagedialog so PageDialog did not get dismissed.
Updated test to ignore "Print To PDF", "OneNote" and "XPS Document Writer"(which again opens filedialog like PDF printer) and run it for several iteration in mach5 platforms which is ok. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196301](https://bugs.openjdk.java.net/browse/JDK-8196301): java/awt/print/PrinterJob/Margins.java times out


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2598/head:pull/2598`
`$ git checkout pull/2598`
