### PR TITLE
8210373: Deadlock in libj2gss.so when loading "j2gss" and "net" libraries in parallel.

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -71,6 +71,9 @@ public final class SunNativeProvider extends Provider {
                         DEBUG = Boolean.parseBoolean(
                             System.getProperty("sun.security.nativegss.debug"));
                         try {
+                            // Ensure the InetAddress class is loaded before
+                            // loading j2gss. The library will access this class
+                            // and a deadlock might happen. See JDK-8210373.
                             Class.forName("java.net.InetAddress");
                             System.loadLibrary("j2gss");
                         } catch (ClassNotFoundException | Error err) {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,9 @@ public final class SunNativeProvider extends Provider {
                         DEBUG = Boolean.parseBoolean(
                             System.getProperty("sun.security.nativegss.debug"));
                         try {
+                            Class.forName("java.net.InetAddress");
                             System.loadLibrary("j2gss");
-                        } catch (Error err) {
+                        } catch (ClassNotFoundException | Error err) {
                             debug("No j2gss library found!");
                             if (DEBUG) err.printStackTrace();
                             return null;


### PR DESCRIPTION
`InetAddress` is loading native library `net` and at the same time `SunNativeProvider` is loading `j2gss`, and in the `OnLoad` function inside `j2gss` it is calling `FindClass(env, "java/net/InetAddress")` and thus a deadlock.

We can access `InetAddress` in `SunNativeProvider.<clinit>` before loading the jgss library. i.e. use `Class.forName` to ensure `InetAddress` is initialized. Thanks to @dholmes-ora for providing this workaround.

No new regression test, hard to reproduce.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210373](https://bugs.openjdk.java.net/browse/JDK-8210373): Deadlock in libj2gss.so when loading "j2gss" and "net" libraries in parallel.


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2655/head:pull/2655`
`$ git checkout pull/2655`
