### PR TITLE
8261803: Remove unused TaskTerminator in g1 full gc ref proc executor

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,7 @@ G1FullGCReferenceProcessingExecutor::G1RefProcTaskProxy::G1RefProcTaskProxy(Proc
                                                                       G1FullCollector* collector) :
      AbstractGangTask("G1 reference processing task"),
      _proc_task(proc_task),
-     _collector(collector),
-     _terminator(_collector->workers(), _collector->oop_queue_set()) { }
+     _collector(collector) { }
 
 void G1FullGCReferenceProcessingExecutor::G1RefProcTaskProxy::work(uint worker_id) {
   G1FullGCMarker* marker = _collector->marker(worker_id);

--- a/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,6 @@ private:
     typedef AbstractRefProcTaskExecutor::ProcessTask ProcessTask;
     ProcessTask&                  _proc_task;
     G1FullCollector*              _collector;
-    TaskTerminator                _terminator;
 
   public:
     G1RefProcTaskProxy(ProcessTask& proc_task,


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261803](https://bugs.openjdk.java.net/browse/JDK-8261803): Remove unused TaskTerminator in g1 full gc ref proc executor


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2629/head:pull/2629`
`$ git checkout pull/2629`
