### PR TITLE
8228748: Remove GCLocker::_doing_gc

### DIFF
--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -44,8 +44,6 @@ class GCLocker: public AllStatic {
   // unlocking.
   static volatile jint _jni_lock_count;  // number of jni active instances.
   static volatile bool _needs_gc;        // heap is filling, we need a GC
-                                         // note: bool is typedef'd as jint
-  static volatile bool _doing_gc;        // unlock_critical() is doing a GC
   static uint _total_collections;        // value for _gc_locker collection
 
 #ifdef ASSERT


### PR DESCRIPTION
Some refactoring in `GCLocker` and more comments in `jni_lock` on how the synchronization works there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8228748](https://bugs.openjdk.java.net/browse/JDK-8228748): Remove GCLocker::_doing_gc


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 17ff21e705be0635d513cbbb0e91af551e6e79f7
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2602/head:pull/2602`
`$ git checkout pull/2602`
