### PR TITLE
8260653: Unreachable nodes keep speculative types alive

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2169,6 +2169,9 @@ void Compile::Optimize() {
   // safepoints
   remove_root_to_sfpts_edges(igvn);
 
+  // Remove unreachable nodes that may keep speculative types alive
+  PhaseRemoveUseless(&igvn, for_igvn(), Remove_Useless);
+
   // Remove the speculative part of types and clean up the graph from
   // the extra CastPP nodes whose only purpose is to carry them. Do
   // that early so that optimizations are not disrupted by the extra

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2169,9 +2169,6 @@ void Compile::Optimize() {
   // safepoints
   remove_root_to_sfpts_edges(igvn);
 
-  // Remove unreachable nodes that may keep speculative types alive
-  PhaseRemoveUseless(&igvn, for_igvn(), Remove_Useless);
-
   // Remove the speculative part of types and clean up the graph from
   // the extra CastPP nodes whose only purpose is to carry them. Do
   // that early so that optimizations are not disrupted by the extra

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -330,10 +330,16 @@ void NodeHash::remove_useless_nodes(VectorSet &useful) {
 void NodeHash::check_no_speculative_types() {
 #ifdef ASSERT
   uint max = size();
+  Unique_Node_List live_nodes;
+  Compile::current()->identify_useful_nodes(live_nodes);
   Node *sentinel_node = sentinel();
   for (uint i = 0; i < max; ++i) {
     Node *n = at(i);
-    if(n != NULL && n != sentinel_node && n->is_Type() && n->outcnt() > 0) {
+    if(n != NULL &&
+       n != sentinel_node &&
+       n->is_Type() &&
+       n->outcnt() > 0 &&
+       live_nodes.member(n)) {
       TypeNode* tn = n->as_Type();
       const Type* t = tn->type();
       const Type* t_no_spec = t->remove_speculative();

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -335,10 +335,10 @@ void NodeHash::check_no_speculative_types() {
   Node *sentinel_node = sentinel();
   for (uint i = 0; i < max; ++i) {
     Node *n = at(i);
-    if(n != NULL &&
-       n != sentinel_node &&
-       n->is_Type() &&
-       live_nodes.member(n)) {
+    if (n != NULL &&
+        n != sentinel_node &&
+        n->is_Type() &&
+        live_nodes.member(n)) {
       TypeNode* tn = n->as_Type();
       const Type* t = tn->type();
       const Type* t_no_spec = t->remove_speculative();

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -338,7 +338,6 @@ void NodeHash::check_no_speculative_types() {
     if(n != NULL &&
        n != sentinel_node &&
        n->is_Type() &&
-       n->outcnt() > 0 &&
        live_nodes.member(n)) {
       TypeNode* tn = n->as_Type();
       const Type* t = tn->type();


### PR DESCRIPTION
The RunThese test fails because after first igvn.optimize() (directly after parsing) there are unreachable nodes cycles left. Later when remove_speculative_types() is called - only reachable nodes will have their speculative type removed. At the end of remove_speculative_types() there is an assert that all speculative types have been removed that will fail.

This problem will not cause crashes in production - it is only a sanity test.

I suggest adding a call to PhaseRemoveUseless before remove_speculative_types. This will cost a few extra cycles but it is the only way we can guarantee that no unreachable nodes are left.

When debugging this I experimented with adding a call to verify_graph_edges to check for dead code at the same spot. This triggers failures in a lot of test. The conclusion is that it is very common that we have dead node cycles - but they very rarely keep speculative types alive.

A big thank you to Dean Long how created the reproducer for this bug.

Please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260653](https://bugs.openjdk.java.net/browse/JDK-8260653): Unreachable nodes keep speculative types alive


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 82ab1066ca9160e76fdd16204199b27475fd8c19
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to ac23dad847470c5e53feb410fc0aa9903500d0f4


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2606/head:pull/2606`
`$ git checkout pull/2606`
