### PR TITLE
JDK-8262163: Extend settings printout in jcmd VM.metaspace

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -106,8 +106,18 @@ static void print_settings(outputStream* out, size_t scale) {
   if (Metaspace::using_class_space()) {
     out->print("CompressedClassSpaceSize: ");
     print_human_readable_size(out, CompressedClassSpaceSize, scale);
+  } else {
+    out->print("No class space");
   }
   out->cr();
+  out->print("Initial GC threshold: ");
+  print_human_readable_size(out, MetaspaceSize, scale);
+  out->cr();
+  out->print("Current GC threshold: ");
+  print_human_readable_size(out, MetaspaceGC::capacity_until_GC(), scale);
+  out->cr();
+  out->print_cr("CDS: %s", (UseSharedSpaces ? "on" : (DumpSharedSpaces ? "dump" : "off")));
+  out->print_cr("MetaspaceReclaimPolicy: %s", MetaspaceReclaimPolicy);
   Settings::print_on(out);
 }
 


### PR DESCRIPTION
This is quite trivial. 

jcmd VM.metaspace prints metaspace settings at the end of its printout. Missing from that printout are some settings which would be nice to see here, eg the GC thresholds and CDS settings (nice to know since CDS affects how metaspace is used).

Example output:

```
Settings:
MaxMetaspaceSize: 17179869184,00 GB
CompressedClassSpaceSize: 1,00 GB
Initial GC threshold: 20,75 MB
Current GC threshold: 21,50 MB
CDS: on
MetaspaceReclaimPolicy: balanced
```
-------
Tests: Manually ran runtime/Metaspace/PrintMetaspaceDcmd.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262163](https://bugs.openjdk.java.net/browse/JDK-8262163): Extend settings printout in jcmd VM.metaspace


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2686/head:pull/2686`
`$ git checkout pull/2686`
