### PR TITLE
8261977: Fix comment for getPrefixed() in canonicalize_md.c

### DIFF
--- a/src/java.base/windows/native/libjava/canonicalize_md.c
+++ b/src/java.base/windows/native/libjava/canonicalize_md.c
@@ -372,11 +372,7 @@ finish:
     return ret;
 }
 
-/* The appropriate location of getPrefixed() is io_util_md.c, but it is
-   also used in a non-OpenJDK context within Oracle. There, canonicalize_md.c
-   is already pulled in and compiled, so to avoid more complicated solutions
-   we keep this method here.
- */
+/* The appropriate location of getPrefixed() is io_util_md.c */
 
 /* copy \\?\ or \\?\UNC\ to the front of path */
 JNIEXPORT WCHAR*


### PR DESCRIPTION
Follow up for JDK-8235397 fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261977](https://bugs.openjdk.java.net/browse/JDK-8261977): Fix comment for getPrefixed() in canonicalize_md.c


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2631/head:pull/2631`
`$ git checkout pull/2631`
