### PR TITLE
8262087: Use atomic boolean type in G1FullGCAdjustTask

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.hpp
@@ -38,7 +38,7 @@ class G1CollectedHeap;
 
 class G1FullGCAdjustTask : public G1FullGCTask {
   G1RootProcessor          _root_processor;
-  volatile uint            _references_done; // Atomic counter / bool
+  volatile bool            _references_done;
   WeakProcessor::Task      _weak_proc_task;
   HeapRegionClaimer        _hrclaimer;
   G1AdjustClosure          _adjust;


### PR DESCRIPTION
Use atomic boolean type to make the intention clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262087](https://bugs.openjdk.java.net/browse/JDK-8262087): Use atomic boolean type in G1FullGCAdjustTask


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2664/head:pull/2664`
`$ git checkout pull/2664`
