### PR TITLE
JDK-8261873: Do not start a deleted thread in jfrRecorderThread.cpp start_thread

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -55,6 +55,7 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
     // osthread was created for the JavaThread due to lack of memory.
     if (new_thread == NULL || new_thread->osthread() == NULL) {
       delete new_thread;
+      new_thread = NULL;
       allocation_failed = true;
     } else {
       java_lang_Thread::set_thread(thread_oop(), new_thread);
@@ -66,8 +67,9 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
   }
   if (allocation_failed) {
     JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", CHECK_NULL);
+  } else {
+    Thread::start(new_thread);
   }
-  Thread::start(new_thread);
   return new_thread;
 }
 


### PR DESCRIPTION
In jfrRecorderThread.cpp start_thread there is a code path where potentially
Thread::start is called on a deleted thread, this should be avoided.

See also the related Sonar finding :

https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=cpp&open=AXck7_QbBBG2CXpcnIyR&resolved=false&severities=BLOCKER&types=BUG

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261873](https://bugs.openjdk.java.net/browse/JDK-8261873): Do not start a deleted thread in jfrRecorderThread.cpp start_thread


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2603/head:pull/2603`
`$ git checkout pull/2603`
