### PR TITLE
8258414: OldObjectSample events too expensive

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -251,7 +251,7 @@ JVM_ENTRY_NO_ENV(jlong, jfr_class_id(JNIEnv* env, jclass jvm, jclass jc))
 JVM_END
 
 JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip))
-  return JfrStackTraceRepository::record(thread, skip);
+  return JfrStackTraceRepository::instance().record(thread, skip);
 JVM_END
 
 JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message))

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -197,6 +197,62 @@ static bool stack_trace_precondition(const ObjectSample* sample) {
   return sample->has_stack_trace_id() && !sample->is_dead();
 }
 
+class StackTraceChunkWriter {
+ private:
+  const JfrStackTraceRepository& _stack_trace_repo;
+  JfrChunkWriter& _chunkwriter;
+  int _count;
+  const JfrStackTrace* resolve(const ObjectSample* sample);
+ public:
+  StackTraceChunkWriter(const JfrStackTraceRepository& stack_trace_repo, JfrChunkWriter& chunkwriter);
+  void sample_do(ObjectSample* sample) {
+    if (stack_trace_precondition(sample)) {
+      const JfrStackTrace* const stack_trace = resolve(sample);
+      DEBUG_ONLY(validate_stack_trace(sample, stack_trace));
+      if (stack_trace->should_write()) {
+        stack_trace->write(_chunkwriter);
+        _count++;
+      }
+    }
+  }
+  int count() const {
+    return _count;
+  }
+};
+
+StackTraceChunkWriter::StackTraceChunkWriter(const JfrStackTraceRepository& stack_trace_repo, JfrChunkWriter& chunkwriter) :
+  _stack_trace_repo(stack_trace_repo), _chunkwriter(chunkwriter), _count(0) {
+}
+
+const JfrStackTrace* StackTraceChunkWriter::resolve(const ObjectSample* sample) {
+  return _stack_trace_repo.lookup(sample->stack_trace_hash(), sample->stack_trace_id());
+}
+
+static int do_write_stacktraces(const ObjectSampler* sampler, JfrStackTraceRepository& stack_trace_repo, JfrChunkWriter& chunkwriter) {
+  assert(sampler != NULL, "invariant");
+  const ObjectSample* const last = sampler->last();
+  if (last != sampler->last_resolved()) {
+    ResourceMark rm;
+    StackTraceChunkWriter writer(stack_trace_repo, chunkwriter);
+    iterate_samples(writer);
+    return writer.count();
+  }
+  return 0;
+}
+
+int ObjectSampleCheckpoint::write_objectsampler_stacktraces(const ObjectSampler* sampler, JfrStackTraceRepository& stack_trace_repo, JfrChunkWriter& chunkwriter) {
+  assert(sampler != NULL, "invariant");
+  assert(LeakProfiler::is_running(), "invariant");
+  JavaThread* const thread = JavaThread::current();
+  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(thread);)
+  // can safepoint here
+  ThreadInVMfromNative transition(thread);
+  MutexLocker lock(ClassLoaderDataGraph_lock);
+  // the lock is needed to ensure the unload lists do not grow in the middle of inspection.
+  return do_write_stacktraces(sampler, stack_trace_repo, chunkwriter);
+}
+
+
 class StackTraceBlobInstaller {
  private:
   const JfrStackTraceRepository& _stack_trace_repo;

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -32,6 +32,7 @@ class EdgeStore;
 class InstanceKlass;
 class JavaThread;
 class JfrCheckpointWriter;
+class JfrChunkWriter;
 class JfrStackTrace;
 class JfrStackTraceRepository;
 class Klass;
@@ -54,6 +55,7 @@ class ObjectSampleCheckpoint : AllStatic {
   static void on_type_set_unload(JfrCheckpointWriter& writer);
   static void on_thread_exit(JavaThread* jt);
   static void on_rotation(const ObjectSampler* sampler, JfrStackTraceRepository& repo);
+  static int write_objectsampler_stacktraces(const ObjectSampler* sampler, JfrStackTraceRepository& stack_trace_repo, JfrChunkWriter& chunkwriter);
 };
 
 #endif // SHARE_JFR_LEAKPROFILER_CHECKPOINT_OBJECTSAMPLECHECKPOINT_HPP

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -162,7 +162,7 @@ static traceid get_thread_id(JavaThread* thread) {
 static void record_stacktrace(JavaThread* thread) {
   assert(thread != NULL, "invariant");
   if (JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
-    JfrStackTraceRepository::instance().record_and_cache(thread);
+    JfrStackTraceRepository::leak_profiler_instance().record_and_cache(thread);
   }
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -162,7 +162,7 @@ static traceid get_thread_id(JavaThread* thread) {
 static void record_stacktrace(JavaThread* thread) {
   assert(thread != NULL, "invariant");
   if (JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
-    JfrStackTraceRepository::record_and_cache(thread);
+    JfrStackTraceRepository::instance().record_and_cache(thread);
   }
 }
 

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -261,7 +261,7 @@ bool JfrThreadSampleClosure::sample_thread_in_java(JavaThread* thread, JfrStackF
     return false;
   }
   EventExecutionSample *event = &_events[_added_java - 1];
-  traceid id = JfrStackTraceRepository::add(sampler.stacktrace());
+  traceid id = JfrStackTraceRepository::instance().add(sampler.stacktrace());
   assert(id != 0, "Stacktrace id should not be 0");
   event->set_stackTrace(id);
   return true;
@@ -281,7 +281,7 @@ bool JfrThreadSampleClosure::sample_thread_in_native(JavaThread* thread, JfrStac
     return false;
   }
   EventNativeMethodSample *event = &_events_native[_added_native - 1];
-  traceid id = JfrStackTraceRepository::add(cb.stacktrace());
+  traceid id = JfrStackTraceRepository::instance().add(cb.stacktrace());
   assert(id != 0, "Stacktrace id should not be 0");
   event->set_stackTrace(id);
   return true;

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -281,6 +281,9 @@ bool JfrRecorder::create_components() {
   if (!create_stacktrace_repository()) {
     return false;
   }
+  if (!create_leak_profiler_stacktrace_repository()) {
+    return false;
+  }
   if (!create_os_interface()) {
     return false;
   }
@@ -302,6 +305,7 @@ static JfrStorage* _storage = NULL;
 static JfrCheckpointManager* _checkpoint_manager = NULL;
 static JfrRepository* _repository = NULL;
 static JfrStackTraceRepository* _stack_trace_repository;
+static JfrStackTraceRepository* _stack_trace_repository_leak_profiler;
 static JfrStringPool* _stringpool = NULL;
 static JfrOSInterface* _os_interface = NULL;
 static JfrThreadSampling* _thread_sampling = NULL;
@@ -353,6 +357,12 @@ bool JfrRecorder::create_stacktrace_repository() {
   return _stack_trace_repository != NULL && _stack_trace_repository->initialize();
 }
 
+bool JfrRecorder::create_leak_profiler_stacktrace_repository() {
+  assert(_stack_trace_repository_leak_profiler == NULL, "invariant");
+  _stack_trace_repository_leak_profiler = JfrStackTraceRepository::create_leak_profiler();
+  return _stack_trace_repository_leak_profiler != NULL && _stack_trace_repository_leak_profiler->initialize();
+}
+
 bool JfrRecorder::create_stringpool() {
   assert(_stringpool == NULL, "invariant");
   assert(_repository != NULL, "invariant");
@@ -391,6 +401,10 @@ void JfrRecorder::destroy_components() {
   if (_stack_trace_repository != NULL) {
     JfrStackTraceRepository::destroy();
     _stack_trace_repository = NULL;
+  }
+  if (_stack_trace_repository_leak_profiler != NULL) {
+    JfrStackTraceRepository::destroy_leak_profiler();
+    _stack_trace_repository_leak_profiler = NULL;
   }
   if (_stringpool != NULL) {
     JfrStringPool::destroy();

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
@@ -50,6 +50,7 @@ class JfrRecorder : public JfrCHeapObj {
   static bool create_post_box();
   static bool create_recorder_thread();
   static bool create_stacktrace_repository();
+  static bool create_leak_profiler_stacktrace_repository();
   static bool create_storage();
   static bool create_stringpool();
   static bool create_thread_sampling();

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -227,7 +227,7 @@ class JfrEvent {
         if (tl->has_cached_stack_trace()) {
           writer.write(tl->cached_stack_trace_id());
         } else {
-          writer.write(JfrStackTraceRepository::record(event_thread));
+          writer.write(JfrStackTraceRepository::instance().record(event_thread));
         }
       } else {
         writer.write<traceid>(0);

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -380,6 +380,7 @@ JfrRecorderService::JfrRecorderService() :
   _chunkwriter(JfrRepository::chunkwriter()),
   _repository(JfrRepository::instance()),
   _stack_trace_repository(JfrStackTraceRepository::instance()),
+  _leak_profiler_stack_trace_repository(JfrStackTraceRepository::leak_profiler_instance()),
   _storage(JfrStorage::instance()),
   _string_pool(JfrStringPool::instance()) {}
 
@@ -438,6 +439,9 @@ void JfrRecorderService::pre_safepoint_clear() {
   _string_pool.clear();
   _storage.clear();
   _stack_trace_repository.clear();
+  if (LeakProfiler::is_running()) {
+    _leak_profiler_stack_trace_repository.clear();
+  }
 }
 
 void JfrRecorderService::invoke_safepoint_clear() {
@@ -453,6 +457,9 @@ void JfrRecorderService::safepoint_clear() {
   _storage.clear();
   _chunkwriter.set_time_stamp();
   _stack_trace_repository.clear();
+  if (LeakProfiler::is_running()) {
+    _leak_profiler_stack_trace_repository.clear();
+  }
   _checkpoint_manager.end_epoch_shift();
 }
 
@@ -540,6 +547,8 @@ void JfrRecorderService::pre_safepoint_write() {
     // Exclusive access to the object sampler instance.
     // The sampler is released (unlocked) later in post_safepoint_write.
     ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire(), _stack_trace_repository);
+    // FLO: not sure about this
+    ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire(), _leak_profiler_stack_trace_repository);
   }
   if (_string_pool.is_modified()) {
     write_stringpool(_string_pool, _chunkwriter);
@@ -547,6 +556,10 @@ void JfrRecorderService::pre_safepoint_write() {
   write_storage(_storage, _chunkwriter);
   if (_stack_trace_repository.is_modified()) {
     write_stacktrace(_stack_trace_repository, _chunkwriter, false);
+  }
+  // FLO: write stack trace from the old object sample hashtable
+  if (_leak_profiler_stack_trace_repository.is_modified()) {
+    write_stacktrace(_leak_profiler_stack_trace_repository, _chunkwriter, false);
   }
 }
 
@@ -566,7 +579,9 @@ void JfrRecorderService::safepoint_write() {
   _checkpoint_manager.on_rotation();
   _storage.write_at_safepoint();
   _chunkwriter.set_time_stamp();
+  // FL0: write stack trace from the old object sample hashtable
   write_stacktrace(_stack_trace_repository, _chunkwriter, true);
+  write_stacktrace(_leak_profiler_stack_trace_repository, _chunkwriter, true);
   _checkpoint_manager.end_epoch_shift();
 }
 
@@ -623,6 +638,9 @@ size_t JfrRecorderService::flush() {
   }
   if (_stack_trace_repository.is_modified()) {
     total_elements += flush_stacktrace(_stack_trace_repository, _chunkwriter);
+  }
+  if (_leak_profiler_stack_trace_repository.is_modified()) {
+    total_elements += flush_stacktrace(_leak_profiler_stack_trace_repository, _chunkwriter);
   }
   return flush_typeset(_checkpoint_manager, _chunkwriter) + total_elements;
 }

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
@@ -40,6 +40,7 @@ class JfrRecorderService : public StackObj {
   JfrChunkWriter& _chunkwriter;
   JfrRepository& _repository;
   JfrStackTraceRepository& _stack_trace_repository;
+  JfrStackTraceRepository& _leak_profiler_stack_trace_repository;
   JfrStorage& _storage;
   JfrStringPool& _string_pool;
 

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
@@ -67,6 +67,7 @@ class JfrStackTrace : public JfrCHeapObj {
   friend class ObjectSampleCheckpoint;
   friend class ObjectSampler;
   friend class OSThreadSampler;
+  friend class StackTraceChunkWriter;
   friend class StackTraceResolver;
  private:
   const JfrStackTrace* _next;

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -32,6 +32,7 @@
 
 static JfrStackTraceRepository* _instance = NULL;
 static JfrStackTraceRepository* _leak_profiler_instance = NULL;
+static bool _serializer_registered = false;
 
 JfrStackTraceRepository::JfrStackTraceRepository() :
   _next_id(0),
@@ -76,7 +77,10 @@ class JfrFrameType : public JfrSerializer {
 };
 
 bool JfrStackTraceRepository::initialize() {
-  return JfrSerializer::register_serializer(TYPE_FRAMETYPE, true, new JfrFrameType());
+  if (!_serializer_registered) {
+    _serializer_registered = JfrSerializer::register_serializer(TYPE_FRAMETYPE, true, new JfrFrameType());
+  }
+  return _serializer_registered;
 }
 
 void JfrStackTraceRepository::destroy() {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "precompiled.hpp"
+#include "jfr/leakprofiler/sampling/objectSample.hpp"
+#include "jfr/leakprofiler/sampling/objectSampler.hpp"
 #include "jfr/metadata/jfrSerializer.hpp"
 #include "jfr/recorder/checkpoint/jfrCheckpointWriter.hpp"
 #include "jfr/recorder/repository/jfrChunkWriter.hpp"

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -31,6 +31,7 @@
 #include "runtime/mutexLocker.hpp"
 
 static JfrStackTraceRepository* _instance = NULL;
+static JfrStackTraceRepository* _leak_profiler_instance = NULL;
 
 JfrStackTraceRepository::JfrStackTraceRepository() :
   _next_id(0),
@@ -43,10 +44,20 @@ JfrStackTraceRepository& JfrStackTraceRepository::instance() {
   return *_instance;
 }
 
+JfrStackTraceRepository& JfrStackTraceRepository::leak_profiler_instance() {
+  return *_leak_profiler_instance;
+}
+
 JfrStackTraceRepository* JfrStackTraceRepository::create() {
   assert(_instance == NULL, "invariant");
   _instance = new JfrStackTraceRepository();
   return _instance;
+}
+
+JfrStackTraceRepository* JfrStackTraceRepository::create_leak_profiler() {
+  assert(_leak_profiler_instance == NULL, "invariant");
+  _leak_profiler_instance = new JfrStackTraceRepository();
+  return _leak_profiler_instance;
 }
 
 class JfrFrameType : public JfrSerializer {
@@ -72,6 +83,12 @@ void JfrStackTraceRepository::destroy() {
   assert(_instance != NULL, "invariant");
   delete _instance;
   _instance = NULL;
+}
+
+void JfrStackTraceRepository::destroy_leak_profiler() {
+  assert(_leak_profiler_instance != NULL, "invariant");
+  delete _leak_profiler_instance;
+  _leak_profiler_instance = NULL;
 }
 
 bool JfrStackTraceRepository::is_modified() const {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -40,6 +40,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   friend class ObjectSampleCheckpoint;
   friend class ObjectSampler;
   friend class StackTraceBlobInstaller;
+  friend class StackTraceChunkWriter;
   friend class StackTraceRepository;
 
  private:

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -41,6 +41,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   friend class ObjectSampler;
   friend class StackTraceBlobInstaller;
   friend class StackTraceChunkWriter;
+  friend class ObjectSamplerStackTraceRepository;
   friend class StackTraceRepository;
 
  private:

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -52,6 +52,8 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   JfrStackTraceRepository();
   static JfrStackTraceRepository* create();
   static void destroy();
+  static JfrStackTraceRepository* create_leak_profiler();
+  static void destroy_leak_profiler();
   bool initialize();
 
   bool is_modified() const;
@@ -66,6 +68,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
 
  public:
   static JfrStackTraceRepository& instance();
+  static JfrStackTraceRepository& leak_profiler_instance();
   traceid record(Thread* thread, int skip = 0);
   void record_and_cache(JavaThread* thread, int skip = 0);
 };

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -47,9 +47,9 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   JfrStackTrace* _table[TABLE_SIZE];
   traceid _next_id;
   u4 _entries;
+  traceid _last_id;
 
   JfrStackTraceRepository();
-  static JfrStackTraceRepository& instance();
   static JfrStackTraceRepository* create();
   static void destroy();
   bool initialize();
@@ -61,12 +61,13 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   const JfrStackTrace* lookup(unsigned int hash, traceid id) const;
 
   traceid add_trace(const JfrStackTrace& stacktrace);
-  static traceid add(const JfrStackTrace& stacktrace);
+  traceid add(const JfrStackTrace& stacktrace);
   traceid record_for(JavaThread* thread, int skip, JfrStackFrame* frames, u4 max_frames);
 
  public:
-  static traceid record(Thread* thread, int skip = 0);
-  static void record_and_cache(JavaThread* thread, int skip = 0);
+  static JfrStackTraceRepository& instance();
+  traceid record(Thread* thread, int skip = 0);
+  void record_and_cache(JavaThread* thread, int skip = 0);
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACEREPOSITORY_HPP

--- a/src/hotspot/share/jfr/support/jfrFlush.cpp
+++ b/src/hotspot/share/jfr/support/jfrFlush.cpp
@@ -75,7 +75,7 @@ bool jfr_save_stacktrace(Thread* thread) {
   if (tl->has_cached_stack_trace()) {
     return false; // no ownership
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(thread));
   return true;
 }
 

--- a/src/hotspot/share/jfr/support/jfrStackTraceMark.cpp
+++ b/src/hotspot/share/jfr/support/jfrStackTraceMark.cpp
@@ -35,7 +35,7 @@ JfrStackTraceMark::JfrStackTraceMark() : _t(Thread::current()), _previous_id(0),
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current()));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(Thread::current()));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previous_hash(0) {
@@ -44,7 +44,7 @@ JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previ
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(t));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_id(0), _previous_hash(0) {
@@ -55,7 +55,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_i
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(_t));
   }
 }
 
@@ -67,7 +67,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId, Thread* t) : _t(NULL), 
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(_t));
   }
 }
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2920,7 +2920,7 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
       EventThreadStart::is_stacktrace_enabled()) {
     JfrThreadLocal* tl = native_thread->jfr_thread_local();
     // skip Thread.start() and Thread.start0()
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::instance().record(thread, 2));
   }
 #endif
 


### PR DESCRIPTION
The purpose of this change is to reduce the size of JFR recordings when the OldObjectSample event is enabled.

## Problem

JFR recordings size blows up when the `OldObjectSample` is enabled. The memory allocation events are known to be very high traffic and will cause a lot of data, just the sheer number of events produced, and if stacktraces are added to this, the associated metadata can be huge as well. Sampled object are stored in a priority queue and their associated stack traces stored in `JFRStackTraceRepository`. When sample candidates are removed from the priority queue, their stacktraces remain in the repository, which will be later written at chunk rotation even if the sample has been removed.

## Implementation

This PR adds a `JFRStackTraceRepository` dedicated to store stack traces for the `OldObjectSample` event. At chunk rotation, every sample stack trace is looked up in this repository and is serialized. Other stack traces are simply removed.

## Benchmarks
On an AWS c5.metal instance (96 cores, 192 Gib), running SPECjvm2008 with default profile.jfc configuration with OldObjectSample event enabled gives
- a recording size 2.78Mb with the PR fix
- a recording size 20.73Mb with the PR fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258414](https://bugs.openjdk.java.net/browse/JDK-8258414): OldObjectSample events too expensive


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2644/head:pull/2644`
`$ git checkout pull/2644`
