### PR TITLE
6245663: (spec) File.renameTo(File) changes the file-system object, not the File instance

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1379,7 +1379,8 @@ public class File
      * that the rename operation was successful.  As instances of {@code File}
      * are immutable, the abstract pathname represented by this {@code File}
      * object does not itself change although the filesystem object it denoted
-     * might have moved.
+     * might have moved to the abstract pathname provided in the {@code dest}
+     * parameter.
      *
      * <p> Note that the {@link java.nio.file.Files} class defines the {@link
      * java.nio.file.Files#move move} method to move or rename a file in a

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1376,7 +1376,10 @@ public class File
      * file from one filesystem to another, it might not be atomic, and it
      * might not succeed if a file with the destination abstract pathname
      * already exists.  The return value should always be checked to make sure
-     * that the rename operation was successful.
+     * that the rename operation was successful.  As instances of {@code File}
+     * are immutable, the abstract pathname represented by this {@code File}
+     * object does not itself change although the filesystem object it denoted
+     * might have moved.
      *
      * <p> Note that the {@link java.nio.file.Files} class defines the {@link
      * java.nio.file.Files#move move} method to move or rename a file in a

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1377,10 +1377,8 @@ public class File
      * might not succeed if a file with the destination abstract pathname
      * already exists.  The return value should always be checked to make sure
      * that the rename operation was successful.  As instances of {@code File}
-     * are immutable, the abstract pathname represented by this {@code File}
-     * object does not itself change although the filesystem object it denoted
-     * might have moved to the abstract pathname provided in the {@code dest}
-     * parameter.
+     * are immutable, this File object is not changed to name the destination
+     * file or directory.
      *
      * <p> Note that the {@link java.nio.file.Files} class defines the {@link
      * java.nio.file.Files#move move} method to move or rename a file in a


### PR DESCRIPTION
Please review this minor specification update to highlight that `File.renameTo(File)` does not modify the `File` instance on which the method is invoked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6245663](https://bugs.openjdk.java.net/browse/JDK-6245663): (spec) File.renameTo(File) changes the file-system object, not the File instance


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to e7ff82d26b8340cc12a3fc9869ff7d7b98697113
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2618/head:pull/2618`
`$ git checkout pull/2618`
