### PR TITLE
JDK-8223355: Redundant output by javadoc

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
@@ -198,7 +198,6 @@ public class DocFilesHandlerImpl implements DocFilesHandler {
         PackageElement pkg = dfElement.getPackageElement();
 
         HtmlDocletWriter docletWriter = new DocFileWriter(configuration, dfilePath, element, pkg);
-        configuration.messages.notice("doclet.Generating_0", docletWriter.filename.getPath());
 
         List<? extends DocTree> localTags = getLocalHeaderTags(utils.getPreamble(dfElement));
         Content localTagsContent = docletWriter.commentTagsToContent(null, dfElement, localTags, false);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
@@ -267,17 +267,22 @@ public abstract class AbstractDoclet implements Doclet {
      */
     protected void generateClassFiles(ClassTree classtree)
             throws DocletException {
+
+        SortedSet<TypeElement> classes = new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
+
         // handle classes specified as files on the command line
         for (PackageElement pkg : configuration.typeElementCatalog.packages()) {
-            generateClassFiles(configuration.typeElementCatalog.allClasses(pkg), classtree);
+            classes.addAll(configuration.typeElementCatalog.allClasses(pkg));
         }
 
-        // handle classes specified in m odules and packages on the command line
+        // handle classes specified in modules and packages on the command line
         SortedSet<PackageElement> packages = new TreeSet<>(utils.comparators.makePackageComparator());
         packages.addAll(configuration.getSpecifiedPackageElements());
         configuration.modulePackages.values().stream().forEach(packages::addAll);
         for (PackageElement pkg : packages) {
-            generateClassFiles(utils.getAllClasses(pkg), classtree);
+            classes.addAll(utils.getAllClasses(pkg));
         }
+
+        generateClassFiles(classes, classtree);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8223355
+ * @summary Redundant output by javadoc
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestGeneratedClasses
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestGeneratedClasses extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestGeneratedClasses tester = new TestGeneratedClasses();
+        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testClasses(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path src_m = src.resolve("m");
+        tb.writeJavaFiles(src_m,
+                "module m { exports p; }",
+                "package p; public class C { }");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "--source-path", src_m.toString(),
+                "-Xdoclint:none",
+                "--module", "m");
+
+        // verify that C.html is only generated once
+        checkOutput(Output.OUT, true,
+                """
+                    Building tree for all the packages and classes...
+                    Generating testClasses/out/m/p/C.html...
+                    Generating testClasses/out/m/p/package-summary.html...""");
+    }
+}

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -54,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -233,6 +235,7 @@ public abstract class JavadocTester {
 
     private boolean automaticCheckAccessibility = true;
     private boolean automaticCheckLinks = true;
+    private boolean automaticCheckUniqueOUT = true;
 
     /** The current subtest number. Incremented when checking(...) is called. */
     private int numTestsRun = 0;
@@ -318,18 +321,10 @@ public abstract class JavadocTester {
         String encodingArg = null;
         for (int i = 0; i < args.length - 2; i++) {
             switch (args[i]) {
-                case "-d":
-                    outputDir = new File(args[++i]);
-                    break;
-                case "-charset":
-                    charsetArg = args[++i];
-                    break;
-                case "-docencoding":
-                    docencodingArg = args[++i];
-                    break;
-                case "-encoding":
-                    encodingArg = args[++i];
-                    break;
+                case "-d" -> outputDir = new File(args[++i]);
+                case "-charset" -> charsetArg = args[++i];
+                case "-docencoding" -> docencodingArg = args[++i];
+                case "-encoding" -> encodingArg = args[++i];
             }
         }
 
@@ -386,6 +381,9 @@ public abstract class JavadocTester {
             if (automaticCheckAccessibility) {
                 checkAccessibility();
             }
+            if (automaticCheckUniqueOUT) {
+                checkUnique(Output.OUT, "^[A-Z][a-z]+ing ", true);
+            }
         }
     }
 
@@ -411,6 +409,13 @@ public abstract class JavadocTester {
      */
     public void setAutomaticCheckLinks(boolean b) {
         automaticCheckLinks = b;
+    }
+
+    /**
+     * Sets whether or not to perform an automatic call of checkUnique(OUT).
+     */
+    public void setAutomaticCheckUniqueOUT(boolean b) {
+        automaticCheckUniqueOUT = b;
     }
 
     /**
@@ -522,6 +527,48 @@ public abstract class JavadocTester {
                         "found \n" +
                         fileString);
             }
+        }
+    }
+
+    /**
+     * Checks that there are no duplicate lines in one of the streams written by javadoc.
+     * @param output the output stream to check
+     */
+    public void checkUnique(Output output) {
+        checkUnique(output, ".*", true);
+    }
+
+    /**
+     * Checks that there are no duplicate lines that either match or don't match a given patter,
+     * in one of the streams written by javadoc.
+     * @param output the output stream to check
+     * @param pattern a pattern to filter the lines to be checked
+     * @param select if {@code true}, lines that match the pattern will be checked for uniqueness;
+     *               if {@code false}, lines that do not match the pattern will be checked
+     */
+    public void checkUnique(Output output, String pattern, boolean select) {
+        checking("checkUnique");
+        Pattern filter = Pattern.compile(pattern);
+        Matcher m = filter.matcher("");
+        Map<String, Integer> linesSofar = new HashMap<>();
+        int lineNumber = 0;
+        int duplicates = 0;
+        for (String line : getOutputLines(output)) {
+            m.reset(line);
+            if (m.find() == select) {
+                Integer prev = linesSofar.putIfAbsent(line, ++lineNumber);
+                if (prev != null) {
+                    out.println("duplicate line detected on line " + lineNumber
+                            + "; first occurrence on line " + prev);
+                    out.println("line: " + line);
+                    duplicates++;
+                }
+            }
+        }
+        if (duplicates == 0) {
+            passed("All lines are unique");
+        } else {
+            failed(duplicates + " duplicate lines found");
         }
     }
 


### PR DESCRIPTION
This change addresses a bug that was observed while playing with small demo API: some files may be generated twice.

The fix is to build a single set of the files to be generated.

Note: this bug also affected the generation of the main JDK API docs.  According to the log file, before the fix we were generating 14812 files; now, we are generating only 10146 files! That's a drop of 4466 files or over 30%!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223355](https://bugs.openjdk.java.net/browse/JDK-8223355): Redundant output  by javadoc


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2652/head:pull/2652`
`$ git checkout pull/2652`
