### PR TITLE
8261225: TieredStopAtLevel should have no effect if TieredCompilation is disabled

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -158,7 +158,7 @@ public:
   static bool is_c1_only() {
     if (!is_interpreter_only() && has_c1()) {
       const bool c1_only = !has_c2() && !is_jvmci_compiler();
-      const bool tiered_degraded_to_c1_only = TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
+      const bool tiered_degraded_to_c1_only = TieredCompilation && TieredStopAtLevel >= CompLevel_simple && TieredStopAtLevel < CompLevel_full_optimization;
       const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
       return c1_only || tiered_degraded_to_c1_only || c1_only_compilation_mode;
     }
@@ -177,9 +177,10 @@ public:
   // Is the JVM in a configuration that permits only c1-compiled methods at level 1?
   static bool is_c1_simple_only() {
     if (is_c1_only()) {
-      const bool tiered_degraded_to_level_1 = TieredStopAtLevel == CompLevel_simple;
+      const bool tiered_degraded_to_level_1 = TieredCompilation && TieredStopAtLevel == CompLevel_simple;
       const bool c1_only_compilation_mode = CompilationModeFlag::quick_only();
-      return tiered_degraded_to_level_1 || c1_only_compilation_mode;
+      const bool tiered_off = !TieredCompilation;
+      return tiered_degraded_to_level_1 || c1_only_compilation_mode || tiered_off;
     }
     return false;
   }

--- a/test/hotspot/jtreg/compiler/tiered/TestEnqueueMethodForCompilation.java
+++ b/test/hotspot/jtreg/compiler/tiered/TestEnqueueMethodForCompilation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestEnqueueMethodForCompilation
+ * @summary If TieredCompilation is disabled, TieredStopAtLevel should have no effect.
+ * @requires vm.flavor == "server"
+ * @library /test/lib /
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:TieredStopAtLevel=1 -XX:-TieredCompilation
+ *                   compiler.tiered.TestEnqueueMethodForCompilation
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:TieredStopAtLevel=2 -XX:-TieredCompilation
+ *                   compiler.tiered.TestEnqueueMethodForCompilation
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:TieredStopAtLevel=3 -XX:-TieredCompilation
+ *                   compiler.tiered.TestEnqueueMethodForCompilation
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:TieredStopAtLevel=4 -XX:-TieredCompilation
+ *                   compiler.tiered.TestEnqueueMethodForCompilation
+ */
+
+package compiler.tiered;
+
+import java.lang.reflect.Method;
+import compiler.whitebox.CompilerWhiteBoxTest;
+
+import sun.hotspot.WhiteBox;
+
+public class TestEnqueueMethodForCompilation {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    public void test() { }
+
+    public static void main(String[] args) throws Exception {
+        Method method = TestEnqueueMethodForCompilation.class.getMethod("test");
+        boolean success = WHITE_BOX.enqueueMethodForCompilation(method, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        if (!success) {
+            throw new RuntimeException("Method could not be enqueued for compilation at level " + CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        }
+    }
+}


### PR DESCRIPTION
Ignore TieredStopAtLevel flag is TieredCompilation is off for compatibility with the old compilation policy. Also did some polishing of things that came up in the process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261225](https://bugs.openjdk.java.net/browse/JDK-8261225): TieredStopAtLevel should have no effect if TieredCompilation is disabled


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2647/head:pull/2647`
`$ git checkout pull/2647`
