### PR TITLE
8261895: java/net/URLPermission/nstest/LookupTest fails with unexpected UnknownHostException

### DIFF
--- a/test/jdk/java/net/URLPermission/nstest/LookupTest.java
+++ b/test/jdk/java/net/URLPermission/nstest/LookupTest.java
@@ -26,7 +26,7 @@
  * @summary A simple smoke test of the HttpURLPermission mechanism, which checks
  *          for either IOException (due to unknown host) or SecurityException
  *          due to lack of permission to connect
- * @run main/othervm LookupTest
+ * @run main/othervm -Djdk.net.hosts.file=LookupTestHosts LookupTest
  */
 
 import java.io.BufferedWriter;
@@ -100,18 +100,16 @@ public class LookupTest {
         }
     }
 
-    static final String CWD = System.getProperty("user.dir", ".");
+    static final String HOSTS_FILE_NAME = System.getProperty("jdk.net.hosts.file");
 
     public static void main(String args[]) throws Exception {
-        String hostsFileName = CWD + "/LookupTestHosts";
-        System.setProperty("jdk.net.hosts.file", hostsFileName);
         addMappingToHostsFile("allowedAndFound.com",
                               InetAddress.getLoopbackAddress().getHostAddress(),
-                              hostsFileName,
+                              HOSTS_FILE_NAME,
                               false);
         addMappingToHostsFile("notAllowedButFound.com",
                               "99.99.99.99",
-                              hostsFileName,
+                              HOSTS_FILE_NAME,
                               true);
         // name "notAllowedAndNotFound.com" is not in map
         // name "allowedButNotfound.com" is not in map


### PR DESCRIPTION
`nstest/LookupTest.java` is a test which uses a **HostsFileNameService** to test the **HttpURLPermission** mechanism with host mappings that are added to a hosts file that is generated at run-time.
 
Intermittent failures of this test can be caused by tools used during JVM start-up accessing/initialising classes sooner than may be expected which can cause unexpected behavior. Due to the fact that **InetAddress** initialises it's Implementation and Name Service fields in a static class initialiser (see [L1132 of InetAddress.java](https://github.com/openjdk/jdk/blob/12f6ba0deb31a29353b35ecea5bb8cb5f71011e6/src/java.base/share/classes/java/net/InetAddress.java#L1132)), setting a system property in the main method to specify the use of **HostsFileNameService** (with the jdk.net.hosts.file property)  has no affect if the class has been previously accessed during JVM start-up and **InetAddress** will default to the **PlatformNameService** which is unsuitable for this test.

This fix improves the robustness of this test by specifying the use of the **HostsFileNameService** in the @run tag for this test via the previously mentioned system property. This gives certainty that the property will be properly set in time for the actual run of this test after the JVM has booted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261895](https://bugs.openjdk.java.net/browse/JDK-8261895): java/net/URLPermission/nstest/LookupTest fails with unexpected UnknownHostException


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2689/head:pull/2689`
`$ git checkout pull/2689`
