### PR TITLE
JDK-8262199: issue in jli args.c

### DIFF
--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -354,11 +354,6 @@ static JLI_List readArgFile(FILE *file) {
     return rv;
 }
 
-static void reportAndExit(const char* fmt, const char* arg) {
-    JLI_ReportMessage(fmt, arg);
-    exit(1);
-}
-
 /*
  * if the arg represent a file, that is, prefix with a single '@',
  * return a list of arguments from the file.
@@ -371,7 +366,8 @@ static JLI_List expandArgFile(const char *arg) {
 
     /* arg file cannot be openned */
     if (fptr == NULL || fstat(fileno(fptr), &st) != 0) {
-        reportAndExit(CFG_ERROR6, arg);
+        JLI_ReportMessage(CFG_ERROR6, arg);
+        exit(1);
     } else {
         if (st.st_size > MAX_ARGF_SIZE) {
             JLI_ReportMessage(CFG_ERROR10, MAX_ARGF_SIZE);
@@ -383,7 +379,8 @@ static JLI_List expandArgFile(const char *arg) {
 
     /* error occurred reading the file */
     if (rv == NULL) {
-        reportAndExit(DLL_ERROR4, arg);
+        JLI_ReportMessage(DLL_ERROR4, arg);
+        exit(1);
     }
     fclose(fptr);
 

--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -359,6 +359,7 @@ static void reportFcloseExit(FILE *fptr, const char* fmt, const char* arg) {
     if (fptr != NULL) fclose(fptr);
     exit(1);
 }
+
 /*
  * if the arg represent a file, that is, prefix with a single '@',
  * return a list of arguments from the file.

--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -354,9 +354,8 @@ static JLI_List readArgFile(FILE *file) {
     return rv;
 }
 
-static void reportFcloseExit(FILE *fptr, const char* fmt, const char* arg) {
+static void reportAndExit(const char* fmt, const char* arg) {
     if (fmt != NULL) JLI_ReportMessage(fmt, arg);
-    if (fptr != NULL) fclose(fptr);
     exit(1);
 }
 
@@ -372,11 +371,11 @@ static JLI_List expandArgFile(const char *arg) {
 
     /* arg file cannot be openned */
     if (fptr == NULL || fstat(fileno(fptr), &st) != 0) {
-        reportFcloseExit(fptr, CFG_ERROR6, arg);
+        reportAndExit(CFG_ERROR6, arg);
     } else {
         if (st.st_size > MAX_ARGF_SIZE) {
             JLI_ReportMessage(CFG_ERROR10, MAX_ARGF_SIZE);
-            reportFcloseExit(fptr, NULL, NULL);
+            reportAndExit(NULL, NULL);
         }
     }
 
@@ -384,7 +383,7 @@ static JLI_List expandArgFile(const char *arg) {
 
     /* error occurred reading the file */
     if (rv == NULL) {
-        reportFcloseExit(fptr, DLL_ERROR4, arg);
+        reportAndExit(DLL_ERROR4, arg);
     }
     fclose(fptr);
 

--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -355,7 +355,7 @@ static JLI_List readArgFile(FILE *file) {
 }
 
 static void reportAndExit(const char* fmt, const char* arg) {
-    if (fmt != NULL) JLI_ReportMessage(fmt, arg);
+    JLI_ReportMessage(fmt, arg);
     exit(1);
 }
 
@@ -375,7 +375,7 @@ static JLI_List expandArgFile(const char *arg) {
     } else {
         if (st.st_size > MAX_ARGF_SIZE) {
             JLI_ReportMessage(CFG_ERROR10, MAX_ARGF_SIZE);
-            reportAndExit(NULL, NULL);
+            exit(1);
         }
     }
 


### PR DESCRIPTION
Sonar reports a finding in args.c, where a file check is done .
Stat performs a check on file, and later fopen is called on the file .

The coding could be slightly rewritten so that the potential issue is removed (however I do not think that it is such a big issue).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262199](https://bugs.openjdk.java.net/browse/JDK-8262199): issue in jli args.c


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2692/head:pull/2692`
`$ git checkout pull/2692`
