### PR TITLE
4710675: JTextArea.setComponentOrientation does not work with correct timing

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1910,6 +1910,8 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
                 // rebuilt.
                 Document document = editor.getDocument();
                 final String I18NProperty = "i18n";
+                // if a default direction of right-to-left has been specified,
+                // we want complex layout even if the text is all left to right.
                 if (ComponentOrientation.RIGHT_TO_LEFT == newValue
                     && ! Boolean.TRUE.equals(document.getProperty(I18NProperty))) {
                     document.putProperty(I18NProperty, Boolean.TRUE);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1908,6 +1908,12 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
             } else if ("componentOrientation" == propertyName) {
                 // Changes in ComponentOrientation require the views to be
                 // rebuilt.
+                Document document = editor.getDocument();
+                final String I18NProperty = "i18n";
+                if (ComponentOrientation.RIGHT_TO_LEFT == newValue
+                    && ! Boolean.TRUE.equals(document.getProperty(I18NProperty))) {
+                    document.putProperty(I18NProperty, Boolean.TRUE);
+                }
                 modelChanged();
             } else if ("font" == propertyName) {
                 modelChanged();

--- a/test/jdk/javax/swing/JTextArea/JTextAreaOrientationTest.java
+++ b/test/jdk/javax/swing/JTextArea/JTextAreaOrientationTest.java
@@ -29,8 +29,8 @@
  * @run main JTextAreaOrientationTest
  */
 import java.awt.ComponentOrientation;
+import java.awt.Graphics;
 import java.awt.Rectangle;
-import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import javax.imageio.ImageIO;
@@ -39,6 +39,8 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
 public class JTextAreaOrientationTest  {
 
@@ -103,14 +105,15 @@ public class JTextAreaOrientationTest  {
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });
-        Robot robot = new Robot();
-        robot.waitForIdle();
-        robot.delay(1000);
+        Thread.sleep(1000);
         SwingUtilities.invokeAndWait(() -> {
             bounds = frame.getBounds();
         });
-        BufferedImage img = robot.createScreenCapture(bounds);
-        robot.delay(1000);
+        BufferedImage img = new BufferedImage(bounds.width, bounds.height, TYPE_INT_RGB);
+        Graphics g = img.getGraphics();
+        frame.paint(g);
+        g.dispose();
+        Thread.sleep(1000);
         SwingUtilities.invokeAndWait(() -> frame.dispose());
         return img;
     }

--- a/test/jdk/javax/swing/JTextArea/JTextAreaOrientationTest.java
+++ b/test/jdk/javax/swing/JTextArea/JTextAreaOrientationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4710675
+ * @key headful
+ * @summary Verify JTextArea.setComponentOrientation honours RIGHT_TO_LEFT orientation.
+ * @run main JTextAreaOrientationTest
+ */
+import java.awt.ComponentOrientation;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class JTextAreaOrientationTest  {
+
+    static JFrame frame;
+    static Rectangle bounds;
+
+    public static boolean compareBufferedImages(BufferedImage bufferedImage0, BufferedImage bufferedImage1) {
+        int width = bufferedImage0.getWidth();
+        int height = bufferedImage0.getHeight();
+
+        if (width != bufferedImage1.getWidth() || height != bufferedImage1.getHeight()) {
+            return false;
+        }
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (bufferedImage0.getRGB(x, y) != bufferedImage1.getRGB(x, y)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+
+            BufferedImage left = test(ComponentOrientation.LEFT_TO_RIGHT);
+            ImageIO.write(left, "png", new File("JTextAreaTest-left.png"));
+            BufferedImage right = test(ComponentOrientation.RIGHT_TO_LEFT);
+            ImageIO.write(right, "png", new File("JTextAreaTest-right.png"));
+            if (compareBufferedImages(left, right)) {
+                throw new RuntimeException("Orientation change is not effected");
+            }
+        }
+    }
+
+    private static BufferedImage test(ComponentOrientation orientation) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("Swing JTextArea component");
+            JTextArea ta = new JTextArea();
+            ta.setText("Swing JTextArea component");
+            ta.setName("jtext");
+            ta.setComponentOrientation(orientation);
+            frame.getContentPane().add(ta);
+            frame.setSize(300, 100);
+            frame.setUndecorated(true);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> {
+            bounds = frame.getBounds();
+        });
+        BufferedImage img = robot.createScreenCapture(bounds);
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> frame.dispose());
+        return img;
+    }
+}


### PR DESCRIPTION
It is seen JTextArea.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT) orientation is not honoured if it is called after setText() and remain at LTR orientation. It changes the orientation only if some more text is typed additionally to existing text.
This behaviour is different from JTextField where the RTL orientation is honoured from start.
Proposed fix is to check for ComponentOrientation propertyChange event and set i18n property if it is not set, so that orientation is honoured as soon as setComponentOrientation() is called.
Checked for all L&Fs in all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-4710675](https://bugs.openjdk.java.net/browse/JDK-4710675): JTextArea.setComponentOrientation does not work with correct timing


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2673/head:pull/2673`
`$ git checkout pull/2673`
