### PR TITLE
8262042: ProblemList javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java on Windows

### DIFF
--- a/test/jaxp/ProblemList.txt
+++ b/test/jaxp/ProblemList.txt
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-# Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,3 +22,5 @@
 # questions.
 #
 ###########################################################################
+
+javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java 8262041 windows-all


### PR DESCRIPTION
A trivial fix to ProblemList javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262042](https://bugs.openjdk.java.net/browse/JDK-8262042): ProblemList javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java on Windows


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2650/head:pull/2650`
`$ git checkout pull/2650`
