### PR TITLE
8248318: Remove superfluous use of boxing in ObjectStreamClass

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -510,7 +510,7 @@ public class ObjectStreamClass implements Serializable {
             AccessController.doPrivileged(new PrivilegedAction<>() {
                 public Void run() {
                     if (isEnum) {
-                        suid = Long.valueOf(0);
+                        suid = 0L;
                         fields = NO_FIELDS;
                         return null;
                     }
@@ -555,7 +555,7 @@ public class ObjectStreamClass implements Serializable {
                 }
             });
         } else {
-            suid = Long.valueOf(0);
+            suid = 0L;
             fields = NO_FIELDS;
         }
 
@@ -673,7 +673,7 @@ public class ObjectStreamClass implements Serializable {
         this.superDesc = superDesc;
         isProxy = true;
         serializable = true;
-        suid = Long.valueOf(0);
+        suid = 0L;
         fields = NO_FIELDS;
         if (osc != null) {
             localDesc = osc;
@@ -698,7 +698,7 @@ public class ObjectStreamClass implements Serializable {
                       ObjectStreamClass superDesc)
         throws InvalidClassException
     {
-        long suid = Long.valueOf(model.getSerialVersionUID());
+        long suid = model.getSerialVersionUID();
         ObjectStreamClass osc = null;
         if (cl != null) {
             osc = lookup(cl, true);
@@ -796,7 +796,7 @@ public class ObjectStreamClass implements Serializable {
         throws IOException, ClassNotFoundException
     {
         name = in.readUTF();
-        suid = Long.valueOf(in.readLong());
+        suid = in.readLong();
         isProxy = false;
 
         byte flags = in.readByte();
@@ -1846,7 +1846,7 @@ public class ObjectStreamClass implements Serializable {
             int mask = Modifier.STATIC | Modifier.FINAL;
             if ((f.getModifiers() & mask) == mask) {
                 f.setAccessible(true);
-                return Long.valueOf(f.getLong(null));
+                return f.getLong(null);
             }
         } catch (Exception ex) {
         }


### PR DESCRIPTION
This change removes some instances of superfluous boxing in java.io.ObjectStreamClass.
Testing: tier 1-3 all clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248318](https://bugs.openjdk.java.net/browse/JDK-8248318): Remove superfluous use of boxing in ObjectStreamClass


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * @vyommani (no known github.com user name / role)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2641/head:pull/2641`
`$ git checkout pull/2641`
