### PR TITLE
JDK-8002152: javadoc could write out files on a worker thread

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/BackgroundWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/BackgroundWriter.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.javadoc.internal.doclets.formats.html;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import jdk.javadoc.internal.doclets.formats.html.markup.HtmlDocument;
+import jdk.javadoc.internal.doclets.toolkit.Messages;
+import jdk.javadoc.internal.doclets.toolkit.util.DocFile;
+import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
+
+/**
+ * A class to write {@link HtmlDocument} objects on a background thread,
+ * using an {@link ExecutorService}.
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+public class BackgroundWriter {
+
+    /**
+     * The number of background threads to create, to write out files.
+     * Just one thread is created, primarily because one is enough.
+     * Experiments show that the utilization of this thread is currently
+     * about 8%, meaning we cannot generate pages fast enough to
+     * warrant more threads. This may change if we ever start to
+     * generate pages on multiple threads.
+     */
+    private static final int BACKGROUND_THREADS = 1;
+
+    /**
+     * The number of tasks awaiting execution.
+     * Since we currently consume (execute) tasks faster than we can
+     * produce them, there is no point in queuing any additional tasks.
+     * That just uses up memory, and so has a regressive impact on
+     * performance, by causing more GC cycles.
+     */
+    private static final int QUEUED_TASKS = 0;
+
+    /**
+     * A messages object, used to write messages should any errors occur.
+     * Note that because the errors are handled here, and not passed up
+     * to the AbstractDoclet, we cannot dump the stack in the case of
+     * an error, although we could set a flag to do so, if necessary.
+     */
+    private final Messages messages;
+
+    /**
+     * The main executor for the background tasks.
+     * It uses a fixed thread pool of {@value #BACKGROUND_THREADS} threads.
+     */
+    private final ExecutorService executor;
+
+    /**
+     * A semaphore to help restrict the number of queued and active tasks.
+     * See "Java Concurrency In Practice", by Brian Goetz et al,
+     * 8.3.3: Saturation Policies (last paragraph) and
+     * Listing 8.4: Using a Semaphore to throttle task submission.
+     */
+    private final Semaphore semaphore;
+
+    /**
+     * The time at which the writer is initialized.
+     */
+    private long start;
+
+    /**
+     * The cumulative time spent writing documents
+     */
+    private double taskBusy = 0;
+
+    /**
+     * Whether to report additional information, such as the overall utilization of the
+     * background thread.
+     */
+    private boolean verbose;
+
+    /**
+     * Creates a {@code BackgroundWriter}.
+     *
+     * @implNote
+     * The writer uses a {@link Executors#newFixedThreadPool fixed thread pool} of
+     * {@value #BACKGROUND_THREADS} background threads, and a blocking queue of up to
+     * {@value #QUEUED_TASKS} queued tasks.
+     *
+     * @param messages used to write out any error messages and other output
+     * @param verbose  if true, writes out debugging info about the utilization of the background thread
+     */
+    public BackgroundWriter(Messages messages, boolean verbose) {
+        this.messages = messages;
+        this.verbose = verbose;
+        executor = Executors.newFixedThreadPool(BACKGROUND_THREADS);
+        semaphore = new Semaphore(QUEUED_TASKS + BACKGROUND_THREADS);
+        start = System.currentTimeMillis();
+    }
+
+    /**
+     * Writes the given document at some point in the future, using the internal executor.
+     * A semaphore is used to throttle the number of requests, although in practice this
+     * rarely takes effect, because it is quicker to write documents than to generate them.
+     *
+     * @param doc  the document to be written
+     * @param file the file to which to write the document
+     */
+    public void writeLater(HtmlDocument doc, DocFile file) {
+        try {
+            semaphore.acquire();
+            try {
+                executor.execute(() -> {
+                    try {
+                        long taskStart  = System.currentTimeMillis();
+                        doc.write(file);
+                        long taskEnd  = System.currentTimeMillis();
+                        taskBusy += (taskEnd - taskStart);
+                    } catch (DocFileIOException e) {
+                        error(e);
+                    } finally {
+                        semaphore.release();
+                    }
+                });
+            } catch (RejectedExecutionException e) {
+                semaphore.release();
+            }
+        } catch (InterruptedException e) {
+            messages.error("doclet.exception.interrupted");
+        }
+
+    }
+
+    /**
+     * Shuts down the internal executor service, releasing all resources.
+     */
+    public void finish() {
+        try {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.MINUTES);
+
+            if (verbose) {
+                double elapsed = System.currentTimeMillis() - start;
+                messages.notice("doclet.bgWriter.utilization", ((int) (taskBusy / elapsed * 100)) + "%");
+            }
+
+        } catch (InterruptedException e) {
+            messages.error("doclet.exception.interrupted");
+        }
+    }
+
+    /**
+     * Reports an exception that occurred on the background thread.
+     *
+     * @param e the exception
+     */
+    private void error(DocFileIOException e) {
+        switch (e.mode) {
+            case READ:
+                messages.error("doclet.exception.read.file",
+                        e.fileName.getPath(), e.getCause());
+                break;
+
+            case WRITE:
+                messages.error("doclet.exception.write.file",
+                        e.fileName.getPath(), e.getCause());
+        }
+    }
+}

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -271,9 +271,8 @@ public class HtmlConfiguration extends BaseConfiguration {
         setTopFile();
         initDocLint(options.doclintOpts(), tagletManager.getAllTagletNames());
 
-        BackgroundWriter.Options bgWriterOptions = options.getBackgroundWriterOptions();
-        if (bgWriterOptions.enabled) {
-            backgroundWriter = new BackgroundWriter(messages, bgWriterOptions);
+        if (BackgroundWriter.IS_ENABLED) {
+            backgroundWriter = new BackgroundWriter(messages);
         }
 
         return true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -205,7 +205,12 @@ public class HtmlConfiguration extends BaseConfiguration {
         docletVersion = v;
 
         conditionalPages = EnumSet.noneOf(ConditionalPage.class);
+
+        if (options.isBackgroundWriterEnabled()) {
+            backgroundWriter = new BackgroundWriter(messages, options.isBackgroundWriterVerbose());
+        }
     }
+
     protected void initConfiguration(DocletEnvironment docEnv,
                                      Function<String, String> resourceKeyMapper) {
         super.initConfiguration(docEnv, resourceKeyMapper);
@@ -225,6 +230,8 @@ public class HtmlConfiguration extends BaseConfiguration {
     public Resources getDocResources() {
         return docResources;
     }
+
+    protected BackgroundWriter backgroundWriter;
 
     /**
      * Returns a utility object providing commonly used fragments of content.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -205,10 +205,6 @@ public class HtmlConfiguration extends BaseConfiguration {
         docletVersion = v;
 
         conditionalPages = EnumSet.noneOf(ConditionalPage.class);
-
-        if (options.isBackgroundWriterEnabled()) {
-            backgroundWriter = new BackgroundWriter(messages, options.isBackgroundWriterVerbose());
-        }
     }
 
     protected void initConfiguration(DocletEnvironment docEnv,
@@ -274,6 +270,12 @@ public class HtmlConfiguration extends BaseConfiguration {
         setCreateOverview();
         setTopFile();
         initDocLint(options.doclintOpts(), tagletManager.getAllTagletNames());
+
+        BackgroundWriter.Options bgWriterOptions = options.getBackgroundWriterOptions();
+        if (bgWriterOptions.enabled) {
+            backgroundWriter = new BackgroundWriter(messages, bgWriterOptions);
+        }
+
         return true;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -377,4 +377,11 @@ public class HtmlDoclet extends AbstractDoclet {
                 fromfile.toString(), path.getPath());
         toFile.copyFile(fromfile);
     }
+
+    @Override
+    protected void finish() {
+        if (configuration.backgroundWriter != null) {
+            configuration.backgroundWriter.finish();
+        }
+    }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -476,7 +476,12 @@ public class HtmlDocletWriter {
 
         HtmlDocument htmlDocument = new HtmlDocument(
                 HtmlTree.HTML(configuration.getLocale().getLanguage(), head, body));
-        htmlDocument.write(DocFile.createFileForOutput(configuration, path));
+        DocFile file = DocFile.createFileForOutput(configuration, path);
+        if (configuration.backgroundWriter == null) {
+            htmlDocument.write(file);
+        } else {
+            configuration.backgroundWriter.writeLater(htmlDocument, file);
+        }
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
@@ -180,11 +180,6 @@ public class HtmlOptions extends BaseOptions {
      */
     private String windowTitle = "";
 
-    /**
-     * Values for the hidden {@code --background-writer} option.
-     */
-    private BackgroundWriter.Options backgroundWriterOptions = new BackgroundWriter.Options();
-
     //</editor-fold>
 
     private HtmlConfiguration config;
@@ -453,14 +448,6 @@ public class HtmlOptions extends BaseOptions {
                         messages.warning("doclet.NoFrames_specified");
                         return true;
                     }
-                },
-
-                new Hidden(resources, "--background-writer", 1) {
-                    @Override
-                    public boolean process(String option, List<String> args) {
-                        // delegate to BackgroundWriter
-                        return getBackgroundWriterOptions().process(messages, args.get(0));
-                    }
                 }
         );
         Set<BaseOptions.Option> allOptions = new TreeSet<>();
@@ -691,12 +678,5 @@ public class HtmlOptions extends BaseOptions {
      */
     String windowTitle() {
         return windowTitle;
-    }
-
-    /**
-     * Default or parsed values for the command-line option {@code --background-writer}.
-     */
-    public BackgroundWriter.Options getBackgroundWriterOptions() {
-        return backgroundWriterOptions;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
@@ -29,7 +29,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -181,9 +180,11 @@ public class HtmlOptions extends BaseOptions {
      */
     private String windowTitle = "";
 
-    private boolean backgroundWriterEnabled = true;
+    /**
+     * Values for the hidden {@code --background-writer} option.
+     */
+    private BackgroundWriter.Options backgroundWriterOptions = new BackgroundWriter.Options();
 
-    private boolean backgroundWriterVerbose = false;
     //</editor-fold>
 
     private HtmlConfiguration config;
@@ -457,18 +458,8 @@ public class HtmlOptions extends BaseOptions {
                 new Hidden(resources, "--background-writer", 1) {
                     @Override
                     public boolean process(String option, List<String> args) {
-                        // if we add more options, we should introduce BackgroundWriter.Options
-                        String flags = args.get(0);
-                        for (String f : flags.split(",")) {
-                            switch (f.toLowerCase(Locale.US)) {
-                                case "off" -> backgroundWriterEnabled = false;
-                                case "verbose" -> backgroundWriterVerbose = true;
-                                default -> {
-                                    messages.warning("doclet.bgWriter.unknown_option", f);
-                                }
-                            }
-                        }
-                        return true;
+                        // delegate to BackgroundWriter
+                        return getBackgroundWriterOptions().process(messages, args.get(0));
                     }
                 }
         );
@@ -702,20 +693,10 @@ public class HtmlOptions extends BaseOptions {
         return windowTitle;
     }
 
-
     /**
-     * Whether or not to use the background writer.
-     * Set by command-lione option {@code --background-writer}.
+     * Default or parsed values for the command-line option {@code --background-writer}.
      */
-    public boolean isBackgroundWriterEnabled() {
-        return backgroundWriterEnabled;
-    }
-
-    /**
-     * Whether or not the background writer should be verbose.
-     * Set by command-lione option {@code --background-writer}.
-     */
-    public boolean isBackgroundWriterVerbose() {
-        return backgroundWriterVerbose;
+    public BackgroundWriter.Options getBackgroundWriterOptions() {
+        return backgroundWriterOptions;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
@@ -29,6 +29,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -179,6 +180,10 @@ public class HtmlOptions extends BaseOptions {
      * Argument for command-line option {@code -windowtitle}.
      */
     private String windowTitle = "";
+
+    private boolean backgroundWriterEnabled = true;
+
+    private boolean backgroundWriterVerbose = false;
     //</editor-fold>
 
     private HtmlConfiguration config;
@@ -447,6 +452,24 @@ public class HtmlOptions extends BaseOptions {
                         messages.warning("doclet.NoFrames_specified");
                         return true;
                     }
+                },
+
+                new Hidden(resources, "--background-writer", 1) {
+                    @Override
+                    public boolean process(String option, List<String> args) {
+                        // if we add more options, we should introduce BackgroundWriter.Options
+                        String flags = args.get(0);
+                        for (String f : flags.split(",")) {
+                            switch (f.toLowerCase(Locale.US)) {
+                                case "off" -> backgroundWriterEnabled = false;
+                                case "verbose" -> backgroundWriterVerbose = true;
+                                default -> {
+                                    messages.warning("doclet.bgWriter.unknown_option", f);
+                                }
+                            }
+                        }
+                        return true;
+                    }
                 }
         );
         Set<BaseOptions.Option> allOptions = new TreeSet<>();
@@ -677,5 +700,22 @@ public class HtmlOptions extends BaseOptions {
      */
     String windowTitle() {
         return windowTitle;
+    }
+
+
+    /**
+     * Whether or not to use the background writer.
+     * Set by command-lione option {@code --background-writer}.
+     */
+    public boolean isBackgroundWriterEnabled() {
+        return backgroundWriterEnabled;
+    }
+
+    /**
+     * Whether or not the background writer should be verbose.
+     * Set by command-lione option {@code --background-writer}.
+     */
+    public boolean isBackgroundWriterVerbose() {
+        return backgroundWriterVerbose;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -536,5 +536,11 @@ doclet.footer_specified=\
 doclet.bgWriter.unknown_option=\
     Unknown option for ''--background-writer'': {0}
 
+doclet.bgWriter.no_value=\
+    No value for ''--background-writer'' option ''{0}''
+
+doclet.bgWriter.bad_value=\
+    Bad value for ''--background-writer'' option ''{0}'': {1}
+
 doclet.bgWriter.utilization=\
-    Background writer utilization: {0}
+    Background writer: threads: {0}, queue: {1}, utilization: {2}

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -533,14 +533,3 @@ doclet.footer_specified=\
     The -footer option is no longer supported and will be ignored.\n\
     It may be removed in a future release.
 
-doclet.bgWriter.unknown_option=\
-    Unknown option for ''--background-writer'': {0}
-
-doclet.bgWriter.no_value=\
-    No value for ''--background-writer'' option ''{0}''
-
-doclet.bgWriter.bad_value=\
-    Bad value for ''--background-writer'' option ''{0}'': {1}
-
-doclet.bgWriter.utilization=\
-    Background writer: threads: {0}, queue: {1}, utilization: {2}

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -532,3 +532,9 @@ doclet.NoFrames_specified=\
 doclet.footer_specified=\
     The -footer option is no longer supported and will be ignored.\n\
     It may be removed in a future release.
+
+doclet.bgWriter.unknown_option=\
+    Unknown option for ''--background-writer'': {0}
+
+doclet.bgWriter.utilization=\
+    Background writer utilization: {0}

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
@@ -146,6 +146,9 @@ public abstract class AbstractDoclet implements Doclet {
         } catch (DocletException | RuntimeException | Error e) {
             messages.error("doclet.internal.exception", e);
             reportInternalError(e);
+
+        } finally {
+            finish();
         }
 
         return false;
@@ -280,4 +283,6 @@ public abstract class AbstractDoclet implements Doclet {
             generateClassFiles(utils.getAllClasses(pkg), classtree);
         }
     }
+
+    protected void finish() { }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Messages.java
@@ -71,6 +71,15 @@ public class Messages {
         return resources;
     }
 
+    /**
+     * Returns the reporter being used when generating messages.
+     *
+     * @return the reporter
+     */
+    public Reporter getReporter() {
+        return reporter;
+    }
+
     // ***** Errors *****
 
     /**
@@ -148,16 +157,6 @@ public class Messages {
         if (!configuration.getOptions().quiet()) {
             report(NOTE, resources.getText(key, args));
         }
-    }
-    /**
-     * Reports an informational notice to the doclet's reporter.
-     * The message is not suppressed if the {@code -quiet} option is set.
-     *
-     * @param key the name of a resource containing the message to be printed
-     * @param args optional arguments to be replaced in the message.
-     */
-    public void noticeAlways(String key, Object... args) {
-        report(NOTE, resources.getText(key, args));
     }
 
     // ***** Internal support *****

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Messages.java
@@ -139,6 +139,7 @@ public class Messages {
 
     /**
      * Reports an informational notice to the doclet's reporter.
+     * The message is suppressed if the {@code -quiet} option is set.
      *
      * @param key the name of a resource containing the message to be printed
      * @param args optional arguments to be replaced in the message.
@@ -147,6 +148,16 @@ public class Messages {
         if (!configuration.getOptions().quiet()) {
             report(NOTE, resources.getText(key, args));
         }
+    }
+    /**
+     * Reports an informational notice to the doclet's reporter.
+     * The message is not suppressed if the {@code -quiet} option is set.
+     *
+     * @param key the name of a resource containing the message to be printed
+     * @param args optional arguments to be replaced in the message.
+     */
+    public void noticeAlways(String key, Object... args) {
+        report(NOTE, resources.getText(key, args));
     }
 
     // ***** Internal support *****

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -47,6 +47,7 @@ doclet.exception.write.file=Error writing file: {0}\n\
 \t({1})
 doclet.exception.read.resource=Error reading system resource: {0}\n\
 \t({1})
+doclet.exception.interrupted=Interrupted!
 doclet.internal.exception=An internal exception has occurred. \n\
 \t({0})
 doclet.internal.report.bug=\

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Messager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Messager.java
@@ -248,7 +248,7 @@ public class Messager extends Log implements Reporter {
     }
 
     // print the error and increment count
-    private void printError(String prefix, String msg) {
+    private synchronized void printError(String prefix, String msg) {
         if (nerrors < MaxErrors) {
             PrintWriter errWriter = getWriter(WriterKind.ERROR);
             printRawLines(errWriter, prefix + ": " + getText("javadoc.error") + " - " + msg);
@@ -295,7 +295,7 @@ public class Messager extends Log implements Reporter {
     }
 
     // print the warning and increment count
-    private void printWarning(String prefix, String msg) {
+    private synchronized void printWarning(String prefix, String msg) {
         if (nwarnings < MaxWarnings) {
             PrintWriter warnWriter = getWriter(WriterKind.WARNING);
             printRawLines(warnWriter, prefix + ": " + getText("javadoc.warning") + " - " + msg);

--- a/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
+++ b/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
@@ -166,6 +166,12 @@ public class CheckResourceKeys {
      * a resource key, verify that a key exists.
      */
     void findMissingKeys(Set<String> codeKeys, Set<String> resourceKeys) {
+        Set<String> sysProps = Set.of(
+                "javadoc.internal.bgWriter.disabled",
+                "javadoc.internal.bgWriter.threads",
+                "javadoc.internal.bgWriter.queue",
+                "javadoc.internal.bgWriter.verbose",
+                "javadoc.internal.show.taglets");
         for (String ck: codeKeys) {
             // ignore these synthesized keys, tested by usageTests
             if (ck.startsWith("doclet.usage.") || ck.startsWith("doclet.xusage."))
@@ -173,8 +179,8 @@ public class CheckResourceKeys {
             // ignore this partial key, tested by usageTests
             if (ck.equals("main.opt."))
                 continue;
-            // ignore this system property name
-            if (ck.equals("javadoc.internal.show.taglets"))
+            // ignore these system property names
+            if (sysProps.contains(ck))
                 continue;
             if (resourceKeys.contains(ck))
                 continue;


### PR DESCRIPTION
The standard doclet works by creating `HtmlDocument` objects and then writing them out. Writing them can be safely done on a separate thread, and doing so results in about an 8% speedup, by overlapping the write/IO time with the time to generate the next page to be written.

The overall impact on the codebase is deliberately small, coming down to a critical `if` statement in `HtmlDocletWriter` to "write now" or "write later". As such, it is easy to disable the feature if necessary, although no issues have been found in practice. The background writer uses an `ExecutorService`, which provides a lot of flexibility, but experiments show that it is sufficient to use a single background thread and to block if new tasks come available while writing a file.

The feature is "default on", with a hidden option to disable it if necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8002152](https://bugs.openjdk.java.net/browse/JDK-8002152): javadoc could write out files on a worker thread


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2665/head:pull/2665`
`$ git checkout pull/2665`
