### PR TITLE
8261929: ClhsdbFindPC fails with java.lang.RuntimeException: 'In java stack' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -202,11 +202,15 @@ public class ClhsdbFindPC {
             parts = parts[1].split(" \\[");
             parts = parts[1].split("\\]");
             String stackAddress = parts[0];  // address of the thread's stack
-            cmdStr = "findpc " + stackAddress;
-            cmds = List.of(cmdStr);
-            expStrMap = new HashMap<>();
-            expStrMap.put(cmdStr, List.of("In java stack"));
-            runTest(withCore, cmds, expStrMap);
+            if (Long.decode(stackAddress) == 0L) {
+                System.out.println("Stack address is " + stackAddress + ". Skipping test.");
+            } else {
+                cmdStr = "findpc " + stackAddress;
+                cmds = List.of(cmdStr);
+                expStrMap = new HashMap<>();
+                expStrMap.put(cmdStr, List.of("In java stack"));
+                runTest(withCore, cmds, expStrMap);
+            }
 
             // Run 'examine <addr>' using a thread's tid as the address. The
             // examine output will be the of the form:


### PR DESCRIPTION
Sometimes due to the state of the java thread, jstack does cannot determine the address of the java frame and instead it is 0x. We need to special case this so the test does not fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261929](https://bugs.openjdk.java.net/browse/JDK-8261929): ClhsdbFindPC fails with java.lang.RuntimeException: 'In java stack' missing from stdout/stderr 


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2637/head:pull/2637`
`$ git checkout pull/2637`
