### PR TITLE
8261857: serviceability/sa/ClhsdbPrintAll.java failed with "Test ERROR java.lang.RuntimeException: 'cannot be cast to' found in stdout"

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAll.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class ClhsdbPrintAll {
                 "Exception Table",
                 "invokedynamic"));
             unExpStrMap.put("printall", List.of(
-                "cannot be cast to"));
+                "cannot be cast to class"));
             test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
         } catch (SkippedException se) {
             throw se;


### PR DESCRIPTION
The test is checking for "cannot be cast to" because at one point there was a bug in `printall` that was causing a `ClassCastException`. See [JDK-8175384](https://bugs.openjdk.java.net/browse/JDK-8175384). However, there is also a "cannot be cast to" message in the `printall` output when disassembling since the java source actually has it in a string literal:

 3203 302 ldc #214(6) <String " cannot be cast to ResourceBundle"> [fast_aldc]

Which comes from the following in the ResourceBundle.java source:

                        throw new ClassCastException(c.getName()
                                + " cannot be cast to ResourceBundle"); 

So this occurrence of "cannot be cast" is fine. The one we don't want comes from `SharedRuntime::generate_class_cast_message()` in `sharedRuntime.cpp`:

`                 "class %s cannot be cast to class %s (%s%s%s)",`

So we can avoid this bug by changing the check to be a bit more explicit and check for "cannot be cast to class" instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261857](https://bugs.openjdk.java.net/browse/JDK-8261857): serviceability/sa/ClhsdbPrintAll.java failed with "Test ERROR java.lang.RuntimeException: 'cannot be cast to' found in stdout"


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2624/head:pull/2624`
`$ git checkout pull/2624`
