### PR TITLE
Replace deprecated mallinfo with mallinfo2

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2229,17 +2229,11 @@ void os::Linux::print_process_memory_info(outputStream* st) {
   // Print glibc outstanding allocations.
   // (note: there is no implementation of mallinfo for muslc)
 #ifdef __GLIBC__
-  struct mallinfo mi = ::mallinfo();
+  struct mallinfo2 mi = ::mallinfo2();
 
-  // mallinfo is an old API. Member names mean next to nothing and, beyond that, are int.
-  // So values may have wrapped around. Still useful enough to see how much glibc thinks
-  // we allocated.
-  const size_t total_allocated = (size_t)(unsigned)mi.uordblks;
+  const size_t total_allocated = mi.uordblks;
   st->print("C-Heap outstanding allocations: " SIZE_FORMAT "K", total_allocated / K);
-  // Since mallinfo members are int, glibc values may have wrapped. Warn about this.
-  if ((vmrss * K) > UINT_MAX && (vmrss * K) > (total_allocated + UINT_MAX)) {
-    st->print(" (may have wrapped)");
-  }
+
   st->cr();
 
 #endif // __GLIBC__


### PR DESCRIPTION
Replace deprecated mallinfo with mallinfo2.

Also removes comments and code related to the old deprecated version.

Related[1]:

The mallinfo2 function is added to report statistics as per mallinfo,
but with larger field widths to accurately report values that are
larger than fit in an integer.
...
The mallinfo function is marked deprecated.  Callers should call
 mallinfo2 instead.

[1] https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html



NOTE: this change was done on Arch Linux, a Linux distro that gets newer software versions much faster than other Linux distros. As a result, other Linux distros may not have a new enough Glibc for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2669/head:pull/2669`
`$ git checkout pull/2669`
