### PR TITLE
8261938: ASN1Formatter.annotate should not return in the finally block

### DIFF
--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -110,11 +110,23 @@ public class ASN1Formatter implements HexPrinter.Formatter {
      * A single well formed tagged-value is read and annotated.
      *
      * @param in  a DataInputStream
-     * @throws IOException if an I/O error occurs
      */
-    public String annotate(DataInputStream in) throws IOException {
+    public String annotate(DataInputStream in) {
         StringBuilder sb = new StringBuilder();
-        this.annotate(in, sb);
+        try {
+            this.annotate(in, sb);
+        } catch (IOException e) {
+            /*
+             * Formatters are designed to be nested, where one formatter can call another and the valuable output
+             * is the formatted string that has been accumulated from the beginning of the stream.
+             *
+             * The choice of DataInputStream was chosen for the convenience of the methods to read different types.
+             * and (declared) exceptions are an unwelcome artifact.
+             *
+             * If an exception was percolated up and the formatted output discarded, it would defeat the purpose.
+             * So we just catch it here and still return useful information about the stream to this point.
+             */
+        }
         return sb.toString();
     }
 

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -114,11 +114,8 @@ public class ASN1Formatter implements HexPrinter.Formatter {
      */
     public String annotate(DataInputStream in) throws IOException {
         StringBuilder sb = new StringBuilder();
-        try {
-            this.annotate(in, sb);
-        } finally {
-            return sb.toString();
-        }
+        this.annotate(in, sb);
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
Hi all,

ASN1Formatter.annotate should be able to throw an IOException according to this comment [1].
But it fails to do so due to the return [2] in the finally block, which would swallow the IOException.

Generally, it seems not good to put a return statement in a finally block because it would overwrite other return-statements or Exceptions [3].

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java#L113
[2] https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java#L120
[3] https://stackoverflow.com/questions/17481251/finally-block-does-not-complete-normally-eclipse-warning

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261938](https://bugs.openjdk.java.net/browse/JDK-8261938): ASN1Formatter.annotate should not return in the finally block


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2620/head:pull/2620`
`$ git checkout pull/2620`
