### PR TITLE
8262097: Improve CompilerConfig ergonomics to fix a VM crash after JDK-8261229

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -555,6 +555,8 @@ void CompilerConfig::ergo_initialize() {
     if (NeverActAsServerClassMachine) {
       set_client_emulation_mode_flags();
     }
+  } else if (!has_c2() && !is_jvmci_compiler()) {
+    set_client_emulation_mode_flags();
   }
 
   set_legacy_emulation_flags();


### PR DESCRIPTION
Hi all,

This bug was found while I was verifying the fix for JDK-8262096.
It was exposed after JDK-8261229.

Testing:
  - tier1~3 on Linux/x64, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262097](https://bugs.openjdk.java.net/browse/JDK-8262097): Improve CompilerConfig ergonomics to fix a VM crash after JDK-8261229


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2668/head:pull/2668`
`$ git checkout pull/2668`
