### PR TITLE
8264032: Improve thread safety of Runtime.version()

### DIFF
--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -816,12 +816,14 @@ public class Runtime {
      * @since  9
      */
     public static Version version() {
-        if (version == null) {
-            version = new Version(VersionProps.versionNumbers(),
+        var v = version;
+        if (v == null) {
+            v = new Version(VersionProps.versionNumbers(),
                     VersionProps.pre(), VersionProps.build(),
                     VersionProps.optional());
+            version = v;
         }
-        return version;
+        return v;
     }
 
     /**


### PR DESCRIPTION
Avoid double-read non volatile static field

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264032](https://bugs.openjdk.java.net/browse/JDK-8264032): Improve thread safety of Runtime.version()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2691/head:pull/2691`
`$ git checkout pull/2691`

To update a local copy of the PR:
`$ git checkout pull/2691`
`$ git pull https://git.openjdk.java.net/jdk pull/2691/head`
