### PR TITLE
8261949: fileStream::readln returns incorrect line string

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -589,8 +589,11 @@ char* fileStream::readln(char *data, int count ) {
   char * ret = NULL;
   if (_file != NULL) {
     ret = ::fgets(data, count, _file);
-    //Get rid of annoying \n char
-    data[::strlen(data)-1] = '\0';
+    // Get rid of annoying \n char only if it presents, it works for Posix
+    // and Windows since the last character of these systems is always '\n'
+    if (data[::strlen(data)-1] == '\n') {
+      data[::strlen(data)-1] = '\0';
+    }
   }
   return ret;
 }

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -589,10 +589,10 @@ char* fileStream::readln(char *data, int count ) {
   char * ret = NULL;
   if (_file != NULL) {
     ret = ::fgets(data, count, _file);
-    // Get rid of annoying \n char only if it presents, it works for Posix
-    // and Windows since the last character of these systems is always '\n'
-    if (data[::strlen(data)-1] == '\n') {
-      data[::strlen(data)-1] = '\0';
+    // Get rid of annoying \n char only if it is present.
+    size_t len = ::strlen(data);
+    if (len > 0 && data[len - 1] == '\n') {
+      data[len - 1] = '\0';
     }
   }
   return ret;


### PR DESCRIPTION
When the last line does not contain a NEWLINE character, fileStream::readln would read
truncated line string:

$ cat file_content:
AA
BB
CC<EOF>

fileStream::readln result:
"AA"
"BB"
"C"

This patch address this problem, it works for Posix and Windows since the last character
of these systems is always '\n'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261949](https://bugs.openjdk.java.net/browse/JDK-8261949): fileStream::readln returns incorrect line string


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2626/head:pull/2626`
`$ git checkout pull/2626`
