### PR TITLE
8262049: [TESTBUG] Fix TestReferenceRefersTo.java for Shenandoah IU mode

### DIFF
--- a/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
@@ -162,6 +162,10 @@ public class TestReferenceRefersTo {
         testObject4 = null;
     }
 
+    private static boolean isShenandoahIUMode() {
+        return WB.getBooleanVMFlag("UseShenandoahGC") && "iu".equals(WB.getStringVMFlag("ShenandoahGCMode"));
+    }
+
     private static void testConcurrentCollection() throws Exception {
         progress("setup concurrent collection test");
         setup();
@@ -197,8 +201,14 @@ public class TestReferenceRefersTo {
             expectCleared(testPhantom1, "testPhantom1");
             expectCleared(testWeak2, "testWeak2");
             expectValue(testWeak3, testObject3, "testWeak3");
-            // This is true for all currently supported concurrent collectors.
-            expectNotCleared(testWeak4, "testWeak4");
+            // This is true for all currently supported concurrent collectors,
+            // except Shenandoah+IU, which allows clearing refs even when
+            // accessed during concurrent marking.
+            if (isShenandoahIUMode()) {
+              expectCleared(testWeak4, "testWeak4");
+            } else {
+              expectNotCleared(testWeak4, "testWeak4");
+            }
 
             progress("verify get returns expected values");
             if (testWeak2.get() != null) {
@@ -213,10 +223,12 @@ public class TestReferenceRefersTo {
             }
 
             TestObject obj4 = testWeak4.get();
-            if (obj4 == null) {
-                fail("testWeak4.get() returned null");
-            } else if (obj4.value != 4) {
-                fail("testWeak4.get().value is " + obj4.value);
+            if (!isShenandoahIUMode()) {
+                if (obj4 == null) {
+                    fail("testWeak4.get() returned null");
+                } else if (obj4.value != 4) {
+                    fail("testWeak4.get().value is " + obj4.value);
+                }
             }
 
             progress("verify queue entries");

--- a/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
@@ -238,7 +238,8 @@ public class TestReferenceRefersTo {
                 fail("testWeak3 notified");
             }
             if ((testWeak4 == null) != (obj4 == null)) {
-                fail("either referent is cleared and we got notified, or neither of this happened");
+                fail("either referent is cleared and we got notified, or neither of this happened: referent: "
+                     + obj4 + ", notified: " + (testWeak == null));
             }
 
         } finally {

--- a/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
@@ -239,7 +239,7 @@ public class TestReferenceRefersTo {
             }
             if ((testWeak4 == null) != (obj4 == null)) {
                 fail("either referent is cleared and we got notified, or neither of this happened: referent: "
-                     + obj4 + ", notified: " + (testWeak == null));
+                     + obj4 + ", notified: " + (testWeak4 == null));
             }
 
         } finally {

--- a/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
@@ -24,7 +24,7 @@
 package gc;
 
 /* @test
- * @requires vm.gc != "Shenandoah"
+ * @requires vm.gc != "Shenandoah" | vm.opt.ShenandoahGCMode != "iu"
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base

--- a/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
@@ -58,7 +58,7 @@ public class TestReferenceRefersToDuringConcMark {
 
     private static ReferenceQueue<TestObject> queue = null;
 
-    private static WeakReference<TestObject> testWeak4 = null;
+    private static WeakReference<TestObject> testWeak = null;
 
     private static void setup() {
         testObjectNone = new TestObject(0);
@@ -66,7 +66,7 @@ public class TestReferenceRefersToDuringConcMark {
 
         queue = new ReferenceQueue<TestObject>();
 
-        testWeak4 = new WeakReference<TestObject>(testObject, queue);
+        testWeak = new WeakReference<TestObject>(testObject, queue);
     }
 
     private static void gcUntilOld(Object o) throws Exception {
@@ -128,7 +128,7 @@ public class TestReferenceRefersToDuringConcMark {
     }
 
     private static void checkInitialStates() throws Exception {
-        expectValue(testWeak4, testObject, "testWeak");
+        expectValue(testWeak, testObject, "testWeak");
     }
 
     private static void discardStrongReferences() {
@@ -179,15 +179,15 @@ public class TestReferenceRefersToDuringConcMark {
                 Reference<? extends TestObject> ref = queue.remove(timeout);
                 if (ref == null) {
                     break;
-                } else if (ref == testWeak4) {
-                    testWeak4 = null;
+                } else if (ref == testWeak) {
+                    testWeak = null;
                 } else {
                     fail("unexpected reference in queue");
                 }
             }
-            if (testWeak4 == null) {
-                if (obj4 != null) {
-                    fail("testWeak4 notified");
+            if (testWeak == null) {
+                if (obj != null) {
+                    fail("testWeak notified");
                 }
             }
 


### PR DESCRIPTION
Shenandoah's IU mode allows referents to be cleared even when accessed during concurrent marking. The test TestReferenceRefersTo.java needs to be adjusted to allow for that.

Test:
 - [x] TestReferenceRefersTo.java + Shenandoah/IU
 - [x] TestReferenceRefersTo.java + Shenandoah/SATB
 - [x] TestReferenceRefersTo.java + G1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262049](https://bugs.openjdk.java.net/browse/JDK-8262049): [TESTBUG] Fix TestReferenceRefersTo.java for Shenandoah IU mode


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2653/head:pull/2653`
`$ git checkout pull/2653`
