### PR TITLE
8253409: Double-rounding possibility in float fma

### DIFF
--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -28,6 +28,7 @@
  * @build Tests
  * @build FusedMultiplyAddTests
  * @run main FusedMultiplyAddTests
+ * @run main/othervm -XX:-UseFMA FusedMultiplyAddTests
  */
 
 /**

--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4851642
+ * @bug 4851642 8253409
  * @summary Tests for Math.fusedMac and StrictMath.fusedMac.
  * @build Tests
  * @build FusedMultiplyAddTests
@@ -350,6 +350,9 @@ public class FusedMultiplyAddTests {
 
             {1.0f+Math.ulp(1.0f), 1.0f+Math.ulp(1.0f), -1.0f-2.0f*Math.ulp(1.0f),
              Math.ulp(1.0f)*Math.ulp(1.0f)},
+
+            // Double-rounding if done in double precision
+            {0x1.fffffep23f, 0x1.000004p28f, 0x1.fep5f, 0x1.000002p52f}
         };
 
         for (float[] testCase: testCases)


### PR DESCRIPTION
In floating-point, usually doing an operation to double precision and then rounding to float gives the right result in float precision. One exception to this is fused multiply add (fma) where "a * b + c" is computed with a single rounding. This requires the equivalent of extra intermediate precision inside the operation. If a float fma is implemented using a double fma rounded to float, for some well-chosen arguments where the final result is near a half-way result in *float*, an incorrect answer will be computed due to double rounding. In more detail, the double result will round up and then the cast to float will round up again whereas a single rounding of the exact answer to float would only round-up once.

The new float fma implementation does the exact arithmetic using BigDecimal where possible, with guard to handle the non-finite and signed zero IEEE 754 details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253409](https://bugs.openjdk.java.net/browse/JDK-8253409):  Double-rounding possibility in float fma


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2684/head:pull/2684`
`$ git checkout pull/2684`
