### PR TITLE
6539707: (fc) MappedByteBuffer.force() method throws an IOException in a very simple test

### DIFF
--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -223,7 +223,8 @@ public abstract class MappedByteBuffer
      * implementation-specific mapping modes. </p>
      *
      * @throws UncheckedIOException
-     *         If the underlying operation fails
+     *         If an I/O error occurs writing the buffer's content to the
+     *         storage device containing the mapped file
      *
      * @return  This buffer
      */
@@ -275,6 +276,10 @@ public abstract class MappedByteBuffer
      * @throws IndexOutOfBoundsException
      *         if the preconditions on the index and length do not
      *         hold.
+     *
+     * @throws UncheckedIOException
+     *         If an I/O error occurs writing the buffer's content to the
+     *         storage device containing the mapped file
      *
      * @return  This buffer
      *

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -26,7 +26,6 @@
 package java.nio;
 
 import java.io.FileDescriptor;
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.ref.Reference;
 import java.util.Objects;
@@ -223,6 +222,9 @@ public abstract class MappedByteBuffer
      * mapping modes. This method may or may not have an effect for
      * implementation-specific mapping modes. </p>
      *
+     * @throws UncheckedIOException 
+     *         If the underlying operation fails
+     *
      * @return  This buffer
      */
     public final MappedByteBuffer force() {
@@ -261,8 +263,6 @@ public abstract class MappedByteBuffer
      * mapping modes. This method may or may not have an effect for
      * implementation-specific mapping modes. </p>
      *
-     * <p> If the force operation fails, then an unspecified error is thrown.
-     *
      * @param  index
      *         The index of the first byte in the buffer region that is
      *         to be written back to storage; must be non-negative
@@ -288,15 +288,7 @@ public abstract class MappedByteBuffer
         if ((address != 0) && (limit != 0)) {
             // check inputs
             Objects.checkFromIndexSize(index, length, limit);
-            try {
-                SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
-            } catch (Exception unspecifiedException) {
-                IOException cause =
-                    unspecifiedException instanceof IOException ?
-                    (IOException)unspecifiedException :
-                    new IOException(unspecifiedException);
-                throw new UncheckedIOException(cause);
-            }
+            SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
         }
         return this;
     }

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -26,6 +26,8 @@
 package java.nio;
 
 import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.ref.Reference;
 import java.util.Objects;
 
@@ -259,6 +261,8 @@ public abstract class MappedByteBuffer
      * mapping modes. This method may or may not have an effect for
      * implementation-specific mapping modes. </p>
      *
+     * <p> If the force operation fails, then an unspecified error is thrown.
+     *
      * @param  index
      *         The index of the first byte in the buffer region that is
      *         to be written back to storage; must be non-negative
@@ -284,7 +288,15 @@ public abstract class MappedByteBuffer
         if ((address != 0) && (limit != 0)) {
             // check inputs
             Objects.checkFromIndexSize(index, length, limit);
-            SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
+            try {
+                SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
+            } catch (Exception unspecifiedException) {
+                IOException cause =
+                    unspecifiedException instanceof IOException ?
+                    (IOException)unspecifiedException :
+                    new IOException(unspecifiedException);
+                throw new UncheckedIOException(cause);
+            }
         }
         return this;
     }

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -222,7 +222,7 @@ public abstract class MappedByteBuffer
      * mapping modes. This method may or may not have an effect for
      * implementation-specific mapping modes. </p>
      *
-     * @throws UncheckedIOException 
+     * @throws UncheckedIOException
      *         If the underlying operation fails
      *
      * @return  This buffer

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -42,8 +42,7 @@ import java.io.UncheckedIOException;
             return true;
         long offset = mappingOffset(address);
         long length = mappingLength(offset, size);
-        return isLoaded0(mappingAddress(address, offset), length,
-            Bits.pageCount(length));
+        return isLoaded0(mappingAddress(address, offset), length, Bits.pageCount(length));
     }
 
     static void load(long address, boolean isSync, long size) {
@@ -90,8 +89,7 @@ import java.io.UncheckedIOException;
         unload0(mappingAddress(address, offset), length);
     }
 
