### PR TITLE
8260366: ExtendedSocketOptions <clinit> can deadlock in some circumstances

### DIFF
--- a/src/java.base/share/classes/sun/net/ext/ExtendedSocketOptions.java
+++ b/src/java.base/share/classes/sun/net/ext/ExtendedSocketOptions.java
@@ -172,21 +172,22 @@ public abstract class ExtendedSocketOptions {
         if (ext != null) {
             return ext;
         }
-        synchronized (ExtendedSocketOptions.class) {
+        try {
+            // If the class is present, it will be initialized which
+            // triggers registration of the extended socket options.
+            Class<?> c = Class.forName("jdk.net.ExtendedSocketOptions");
             ext = instance;
-            if (ext != null) {
-                return ext;
-            }
-            try {
-                // If the class is present, it will be initialized which
-                // triggers registration of the extended socket options.
-                Class<?> c = Class.forName("jdk.net.ExtendedSocketOptions");
-            } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
+            synchronized (ExtendedSocketOptions.class) {
+                ext = instance;
+                if (ext != null) {
+                    return ext;
+                }
                 // the jdk.net module is not present => no extended socket options
-                instance = new NoExtendedSocketOptions();
+                ext = instance = new NoExtendedSocketOptions();
             }
         }
-        return instance;
+        return ext;
     }
 
     /** Registers support for extended socket options. Invoked by the jdk.net module. */

--- a/src/java.base/share/classes/sun/net/ext/ExtendedSocketOptions.java
+++ b/src/java.base/share/classes/sun/net/ext/ExtendedSocketOptions.java
@@ -168,12 +168,14 @@ public abstract class ExtendedSocketOptions {
     private static volatile ExtendedSocketOptions instance;
 
     public static ExtendedSocketOptions getInstance() {
-        if (instance != null) {
-            return instance;
+        ExtendedSocketOptions ext = instance;
+        if (ext != null) {
+            return ext;
         }
         synchronized (ExtendedSocketOptions.class) {
-            if (instance != null) {
-                return instance;
+            ext = instance;
+            if (ext != null) {
+                return ext;
             }
             try {
                 // If the class is present, it will be initialized which

--- a/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
+++ b/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
+++ b/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
@@ -37,6 +37,10 @@ import java.util.concurrent.Future;
  * @modules java.base/sun.net.ext:open
  *          jdk.net
  * @run testng/othervm ExtendedSocketOptionsTest
+ * @run testng/othervm ExtendedSocketOptionsTest
+ * @run testng/othervm ExtendedSocketOptionsTest
+ * @run testng/othervm ExtendedSocketOptionsTest
+ * @run testng/othervm ExtendedSocketOptionsTest
  */
 public class ExtendedSocketOptionsTest {
 

--- a/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
+++ b/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * @test
+ * @bug 8260366
+ * @summary Verify that concurrent classloading of sun.net.ext.ExtendedSocketOptions and
+ * jdk.net.ExtendedSocketOptions doesn't lead to a deadlock
+ * @run testng/othervm --add-exports=java.base/sun.net.ext=ALL-UNNAMED ExtendedSocketOptionsTest
+ */
+public class ExtendedSocketOptionsTest {
+
+    /**
+     * Loads {@code jdk.net.ExtendedSocketOptions} and {@code sun.net.ext.ExtendedSocketOptions}
+     * concurrently in a thread of their own and expects the classloading of both those classes
+     * to succeed. Additionally, after the classloading is successfully done, calls the
+     * sun.net.ext.ExtendedSocketOptions#getInstance() and expects it to return a registered
+     * ExtendedSocketOptions instance.
+     */
+    @Test
+    public void testConcurrentClassLoad() throws Exception {
+        final Callable<Class<?>> task1 = new Task("jdk.net.ExtendedSocketOptions");
+        final Callable<Class<?>> task2 = new Task("sun.net.ext.ExtendedSocketOptions");
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            final Future<Class<?>>[] results = new Future[2];
+            // submit
+            for (int i = 0; i < 2; i++) {
+                results[i] = executor.submit(i == 0 ? task1 : task2);
+            }
+            // wait for completion
+            for (int i = 0; i < 2; i++) {
+                final Class<?> k = results[i].get();
+                System.out.println("Completed loading " + k.getName());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+        // check that the sun.net.ext.ExtendedSocketOptions#getInstance() does indeed return
+        // the registered instance
+        final Class<?> k = Class.forName("sun.net.ext.ExtendedSocketOptions");
+        final Object extSocketOptions = k.getDeclaredMethod("getInstance").invoke(null);
+        Assert.assertNotNull(extSocketOptions, "sun.net.ext.ExtendedSocketOptions#getInstance()" +
+                " unexpectedly returned null");
+    }
+
+    private static class Task implements Callable<Class<?>> {
+        private final String className;
+
+        private Task(final String className) {
+            this.className = className;
+        }
+
+        public Class<?> call() {
+            System.out.println(Thread.currentThread().getName() + " loading " + this.className);
+            try {
+                return Class.forName(this.className);
+            } catch (Exception e) {
+                System.err.println("Failed to load " + this.className);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
+++ b/test/jdk/sun/net/ext/ExtendedSocketOptionsTest.java
@@ -34,7 +34,9 @@ import java.util.concurrent.Future;
  * @bug 8260366
  * @summary Verify that concurrent classloading of sun.net.ext.ExtendedSocketOptions and
  * jdk.net.ExtendedSocketOptions doesn't lead to a deadlock
- * @run testng/othervm --add-exports=java.base/sun.net.ext=ALL-UNNAMED ExtendedSocketOptionsTest
+ * @modules java.base/sun.net.ext:open
+ *          jdk.net
+ * @run testng/othervm ExtendedSocketOptionsTest
  */
 public class ExtendedSocketOptionsTest {
 


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue reported in https://bugs.openjdk.java.net/browse/JDK-8260366?

The issue relates to the concurrent classloading of `sun.net.ext.ExtendedSocketOptions` and `jdk.net.ExtendedSocketOptions` leading to a deadlock. This is because the `sun.net.ext.ExtendedSocketOptions` in its static block does a `Class.forName("jdk.net.ExtendedSocketOptions")`. The `jdk.net.ExtendedSocketOptions` in its own static block calls the `register` method on `sun.net.ext.ExtendedSocketOptions`. If 2 threads concurrently try loading these classes (one loading the `sun.net.ext.ExtendedSocketOptions` and the other loading `jdk.net.ExtendedSocketOptions`), it can so happen that each one ends up holding a classloading lock in the static block of the respective class, while waiting for the other thread to release the lock, thus leading to a deadlock. The stacktrace posted in the linked JBS issue has the necessary details on the deadlock.

The commit here breaks this deadlock by moving out the `Class.forName("jdk.net.ExtendedSocketOptions")` call from the static block of `sun.net.ext.ExtendedSocketOptions` to the `getInstance()` method, thus lazily loading (on first call to `getInstance()`) and registering the `jdk.net.ExtendedSocketOptions`.

Extra attention needs to be given to the `sun.net.ext.ExtendedSocketOptions#register(ExtendedSocketOptions extOptions)` method. Before the change in this PR, when the `sun.net.ext.ExtendedSocketOptions` would successfully complete loading, it was guaranteed that the registered `ExtendedSocketOptions` would either be the one registered from the `jdk.net.ExtendedSocketOptions` or a `NoExtendedSocketOptions`. There wasn't any window of chance for any code (be it in the JDK or in application code) to call the `sun.net.ext.ExtendedSocketOptions#register` to register any different/other implementation/instance of the `ExtendedSocketOptions`. However, with this change in the PR, there is now a window of chance where any code in the JDK (or even application code?) can potentially call the `sun.net.ext.ExtendedSocketOptions#register` before either the `jdk.net.ExtendedSocketOptions` is loaded or the `sun.net.ext.ExtendedSocketOptions#getInstance()` method is called, thus allowing for some other implementation of the `ExtendedSocketOptions` to be registered. However, I'm not sure if it's a practical scenario - although the `sun.net.ext.ExtendedSocketOptions#register` is marked `public`, the comment on that method and the fact that it resides in an internal, not exposed by default class/module, makes me believe that this `register` method isn't supposed to be called by anyone other than the `jdk.net.ExtendedSocketOptions`. If at all this `register` method is allowed to be called from other places, then due to the change in this PR, additional work needs to be probably done in its implementation to allow for the `jdk.net.ExtendedSocketOptions` to be given first priority(?) to be registered first. I'll need input on whether I should worry about this case or if it's fine in its current form in this PR.

This PR also contains a jtreg test which reproduces the issue and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260366](https://bugs.openjdk.java.net/browse/JDK-8260366): ExtendedSocketOptions <clinit> can deadlock in some circumstances


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2601/head:pull/2601`
`$ git checkout pull/2601`
