### PR TITLE
8261925: ProblemList com/sun/jdi/AfterThreadDeathTest.java on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -788,7 +788,7 @@ com/sun/jdi/NashornPopFrameTest.java                            8225620 generic-
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
-com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-x64
+com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
I am seeing exactly the same error in GitHub Actions on x86_32, as in [JDK-8232839](https://bugs.openjdk.java.net/browse/JDK-8232839). [JDK-8258832](JDK-8258832) put it on problemlist for linux-x64, let's elevate that to linux-all.

Additional testing:
 - [x] Test on Linux x86_64 (still skipped)
 - [x] Test on Linux x86_32 (now skipped)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261925](https://bugs.openjdk.java.net/browse/JDK-8261925): ProblemList com/sun/jdi/AfterThreadDeathTest.java on Linux


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2614/head:pull/2614`
`$ git checkout pull/2614`
