### PR TITLE
8261984: Shenandoah: Remove unused ShenandoahPushWorkerQueuesScope class

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,16 +69,6 @@ ShenandoahPushWorkerScope::~ShenandoahPushWorkerScope() {
   // Restore old worker value
   uint nworkers = _workers->update_active_workers(_old_workers);
   assert(nworkers == _old_workers, "Must be able to restore");
-}
-
-ShenandoahPushWorkerQueuesScope::ShenandoahPushWorkerQueuesScope(WorkGang* workers, ShenandoahObjToScanQueueSet* queues, uint nworkers, bool check) :
-  ShenandoahPushWorkerScope(workers, nworkers, check), _queues(queues) {
-  _queues->reserve(_n_workers);
-}
-
-ShenandoahPushWorkerQueuesScope::~ShenandoahPushWorkerQueuesScope() {
-  // Restore old worker value
-  _queues->reserve(_old_workers);
 }
 
 AbstractGangWorker* ShenandoahWorkGang::install_worker(uint which) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,15 +49,6 @@ protected:
 public:
   ShenandoahPushWorkerScope(WorkGang* workers, uint nworkers, bool do_check = true);
   ~ShenandoahPushWorkerScope();
-};
-
-class ShenandoahPushWorkerQueuesScope : public ShenandoahPushWorkerScope {
-private:
-  ShenandoahObjToScanQueueSet* _queues;
-
-public:
-  ShenandoahPushWorkerQueuesScope(WorkGang* workers, ShenandoahObjToScanQueueSet* queues, uint nworkers, bool do_check = true);
-  ~ShenandoahPushWorkerQueuesScope();
 };
 
 class ShenandoahWorkGang : public WorkGang {


### PR DESCRIPTION
Please review this trivial change that removes unused ShenandoahPushWorkerQueuesScope class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261984](https://bugs.openjdk.java.net/browse/JDK-8261984): Shenandoah: Remove unused ShenandoahPushWorkerQueuesScope class


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2632/head:pull/2632`
`$ git checkout pull/2632`
