### PR TITLE
8262018: Wrong format in SAP copyright header of OsVersionTest

### DIFF
--- a/test/jdk/java/lang/System/OsVersionTest.java
+++ b/test/jdk/java/lang/System/OsVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The fix for JDK-8261753 introduced a ',' after the copyright years which is not the expected format for SAP copyrights.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262018](https://bugs.openjdk.java.net/browse/JDK-8262018): Wrong format in SAP copyright header of OsVersionTest


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2642/head:pull/2642`
`$ git checkout pull/2642`
