### PR TITLE
8261919: java/util/Locale/LocaleProvidersRun.java failed with "RuntimeException: Expected log was not emitted. LogRecord: null"

### DIFF
--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -29,6 +29,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.time.temporal.WeekFields;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.StreamHandler;
@@ -402,22 +403,20 @@ public class LocaleProviders {
         DateFormat.getDateInstance();
         LogConfig.handler.flush();
 
-        var r = LogConfig.lra[0];
-        if (r == null ||
-            r.getLevel() != Level.INFO ||
-            !r.getMessage().equals(expected)) {
-            throw new RuntimeException("Expected log was not emitted. LogRecord: " +
-                    (r == null ? null : r.getMessage()));
+        if (LogConfig.logRecordList.stream()
+                .noneMatch(r -> r.getLevel() == Level.INFO &&
+                                r.getMessage().equals(expected))) {
+            throw new RuntimeException("Expected log was not emitted.");
         }
     }
 
     // Set the root logger on loading the logging class
     public static class LogConfig {
-        final static LogRecord[] lra = new LogRecord[1];
+        final static CopyOnWriteArrayList<LogRecord> logRecordList = new CopyOnWriteArrayList<>();
         final static StreamHandler handler = new StreamHandler() {
             @Override
             public void publish(LogRecord record) {
-                lra[0] = record;
+                logRecordList.add(record);
                 System.out.println("LogRecord: " + record.getMessage());
             }
         };

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -398,22 +398,31 @@ public class LocaleProviders {
     }
 
     static void bug8245241Test(String expected) {
-        LogRecord[] lra = new LogRecord[1];
-        StreamHandler handler = new StreamHandler() {
+        // this will ensure LocaleProviderAdapter initialization
+        DateFormat.getDateInstance();
+        LogConfig.handler.flush();
+
+        var r = LogConfig.lra[0];
+        if (r == null ||
+            r.getLevel() != Level.INFO ||
+            !r.getMessage().equals(expected)) {
+            throw new RuntimeException("Expected log was not emitted. LogRecord: " +
+                    (r == null ? null : r.getMessage()));
+        }
+    }
+
+    // Set the root logger on loading the logging class
+    public static class LogConfig {
+        final static LogRecord[] lra = new LogRecord[1];
+        final static StreamHandler handler = new StreamHandler() {
             @Override
             public void publish(LogRecord record) {
                 lra[0] = record;
+                System.out.println("LogRecord: " + record.getMessage());
             }
         };
-        getLogManager().getLogger("").addHandler(handler);
-
-        DateFormat.getDateInstance(); // this will init LocaleProviderAdapter
-        handler.flush();
-
-        if (lra[0] == null ||
-            lra[0].getLevel() != Level.INFO ||
-            !lra[0].getMessage().equals(expected)) {
-            throw new RuntimeException("Expected log was not emitted. LogRecord: " + lra[0]);
+        static {
+            getLogManager().getLogger("").addHandler(handler);
         }
     }
 

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 6336885 7196799 7197573 7198834 8000245 8000615 8001440 8008577
  *      8010666 8013086 8013233 8013903 8015960 8028771 8054482 8062006
  *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
- *      8246721 8248695 8257964
+ *      8246721 8248695 8257964 8261919
  * @summary tests for "java.locale.providers" system property
  * @library /test/lib
  * @build LocaleProviders
@@ -184,6 +184,7 @@ public class LocaleProvidersRun {
                 .addToolArg("-esa")
                 .addToolArg("-cp")
                 .addToolArg(Utils.TEST_CLASS_PATH)
+                .addToolArg("-Djava.util.logging.config.class=LocaleProviders$LogConfig")
                 .addToolArg("-Djava.locale.providers=" + prefList)
                 .addToolArg("--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED")
                 .addToolArg("LocaleProviders")


### PR DESCRIPTION
Please review the fix to this test case failure that occurs with the usage tracker enabled JRE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261919](https://bugs.openjdk.java.net/browse/JDK-8261919): java/util/Locale/LocaleProvidersRun.java failed with "RuntimeException: Expected log was not emitted. LogRecord: null"


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to bfa3a8e5b52ff32fc2c4fe4d3e1e75ab7528a481
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2683/head:pull/2683`
`$ git checkout pull/2683`
