### PR TITLE
8261954: Dependencies: Improve iteration over class hierarchy under context class

### DIFF
--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1356,7 +1356,7 @@ Klass* ClassHierarchyWalker::find_witness_anywhere(InstanceKlass* context_type, 
 
   assert(!context_type->is_interface(), "not allowed");
 
-  for (ClassHierarchyIterator iter(context_type); iter.next();) {
+  for (ClassHierarchyIterator iter(context_type); !iter.done(); iter.next()) {
     Klass* sub = iter.klass();
 
     if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1000,19 +1000,23 @@ class ClassHierarchyWalker {
   // The walker is initialized to recognize certain methods and/or types
   // as friendly participants.
   ClassHierarchyWalker(Klass* participant, Method* m) {
+    _mode = false;
     initialize_from_method(m);
     initialize(participant);
   }
   ClassHierarchyWalker(Method* m) {
+    _mode = false;
     initialize_from_method(m);
     initialize(NULL);
   }
   ClassHierarchyWalker(Klass* participant = NULL) {
+    _mode = false;
     _name      = NULL;
     _signature = NULL;
     initialize(participant);
   }
   ClassHierarchyWalker(Klass* participants[], int num_participants) {
+    _mode = false;
     _name      = NULL;
     _signature = NULL;
     initialize(NULL);
@@ -1020,6 +1024,8 @@ class ClassHierarchyWalker {
       add_participant(participants[i]);
     }
   }
+
+  bool _mode;
 
   // This is common code for two searches:  One for concrete subtypes,
   // the other for concrete method implementations and overrides.
@@ -1134,6 +1140,11 @@ class ClassHierarchyWalker {
           // of 'k' override 'm' and are participates of the current search.
           ClassHierarchyWalker wf(_participants, _num_participants);
           Klass* w = wf.find_witness_subtype(ik);
+#ifdef ASSERT
+          ClassHierarchyWalker wf1(_participants, _num_participants); wf1._mode = true;
+          Klass* w1 = wf1.find_witness_subtype(ik);
+          assert((w == NULL) == (w1 == NULL), "");
+#endif // ASSERT
           if (w != NULL) {
             Method* wm = InstanceKlass::cast(w)->find_instance_method(_name, _signature, Klass::PrivateLookupMode::skip);
             if (!Dependencies::is_concrete_method(wm, w)) {
@@ -1189,8 +1200,11 @@ class ClassHierarchyWalker {
 
  private:
   // the actual search method:
-  Klass* find_witness_anywhere(InstanceKlass* context_type,
-                               bool participants_hide_witnesses);
+  Klass* find_witness_anywhere(Klass* context_type,
+                               bool participants_hide_witnesses,
+                               bool top_level_call = true);
+  Klass* find_witness_anywhere_new(InstanceKlass* context_type,
+                                   bool participants_hide_witnesses);
   // the spot-checking version:
   Klass* find_witness_in(KlassDepChange& changes,
                          InstanceKlass* context_type,
@@ -1208,7 +1222,11 @@ class ClassHierarchyWalker {
     if (changes != NULL) {
       return find_witness_in(*changes, context_type, participants_hide_witnesses);
     } else {
-      return find_witness_anywhere(context_type, participants_hide_witnesses);
+      if (_mode) {
+        return find_witness_anywhere_new(context_type, participants_hide_witnesses);
+      } else {
+        return find_witness_anywhere(context_type, participants_hide_witnesses);
+      }
     }
   }
   Klass* find_witness_definer(Klass* k, KlassDepChange* changes = NULL) {
@@ -1222,7 +1240,11 @@ class ClassHierarchyWalker {
     if (changes != NULL) {
       return find_witness_in(*changes, context_type, !participants_hide_witnesses);
     } else {
-      return find_witness_anywhere(context_type, !participants_hide_witnesses);
+      if (_mode) {
+        return find_witness_anywhere_new(context_type, !participants_hide_witnesses);
+      } else {
+        return find_witness_anywhere(context_type, !participants_hide_witnesses);
+      }
     }
   }
 };
@@ -1320,7 +1342,125 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
 }
 
 // Walk hierarchy under a context type, looking for unexpected types.
-Klass* ClassHierarchyWalker::find_witness_anywhere(InstanceKlass* context_type, bool participants_hide_witnesses) {
+// Do not report participant types, and recursively walk beneath
+// them only if participants_hide_witnesses is false.
+// If top_level_call is false, skip testing the context type,
+// because the caller has already considered it.
+Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
+                                                   bool participants_hide_witnesses,
+                                                   bool top_level_call) {
+  // Current thread must be in VM (not native mode, as in CI):
+  assert(must_be_in_vm(), "raw oops here");
+  // Must not move the class hierarchy during this check:
+  assert_locked_or_safepoint(Compile_lock);
+
+  bool do_counts = count_find_witness_calls();
+
+  // Check the root of the sub-hierarchy first.
+  if (top_level_call) {
+    if (do_counts) {
+      NOT_PRODUCT(deps_find_witness_calls++);
+      NOT_PRODUCT(deps_find_witness_steps++);
+    }
+    if (is_participant(context_type)) {
+      if (participants_hide_witnesses)  return NULL;
+      // else fall through to search loop...
+    } else if (is_witness(context_type) && !ignore_witness(context_type)) {
+      // The context is an abstract class or interface, to start with.
+      return context_type;
+    }
+  }
+
+  // Now we must check each implementor and each subclass.
+  // Use a short worklist to avoid blowing the stack.
+  // Each worklist entry is a *chain* of subklass siblings to process.
+  const int CHAINMAX = 100;  // >= 1 + InstanceKlass::implementors_limit
+  Klass* chains[CHAINMAX];
+  int    chaini = 0;  // index into worklist
+  Klass* chain;       // scratch variable
+#define ADD_SUBCLASS_CHAIN(k)                     {  \
+    assert(chaini < CHAINMAX, "oob");                \
+    chain = k->subklass();                           \
+    if (chain != NULL)  chains[chaini++] = chain;    }
+
+  // Look for non-abstract subclasses.
+  // (Note:  Interfaces do not have subclasses.)
+  ADD_SUBCLASS_CHAIN(context_type);
+
+  // If it is an interface, search its direct implementors.
+  // (Their subclasses are additional indirect implementors.
+  // See InstanceKlass::add_implementor.)
+  // (Note:  nof_implementors is always zero for non-interfaces.)
+  if (top_level_call) {
+    int nof_impls = InstanceKlass::cast(context_type)->nof_implementors();
+    if (nof_impls > 1) {
+      // Avoid this case: *I.m > { A.m, C }; B.m > C
+      // Here, I.m has 2 concrete implementations, but m appears unique
+      // as A.m, because the search misses B.m when checking C.
+      // The inherited method B.m was getting missed by the walker
+      // when interface 'I' was the starting point.
+      // %%% Until this is fixed more systematically, bail out.
+      // (Old CHA had the same limitation.)
+      return context_type;
+    }
+    if (nof_impls > 0) {
+      Klass* impl = InstanceKlass::cast(context_type)->implementor();
+      assert(impl != NULL, "just checking");
+      // If impl is the same as the context_type, then more than one
+      // implementor has seen. No exact info in this case.
+      if (impl == context_type) {
+        return context_type;  // report an inexact witness to this sad affair
+      }
+      if (do_counts)
+        { NOT_PRODUCT(deps_find_witness_steps++); }
+      if (is_participant(impl)) {
+        if (!participants_hide_witnesses) {
+          ADD_SUBCLASS_CHAIN(impl);
+        }
+      } else if (is_witness(impl) && !ignore_witness(impl)) {
+        return impl;
+      } else {
+        ADD_SUBCLASS_CHAIN(impl);
+      }
+    }
+  }
+
+  // Recursively process each non-trivial sibling chain.
+  while (chaini > 0) {
+    Klass* chain = chains[--chaini];
+    for (Klass* sub = chain; sub != NULL; sub = sub->next_sibling()) {
+      if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }
+      if (is_participant(sub)) {
+        if (participants_hide_witnesses)  continue;
+        // else fall through to process this guy's subclasses
+      } else if (is_witness(sub) && !ignore_witness(sub)) {
+        return sub;
+      }
+      if (chaini < (VerifyDependencies? 2: CHAINMAX)) {
+        // Fast path.  (Partially disabled if VerifyDependencies.)
+        ADD_SUBCLASS_CHAIN(sub);
+      } else {
+        // Worklist overflow.  Do a recursive call.  Should be rare.
+        // The recursive call will have its own worklist, of course.
+        // (Note that sub has already been tested, so that there is
+        // no need for the recursive call to re-test.  That's handy,
+        // since the recursive call sees sub as the context_type.)
+        if (do_counts) { NOT_PRODUCT(deps_find_witness_recursions++); }
+        Klass* witness = find_witness_anywhere(sub,
+                                                 participants_hide_witnesses,
+                                                 /*top_level_call=*/ false);
+        if (witness != NULL)  return witness;
+      }
+    }
+  }
+
+  // No witness found.  The dependency remains unbroken.
+  return NULL;
+#undef ADD_SUBCLASS_CHAIN
+}
+
+// Walk hierarchy under a context type, looking for unexpected types.
+Klass* ClassHierarchyWalker::find_witness_anywhere_new(InstanceKlass* context_type, bool participants_hide_witnesses) {
   // Current thread must be in VM (not native mode, as in CI):
   assert(must_be_in_vm(), "raw oops here");
   // Must not move the class hierarchy during this check:
@@ -1474,7 +1614,14 @@ Klass* Dependencies::check_abstract_with_unique_concrete_subtype(Klass* ctxk,
                                                                  Klass* conck,
                                                                  KlassDepChange* changes) {
   ClassHierarchyWalker wf(conck);
-  return wf.find_witness_subtype(ctxk, changes);
+  Klass* k = wf.find_witness_subtype(ctxk, changes);
+#ifdef ASSERT
+  ClassHierarchyWalker wf1(conck);
+  wf1._mode = true;
+  Klass* k1 = wf1.find_witness_subtype(ctxk, changes);
+  assert((k == NULL) == (k1 == NULL), "");
+#endif // ASSERT
+  return k;
 }
 
 
@@ -1487,8 +1634,18 @@ Klass* Dependencies::find_unique_concrete_subtype(Klass* ctxk) {
   ClassHierarchyWalker wf(ctxk);   // Ignore ctxk when walking.
   wf.record_witnesses(1);          // Record one other witness when walking.
   Klass* wit = wf.find_witness_subtype(ctxk);
+#ifdef ASSERT
+  ClassHierarchyWalker wf1(ctxk); wf1._mode = true;
+  wf1.record_witnesses(1);          // Record one other witness when walking.
+  Klass* wit1 = wf1.find_witness_subtype(ctxk);
+  assert((wit == NULL) == (wit1 == NULL), "");
+#endif // ASSERT
   if (wit != NULL)  return NULL;   // Too many witnesses.
   Klass* conck = wf.participant(0);
+#ifdef ASSERT
+  Klass* conck1 = wf1.participant(0);
+  assert((conck == NULL) == (conck1 == NULL), "");
+#endif // ASSERT
   if (conck == NULL) {
     return ctxk;                   // Return ctxk as a flag for "no subtypes".
   } else {
@@ -1519,7 +1676,13 @@ Klass* Dependencies::check_unique_concrete_method(Klass*  ctxk,
   // This is probably not important, since we don't use dependencies
   // to track final methods.  (They can't be "definalized".)
   ClassHierarchyWalker wf(uniqm->method_holder(), uniqm);
-  return wf.find_witness_definer(ctxk, changes);
+  Klass* k = wf.find_witness_definer(ctxk, changes);
+#ifdef ASSERT
+  ClassHierarchyWalker wf1(uniqm->method_holder(), uniqm); wf1._mode = true;
+  Klass* k1 = wf.find_witness_definer(ctxk, changes);
+  assert((k == NULL) == (k1 == NULL), "");
+#endif // ASSERT
+  return k;
 }
 
 // Find the set of all non-abstract methods under ctxk that match m.
@@ -1535,8 +1698,20 @@ Method* Dependencies::find_unique_concrete_method(Klass* ctxk, Method* m) {
   assert(wf.check_method_context(ctxk, m), "proper context");
   wf.record_witnesses(1);
   Klass* wit = wf.find_witness_definer(ctxk);
+#ifdef ASSERT
+  ClassHierarchyWalker wf1(m); wf1._mode = true;
+  assert(wf1.check_method_context(ctxk, m), "proper context");
+  wf1.record_witnesses(1);
+  Klass* wit1 = wf1.find_witness_definer(ctxk);
+  assert((wit == NULL) == (wit1 == NULL), "");
+#endif // ASSERT
   if (wit != NULL)  return NULL;  // Too many witnesses.
   Method* fm = wf.found_method(0);  // Will be NULL if num_parts == 0.
+#ifdef ASSERT
+  Method* fm1 = wf1.found_method(0);  // Will be NULL if num_parts == 0.
+  assert((fm == NULL) == (fm1 == NULL), "");
+  assert((fm == m)    == (fm1 == m),    "");
+#endif // ASSERT
   if (Dependencies::is_concrete_method(m, ctxk)) {
     if (fm == NULL) {
       // It turns out that m was always the only implementation.

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1188,16 +1188,17 @@ class ClassHierarchyWalker {
 
  private:
   // the actual search method:
-  Klass* find_witness_anywhere(Klass* context_type,
-                                 bool participants_hide_witnesses,
-                                 bool top_level_call = true);
+  Klass* find_witness_anywhere(InstanceKlass* context_type,
+                               bool participants_hide_witnesses);
   // the spot-checking version:
   Klass* find_witness_in(KlassDepChange& changes,
-                         Klass* context_type,
-                           bool participants_hide_witnesses);
+                         InstanceKlass* context_type,
+                         bool participants_hide_witnesses);
  public:
-  Klass* find_witness_subtype(Klass* context_type, KlassDepChange* changes = NULL) {
+  Klass* find_witness_subtype(Klass* k, KlassDepChange* changes = NULL) {
     assert(doing_subtype_search(), "must set up a subtype search");
+    assert(k->is_instance_klass(), "required");
+    InstanceKlass* context_type = InstanceKlass::cast(k);
     // When looking for unexpected concrete types,
     // do not look beneath expected ones.
     const bool participants_hide_witnesses = true;
@@ -1209,8 +1210,10 @@ class ClassHierarchyWalker {
       return find_witness_anywhere(context_type, participants_hide_witnesses);
     }
   }
-  Klass* find_witness_definer(Klass* context_type, KlassDepChange* changes = NULL) {
+  Klass* find_witness_definer(Klass* k, KlassDepChange* changes = NULL) {
     assert(!doing_subtype_search(), "must set up a method definer search");
+    assert(k->is_instance_klass(), "required");
+    InstanceKlass* context_type = InstanceKlass::cast(k);
     // When looking for unexpected concrete methods,
     // look beneath expected ones, to see if there are overrides.
     const bool participants_hide_witnesses = true;
@@ -1271,7 +1274,7 @@ static bool count_find_witness_calls() {
 
 
 Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
-                                             Klass* context_type,
+                                             InstanceKlass* context_type,
                                              bool participants_hide_witnesses) {
   assert(changes.involves_context(context_type), "irrelevant dependency");
   Klass* new_type = changes.new_type();
@@ -1284,7 +1287,7 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
   // Must not move the class hierarchy during this check:
   assert_locked_or_safepoint(Compile_lock);
 
-  int nof_impls = InstanceKlass::cast(context_type)->nof_implementors();
+  int nof_impls = context_type->nof_implementors();
   if (nof_impls > 1) {
     // Avoid this case: *I.m > { A.m, C }; B.m > C
     // %%% Until this is fixed more systematically, bail out.
@@ -1315,15 +1318,8 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
   return NULL;
 }
 
-
 // Walk hierarchy under a context type, looking for unexpected types.
-// Do not report participant types, and recursively walk beneath
-// them only if participants_hide_witnesses is false.
-// If top_level_call is false, skip testing the context type,
-// because the caller has already considered it.
-Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
-                                                   bool participants_hide_witnesses,
-                                                   bool top_level_call) {
+Klass* ClassHierarchyWalker::find_witness_anywhere(InstanceKlass* context_type, bool participants_hide_witnesses) {
   // Current thread must be in VM (not native mode, as in CI):
   assert(must_be_in_vm(), "raw oops here");
   // Must not move the class hierarchy during this check:
@@ -1332,106 +1328,50 @@ Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
   bool do_counts = count_find_witness_calls();
 
   // Check the root of the sub-hierarchy first.
-  if (top_level_call) {
-    if (do_counts) {
-      NOT_PRODUCT(deps_find_witness_calls++);
-      NOT_PRODUCT(deps_find_witness_steps++);
-    }
-    if (is_participant(context_type)) {
-      if (participants_hide_witnesses)  return NULL;
-      // else fall through to search loop...
-    } else if (is_witness(context_type) && !ignore_witness(context_type)) {
-      // The context is an abstract class or interface, to start with.
-      return context_type;
-    }
+  if (do_counts) {
+    NOT_PRODUCT(deps_find_witness_calls++);
   }
 
-  // Now we must check each implementor and each subclass.
-  // Use a short worklist to avoid blowing the stack.
-  // Each worklist entry is a *chain* of subklass siblings to process.
-  const int CHAINMAX = 100;  // >= 1 + InstanceKlass::implementors_limit
-  Klass* chains[CHAINMAX];
-  int    chaini = 0;  // index into worklist
-  Klass* chain;       // scratch variable
-#define ADD_SUBCLASS_CHAIN(k)                     {  \
-    assert(chaini < CHAINMAX, "oob");                \
-    chain = k->subklass();                           \
-    if (chain != NULL)  chains[chaini++] = chain;    }
-
-  // Look for non-abstract subclasses.
-  // (Note:  Interfaces do not have subclasses.)
-  ADD_SUBCLASS_CHAIN(context_type);
-
+  // (Note: Interfaces do not have subclasses.)
   // If it is an interface, search its direct implementors.
-  // (Their subclasses are additional indirect implementors.
-  // See InstanceKlass::add_implementor.)
-  // (Note:  nof_implementors is always zero for non-interfaces.)
-  if (top_level_call) {
-    int nof_impls = InstanceKlass::cast(context_type)->nof_implementors();
-    if (nof_impls > 1) {
+  // (Their subclasses are additional indirect implementors. See InstanceKlass::add_implementor().)
+  if (context_type->is_interface()) {
+    int nof_impls = context_type->nof_implementors();
+    if (nof_impls == 0) {
+      return NULL; // no implementors
+    } else if (nof_impls == 1) { // unique implementor
+      assert(context_type != context_type->implementor(), "not unique");
+      context_type = InstanceKlass::cast(context_type->implementor());
+    } else { // nof_impls >= 2
       // Avoid this case: *I.m > { A.m, C }; B.m > C
       // Here, I.m has 2 concrete implementations, but m appears unique
       // as A.m, because the search misses B.m when checking C.
       // The inherited method B.m was getting missed by the walker
       // when interface 'I' was the starting point.
       // %%% Until this is fixed more systematically, bail out.
-      // (Old CHA had the same limitation.)
       return context_type;
     }
-    if (nof_impls > 0) {
-      Klass* impl = InstanceKlass::cast(context_type)->implementor();
-      assert(impl != NULL, "just checking");
-      // If impl is the same as the context_type, then more than one
-      // implementor has seen. No exact info in this case.
-      if (impl == context_type) {
-        return context_type;  // report an inexact witness to this sad affair
-      }
-      if (do_counts)
-        { NOT_PRODUCT(deps_find_witness_steps++); }
-      if (is_participant(impl)) {
-        if (!participants_hide_witnesses) {
-          ADD_SUBCLASS_CHAIN(impl);
-        }
-      } else if (is_witness(impl) && !ignore_witness(impl)) {
-        return impl;
-      } else {
-        ADD_SUBCLASS_CHAIN(impl);
-      }
-    }
   }
 
-  // Recursively process each non-trivial sibling chain.
-  while (chaini > 0) {
-    Klass* chain = chains[--chaini];
-    for (Klass* sub = chain; sub != NULL; sub = sub->next_sibling()) {
-      if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }
-      if (is_participant(sub)) {
-        if (participants_hide_witnesses)  continue;
-        // else fall through to process this guy's subclasses
-      } else if (is_witness(sub) && !ignore_witness(sub)) {
-        return sub;
+  assert(!context_type->is_interface(), "not allowed");
+
+  for (ClassHierarchyIterator iter(context_type); iter.next();) {
+    Klass* sub = iter.klass();
+
+    if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }
+
+    // Do not report participant types.
+    if (is_participant(sub)) {
+      // Walk beneath a participant only when it doesn't hide witnesses.
+      if (participants_hide_witnesses) {
+        iter.skip_subclasses();
       }
-      if (chaini < (VerifyDependencies? 2: CHAINMAX)) {
-        // Fast path.  (Partially disabled if VerifyDependencies.)
-        ADD_SUBCLASS_CHAIN(sub);
-      } else {
-        // Worklist overflow.  Do a recursive call.  Should be rare.
-        // The recursive call will have its own worklist, of course.
-        // (Note that sub has already been tested, so that there is
-        // no need for the recursive call to re-test.  That's handy,
-        // since the recursive call sees sub as the context_type.)
-        if (do_counts) { NOT_PRODUCT(deps_find_witness_recursions++); }
-        Klass* witness = find_witness_anywhere(sub,
-                                               participants_hide_witnesses,
-                                               /*top_level_call=*/ false);
-        if (witness != NULL)  return witness;
-      }
+    } else if (is_witness(sub) && !ignore_witness(sub)) {
+      return sub; // found a witness
     }
   }
-
   // No witness found.  The dependency remains unbroken.
   return NULL;
-#undef ADD_SUBCLASS_CHAIN
 }
 
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -4284,3 +4284,24 @@ void InstanceKlass::log_to_classlist(const ClassFileStream* stream) const {
   }
 #endif // INCLUDE_CDS
 }
+
+// Make a step iterating over the class hierarchy under the root class.
+// Skips subclasses if requested.
+void ClassHierarchyIterator::next() {
+  assert(_current != NULL, "required");
+  if (_visit_subclasses && _current->subklass() != NULL) {
+    _current = _current->subklass();
+    return; // visit next subclass
+  }
+  _visit_subclasses = true; // reset
+  while (_current->next_sibling() == NULL && _current != _root) {
+    _current = _current->superklass(); // backtrack; no more sibling subclasses left
+  }
+  if (_current == _root) {
+    // Iteration is over (back at root after backtracking). Invalidate the iterator.
+    _current = NULL;
+    return;
+  }
+  _current = _current->next_sibling();
+  return; // visit next sibling subclass
+}

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1454,24 +1454,7 @@ class ClassHierarchyIterator : public StackObj {
 
   // Make a step iterating over the class hierarchy under the root class.
   // Skips subclasses if requested.
-  void next() {
-    assert(_current != NULL, "required");
-    if (_visit_subclasses && _current->subklass() != NULL) {
-      _current = _current->subklass();
-      return; // visit next subclass
-    }
-    _visit_subclasses = true; // reset
-    while (_current->next_sibling() == NULL && _current != _root) {
-      _current = _current->superklass(); // backtrack; no more sibling subclasses left
-    }
-    if (_current == _root) {
-      // Iteration is over (back at root after backtracking). Invalidate the iterator.
-      _current = NULL;
-      return;
-    }
-    _current = _current->next_sibling();
-    return; // visit next sibling subclass
-  }
+  void next();
 
   Klass* klass() {
     assert(!done(), "sanity");


### PR DESCRIPTION
Simplify `ClassHierarchyWalker::find_witness_anywhere()` which iterates over class hierarchy under context class searching for witnesses.

Current implementation traverses the hierarchy in a breadth-first manner and keeps a stack-allocated array to keep a worklist.
But all the subclasses are already part of a singly linked list formed by `Klass::subklass()`/`next_sibling()`/`superklass()`.

Proposed refactoring gets rid of the explicit worklist and switches to the traversal over the linked list (encapsulated into `ClassHierarchyIterator`). It performs depth-first pre-order hierarchy traversal. 

(There are some other minor refactorings applied in `ClassHierarchyWalker` along the way.) 

Testing:
- [x] hs-tier1 - hs-tier8
- [x] additional verification that CHA decisions aren't affected

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261954](https://bugs.openjdk.java.net/browse/JDK-8261954): Dependencies: Improve iteration over class hierarchy under context class 


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to ae78e51e4248c2ccfa73c772fb1db1baad2c2903
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to ae78e51e4248c2ccfa73c772fb1db1baad2c2903
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to ae78e51e4248c2ccfa73c772fb1db1baad2c2903


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2630/head:pull/2630`
`$ git checkout pull/2630`
