### PR TITLE
JDK-8262277: URLClassLoader.getResource throws undocumented IllegalArgumentException

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -600,7 +600,7 @@ public class URLClassPath {
             try {
                 url = new URL(base, ParseUtil.encodePath(name, false));
             } catch (MalformedURLException e) {
-                throw new IllegalArgumentException("name");
+                return null;
             }
 
             try {
@@ -636,7 +636,7 @@ public class URLClassPath {
             try {
                 url = new URL(base, ParseUtil.encodePath(name, false));
             } catch (MalformedURLException e) {
-                throw new IllegalArgumentException("name");
+                return null;
             }
             final URLConnection uc;
             try {

--- a/test/jdk/java/net/URLClassLoader/FindResourceDoesNotThrowException.java
+++ b/test/jdk/java/net/URLClassLoader/FindResourceDoesNotThrowException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8262277
+ * @summary Test if URLClassLoader throws IllegalArgumentException when getting
+ * or finding resources.
+ */
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+
+public class FindResourceDoesNotThrowException {
+    public static void main(String[] args) throws Exception {
+        // URL ends in slash, does not start with file: or jar:
+        URL url = new URL("https://127.0.0.1/");
+        // resource name is not a valid url component
+        String resource = "c:/windows";
+        try (URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{url})) {
+            if (urlClassLoader.findResource(resource) != null) {
+                throw new RuntimeException("findResource should return null");
+            }
+            if (urlClassLoader.getResource(resource) != null) {
+                throw new RuntimeException("getResource should return null");
+            }
+            if (urlClassLoader.findResources(resource).hasMoreElements()) {
+                throw new RuntimeException("findResources should return an empty enumeration");
+            }
+            if (urlClassLoader.getResources(resource).hasMoreElements()) {
+                throw new RuntimeException("getResources should return an empty enumeration");
+            }
+        }
+    }
+    private FindResourceDoesNotThrowException() {}
+}


### PR DESCRIPTION
`java.net.URLClassLoader.getResource` can throw an undocumented `IllegalArgumentException`.

According to the javadoc for the `getResource` and `findResource` methods, neither should be throwing `IllegalArgumentException` - they should return null if the resource can't be resolved.

Quoting the javadoc for [`URLClassLoader.html#findResource`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLClassLoader.html#findResource(java.lang.String))
> Returns:
>     a URL for the resource, or null if the resource could not be found, or if the loader is closed.

And quoting the javadoc for [`ClassLoader.html#getResource`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ClassLoader.html#getResource(java.lang.String))
> Returns:
>     URL object for reading the resource; null if the resource could not be found, a URL could not be constructed to locate the resource, the resource is in a package that is not opened unconditionally, or access to the resource is denied by the security manager.

Neither mentions throwing `IllegalArgumentException` and both are clear that when URL can't be constructed, `null` should be returned.

Here's a stack trace:
```
java.lang.IllegalArgumentException: name
        at java.base/jdk.internal.loader.URLClassPath$Loader.findResource(URLClassPath.java:600)
        at java.base/jdk.internal.loader.URLClassPath.findResource(URLClassPath.java:291)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:655)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:653)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/java.net.URLClassLoader.findResource(URLClassLoader.java:652)
```

Looking at [`URLClassPath.findResource`](https://github.com/openjdk/jdk/blob/2b00367e1154feb2c05b84a11d62fb5750e46acf/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java#L603)
```java
        URL findResource(final String name, boolean check) {
            URL url;
            try {
                url = new URL(base, ParseUtil.encodePath(name, false));
            } catch (MalformedURLException e) {
                throw new IllegalArgumentException("name");
            }
```

Instead of throwing `IllegalArgumentException`, that line should simply return `null`.

A similar issue exists at [`URLClassPath.getResource`](https://github.com/openjdk/jdk/blob/2b00367e1154feb2c05b84a11d62fb5750e46acf/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java#L639)
```java
        URL findResource(final String name, boolean check) {
            URL url;
            try {
                url = new URL(base, ParseUtil.encodePath(name, false));
            } catch (MalformedURLException e) {
                throw new IllegalArgumentException("name");
            }
```

Instead of throwing `IllegalArgumentException`, that line should simply return `null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262277](https://bugs.openjdk.java.net/browse/JDK-8262277): URLClassLoader.getResource throws undocumented IllegalArgumentException


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2662/head:pull/2662`
`$ git checkout pull/2662`
