### PR TITLE
8261728: SimpleDateFormat should link to DateTimeFormatter

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,8 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * Date formats are not synchronized.
  * It is recommended to create separate format instances for each thread.
  * If multiple threads access a format concurrently, it must be synchronized
- * externally.
+ * externally. Consider using {@link java.time.format.DateTimeFormatter} as an
+ * immutable and thread-safe alternative.
  *
  * @implSpec
  * <ul><li>The {@link #format(Date, StringBuffer, FieldPosition)} and
@@ -173,6 +174,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * @see          java.util.Calendar
  * @see          java.util.GregorianCalendar
  * @see          java.util.TimeZone
+ * @see          java.time.format.DateTimeFormatter
  * @author       Mark Davis, Chen-Lieh Huang, Alan Liu
  * @since 1.1
  */

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -146,7 +146,8 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * Date formats are not synchronized.
  * It is recommended to create separate format instances for each thread.
  * If multiple threads access a format concurrently, it must be synchronized
- * externally. Consider using {@link java.time.format.DateTimeFormatter} as an
+ * externally.
+ * @apiNote Consider using {@link java.time.format.DateTimeFormatter} as an
  * immutable and thread-safe alternative.
  *
  * @implSpec

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -427,7 +427,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * Date formats are not synchronized.
  * It is recommended to create separate format instances for each thread.
  * If multiple threads access a format concurrently, it must be synchronized
- * externally. Consider using {@link java.time.format.DateTimeFormatter} as an
+ * externally.
+ * @apiNote Consider using {@link java.time.format.DateTimeFormatter} as an
  * immutable and thread-safe alternative.
  *
  * @see          <a href="http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html">Java Tutorial</a>

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,13 +427,15 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * Date formats are not synchronized.
  * It is recommended to create separate format instances for each thread.
  * If multiple threads access a format concurrently, it must be synchronized
- * externally.
+ * externally. Consider using {@link java.time.format.DateTimeFormatter} as an
+ * immutable and thread-safe alternative.
  *
  * @see          <a href="http://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html">Java Tutorial</a>
  * @see          java.util.Calendar
  * @see          java.util.TimeZone
  * @see          DateFormat
  * @see          DateFormatSymbols
+ * @see          java.time.format.DateTimeFormatter
  * @author       Mark Davis, Chen-Lieh Huang, Alan Liu
  * @since 1.1
  */


### PR DESCRIPTION
Please review this simple doc fix. A CSR will be filed accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261728](https://bugs.openjdk.java.net/browse/JDK-8261728): SimpleDateFormat should link to DateTimeFormatter


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2616/head:pull/2616`
`$ git checkout pull/2616`
