### PR TITLE
8262197: JDK-8242032 uses wrong contains_reference() in assertion code 

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -148,7 +148,7 @@ void OtherRegionsTable::add_reference(OopOrNarrowOopStar from, uint tid) {
 
     // Rechecking if the region is coarsened, while holding the lock.
     if (is_region_coarsened(from_hrm_ind)) {
-      assert(contains_reference(from), "We just found " PTR_FORMAT " in the Coarse table", p2i(from));
+      assert(contains_reference_locked(from), "We just found " PTR_FORMAT " in the Coarse table", p2i(from));
       return;
     }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes use of the wrong HeapRegionRemSet::contains_reference() method, causing a thread lock the same mutex again, resulting in problems like assertion failures?

The code in question has been introduced in JDK-8242032:


    +    // Rechecking if the region is coarsened, while holding the lock.
    +    if (is_region_coarsened(from_hrm_ind)) {
    +      assert(contains_reference(from), "We just found " PTR_FORMAT " in the Coarse table", p2i(from));
    +      return;
    +    }

The problem is the call to `contains_reference`, which locks the same lock that "we know we are already locking" per the comment above. Correct is using `contains_reference_locked` added for just this purpose.

In the original change the PR already mentioned that the situation where this condition should hold could not be reproduced - now we know that it actually occurs ;) 

Testing: tier1. Trying to reproduce with the original some of the failing tests without luck - however the problematic line and the fix is very obvious.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262197](https://bugs.openjdk.java.net/browse/JDK-8262197): JDK-8242032 uses wrong contains_reference() in assertion code 


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2690/head:pull/2690`
`$ git checkout pull/2690`