-    static void force(FileDescriptor fd, long address, boolean isSync,
-        long index, long length) {
+    static void force(FileDescriptor fd, long address, boolean isSync, long index, long length) {
         if (isSync) {
             // simply force writeback of associated cache lines
             Unsafe.getUnsafe().writebackMemory(address + index, length);
@@ -99,8 +97,7 @@ import java.io.UncheckedIOException;
             // force writeback via file descriptor
             long offset = mappingOffset(address, index);
             try {
-                force0(fd, mappingAddress(address, offset, index),
-                    mappingLength(offset, length));
+                force0(fd, mappingAddress(address, offset, index), mappingLength(offset, length));
             } catch (IOException cause) {
                 throw new UncheckedIOException(cause);
             }
@@ -109,12 +106,10 @@ import java.io.UncheckedIOException;
 
     // native methods
 
-    private static native boolean isLoaded0(long address, long length,
-        int pageCount);
+    private static native boolean isLoaded0(long address, long length, int pageCount);
     private static native void load0(long address, long length);
     private static native void unload0(long address, long length);
-    private static native void force0(FileDescriptor fd, long address,
-        long length) throws IOException;
+    private static native void force0(FileDescriptor fd, long address, long length) throws IOException;
 
     // utility methods
 
@@ -147,8 +142,7 @@ import java.io.UncheckedIOException;
     // mappingOffset(index) returns the largest page aligned address
     // of the mapping less than or equal to the address of the buffer
     // element identified by index.
-    private static long mappingAddress(long address, long mappingOffset,
-        long index) {
+    private static long mappingAddress(long address, long mappingOffset, long index) {
         long indexAddress = address + index;
         return indexAddress - mappingOffset;
     }

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -28,6 +28,8 @@ package java.nio;
 import jdk.internal.misc.Unsafe;
 
 import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /* package */ class MappedMemoryUtils {
 
@@ -94,7 +96,12 @@ import java.io.FileDescriptor;
         } else {
             // force writeback via file descriptor
             long offset = mappingOffset(address, index);
-            force0(fd, mappingAddress(address, offset, index), mappingLength(offset, length));
+            try {
+                force0(fd, mappingAddress(address, offset, index),
+                    mappingLength(offset, length));
+            } catch (IOException cause) {
+                throw new UncheckedIOException(cause);
+            }
         }
     }
 

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -42,7 +42,8 @@ import java.io.UncheckedIOException;
             return true;
         long offset = mappingOffset(address);
         long length = mappingLength(offset, size);
-        return isLoaded0(mappingAddress(address, offset), length, Bits.pageCount(length));
+        return isLoaded0(mappingAddress(address, offset), length,
+            Bits.pageCount(length));
     }
 
     static void load(long address, boolean isSync, long size) {
@@ -89,7 +90,8 @@ import java.io.UncheckedIOException;
         unload0(mappingAddress(address, offset), length);
     }
 
-    static void force(FileDescriptor fd, long address, boolean isSync, long index, long length) {
+    static void force(FileDescriptor fd, long address, boolean isSync,
+        long index, long length) {
         if (isSync) {
             // simply force writeback of associated cache lines
             Unsafe.getUnsafe().writebackMemory(address + index, length);
@@ -107,10 +109,12 @@ import java.io.UncheckedIOException;
 
     // native methods
 
-    private static native boolean isLoaded0(long address, long length, int pageCount);
+    private static native boolean isLoaded0(long address, long length,
+        int pageCount);
     private static native void load0(long address, long length);
     private static native void unload0(long address, long length);
-    private static native void force0(FileDescriptor fd, long address, long length);
+    private static native void force0(FileDescriptor fd, long address,
+        long length) throws IOException;
 
     // utility methods
 
@@ -143,7 +147,8 @@ import java.io.UncheckedIOException;
     // mappingOffset(index) returns the largest page aligned address
     // of the mapping less than or equal to the address of the buffer
     // element identified by index.
-    private static long mappingAddress(long address, long mappingOffset, long index) {
+    private static long mappingAddress(long address, long mappingOffset,
+        long index) {
         long indexAddress = address + index;
         return indexAddress - mappingOffset;
     }

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
         if ((result != 0) || (GetLastError() != ERROR_LOCK_VIOLATION))
             break;
         retry++;
-    } while (retry < 3);
+    } while (retry < 5);
 
     /**
      * FlushViewOfFile only initiates the writing of dirty pages to disk

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package jdk.incubator.foreign;
 
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 
+import java.io.UncheckedIOException;
 import java.nio.MappedByteBuffer;
 import java.util.Objects;
 
@@ -149,6 +150,7 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
+     * @throws UncheckedIOException if the underlying native operation fails
      */
     public static void force(MemorySegment segment) {
         toMappedSegment(segment).force();

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
@@ -150,7 +150,7 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
-     * @throws UncheckedIOException if the underlying native operation fails
+     * @throws UncheckedIOException if there is an I/O error writing the contents of the segment to the associated storage device
      */
     public static void force(MemorySegment segment) {
         toMappedSegment(segment).force();

--- a/test/jdk/java/nio/MappedByteBuffer/ForceException.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceException.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 6539707
+ * @summary Test behavior of force() with respect to throwing exceptions
+ * @run main ForceException
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class ForceException {
+    public static void main(String[] args) throws IOException {
+        int blockSize = 2048 * 1024;
+        int numberOfBlocks = 200;
+        int fileLength = numberOfBlocks * blockSize;
+
+        File file = new File(System.getProperty("test.src", "."), "test.dat");
+        file.deleteOnExit();
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.setLength(fileLength);
+
+            int pos = (numberOfBlocks - 1) * blockSize;
+            int size = (int)Math.min(blockSize, fileLength - pos);
+            MappedByteBuffer mbb =
+                raf.getChannel().map(FileChannel.MapMode.READ_WRITE, pos, size);
+
+            System.out.printf("Write region 0x%s..0x%s%n",
+                Long.toHexString(pos), Long.toHexString(size));
+            for (int k = 0; k < mbb.limit(); k++) {
+                mbb.put(k, (byte)65);
+            }
+
+            // Catch and process UncheckedIOException; other Throwables fail
+            try {
+                System.out.println("Force");
+                mbb.force();
+            } catch (UncheckedIOException legal) {
+                System.out.printf("Caught legal exception %s%n", legal);
+                IOException cause = legal.getCause(); // can't be null
+                // Throw the cause if flush failed (should be only on Windows)
+                if (cause.getMessage().startsWith("Flush failed")) {
+                    throw cause;
+                }
+            }
+
+            System.out.println("OK");
+        }
+    }
+}


### PR DESCRIPTION
This change proposes to increase the number of retries of `FlushViewOfFile` in the Windows native implementation of `MappedByteBuffer.force()`, and to catch any exception thrown by the native `force()` and rethrow an `UncheckedIOException` with cause set to the intercepted exception. A sentence is added to the specification of `MappedByteBuffer.force()` regarding unspecified errors. The test from the issue description is revised to fail if `force()` throws an exception which is not an `UncheckedIOException`, or if it is an `UncheckedIOException` whose message indicates it was thrown by the Windows native implementation of `force()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6539707](https://bugs.openjdk.java.net/browse/JDK-6539707): (fc) MappedByteBuffer.force() method throws an IOException in a very simple test


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2636/head:pull/2636`
`$ git checkout pull/2636`
