### PR TITLE
JDK-8262074: Consolidate the default value of MetaspaceSize

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
@@ -52,7 +52,6 @@ define_pd_global(bool, ProfileInterpreter,           false);
 define_pd_global(intx, CodeCacheExpansionSize,       32*K );
 define_pd_global(uintx, CodeCacheMinBlockLength,     1);
 define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
-define_pd_global(uintx, MetaspaceSize,               12*M );
 define_pd_global(bool, NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );

--- a/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
@@ -77,9 +77,6 @@ define_pd_global(intx, NonNMethodCodeHeapSize,       5*M );
 define_pd_global(uintx, CodeCacheMinBlockLength,     6);
 define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 
-// Heap related flags
-define_pd_global(uintx,MetaspaceSize,    ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool, NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/cpu/arm/c1_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c1_globals_arm.hpp
@@ -53,7 +53,6 @@ define_pd_global(bool, ProfileInterpreter,           false);
 define_pd_global(size_t, CodeCacheExpansionSize,     32*K );
 define_pd_global(uintx, CodeCacheMinBlockLength,     1);
 define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
-define_pd_global(size_t, MetaspaceSize,              12*M );
 define_pd_global(bool, NeverActAsServerClassMachine, true);
 define_pd_global(uint64_t, MaxRAM,                   1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );

--- a/src/hotspot/cpu/arm/c2_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_globals_arm.hpp
@@ -100,9 +100,6 @@ define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false); // Not needed
 
