### PR TITLE
8254717: isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKeyFactory.java
@@ -106,7 +106,7 @@ public final class DESKeyFactory extends SecretKeyFactorySpi {
 
                 // Check if requested key spec is amongst the valid ones
                 if ((keySpec != null) &&
-                    DESKeySpec.class.isAssignableFrom(keySpec)) {
+                    keySpec.isAssignableFrom(DESKeySpec.class)) {
                     return new DESKeySpec(key.getEncoded());
 
                 } else {

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeKeyFactory.java
@@ -102,7 +102,7 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
                 && (key.getFormat().equalsIgnoreCase("RAW"))) {
 
                 // Check if requested key spec is amongst the valid ones
-                if (DESedeKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESedeKeySpec.class)) {
                     return new DESedeKeySpec(key.getEncoded());
 
                 } else {

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKeyFactory.java
@@ -145,7 +145,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
 
         if (key instanceof javax.crypto.interfaces.DHPublicKey) {
 
-            if (DHPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(DHPublicKeySpec.class)) {
                 javax.crypto.interfaces.DHPublicKey dhPubKey
                     = (javax.crypto.interfaces.DHPublicKey) key;
                 params = dhPubKey.getParams();
@@ -153,7 +153,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                                                         params.getP(),
                                                         params.getG()));
 
-            } else if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
             } else {
@@ -163,7 +163,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
 
         } else if (key instanceof javax.crypto.interfaces.DHPrivateKey) {
 
-            if (DHPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(DHPrivateKeySpec.class)) {
                 javax.crypto.interfaces.DHPrivateKey dhPrivKey
                     = (javax.crypto.interfaces.DHPrivateKey)key;
                 params = dhPrivKey.getParams();
@@ -171,7 +171,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                                                          params.getP(),
                                                          params.getG()));
 
