### PR TITLE
8261502: ECDHKeyAgreement: Allows alternate ECPrivateKey impl and revised exception handling

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,33 @@
 
 package sun.security.ec;
 
-import java.math.*;
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
-import java.util.Optional;
-
-import javax.crypto.*;
-import javax.crypto.spec.*;
-
+import sun.security.ec.point.AffinePoint;
+import sun.security.ec.point.Point;
 import sun.security.util.ArrayUtil;
 import sun.security.util.CurveDB;
-import sun.security.util.ECUtil;
 import sun.security.util.NamedCurve;
-import sun.security.util.math.*;
-import sun.security.ec.point.*;
+import sun.security.util.math.ImmutableIntegerModuloP;
+import sun.security.util.math.IntegerFieldModuloP;
+import sun.security.util.math.MutableIntegerModuloP;
+import sun.security.util.math.SmallValue;
+
+import javax.crypto.KeyAgreementSpi;
+import javax.crypto.SecretKey;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.EllipticCurve;
+import java.util.Optional;
 
 /**
  * KeyAgreement implementation for ECDH.
@@ -49,7 +61,8 @@ import sun.security.ec.point.*;
 public final class ECDHKeyAgreement extends KeyAgreementSpi {
 
     // private key, if initialized
-    private ECPrivateKey privateKey;
+    private ECPrivateKeyImpl privateKey;
+    ECOperations privateKeyOps;
 
     // public key, non-null between doPhase() & generateSecret() only
     private ECPublicKey publicKey;
@@ -63,16 +76,35 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     public ECDHKeyAgreement() {
     }
 
+    // Generic init
+    private void init(Key key) throws
+        InvalidKeyException, InvalidAlgorithmParameterException {
+        if (!(key instanceof PrivateKey)) {
+            throw new InvalidKeyException("Key must be instance of PrivateKey");
+        }
+        privateKey = new ECPrivateKeyImpl(
+            ((ECPrivateKey)ECKeyFactory.toECKey(key)).getEncoded());
+        publicKey = null;
+        Optional<ECOperations> opsOpt =
+            ECOperations.forParameters(privateKey.getParams());
+        if (opsOpt.isEmpty()) {
+            NamedCurve nc = CurveDB.lookup(privateKey.getParams());
+            throw new InvalidAlgorithmParameterException(
+                "Curve not supported: " + (nc != null ? nc.toString() :
+                    "unknown"));
+        }
+        privateKeyOps = opsOpt.get();
+    }
+
     // see JCE spec
     @Override
     protected void engineInit(Key key, SecureRandom random)
             throws InvalidKeyException {
-        if (!(key instanceof PrivateKey)) {
-            throw new InvalidKeyException
-                        ("Key must be instance of PrivateKey");
+        try {
+            init(key);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new InvalidKeyException(e);
         }
-        privateKey = (ECPrivateKey) ECKeyFactory.toECKey(key);
-        publicKey = null;
     }
 
     // see JCE spec
@@ -84,7 +116,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
             throw new InvalidAlgorithmParameterException
                         ("Parameters not supported");
         }
-        engineInit(key, random);
+        init(key);
     }
 
     // see JCE spec
@@ -108,9 +140,12 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
 
         this.publicKey = (ECPublicKey) key;
 
-        ECParameterSpec params = publicKey.getParams();
-        int keyLenBits = params.getCurve().getField().getFieldSize();
+        int keyLenBits =
+            publicKey.getParams().getCurve().getField().getFieldSize();
         secretLen = (keyLenBits + 7) >> 3;
+
+        // Validate public key
+        validate(privateKeyOps, publicKey);
 
         return null;
     }
@@ -127,11 +162,12 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     }
 
     /*
-     * Check whether a public key is valid. Throw ProviderException
-     * if it is not valid or could not be validated.
+     * Check whether a public key is valid.
      */
     private static void validate(ECOperations ops, ECPublicKey key)
         throws InvalidKeyException {
+
+        ECParameterSpec spec = key.getParams();
 
         // ensure that integers are in proper range
         BigInteger x = key.getW().getAffineX();
@@ -142,7 +178,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         validateCoordinate(y, p);
 
         // ensure the point is on the curve
-        EllipticCurve curve = key.getParams().getCurve();
+        EllipticCurve curve = spec.getCurve();
         BigInteger rhs = x.modPow(BigInteger.valueOf(3), p).add(curve.getA()
             .multiply(x)).add(curve.getB()).mod(p);
         BigInteger lhs = y.modPow(BigInteger.valueOf(2), p).mod(p);
@@ -154,7 +190,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         ImmutableIntegerModuloP xElem = ops.getField().getElement(x);
         ImmutableIntegerModuloP yElem = ops.getField().getElement(y);
         AffinePoint affP = new AffinePoint(xElem, yElem);
-        byte[] order = key.getParams().getOrder().toByteArray();
+        byte[] order = spec.getOrder().toByteArray();
         ArrayUtil.reverse(order);
         Point product = ops.multiply(affP, order);
         if (!ops.isNeutral(product)) {
@@ -170,20 +206,14 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
             throw new IllegalStateException("Not initialized correctly");
         }
 
-        Optional<byte[]> resultOpt;
+        byte[] result;
         try {
-            resultOpt = deriveKeyImpl(privateKey, publicKey);
+            result = deriveKeyImpl(privateKey, privateKeyOps, publicKey);
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
-        if (resultOpt.isEmpty()) {
-            NamedCurve nc = CurveDB.lookup(publicKey.getParams());
-            throw new IllegalStateException(
-                new InvalidAlgorithmParameterException("Curve not supported: " +
-                    (nc != null ? nc.toString() : "unknown")));
-        }
         publicKey = null;
-        return resultOpt.get();
+        return result;
     }
 
     // see JCE spec
@@ -216,49 +246,30 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     }
 
     private static
