### PR TITLE
8261483: jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java failed with "AssertionError: Should have GCd a method handle by now"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -817,8 +817,6 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 
 javax/script/Test7.java                                         8239361 generic-all
 
-jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java            8261483 generic-all
-
 ############################################################################
 
 # jdk_jfr


### PR DESCRIPTION
8261483: jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java failed with "AssertionError: Should have GCd a method handle by now"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261483](https://bugs.openjdk.java.net/browse/JDK-8261483): jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java failed with "AssertionError: Should have GCd a method handle by now"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Peter Levart](https://openjdk.java.net/census#plevart) (@plevart - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2617/head:pull/2617`
`$ git checkout pull/2617`
