### PR TITLE
8262066: ProblemList java/util/Locale/LocaleProvidersRun.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -796,7 +796,7 @@ com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-al
 
 # jdk_util
 
-java/util/Locale/LocaleProvidersRun.java                        8261919 generic-all
+java/util/Locale/LocaleProvidersRun.java                        8261919 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -796,6 +796,8 @@ com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-al
 
 # jdk_util
 
+java/util/Locale/LocaleProvidersRun.java                        8261919 generic-all
+
 ############################################################################
 
 # jdk_instrument


### PR DESCRIPTION
The subject test case is failing under the JMS-enabled environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262066](https://bugs.openjdk.java.net/browse/JDK-8262066): ProblemList java/util/Locale/LocaleProvidersRun.java


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2657/head:pull/2657`
`$ git checkout pull/2657`
