### PR TITLE
8261939: os::strdup_check_oom() should be used in os::same_files() in os_windows.cpp

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4481,9 +4481,9 @@ bool os::same_files(const char* file1, const char* file2) {
     return true;
   }
 
-  char* native_file1 = os::strdup(file1);
+  char* native_file1 = os::strdup_check_oom(file1);
   native_file1 = os::native_path(native_file1);
-  char* native_file2 = os::strdup(file2);
+  char* native_file2 = os::strdup_check_oom(file2);
   native_file2 = os::native_path(native_file2);
   if (strcmp(native_file1, native_file2) == 0) {
     os::free(native_file1);


### PR DESCRIPTION
This to to address a review comment for JDK-8202750: 
https://github.com/openjdk/jdk/pull/2581#discussion_r577984793

I forgot to push this change before integration for JDK-8202750.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261939](https://bugs.openjdk.java.net/browse/JDK-8261939): os::strdup_check_oom() should be used in os::same_files() in os_windows.cpp


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2621/head:pull/2621`
`$ git checkout pull/2621`
