### PR TITLE
8258444: Clean up specifications of java.io.Reader.read(char[],int,int) in subclass overrides

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -28,6 +28,7 @@ package java.io;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -71,7 +72,7 @@ public class BufferedReader extends Reader {
 
     private Reader in;
 
-    private char cb[];
+    private char[] cb;
     private int nChars, nextChar;
 
     private static final int INVALIDATED = -2;
@@ -146,7 +147,7 @@ public class BufferedReader extends Reader {
                     dst = delta;
                 } else {
                     /* Reallocate buffer to accommodate read-ahead limit */
-                    char ncb[] = new char[readAheadLimit];
+                    char[] ncb = new char[readAheadLimit];
                     System.arraycopy(cb, markedChar, ncb, 0, delta);
                     cb = ncb;
                     markedChar = 0;
@@ -237,7 +238,8 @@ public class BufferedReader extends Reader {
      * attempts to read as many characters as possible by repeatedly invoking
      * the {@code read} method of the underlying stream.  This iterated
      * {@code read} continues until one of the following conditions becomes
-     * true: <ul>
+     * true:
+     * <ul>
      *
      *   <li> The specified number of characters have been read,
      *
@@ -248,7 +250,8 @@ public class BufferedReader extends Reader {
      *   returns {@code false}, indicating that further input requests
      *   would block.
      *
-     * </ul> If the first {@code read} on the underlying stream returns
+     * </ul>
+     * If the first {@code read} on the underlying stream returns
      * {@code -1} to indicate end-of-file then this method returns
      * {@code -1}.  Otherwise this method returns the number of characters
      * actually read.
@@ -264,23 +267,20 @@ public class BufferedReader extends Reader {
      * Thus redundant {@code BufferedReader}s will not copy data
      * unnecessarily.
      *
-     * @param      cbuf  Destination buffer
-     * @param      off   Offset at which to start storing characters
-     * @param      len   Maximum number of characters to read
+     * @param      cbuf  {@inheritDoc}
+     * @param      off   {@inheritDoc}
+     * @param      len   {@inheritDoc}
      *
-     * @return     The number of characters read, or -1 if the end of the
-     *             stream has been reached
+     * @return     {@inheritDoc}
      *
-     * @throws     IOException  If an I/O error occurs
      * @throws     IndexOutOfBoundsException {@inheritDoc}
+     * @throws     IOException  {@inheritDoc}
      */
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
-            if ((off < 0) || (off > cbuf.length) || (len < 0) ||
-                ((off + len) > cbuf.length) || ((off + len) < 0)) {
-                throw new IndexOutOfBoundsException();
-            } else if (len == 0) {
+            Objects.checkFromIndexSize(off, len, cbuf.length);
+            if (len == 0) {
                 return 0;
             }
 

--- a/src/java.base/share/classes/java/io/CharArrayReader.java
+++ b/src/java.base/share/classes/java/io/CharArrayReader.java
@@ -25,6 +25,8 @@
 
 package java.io;
 
+import java.util.Objects;
+
 /**
  * This class implements a character buffer that can be used as a
  * character-input stream.
@@ -34,7 +36,7 @@ package java.io;
  */
 public class CharArrayReader extends Reader {
     /** The character buffer. */
-    protected char buf[];
+    protected char[] buf;
 
     /** The current buffer position. */
     protected int pos;
@@ -52,7 +54,7 @@ public class CharArrayReader extends Reader {
      * Creates a CharArrayReader from the specified array of chars.
      * @param buf       Input buffer (not copied)
      */
-    public CharArrayReader(char buf[]) {
+    public CharArrayReader(char[] buf) {
         this.buf = buf;
         this.pos = 0;
         this.count = buf.length;
@@ -75,7 +77,7 @@ public class CharArrayReader extends Reader {
      * @param offset    Offset of the first char to read
      * @param length    Number of chars to read
      */
-    public CharArrayReader(char buf[], int offset, int length) {
+    public CharArrayReader(char[] buf, int offset, int length) {
         if ((offset < 0) || (offset > buf.length) || (length < 0) ||
             ((offset + length) < 0)) {
             throw new IllegalArgumentException();
@@ -109,22 +111,27 @@ public class CharArrayReader extends Reader {
 
     /**
      * Reads characters into a portion of an array.
-     * @param   b  Destination buffer
-     * @param   off  Offset at which to start storing characters
-     * @param   len   Maximum number of characters to read
-     * @return  The actual number of characters read, or -1 if
-     *          the end of the stream has been reached
      *
-     * @throws  IOException  If an I/O error occurs
-     * @throws  IndexOutOfBoundsException {@inheritDoc}
+     * <p> If {@code len} is zero, then no characters are read and {@code 0} is
+     * returned; otherwise, there is an attempt to read at least one character.
+     * If no character is available because the stream is at its end, the value
+     * {@code -1} is returned; otherwise, at least one character is read and
+     * stored into {@code cbuf}.
+     *
+     * @param      cbuf  {@inheritDoc}
+     * @param      off   {@inheritDoc}
+     * @param      len   {@inheritDoc}
+     *
+     * @return     {@inheritDoc}
+     *
+     * @throws     IndexOutOfBoundsException  {@inheritDoc}
+     * @throws     IOException  {@inheritDoc}
      */
-    public int read(char b[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
-            if ((off < 0) || (off > b.length) || (len < 0) ||
-                ((off + len) > b.length) || ((off + len) < 0)) {
-                throw new IndexOutOfBoundsException();
-            } else if (len == 0) {
+            Objects.checkFromIndexSize(off, len, cbuf.length);
+            if (len == 0) {
                 return 0;
             }
 
@@ -139,7 +146,7 @@ public class CharArrayReader extends Reader {
             if (len <= 0) {
                 return 0;
             }
-            System.arraycopy(buf, pos, b, off, len);
+            System.arraycopy(buf, pos, cbuf, off, len);
             pos += len;
             return len;
         }

--- a/src/java.base/share/classes/java/io/FilterReader.java
+++ b/src/java.base/share/classes/java/io/FilterReader.java
@@ -66,12 +66,9 @@ public abstract class FilterReader extends Reader {
     }
 
     /**
-     * Reads characters into a portion of an array.
-     *
-     * @throws     IOException  If an I/O error occurs
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
+     * {@inheritDoc}
      */
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         return in.read(cbuf, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/FilterReader.java
+++ b/src/java.base/share/classes/java/io/FilterReader.java
@@ -67,6 +67,7 @@ public abstract class FilterReader extends Reader {
 
     /**
      * {@inheritDoc}
+     * @throws     IndexOutOfBoundsException  {@inheritDoc}
      */
     public int read(char[] cbuf, int off, int len) throws IOException {
         return in.read(cbuf, off, len);

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -163,6 +163,7 @@ public class InputStreamReader extends Reader {
 
     /**
      * {@inheritDoc}
+     * @throws     IndexOutOfBoundsException  {@inheritDoc}
      */
     public int read(char[] cbuf, int off, int len) throws IOException {
         return sd.read(cbuf, off, len);

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,20 +162,10 @@ public class InputStreamReader extends Reader {
     }
 
     /**
-     * Reads characters into a portion of an array.
-     *
-     * @param      cbuf     Destination buffer
-     * @param      offset   Offset at which to start storing characters
-     * @param      length   Maximum number of characters to read
-     *
-     * @return     The number of characters read, or -1 if the end of the
-     *             stream has been reached
-     *
-     * @throws     IOException  If an I/O error occurs
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
+     * {@inheritDoc}
      */
-    public int read(char cbuf[], int offset, int length) throws IOException {
-        return sd.read(cbuf, offset, length);
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        return sd.read(cbuf, off, len);
     }
 
     /**

--- a/src/java.base/share/classes/java/io/LineNumberReader.java
+++ b/src/java.base/share/classes/java/io/LineNumberReader.java
@@ -162,28 +162,29 @@ public class LineNumberReader extends BufferedReader {
     }
 
     /**
-     * Read characters into a portion of an array.
-     * <a href="#lt">Line terminators</a> are compressed into single newline
+     * Reads characters into a portion of an array.  This method will block
+     * until some input is available, an I/O error occurs, or the end of the
+     * stream is reached.
+     *
+     * <p> If {@code len} is zero, then no characters are read and {@code 0} is
+     * returned; otherwise, there is an attempt to read at least one character.
+     * If no character is available because the stream is at its end, the value
+     * {@code -1} is returned; otherwise, at least one character is read and
+     * stored into {@code cbuf}.
+     *
+     * <p><a href="#lt">Line terminators</a> are compressed into single newline
      * ('\n') characters.  The current line number is incremented whenever a
      * line terminator is read, or when the end of the stream is reached and
      * the last character in the stream is not a line terminator.
      *
-     * @param  cbuf
-     *         Destination buffer
+     * @param  cbuf  {@inheritDoc}
+     * @param  off   {@inheritDoc}
+     * @param  len   {@inheritDoc}
      *
-     * @param  off
-     *         Offset at which to start storing characters
-     *
-     * @param  len
-     *         Maximum number of characters to read
-     *
-     * @return  The number of characters read, or -1 if the end of the stream
-     *          has already been reached
-     *
-     * @throws  IOException
-     *          If an I/O error occurs
+     * @return  {@inheritDoc}
      *
      * @throws  IndexOutOfBoundsException {@inheritDoc}
+     * @throws  IOException {@inheritDoc}
      */
     @SuppressWarnings("fallthrough")
     public int read(char cbuf[], int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/PipedReader.java
+++ b/src/java.base/share/classes/java/io/PipedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import java.util.Objects;
 
 /**
  * Piped character-input streams.
@@ -270,23 +271,22 @@ public class PipedReader extends Reader {
     }
 
     /**
-     * Reads up to {@code len} characters of data from this piped
-     * stream into an array of characters. Less than {@code len} characters
-     * will be read if the end of the data stream is reached or if
-     * {@code len} exceeds the pipe's buffer size. This method
-     * blocks until at least one character of input is available.
+     * {@inheritDoc}
      *
-     * @param      cbuf     the buffer into which the data is read.
-     * @param      off   the start offset of the data.
-     * @param      len   the maximum number of characters read.
-     * @return     the total number of characters read into the buffer, or
-     *             {@code -1} if there is no more data because the end of
-     *             the stream has been reached.
+     * <p> Fewer than {@code len} characters will be read if
+     * {@code len} exceeds the pipe's buffer size.
+     *
+     * @param      cbuf  {@inheritDoc}
+     * @param      off   {@inheritDoc}
+     * @param      len   {@inheritDoc}
+     *
+     * @return     {@inheritDoc}
+     *
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      * @throws     IOException  if the pipe is
      *             <a href=PipedInputStream.html#BROKEN> {@code broken}</a>,
      *             {@link #connect(java.io.PipedWriter) unconnected}, closed,
      *             or an I/O error occurs.
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     public synchronized int read(char cbuf[], int off, int len)  throws IOException {
         if (!connected) {
@@ -298,10 +298,8 @@ public class PipedReader extends Reader {
             throw new IOException("Write end dead");
         }
 
-        if ((off < 0) || (off > cbuf.length) || (len < 0) ||
-            ((off + len) > cbuf.length) || ((off + len) < 0)) {
-            throw new IndexOutOfBoundsException();
-        } else if (len == 0) {
+        Objects.checkFromIndexSize(off, len, cbuf.length);
+        if (len == 0) {
             return 0;
         }
 

--- a/src/java.base/share/classes/java/io/PushbackReader.java
+++ b/src/java.base/share/classes/java/io/PushbackReader.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import java.util.Objects;
 
 /**
  * A character-stream reader that allows characters to be pushed back into the
@@ -92,28 +93,14 @@ public class PushbackReader extends FilterReader {
     }
 
     /**
-     * Reads characters into a portion of an array.
-     *
-     * @param      cbuf  Destination buffer
-     * @param      off   Offset at which to start writing characters
-     * @param      len   Maximum number of characters to read
-     *
-     * @return     The number of characters read, or -1 if the end of the
-     *             stream has been reached
-     *
-     * @throws     IOException  If an I/O error occurs
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
+     * {@inheritDoc}
      */
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             try {
-                if (len <= 0) {
-                    if (len < 0) {
-                        throw new IndexOutOfBoundsException();
-                    } else if ((off < 0) || (off > cbuf.length)) {
-                        throw new IndexOutOfBoundsException();
-                    }
+                Objects.checkFromIndexSize(off, len, cbuf.length);
+                if (len == 0) {
                     return 0;
                 }
                 int avail = buf.length - pos;
@@ -172,7 +159,7 @@ public class PushbackReader extends FilterReader {
      * @throws     IOException  If there is insufficient room in the pushback
      *                          buffer, or if some other I/O error occurs
      */
-    public void unread(char cbuf[], int off, int len) throws IOException {
+    public void unread(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if (len > pos)
@@ -193,7 +180,7 @@ public class PushbackReader extends FilterReader {
      * @throws     IOException  If there is insufficient room in the pushback
      *                          buffer, or if some other I/O error occurs
      */
-    public void unread(char cbuf[]) throws IOException {
+    public void unread(char[] cbuf) throws IOException {
         unread(cbuf, 0, cbuf.length);
     }
 

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -253,10 +253,10 @@ public abstract class Reader implements Readable, Closeable {
      * @return     The number of characters read, or -1 if the end of the
      *             stream has been reached
      *
-     * @throws     IOException  If an I/O error occurs
      * @throws     IndexOutOfBoundsException
      *             If {@code off} is negative, or {@code len} is negative,
      *             or {@code len} is greater than {@code cbuf.length - off}
+     * @throws     IOException  If an I/O error occurs
      */
     public abstract int read(char cbuf[], int off, int len) throws IOException;
 

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import java.util.Objects;
 
 /**
  * A character stream whose source is a string.
@@ -74,25 +75,28 @@ public class StringReader extends Reader {
     }
 
     /**
-     * Reads characters into a portion of an array.
+     * Reads characters into a portion of an array.  
      *
-     * @param      cbuf  Destination buffer
-     * @param      off   Offset at which to start writing characters
-     * @param      len   Maximum number of characters to read
+     * <p> If {@code len} is zero, then no characters are read and {@code 0} is
+     * returned; otherwise, there is an attempt to read at least one character.
+     * If no character is available because the stream is at its end, the value
+     * {@code -1} is returned; otherwise, at least one character is read and
+     * stored into {@code cbuf}.
      *
-     * @return     The number of characters read, or -1 if the end of the
-     *             stream has been reached
+     * @param      cbuf  {@inheritDoc}
+     * @param      off   {@inheritDoc}
+     * @param      len   {@inheritDoc}
      *
-     * @throws     IOException  If an I/O error occurs
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
+     * @return     {@inheritDoc}
+     *
+     * @throws     IndexOutOfBoundsException  {@inheritDoc}
+     * @throws     IOException  {@inheritDoc}
      */
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
-            if ((off < 0) || (off > cbuf.length) || (len < 0) ||
-                ((off + len) > cbuf.length) || ((off + len) < 0)) {
-                throw new IndexOutOfBoundsException();
-            } else if (len == 0) {
+            Objects.checkFromIndexSize(off, len, cbuf.length); 
+            if (len == 0) {
                 return 0;
             }
             if (next >= length)

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -75,7 +75,7 @@ public class StringReader extends Reader {
     }
 
     /**
-     * Reads characters into a portion of an array.  
+     * Reads characters into a portion of an array.
      *
      * <p> If {@code len} is zero, then no characters are read and {@code 0} is
      * returned; otherwise, there is an attempt to read at least one character.
@@ -95,7 +95,7 @@ public class StringReader extends Reader {
     public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
-            Objects.checkFromIndexSize(off, len, cbuf.length); 
+            Objects.checkFromIndexSize(off, len, cbuf.length);
             if (len == 0) {
                 return 0;
             }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258444](https://bugs.openjdk.java.net/browse/JDK-8258444): Clean up specifications of java.io.Reader.read(char[],int,int) in subclass overrides


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2680/head:pull/2680`
`$ git checkout pull/2680`