-// Heap related flags
-define_pd_global(size_t, MetaspaceSize,              ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool, NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/cpu/ppc/c1_globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c1_globals_ppc.hpp
@@ -51,7 +51,6 @@ define_pd_global(uintx,    NonNMethodCodeHeapSize,       5*M );
 define_pd_global(uintx,    CodeCacheExpansionSize,       32*K);
 define_pd_global(uintx,    CodeCacheMinBlockLength,      1);
 define_pd_global(uintx,    CodeCacheMinimumUseSpace,     400*K);
-define_pd_global(size_t,   MetaspaceSize,                12*M);
 define_pd_global(bool,     NeverActAsServerClassMachine, true);
 define_pd_global(size_t,   NewSizeThreadIncrease,        16*K);
 define_pd_global(uint64_t, MaxRAM,                       1ULL*G);

--- a/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
@@ -93,9 +93,6 @@ define_pd_global(uintx,    CodeCacheMinimumUseSpace,     400*K);
 
 define_pd_global(bool,     TrapBasedRangeChecks,          true);
 
-// Heap related flags
-define_pd_global(size_t,   MetaspaceSize,                ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool,     NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/cpu/s390/c1_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/c1_globals_s390.hpp
@@ -51,7 +51,6 @@ define_pd_global(uintx,    NonNMethodCodeHeapSize,       5*M);
 define_pd_global(uintx,    CodeCacheExpansionSize,       32*K);
 define_pd_global(uintx,    CodeCacheMinBlockLength,      1);
 define_pd_global(uintx,    CodeCacheMinimumUseSpace,     400*K);
-define_pd_global(size_t,   MetaspaceSize,                12*M);
 define_pd_global(bool,     NeverActAsServerClassMachine, true);
 define_pd_global(size_t,   NewSizeThreadIncrease,        16*K);
 define_pd_global(uint64_t, MaxRAM,                       1ULL*G);

--- a/src/hotspot/cpu/s390/c2_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_globals_s390.hpp
@@ -82,9 +82,6 @@ define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false); // Not needed on z/Architecture.
 
-// Heap related flags
-define_pd_global(size_t, MetaspaceSize,              ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool, NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/cpu/x86/c1_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_globals_x86.hpp
@@ -51,7 +51,6 @@ define_pd_global(bool,   ProfileInterpreter,           false);
 define_pd_global(uintx,  CodeCacheExpansionSize,       32*K );
 define_pd_global(uintx,  CodeCacheMinBlockLength,      1    );
 define_pd_global(uintx,  CodeCacheMinimumUseSpace,     400*K);
-define_pd_global(size_t, MetaspaceSize,                12*M );
 define_pd_global(bool,   NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t, MaxRAM,                    1ULL*G);
 define_pd_global(bool,   CICompileOSR,                 true );

--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -91,9 +91,6 @@ define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false); // Not needed on x86.
 
-// Heap related flags
-define_pd_global(size_t, MetaspaceSize,              ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool, NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -191,9 +191,6 @@ void set_client_emulation_mode_flags() {
   if (FLAG_IS_DEFAULT(CodeCacheExpansionSize)) {
     FLAG_SET_ERGO(CodeCacheExpansionSize, 32*K);
   }
-  if (FLAG_IS_DEFAULT(MetaspaceSize)) {
-    FLAG_SET_ERGO(MetaspaceSize, MIN2(12*M, MaxMetaspaceSize));
-  }
   if (FLAG_IS_DEFAULT(MaxRAM)) {
     // Do not use FLAG_SET_ERGO to update MaxRAM, as this will impact
     // heap setting done based on available phys_mem (see Arguments::set_heap_size).
@@ -443,9 +440,6 @@ void CompilerConfig::set_jvmci_specific_flags() {
       }
       if (FLAG_IS_DEFAULT(InitialCodeCacheSize)) {
         FLAG_SET_DEFAULT(InitialCodeCacheSize, MAX2(16*M, InitialCodeCacheSize));
-      }
-      if (FLAG_IS_DEFAULT(MetaspaceSize)) {
-        FLAG_SET_DEFAULT(MetaspaceSize, MIN2(MAX2(12*M, MetaspaceSize), MaxMetaspaceSize));
       }
       if (FLAG_IS_DEFAULT(NewSizeThreadIncrease)) {
         FLAG_SET_DEFAULT(NewSizeThreadIncrease, MAX2(4*K, NewSizeThreadIncrease));

--- a/src/hotspot/share/compiler/compiler_globals_pd.hpp
+++ b/src/hotspot/share/compiler/compiler_globals_pd.hpp
@@ -70,7 +70,6 @@ define_pd_global(uintx,  NonNMethodCodeHeapSize,     32*M);
 define_pd_global(uintx,  CodeCacheExpansionSize,     32*K);
 define_pd_global(uintx,  CodeCacheMinBlockLength,    1);
 define_pd_global(uintx,  CodeCacheMinimumUseSpace,   200*K);
-define_pd_global(size_t, MetaspaceSize,              ScaleForWordSize(4*M));
 define_pd_global(bool, NeverActAsServerClassMachine, true);
 define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
 #define CI_COMPILER_COUNT 0

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1470,7 +1470,7 @@ const intx ObjectAlignmentInBytes = 8;
           "Force inlining of throwing methods smaller than this")           \
           range(0, max_jint)                                                \
                                                                             \
-  product(size_t, MetaspaceSize, NOT_LP64(14 * M) LP64_ONLY(20 * M),        \
+  product(size_t, MetaspaceSize, NOT_LP64(16 * M) LP64_ONLY(21 * M),        \
           "Initial threshold (in bytes) at which a garbage collection "     \
           "is done to reduce Metaspace usage")                              \
           constraint(MetaspaceSizeConstraintFunc,AfterErgo)                 \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1470,7 +1470,7 @@ const intx ObjectAlignmentInBytes = 8;
           "Force inlining of throwing methods smaller than this")           \
           range(0, max_jint)                                                \
                                                                             \
-  product_pd(size_t, MetaspaceSize,                                         \
+  product(size_t, MetaspaceSize, NOT_LP64(14 * M) LP64_ONLY(20 * M),        \
           "Initial threshold (in bytes) at which a garbage collection "     \
           "is done to reduce Metaspace usage")                              \
           constraint(MetaspaceSizeConstraintFunc,AfterErgo)                 \


### PR DESCRIPTION
I was looking at whether the default values for MetaspaceSize (the initial threshold to start off a metaspace-motivated GC) still make sense after JEP-387.

The default is dependent on compiler tier and bitness. It is also spread across all platforms.

In addition to that, it also may get modified after Metaspace::ergo_initialize() in client-compiler-emulation-mode:

https://github.com/openjdk/jdk/blob/2b00367e1154feb2c05b84a11d62fb5750e46acf/src/hotspot/share/compiler/compilerDefinitions.cpp#L194-L196

which is unexpected and causes confusion (eg JDK-8261907, JDK-8261907).

The reasons for this seem to originate from PermGen times:
https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2021-February/045536.html

----

Today, MetaspaceSize defaults to:

- no compiler (eg Zero):      **4M** (32bit)   **5.19M** (64bit)
- C1-only build:  	   **12M**
- C1+C2 build (standard):    **16M** 	(32bit) **20,75M** (64bit)

I was surprised to see that they do not depend on any compiler *runtime* switches. It only depends on build time decisions.

---

How much do we use? I analyzed a simple java app to see the difference VM settings make on initial metaspace consumption. Committed space, used in brackets:


```
(Note:                  (used)          committed
CDS on:

64bit:       		(181,58 KB)     384 KB  (a)
64bit tier1 only:       (170,04 KB)     384 KB
64bit Xint:		(16,62 KB)      256 KB

32bit    		(178 KB)        256 KB
32bit tier1 only: 	(144 KB)        256 KB
32bit Xint: 		(11 KB) (b)     128 KB  

CDS off:

64bit:			(5,06 MB)       5.62 MB
64bit tier1 only:       (5,00 MB)       5,56 MB
64bit Xint:		(4,84 MB)       5.44 MB

32bit    		(3,69 MB)       3.75 MB
32bit tier1 only: 	(3,65 MB)       3.75 MB
32bit Xint: 		(3,52 MB)       3.62 MB

Class space on/off

CDS off, 64bit, +CompressedClassPointers: 5.44M
CDS off, 64bit, -CompressedClassPointers: 5.38M

```

_Notes:
(a) Since JEP-387, with CDS=on, we pay very little committed footprint upfront (384K). For comparison, JDK 15 commits here 5.75M.
(b) The seemingly high difference between Xint and C1+C2 - 11K vs 178K - is misleading: All initial classes get compiled, but since most of their metadata live in CDS, not in Metaspace, all we allocate at the start are MethodCounters. Hence, with -Xint, we almost allocate nothing. That changes as soon as we start loading application classes._

Conclusions:
- CDS=off increases metaspace footprint by a flat amount, in my case ~5MB, which makes sense.
- Running with (any) compiler has not much influence once we start using Metaspace for real. The difference between C1-only and C1+C2 is neglectible, the difference between Xint and C1+C2 amounts to about 2% wrt to initial metaspace consumption.
- Running with or without compressed Klass pointers makes not much difference. With class space, we pay for certain overhead twice, but at this early stage this is not noticeable.
- The difference between 64bit and 32bit is more like 1.4-1.5, not the 1.3 factor we currently assume

-----

Proposal:

1) I propose to make MetaspaceSize independent from compiler. For one, if the intention was to have a lower threshold with compilers deactivated, that has never worked. E.g. on 64bit we always had a threshold of 20.75MB regardless of Xint/TieredStopAtLevel. Even if it worked, the compiler does not make that much difference in metaspace footprint.

2) I propose to slightly lower MetaspaceSize - on 32bit from 16M to 14M, on 64bit from 20.75M to 20M. This takes the slightly lower metaspace footprint since JEP 387 into account (less waste) and the scale I found to be higher than 1.3. 

This is all very cautious. For the standard VM, very little changes, so this is mainly a cleanup patch. We could probably tune MetaspaceSize down to much lower levels. And/or make size it differently depending on UseSharedSpaces. However, atm I don't have time to hunt regressions due to too early GCs.

-----

Tests: GA, nightlies at SAP

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262074](https://bugs.openjdk.java.net/browse/JDK-8262074): Consolidate the default value of MetaspaceSize


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 6b3c81ab8c0a9fc26679a1af60523b49b6bbaf35
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2675/head:pull/2675`
`$ git checkout pull/2675`