-    Optional<byte[]> deriveKeyImpl(ECPrivateKey priv, ECPublicKey pubKey)
-        throws InvalidKeyException {
-
-        ECParameterSpec ecSpec = priv.getParams();
-        EllipticCurve curve = ecSpec.getCurve();
-        Optional<ECOperations> opsOpt = ECOperations.forParameters(ecSpec);
-        if (opsOpt.isEmpty()) {
-            return Optional.empty();
-        }
-        ECOperations ops = opsOpt.get();
-        if (! (priv instanceof ECPrivateKeyImpl)) {
-            return Optional.empty();
-        }
-        ECPrivateKeyImpl privImpl = (ECPrivateKeyImpl) priv;
-        byte[] sArr = privImpl.getArrayS();
-
-        // to match the native implementation, validate the public key here
-        // and throw ProviderException if it is invalid
-        validate(ops, pubKey);
+    byte[] deriveKeyImpl(ECPrivateKeyImpl priv, ECOperations ops,
+        ECPublicKey pubKey) throws InvalidKeyException {
 
         IntegerFieldModuloP field = ops.getField();
         // convert s array into field element and multiply by the cofactor
-        MutableIntegerModuloP scalar = field.getElement(sArr).mutable();
+        MutableIntegerModuloP scalar = field.getElement(priv.getArrayS()).mutable();
         SmallValue cofactor =
             field.getSmallValue(priv.getParams().getCofactor());
         scalar.setProduct(cofactor);
-        int keySize = (curve.getField().getFieldSize() + 7) / 8;
-        byte[] privArr = scalar.asByteArray(keySize);
-
+        int keySize =
+            (priv.getParams().getCurve().getField().getFieldSize() + 7) / 8;
         ImmutableIntegerModuloP x =
             field.getElement(pubKey.getW().getAffineX());
         ImmutableIntegerModuloP y =
             field.getElement(pubKey.getW().getAffineY());
-        AffinePoint affPub = new AffinePoint(x, y);
-        Point product = ops.multiply(affPub, privArr);
+        Point product = ops.multiply(new AffinePoint(x, y),
+            scalar.asByteArray(keySize));
         if (ops.isNeutral(product)) {
             throw new InvalidKeyException("Product is zero");
         }
-        AffinePoint affProduct = product.asAffine();
 
-        byte[] result = affProduct.getX().asByteArray(keySize);
+        byte[] result = product.asAffine().getX().asByteArray(keySize);
         ArrayUtil.reverse(result);
 
-        return Optional.of(result);
+        return result;
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -61,7 +61,7 @@ import java.util.Optional;
 public final class ECDHKeyAgreement extends KeyAgreementSpi {
 
     // private key, if initialized
-    private ECPrivateKeyImpl privateKey;
+    private ECPrivateKey privateKey;
     ECOperations privateKeyOps;
 
     // public key, non-null between doPhase() & generateSecret() only
@@ -82,8 +82,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         if (!(key instanceof PrivateKey)) {
             throw new InvalidKeyException("Key must be instance of PrivateKey");
         }
-        privateKey = new ECPrivateKeyImpl(
-            ((ECPrivateKey)ECKeyFactory.toECKey(key)).getEncoded());
+        privateKey = (ECPrivateKey)ECKeyFactory.toECKey(key);
         publicKey = null;
         Optional<ECOperations> opsOpt =
             ECOperations.forParameters(privateKey.getParams());
@@ -246,12 +245,12 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     }
 
     private static
-    byte[] deriveKeyImpl(ECPrivateKeyImpl priv, ECOperations ops,
+    byte[] deriveKeyImpl(ECPrivateKey priv, ECOperations ops,
         ECPublicKey pubKey) throws InvalidKeyException {
 
         IntegerFieldModuloP field = ops.getField();
         // convert s array into field element and multiply by the cofactor
-        MutableIntegerModuloP scalar = field.getElement(priv.getArrayS()).mutable();
+        MutableIntegerModuloP scalar = field.getElement(priv.getS()).mutable();
         SmallValue cofactor =
             field.getSmallValue(priv.getParams().getCofactor());
         scalar.setProduct(cofactor);

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8238911
+ * @bug 8261502
  * @summary Check that ECPrivateKey's that are not ECPrivateKeyImpl can use
  * ECDHKeyAgreement
  */

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/ECKeyCheck.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8238911
+ * @summary Check that ECPrivateKey's that are not ECPrivateKeyImpl can use
+ * ECDHKeyAgreement
+ */
+
+import javax.crypto.KeyAgreement;
+import java.math.BigInteger;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+
+public class ECKeyCheck {
+
+    public static final void main(String args[]) throws Exception {
+        ECGenParameterSpec spec = new ECGenParameterSpec("secp256r1");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(spec);
+
+        ECPrivateKey privKey = (ECPrivateKey) kpg.generateKeyPair().getPrivate();
+        ECPublicKey pubKey = (ECPublicKey) kpg.generateKeyPair().getPublic();
+        generateECDHSecret(privKey, pubKey);
+        generateECDHSecret(new newPrivateKeyImpl(privKey), pubKey);
+    }
+
+    private static byte[] generateECDHSecret(ECPrivateKey privKey,
+        ECPublicKey pubKey) throws Exception {
+        KeyAgreement ka = KeyAgreement.getInstance("ECDH");
+        ka.init(privKey);
+        ka.doPhase(pubKey, true);
+        return ka.generateSecret();
+    }
+
+    // Test ECPrivateKey class
+    private static class newPrivateKeyImpl implements ECPrivateKey {
+        private ECPrivateKey p;
+
+        newPrivateKeyImpl(ECPrivateKey p) {
+            this.p = p;
+        }
+
+        public BigInteger getS() {
+            return p.getS();
+        }
+
+        public byte[] getEncoded() {
+            return p.getEncoded();
+        }
+
+        public String getFormat() {
+            return p.getFormat();
+        }
+
+        public String getAlgorithm() {
+            return p.getAlgorithm();
+        }
+
+        public ECParameterSpec getParams() {
+            return p.getParams();
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I need a code review of this change to ECDH.  It is a combination of fixing the implementation to not only accept ECPrivateKeyImpl along with a fix to the exception handling.  They started as two fixes, but with the exception handling the underlying code changed significantly that made the ECPrivateKey change in a different place.  The new exception handling is a result of no longer having the native library.  Many of the checks waited until generateSecret() to send the keys to the native library. Now that native is gone, checks can happen when keys are provided to the methods and proper exceptions can be thrown instead of wrapping everything as a ProviderException

thanks,

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261502](https://bugs.openjdk.java.net/browse/JDK-8261502): ECDHKeyAgreement: Allows alternate ECPrivateKey impl and revised exception handling


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to aec24cc107bd3bd7ac931d7ab6af116642102de7


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2659/head:pull/2659`
`$ git checkout pull/2659`

To update a local copy of the PR:
`$ git checkout pull/2659`
`$ git pull https://git.openjdk.java.net/jdk pull/2659/head`
