### PR TITLE
8253940: com/sun/jdi/JdwpAttachTest.java failed with "RuntimeException: ERROR: LingeredApp.startApp was able to attach"

### DIFF
--- a/test/jdk/com/sun/jdi/JdwpAttachTest.java
+++ b/test/jdk/com/sun/jdi/JdwpAttachTest.java
@@ -84,11 +84,13 @@ public class JdwpAttachTest {
             }
         }
 
-        // by using "localhost" or empty hostname
-        // we should be able to attach to both IPv4 and IPv6 addresses (127.0.0.1 & ::1).
+        // By using "localhost" or empty hostname we should be able to attach
+        // to both IPv4 and IPv6 addresses (127.0.0.1 & ::1).
+        // By default test verifies only "preferred" family (IPv4 or IPv6).
+        // Need to set testPotentiallyUnstableCases to true to perform full testing.
         InetAddress localAddresses[] = InetAddress.getAllByName("localhost");
         for (int i = 0; i < localAddresses.length; i++) {
-            if (testPotentiallyUnstableCases || addressIfSafeToConnectToLocalhost(localAddresses[i])) {
+            if (testPotentiallyUnstableCases || addressIsSafeToConnectToLocalhost(localAddresses[i])) {
                 attachTest(localAddresses[i].getHostAddress(), "", true);
             }
         }
@@ -174,10 +176,10 @@ public class JdwpAttachTest {
     }
 
     // Attach to localhost tries to connect to both IPv4 and IPv6 loopback addresses.
-    // But sometimes it causes interference with other processes which can listen on the same port but different
-    // loopback address.
+    // But sometimes it causes interference with other processes which can listen
+    // on the same port but different loopback address.
     // The method checks if the address is safe to test with current network config.
-    private static boolean addressIfSafeToConnectToLocalhost(InetAddress addr) {
+    private static boolean addressIsSafeToConnectToLocalhost(InetAddress addr) {
         boolean ipv6 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses"));
         return ipv6 == (addr instanceof Inet6Address);
     }

--- a/test/jdk/com/sun/jdi/JdwpAttachTest.java
+++ b/test/jdk/com/sun/jdi/JdwpAttachTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,12 @@ import java.util.concurrent.Executors;
 public class JdwpAttachTest {
 
     // Set to true to perform testing of attach from wrong address (expected to fail).
-    // It's off by default as it caused significant test time increase\
+    // It's off by default as it caused significant test time increase
     // (tests <number_of_addresses> * <number_of_addresses> cases, each case fails by timeout).
     private static boolean testFailedAttach = false;
+
+    // A flag to exclude testcases which can cause intermittent CI failures.
+    private static boolean testPotentiallyUnstableCases = false;
 
     public static void main(String[] args) throws Exception {
         List<InetAddress> addresses = Utils.getAddressesWithSymbolicAndNumericScopes();
@@ -82,10 +85,12 @@ public class JdwpAttachTest {
         }
 
         // by using "localhost" or empty hostname
-        // we should be able to attach to both IPv4 and IPv6 addresses (127.0.0.1 & ::1)
+        // we should be able to attach to both IPv4 and IPv6 addresses (127.0.0.1 & ::1).
         InetAddress localAddresses[] = InetAddress.getAllByName("localhost");
         for (int i = 0; i < localAddresses.length; i++) {
-            attachTest(localAddresses[i].getHostAddress(), "", true);
+            if (testPotentiallyUnstableCases || addressIfSafeToConnectToLocalhost(localAddresses[i])) {
+                attachTest(localAddresses[i].getHostAddress(), "", true);
+            }
         }
     }
 
@@ -166,6 +171,15 @@ public class JdwpAttachTest {
             throw new IllegalArgumentException("Argument " + name + " is not defined");
         }
         arg.setValue(value);
+    }
+
+    // Attach to localhost tries to connect to both IPv4 and IPv6 loopback addresses.
+    // But sometimes it causes interference with other processes which can listen on the same port but different
+    // loopback address.
+    // The method checks if the address is safe to test with current network config.
+    private static boolean addressIfSafeToConnectToLocalhost(InetAddress addr) {
+        boolean ipv6 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses"));
+        return ipv6 == (addr instanceof Inet6Address);
     }
 
     private static long startTime = System.currentTimeMillis();


### PR DESCRIPTION
Failures related to "no route to host" and "cannot bind to address" errors are covered by https://git.openjdk.java.net/jdk/pull/2633

This change fixes failures with listening on IPv6 loopback and attaching to "localhost" (the test connects to some other process which listens on the same port on IPv4 loopback and as a result gets "handshake failed - received >< - expected >JDWP-Handshake<" error)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253940](https://bugs.openjdk.java.net/browse/JDK-8253940): com/sun/jdi/JdwpAttachTest.java failed with "RuntimeException: ERROR: LingeredApp.startApp was able to attach"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2654/head:pull/2654`
`$ git checkout pull/2654`
