### PR TITLE
8262094: Handshake timeout scaled wrong

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -38,6 +38,7 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/filterQueue.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/preserveException.hpp"
 
 class HandshakeOperation : public CHeapObj<mtThread> {
@@ -178,7 +179,7 @@ class VM_Handshake: public VM_Operation {
   HandshakeOperation* const _op;
 
   VM_Handshake(HandshakeOperation* op) :
-      _handshake_timeout(TimeHelper::millis_to_counter(HandshakeTimeout)), _op(op) {}
+      _handshake_timeout(millis_to_nanos(HandshakeTimeout)), _op(op) {}
 
   bool handshake_has_timed_out(jlong start_time);
   static void handle_timeout();


### PR DESCRIPTION
Parameter HandshakeTimeout is in milliseconds.
Internally we use nanoseconds.
HandshakeTimeout must be scaled to nanoseconds.

Passes T1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262094](https://bugs.openjdk.java.net/browse/JDK-8262094): Handshake timeout scaled wrong


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2666/head:pull/2666`
`$ git checkout pull/2666`
