### PR TITLE
8261940: Fix references to IOException in BigDecimal javadoc 

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -4219,7 +4219,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * deserialize it).
      *
      * @param  s the stream being read.
-     * @throws IOException if an I/O error occurs
+     * @throws java.io.IOException if an I/O error occurs
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
     @java.io.Serial
@@ -4240,7 +4240,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
     * Serialize this {@code BigDecimal} to the stream in question
     *
     * @param  s the stream to serialize to.
-    * @throws IOException if an I/O error occurs
+    * @throws java.io.IOException if an I/O error occurs
     */
     @java.io.Serial
    private void writeObject(java.io.ObjectOutputStream s)

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -30,6 +30,7 @@
 package java.math;
 
 import static java.math.BigInteger.LONG_MASK;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -4219,12 +4220,12 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * deserialize it).
      *
      * @param  s the stream being read.
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
     @java.io.Serial
     private void readObject(java.io.ObjectInputStream s)
-        throws java.io.IOException, ClassNotFoundException {
+        throws IOException, ClassNotFoundException {
         // Read in all fields
         s.defaultReadObject();
         // validate possibly bad fields
@@ -4240,11 +4241,11 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
     * Serialize this {@code BigDecimal} to the stream in question
     *
     * @param  s the stream to serialize to.
-    * @throws java.io.IOException if an I/O error occurs
+    * @throws IOException if an I/O error occurs
     */
     @java.io.Serial
    private void writeObject(java.io.ObjectOutputStream s)
-       throws java.io.IOException {
+       throws IOException {
        // Must inflate to maintain compatible serial form.
        if (this.intVal == null)
            UnsafeHolder.setIntValVolatile(this, BigInteger.valueOf(this.intCompact));


### PR DESCRIPTION
Noticed by some of  Jon Gibbons's doc linting & checking tooling, this changeset fixes two javadoc issues for BigDecimal's serialization-related methods, improving the serial form page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261940](https://bugs.openjdk.java.net/browse/JDK-8261940): Fix references to IOException in BigDecimal javadoc


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 27ff1d780d6b1992c4cbe7bf4253069b70fbaa7d
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 27ff1d780d6b1992c4cbe7bf4253069b70fbaa7d
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 27ff1d780d6b1992c4cbe7bf4253069b70fbaa7d
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 27ff1d780d6b1992c4cbe7bf4253069b70fbaa7d


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2623/head:pull/2623`
`$ git checkout pull/2623`
