### PR TITLE
8224775: test/jdk/com/sun/jdi/JdwpListenTest.java failed to attach

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -361,8 +361,8 @@ public final class Utils {
             // So on Windows test only addresses with numeric scope.
             // On other platforms test both symbolic and numeric scopes.
             conf.ip6Addresses()
-                    // test only IPv6 link-local addresses (JDK-8224775)
-                    .filter(Inet6Address::isLinkLocalAddress)
+                    // test only IPv6 loopback and link-local addresses (JDK-8224775)
+                    .filter(addr -> addr.isLinkLocalAddress() || addr.isLoopbackAddress())
                     .forEach(addr6 -> {
                         try {
                             result.add(Inet6Address.getByAddress(null, addr6.getAddress(), addr6.getScopeId()));

--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -360,17 +360,20 @@ public final class Utils {
             // which are incompatible with native Windows routines.
             // So on Windows test only addresses with numeric scope.
             // On other platforms test both symbolic and numeric scopes.
-            conf.ip6Addresses().forEach(addr6 -> {
-                try {
-                    result.add(Inet6Address.getByAddress(null, addr6.getAddress(), addr6.getScopeId()));
-                } catch (UnknownHostException e) {
-                    // cannot happen!
-                    throw new RuntimeException("Unexpected", e);
-                }
-                if (!Platform.isWindows()) {
-                    result.add(addr6);
-                }
-            });
+            conf.ip6Addresses()
+                    // test only IPv6 link-local addresses (JDK-8224775)
+                    .filter(Inet6Address::isLinkLocalAddress)
+                    .forEach(addr6 -> {
+                        try {
+                            result.add(Inet6Address.getByAddress(null, addr6.getAddress(), addr6.getScopeId()));
+                        } catch (UnknownHostException e) {
+                            // cannot happen!
+                            throw new RuntimeException("Unexpected", e);
+                        }
+                        if (!Platform.isWindows()) {
+                            result.add(addr6);
+                        }
+                    });
         } catch (IOException e) {
             // cannot happen!
             throw new RuntimeException("Unexpected", e);


### PR DESCRIPTION
The fix also partially fixes JdwpAttachTest failures (JDK-8253940).
The failures are caused by network configuration changes during test execution ("global" IPv6 addresses disappears from interface).
To minimize chances of intermittent failures like this java.net tests use only link-local addresses whenever possible.
The fix does the same for JDI tests (Utils.getAddressesWithSymbolicAndNumericScopes  is used by JdwpListenTest and JdwpAttachTest)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8224775](https://bugs.openjdk.java.net/browse/JDK-8224775): test/jdk/com/sun/jdi/JdwpListenTest.java failed to attach


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 96176a61db680379552f3e6a06f3a8a5b428f0ee
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2633/head:pull/2633`
`$ git checkout pull/2633`
