### PR TITLE
8263552: Use String.valueOf() for char-to-String conversions

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -830,7 +830,7 @@ public class ObjectStreamClass implements Serializable {
             char tcode = (char) in.readByte();
             String fname = in.readUTF();
             String signature = ((tcode == 'L') || (tcode == '[')) ?
-                in.readTypeString() : new String(new char[] { tcode });
+                in.readTypeString() : String.valueOf(tcode);
             try {
                 fields[i] = new ObjectStreamField(fname, signature, false);
             } catch (RuntimeException e) {

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -452,7 +452,7 @@ final class CryptoPolicyParser {
             break;
         default:
             throw new ParsingException(st.lineno(), expect,
-                               new String(new char[] {(char)lookahead}));
+                               String.valueOf((char)lookahead));
         }
         return value;
     }

--- a/src/java.base/share/classes/jdk/internal/reflect/SignatureIterator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/SignatureIterator.java
@@ -49,7 +49,7 @@ class SignatureIterator {
         char c = sig.charAt(idx);
         if (c != '[' && c != 'L') {
             ++idx;
-            return new String(new char[] { c });
+            return String.valueOf(c);
         }
         // Walk forward to end of entry
         int endIdx = idx;

--- a/src/java.base/share/classes/sun/invoke/util/Wrapper.java
+++ b/src/java.base/share/classes/sun/invoke/util/Wrapper.java
@@ -57,7 +57,7 @@ public enum Wrapper {
         this.wrapperType = wtype;
         this.primitiveType = ptype;
         this.basicTypeChar = tchar;
-        this.basicTypeString = new String(new char[] {this.basicTypeChar});
+        this.basicTypeString = String.valueOf(this.basicTypeChar);
         this.emptyArray = emptyArray;
         this.format = format;
         this.wrapperSimpleName = wtypeName;

--- a/src/java.base/share/classes/sun/security/provider/PolicyParser.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyParser.java
@@ -812,7 +812,7 @@ public class PolicyParser {
             break;
         default:
             throw new ParsingException(st.lineno(), expect,
-                               new String(new char[] {(char)lookahead}));
+                               String.valueOf((char)lookahead));
         }
         return value;
     }

--- a/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
@@ -465,7 +465,7 @@ public class NumberFormatter extends InternationalFormatter {
         }
         else {
             string = getReplaceString(offset, replaceLength,
-                                      new String(new char[] { aChar }));
+                                      String.valueOf(aChar));
         }
         return stringToValue(string);
     }


### PR DESCRIPTION
This is a very simple and trivial improvement about getting rid of pointless char wrapping into array

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263552](https://bugs.openjdk.java.net/browse/JDK-8263552): Use String.valueOf() for char-to-String conversions


### Reviewers
 * @turbanoff (no known github.com user name / role)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2660/head:pull/2660`
`$ git checkout pull/2660`
