### PR TITLE
8262096: Vector API fails to work without C2

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -365,7 +365,7 @@ JVM_ENTRY(jint, VectorSupport_GetMaxLaneCount(JNIEnv *env, jclass vsclazz, jobje
   oop mirror = JNIHandles::resolve_non_null(clazz);
   if (java_lang_Class::is_primitive(mirror)) {
     BasicType bt = java_lang_Class::primitive_type(mirror);
-    return COMPILER2_PRESENT(Matcher::max_vector_size(bt)) NOT_COMPILER2(MaxVectorSize / type2aelembytes(bt));
+    return COMPILER2_PRESENT(Matcher::max_vector_size(bt)) NOT_COMPILER2(64 / type2aelembytes(bt));
   }
   return -1;
 } JVM_END

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -362,13 +362,11 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
  */
 
 JVM_ENTRY(jint, VectorSupport_GetMaxLaneCount(JNIEnv *env, jclass vsclazz, jobject clazz)) {
-#ifdef COMPILER2
   oop mirror = JNIHandles::resolve_non_null(clazz);
   if (java_lang_Class::is_primitive(mirror)) {
     BasicType bt = java_lang_Class::primitive_type(mirror);
-    return Matcher::max_vector_size(bt);
+    return COMPILER2_PRESENT(Matcher::max_vector_size(bt)) NOT_COMPILER2(MaxVectorSize / type2aelembytes(bt));
   }
-#endif // COMPILER2
   return -1;
 } JVM_END
 


### PR DESCRIPTION
Hi all,

Vector API won't work without C2.
The reason is that VectorSupport_GetMaxLaneCount [1] always returns -1 if C2 is not present.
But it should work even there is no JIT compiler since it's Java-level's api.
So let's fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/vectorSupport.cpp#L364

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262096](https://bugs.openjdk.java.net/browse/JDK-8262096): Vector API fails to work without C2


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2667/head:pull/2667`
`$ git checkout pull/2667`
