### PR TITLE
8258855: Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -697,8 +697,6 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java          8258855 linux-all
-sun/security/krb5/auto/ReplayCacheTestProc.java                 8258855 linux-all
 
 ############################################################################
 

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -29,7 +29,9 @@
  * @build jdk.test.lib.Platform
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.net.hosts.file=TestHosts
- *      ReplayCacheTestProc
+ *      -Dtest.libs=J ReplayCacheTestProc
+ * @run main/othervm/timeout=300 -Djdk.net.hosts.file=TestHosts
+ *      -Dtest.libs=N ReplayCacheTestProc
  */
 
 import java.io.*;
@@ -45,6 +47,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
 import sun.security.jgss.GSSUtil;
 import sun.security.krb5.internal.rcache.AuthTime;
@@ -53,9 +56,8 @@ import sun.security.krb5.internal.rcache.AuthTime;
  * This test runs multiple acceptor Procs to mimic AP-REQ replays.
  * These system properties are supported:
  *
- * - test.libs on what types of acceptors to use
+ * - test.libs on what types of acceptors to use. Cannot be null.
  *   Format: CSV of (J|N|N<suffix>=<libname>|J<suffix>=<launcher>)
- *   Default: J,N on Solaris and Linux where N is available, or J
  *   Example: J,N,N14=/krb5-1.14/lib/libgssapi_krb5.so,J8=/java8/bin/java
  *
  * - test.runs on manual runs. If empty, a iterate through all pattern
@@ -117,6 +119,15 @@ public class ReplayCacheTestProc {
             Ex[] result;
             int numPerType = 2; // number of acceptors per type
 
+            // User-provided libs
+            String userLibs = System.getProperty("test.libs");
+            Asserts.assertNotNull(userLibs, "test.libs property must be provided");
+            libs = userLibs.split(",");
+            if (Arrays.asList(libs).contains("N") && !isNativeLibAvailable()) {
+                System.out.println("Native mode not available - skipped");
+                return;
+            }
+
             KDC kdc = KDC.create(OneKDC.REALM, HOST, 0, true);
             for (int i=0; i<nc; i++) {
                 kdc.addPrincipal(client(i), OneKDC.PASS);
@@ -133,25 +144,6 @@ public class ReplayCacheTestProc {
 
             // Write KTAB after krb5.conf so it contains no aes-sha2 keys
             kdc.writeKtab(OneKDC.KTAB);
-
-            // User-provided libs
-            String userLibs = System.getProperty("test.libs");
-
-            if (userLibs != null) {
-                libs = userLibs.split(",");
-            } else {
-                if (Platform.isOSX() || Platform.isWindows()) {
-                    // macOS uses Heimdal and Windows has no native lib
-                    libs = new String[]{"J"};
-                } else {
-                    if (acceptor("N", "sanity").waitFor() != 0) {
-                        Proc.d("Native mode sanity check failed, only java");
-                        libs = new String[]{"J"};
-                    } else {
-                        libs = new String[]{"J", "N"};
-                    }
-                }
-            }
 
             pi = Proc.create("ReplayCacheTestProc").debug("C")
                     .inheritProp("jdk.net.hosts.file")
@@ -327,6 +319,13 @@ public class ReplayCacheTestProc {
             Proc.d(e);
             throw e;
         }
+    }
+
+    // returns true if native lib is available in running platform
+    // macOS uses Heimdal and Windows has no native lib
+    private static boolean isNativeLibAvailable() throws Exception {
+        return !Platform.isOSX() && !Platform.isWindows()
+                && acceptor("N", "sanity").waitFor() == 0;
     }
 
     // returns the client name

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -124,6 +124,7 @@ public class ReplayCacheTestProc {
             Asserts.assertNotNull(userLibs, "test.libs property must be provided");
             libs = userLibs.split(",");
             if (Arrays.asList(libs).contains("N") && !isNativeLibAvailable()) {
+                // Skip test when native GSS libs are not available in running platform
                 System.out.println("Native mode not available - skipped");
                 return;
             }

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
@@ -34,9 +34,4 @@
  *           -Djdk.net.hosts.file=TestHosts
  *           -Dtest.service=host
  *           -Dtest.libs=J ReplayCacheTestProc
- * @run main/othervm/timeout=300 -Djdk.krb5.rcache.useMD5=true
- *           -Djdk.net.hosts.file=TestHosts
- *           -Dtest.service=host
- *           -Dtest.libs=N ReplayCacheTestProc
- *
  */

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
@@ -32,5 +32,11 @@
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.krb5.rcache.useMD5=true
  *           -Djdk.net.hosts.file=TestHosts
- *           -Dtest.service=host ReplayCacheTestProc
+ *           -Dtest.service=host
+ *           -Dtest.libs=J ReplayCacheTestProc
+ * @run main/othervm/timeout=300 -Djdk.krb5.rcache.useMD5=true
+ *           -Djdk.net.hosts.file=TestHosts
+ *           -Dtest.service=host
+ *           -Dtest.libs=N ReplayCacheTestProc
+ *
  */


### PR DESCRIPTION
Kerberos new replay cache format released in 1.18 (installed in OL8.3) is causing the tests failures:
`https://web.mit.edu/kerberos/www/krb5-latest/doc/formats/rcache_file_format.html`

New and old format are not compatible, that means they cannot share a rcache file. Since there is no interoperability between java GSS-API and native GSS-API new rcache format at the moment, this patch only enables the test scenarios that mimic AP-REQ replays with multiple processes using native GSS-API only (when available) and multiple processes using Java own implementation API only. 

If there is a decision to support the new format in the future, tests will be revisited accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258855](https://bugs.openjdk.java.net/browse/JDK-8258855): Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to abfa28babebc988f734c9528dcbe2ccbcdea3c18
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2676/head:pull/2676`
`$ git checkout pull/2676`
