### PR TITLE
8261920: [AIX] jshell command throws java.io.IOError on non English locales

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/ExecHelper.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/ExecHelper.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -29,6 +30,12 @@ public final class ExecHelper {
         try {
             Log.trace("Running: ", cmd);
             ProcessBuilder pb = new ProcessBuilder(cmd);
+            if (OSUtils.IS_AIX) {
+                Map<String,String> env = pb.environment();
+                env.put("PATH", "/opt/freeware/bin:" + env.get("PATH"));
+                env.put("LANG", "C");
+                env.put("LC_ALL", "C");
+            }
             if (redirectInput) {
                 pb.redirectInput(ProcessBuilder.Redirect.INHERIT);
             }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
@@ -32,6 +32,7 @@ public class OSUtils {
             && System.getenv("ConEmuPID") != null;
 
     public static final boolean IS_OSX = System.getProperty("os.name").toLowerCase().contains("mac");
+    public static final boolean IS_AIX = System.getProperty("os.name").equals("AIX");
 
     public static String TTY_COMMAND;
     public static String STTY_COMMAND;


### PR DESCRIPTION
jshell uses JLine library.
JLine checks word "columns" in "stty -a" command output to find out terminal size.
The word "columns" was translated on AIX's Japanese locale (other locales also), so above error was happened.

OpenJDK for AIX developer could not find this issue because he/she requires AIX Toolbox's coreutils rpm package as build tools.
Another stty command is in /opt/freeware/bin/stty, it's in coreutils rpm package.

Standard users' system may not have coreutils rpm package or they may not set /opt/freeware/bin in PATH environment variable.
stty command should be executed with C locale to get English message.
Additionally, JLine library requires -F option. AIX's stty command does not support -F option,
but stty command which is in coreutils rpm package supports -F option.
On standard jshell usage, -F option may not be used. But when the system has coreutils rpm package, jshell should use this one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261920](https://bugs.openjdk.java.net/browse/JDK-8261920): [AIX] jshell command throws java.io.IOError on non English locales


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2622/head:pull/2622`
`$ git checkout pull/2622`
