### PR TITLE
8262157: LingeredApp.startAppExactJvmOpts does not print app output when launching fails

### DIFF
--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -88,6 +88,7 @@ public class LingeredApp {
     private ByteArrayOutputStream stdoutBuffer;
     private Thread outPumperThread;
     private Thread errPumperThread;
+    private boolean finishAppCalled = false;
 
     protected Process appProcess;
     protected OutputBuffer output;
@@ -367,6 +368,11 @@ public class LingeredApp {
 
     private void finishApp() {
         if (appProcess != null) {
+            if (finishAppCalled) {
+                return;
+            } else {
+                finishAppCalled = true;
+            }
             OutputBuffer output = getOutput();
             String msg =
                     " LingeredApp stdout: [" + output.getStdout() + "];\n" +

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -416,6 +416,7 @@ public class LingeredApp {
             theApp.runAppExactJvmOpts(jvmOpts);
             theApp.waitAppReady();
         } catch (Exception ex) {
+            theApp.finishApp();
             theApp.deleteLock();
             throw ex;
         }

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -422,6 +422,7 @@ public class LingeredApp {
             theApp.runAppExactJvmOpts(jvmOpts);
             theApp.waitAppReady();
         } catch (Exception ex) {
+            System.out.println("LingeredApp failed to start: " + ex);
             theApp.finishApp();
             theApp.deleteLock();
             throw ex;
@@ -448,14 +449,7 @@ public class LingeredApp {
      */
     public static LingeredApp startApp(String... additionalJvmOpts) throws IOException {
         LingeredApp a = new LingeredApp();
-        try {
-            startApp(a, additionalJvmOpts);
-        } catch (Exception ex) {
-            System.out.println("LingeredApp failed to start: " + ex);
-            a.finishApp();
-            throw ex;
-        }
-
+        startApp(a, additionalJvmOpts);
         return a;
     }
 


### PR DESCRIPTION
Hi, Please review

 When debugging for other test case which uses jcmd to attach LingeredApp process, found there is no error information logged when the app started with function 'startAppExactJvmOpts' exits due to some reason. This is not convenient for trace what is the app failure.
 This simple fix for adding finishApp to print out error information when LingeredApp could not start with startAppExactJvmOpts, this is similar to startApp.

Tests: This is a simple fix and done tests with test/jdk/sun/tools/jinfo which uses the function startAppExactJvmOpts to create LingeredApp, also the test case in debugging, which indeed captured the error message upon start error.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262157](https://bugs.openjdk.java.net/browse/JDK-8262157): LingeredApp.startAppExactJvmOpts does not print app output when launching fails


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to f8cbc91b8543d5ce43d5d5259c99118926b1189c
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2679/head:pull/2679`
`$ git checkout pull/2679`
