### PR TITLE
8262041: javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java fails after JDK-8260858

### DIFF
--- a/test/jaxp/ProblemList.txt
+++ b/test/jaxp/ProblemList.txt
@@ -23,4 +23,3 @@
 #
 ###########################################################################
 
-javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java 8262041 windows-all

--- a/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java
@@ -190,7 +190,7 @@ public class PrettyPrintTest {
             boolean val, String expected)
             throws Exception {
         String result = transform(null, expected, false, pretty, p, sp, val);
-        Assert.assertEquals(result, expected);
+        Assert.assertEquals(result.replaceAll("\r\n", "\n"), expected);
     }
 
     /*
@@ -203,7 +203,7 @@ public class PrettyPrintTest {
             boolean sp, boolean val, String expected)
             throws Exception {
         String result = transform(xsl, expected, false, pretty, p, sp, val);
-        Assert.assertEquals(result, expected);
+        Assert.assertEquals(result.replaceAll("\r\n", "\n"), expected);
     }
 
     /*


### PR DESCRIPTION
A quick fix to the test, removing Windows carriage return in the result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262041](https://bugs.openjdk.java.net/browse/JDK-8262041): javax/xml/jaxp/unittest/common/prettyprint/PrettyPrintTest.java fails after JDK-8260858


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2656/head:pull/2656`
`$ git checkout pull/2656`
