### PR TITLE
8252709: Enable JVMCI when building linux-aarch64 at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -477,7 +477,6 @@ var getJibProfilesProfiles = function (input, common, data) {
             dependencies: ["devkit", "gtest", "build_devkit", "pandoc"],
             configure_args: [
                 "--openjdk-target=aarch64-linux-gnu",
-		"--disable-jvm-feature-jvmci",
             ],
         },
 


### PR DESCRIPTION
To allow for better testing of JVMCI support on AArch64 in aid of producing a reliable GraalVM release on this platform, it should be included by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252709](https://bugs.openjdk.java.net/browse/JDK-8252709): Enable JVMCI when building linux-aarch64 at Oracle


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2677/head:pull/2677`
`$ git checkout pull/2677`