-            } else if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
             } else {

--- a/src/java.base/share/classes/sun/security/provider/DSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAKeyFactory.java
@@ -148,7 +148,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> x509KeySpec = Class.forName
                     ("java.security.spec.X509EncodedKeySpec");
 
-                if (dsaPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPubKeySpec)) {
                     java.security.interfaces.DSAPublicKey dsaPubKey
                         = (java.security.interfaces.DSAPublicKey)key;
                     params = dsaPubKey.getParams();
@@ -157,7 +157,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                                                              params.getQ(),
                                                              params.getG()));
 
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
                 } else {
@@ -173,7 +173,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> pkcs8KeySpec = Class.forName
                     ("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (dsaPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPrivKeySpec)) {
                     java.security.interfaces.DSAPrivateKey dsaPrivKey
                         = (java.security.interfaces.DSAPrivateKey)key;
                     params = dsaPrivKey.getParams();
@@ -182,7 +182,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                                                               params.getQ(),
                                                               params.getG()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
                 } else {

--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -389,13 +389,13 @@ public class RSAKeyFactory extends KeyFactorySpi {
         }
         if (key instanceof RSAPublicKey) {
             RSAPublicKey rsaKey = (RSAPublicKey)key;
-            if (RSA_PUB_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(RSA_PUB_KEYSPEC_CLS)) {
                 return keySpec.cast(new RSAPublicKeySpec(
                     rsaKey.getModulus(),
                     rsaKey.getPublicExponent(),
                     rsaKey.getParams()
                 ));
-            } else if (X509_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509_KEYSPEC_CLS)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
             } else {
                 throw new InvalidKeySpecException
@@ -403,9 +403,9 @@ public class RSAKeyFactory extends KeyFactorySpi {
                         + "X509EncodedKeySpec for RSA public keys");
             }
         } else if (key instanceof RSAPrivateKey) {
-            if (PKCS8_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8_KEYSPEC_CLS)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (RSA_PRIVCRT_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
                 if (key instanceof RSAPrivateCrtKey) {
                     RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
                     return keySpec.cast(new RSAPrivateCrtKeySpec(
@@ -423,7 +423,7 @@ public class RSAKeyFactory extends KeyFactorySpi {
                     throw new InvalidKeySpecException
                     ("RSAPrivateCrtKeySpec can only be used with CRT keys");
                 }
-            } else if (RSA_PRIV_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(RSA_PRIV_KEYSPEC_CLS)) {
                 RSAPrivateKey rsaKey = (RSAPrivateKey)key;
                 return keySpec.cast(new RSAPrivateKeySpec(
                     rsaKey.getModulus(),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
@@ -214,7 +214,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DHPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DHPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
@@ -241,7 +241,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DHPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DHPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
@@ -210,7 +210,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DSAPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
@@ -239,7 +239,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DSAPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
@@ -284,7 +284,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_EC_POINT),
@@ -315,7 +315,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyFactory.java
@@ -73,8 +73,8 @@ abstract class P11KeyFactory extends KeyFactorySpi {
                 ("key and keySpec must not be null");
         }
         // delegate to our Java based providers for PKCS#8 and X.509
-        if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)
-                || X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)
+                || keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
             try {
                 return implGetSoftwareFactory().getKeySpec(key, keySpec);
             } catch (GeneralSecurityException e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -252,7 +252,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(RSAPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
@@ -277,7 +277,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
@@ -307,7 +307,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                 attributes[7].getBigInteger()
             );
             return keySpec.cast(spec);
-        } else if (RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        } else if (keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -341,11 +341,11 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             throw new InvalidKeySpecException
                 ("key and keySpec must not be null");
         }
-        if (SecretKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(SecretKeySpec.class)) {
             return new SecretKeySpec(getKeyBytes(key), algorithm);
         } else if (algorithm.equalsIgnoreCase("DES")) {
             try {
-                if (DESKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESKeySpec.class)) {
                     return new DESKeySpec(getKeyBytes(key));
                 }
             } catch (InvalidKeyException e) {
@@ -353,7 +353,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             }
         } else if (algorithm.equalsIgnoreCase("DESede")) {
             try {
-                if (DESedeKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESedeKeySpec.class)) {
                     return new DESedeKeySpec(getKeyBytes(key));
                 }
             } catch (InvalidKeyException e) {

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
@@ -256,12 +256,12 @@ public final class ECKeyFactory extends KeyFactorySpi {
         }
         if (key instanceof ECPublicKey) {
             ECPublicKey ecKey = (ECPublicKey)key;
-            if (ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
                 return keySpec.cast(new ECPublicKeySpec(
                     ecKey.getW(),
                     ecKey.getParams()
                 ));
-            } else if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
             } else {
                 throw new InvalidKeySpecException
@@ -269,9 +269,9 @@ public final class ECKeyFactory extends KeyFactorySpi {
                         + "X509EncodedKeySpec for EC public keys");
             }
         } else if (key instanceof ECPrivateKey) {
-            if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
                 ECPrivateKey ecKey = (ECPrivateKey)key;
                 return keySpec.cast(new ECPrivateKeySpec(
                     ecKey.getS(),

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHKeyFactory.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHKeyFactory.java
@@ -189,12 +189,12 @@ public class XDHKeyFactory extends KeyFactorySpi {
             checkLockedParams(InvalidKeySpecException::new,
                 ((XECPublicKey) key).getParams());
 
-            if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 if (!key.getFormat().equals("X.509")) {
                     throw new InvalidKeySpecException("Format is not X.509");
                 }
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
-            } else if (XECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(XECPublicKeySpec.class)) {
                 XECPublicKey xecKey = (XECPublicKey) key;
                 return keySpec.cast(
                     new XECPublicKeySpec(xecKey.getParams(), xecKey.getU()));
@@ -206,12 +206,12 @@ public class XDHKeyFactory extends KeyFactorySpi {
             checkLockedParams(InvalidKeySpecException::new,
                 ((XECPrivateKey) key).getParams());
 
-            if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 if (!key.getFormat().equals("PKCS#8")) {
                     throw new InvalidKeySpecException("Format is not PKCS#8");
                 }
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (XECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(XECPrivateKeySpec.class)) {
                 XECPrivateKey xecKey = (XECPrivateKey) key;
                 byte[] scalar = xecKey.getScalar().orElseThrow(
                     () -> new InvalidKeySpecException("No private key value")

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAKeyFactory.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAKeyFactory.java
@@ -182,12 +182,12 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             checkLockedParams(InvalidKeySpecException::new,
                 ((EdECPublicKey) key).getParams());
 
-            if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 if (!key.getFormat().equals("X.509")) {
                     throw new InvalidKeySpecException("Format is not X.509");
                 }
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
-            } else if (EdECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(EdECPublicKeySpec.class)) {
                 EdECPublicKey edKey = (EdECPublicKey) key;
                 return keySpec.cast(
                     new EdECPublicKeySpec(edKey.getParams(), edKey.getPoint()));
@@ -199,12 +199,12 @@ public class EdDSAKeyFactory extends KeyFactorySpi {
             checkLockedParams(InvalidKeySpecException::new,
                 ((EdECPrivateKey) key).getParams());
 
-            if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 if (!key.getFormat().equals("PKCS#8")) {
                     throw new InvalidKeySpecException("Format is not PKCS#8");
                 }
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (EdECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(EdECPrivateKeySpec.class)) {
                 EdECPrivateKey edKey = (EdECPrivateKey) key;
                 byte[] scalar = edKey.getBytes().orElseThrow(
                     () -> new InvalidKeySpecException("No private key value")

--- a/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2011, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8254717
+ * @summary Two users facing implications caused by "isAssignableFrom" checks in "engineGetKeySpec" being backwards.
+ * @author Greg Rubin, Ziyi Luo
+ */
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.*;
+
+public class KeyFactoryGetKeySpecForInvalidSpec {
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA");
+        kg.initialize(2048);
+        KeyPair pair = kg.generateKeyPair();
+
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+
+        // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
+        // (because the private key has CRT parts).
+        KeySpec spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateKeySpec.class);
+        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+
+        // This next line should give an InvalidKeySpec exception
+        try {
+            spec = factory.getKeySpec(pair.getPublic(), FakeX509Spec.class);
+            throw new Exception("InvalidKeySpecException is expected but not thrown");
+        } catch (final ClassCastException ex) {
+            throw new Exception("InvalidKeySpecException is expected ClassCastException is thrown", ex);
+        } catch (final InvalidKeySpecException ex) {
+            // Pass
+        }
+    }
+
+    public static class FakeX509Spec extends X509EncodedKeySpec {
+        public FakeX509Spec(byte[] encodedKey) {
+            super(encodedKey);
+        }
+
+        public FakeX509Spec(byte[] encodedKey, String algorithm) {
+            super(encodedKey, algorithm);
+        }
+    }
+}


### PR DESCRIPTION
All of the "isAssignableFrom" checks in "engineGetKeySpec" appear to be backwards in Java's KeyFactorySpi.engineGetKeySpec implementations. In most cases, the requested KeySpec is equal to the concrete implementation so the inversion does not matter. But there are few cases, as presented in the added jtreg test, will cause unexpected behavior (e.g., ClassCastException rather than an InvalidKeySpecException). The fix is trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8254717](https://bugs.openjdk.java.net/browse/JDK-8254717): isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2681/head:pull/2681`
`$ git checkout pull/2681`
