### PR TITLE
8262185: G1: Prune collection set candidates early

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -42,7 +42,7 @@ void G1CollectionSetCandidates::prune(uint keep_min_regions, size_t prune_total_
   while (regions_left > keep_min_regions) {
     uint cur_idx = regions_left - 1;
     // Do not prune more than prune_total_bytes.
-    if ((at(cur_idx)->reclaimable_bytes() + pruned_bytes) <= prune_total_bytes) {
+    if ((at(cur_idx)->reclaimable_bytes() + pruned_bytes) > prune_total_bytes) {
       break;
     }
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -36,19 +36,20 @@ void G1CollectionSetCandidates::remove(uint num_regions) {
 }
 
 void G1CollectionSetCandidates::prune(uint keep_min_regions, size_t prune_total_bytes) {
-  uint i = _num_regions;
+  uint regions_left = _num_regions;
   size_t reclaimed_bytes = 0;
-  while (i > keep_min_regions && (at(i - 1)->reclaimable_bytes() + reclaimed_bytes) <= prune_total_bytes) {
-    uint cur_idx = i - 1;
+  while (regions_left > keep_min_regions &&
+         (at(regions_left - 1)->reclaimable_bytes() + reclaimed_bytes) <= prune_total_bytes) {
+    uint cur_idx = regions_left - 1;
 
     reclaimed_bytes += at(cur_idx)->reclaimable_bytes();
     at(cur_idx)->rem_set()->clear(true /* only_cardset */);
     // Clear HeapRegion reference to make sure it is not going to be used.
     _regions[cur_idx] = NULL;
-    i--;
+    regions_left--;
   }
   _remaining_reclaimable_bytes -= reclaimed_bytes;
-  _num_regions -= _num_regions - i;
+  _num_regions = regions_left;
 }
 
 void G1CollectionSetCandidates::iterate(HeapRegionClosure* cl) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -35,9 +35,10 @@ void G1CollectionSetCandidates::remove(uint num_regions) {
   }
 }
 
-void G1CollectionSetCandidates::remove_from_end(uint num_remove) {
+void G1CollectionSetCandidates::remove_from_end(uint num_remove, size_t wasted) {
   assert(num_remove <= num_remaining(), "trying to remove more regions than remaining");
 
+#ifdef ASSERT
   size_t reclaimable = 0;
 
   for (uint i = 0; i < num_remove; i++) {
@@ -46,8 +47,11 @@ void G1CollectionSetCandidates::remove_from_end(uint num_remove) {
     // Make sure we crash if we access it.
     _regions[cur_idx] = NULL;
   }
+
+  assert(reclaimable == wasted, "Recalculated reclaimable inconsistent");
+#endif
   _num_regions -= num_remove;
-  _remaining_reclaimable_bytes -= reclaimable;
+  _remaining_reclaimable_bytes -= wasted;
 }
 
 void G1CollectionSetCandidates::iterate(HeapRegionClosure* cl) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -50,28 +50,6 @@ void G1CollectionSetCandidates::remove_from_end(uint num_remove) {
   _remaining_reclaimable_bytes -= reclaimable;
 }
 
-void G1CollectionSetCandidates::prune(uint keep_min_regions,
-                                      size_t prune_total_bytes,
-                                      HeapRegionClosure* cl) {
-  uint regions_left;
-  size_t pruned_bytes = 0;
-
-  for (regions_left = _num_regions; regions_left > keep_min_regions; regions_left--) {
-    uint cur_idx = regions_left - 1;
-    HeapRegion* region = at(cur_idx);
-    // Do not prune more than prune_total_bytes.
-    if ((region->reclaimable_bytes() + pruned_bytes) > prune_total_bytes) {
-      break;
-    }
-    pruned_bytes += region->reclaimable_bytes();
-    cl->do_heap_region(region);
-    // Clear HeapRegion reference to make sure it is not going to be used.
-    _regions[cur_idx] = NULL;
-  }
-  _remaining_reclaimable_bytes -= pruned_bytes;
-  _num_regions = regions_left;
-}
-
 void G1CollectionSetCandidates::iterate(HeapRegionClosure* cl) {
   for (uint i = _front_idx; i < _num_regions; i++) {
     HeapRegion* r = _regions[i];

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -77,7 +77,7 @@ public:
   // Remove num_regions from the front of the collection set candidate list.
   void remove(uint num_regions);
   // Remove num_remove regions from the back of the collection set candidate list.
-  void remove_from_end(uint num_remove);
+  void remove_from_end(uint num_remove, size_t wasted);
 
   // Iterate over all remaining collection set candidate regions.
   void iterate(HeapRegionClosure* cl);

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -75,8 +75,8 @@ public:
   }
 
   // Remove collection set candidates which would reclaim at most prune_total_bytes
-  // bytes and keeping at least keep_min_regions beginning the least efficient
-  // collection set candidates regions.
+  // bytes and keeping at least keep_min_regions. Removes the least efficient
+  // collection set candidate regions first.
   void prune(uint keep_min_regions, size_t prune_total_bytes);
 
   // Remove num_regions from the front of the collection set candidate list.

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,9 +81,14 @@ public:
 
   // Remove num_regions from the front of the collection set candidate list.
   void remove(uint num_regions);
+  // Remove num_remove regions from the back of the collection set candidate list.
+  void remove_from_end(uint num_remove);
 
   // Iterate over all remaining collection set candidate regions.
   void iterate(HeapRegionClosure* cl);
+  // Iterate over all remaining collectin set candidate regions from the end
+  // to the beginning of the set.
+  void iterate_backwards(HeapRegionClosure* cl);
 
   // Return the number of candidate regions remaining.
   uint num_remaining() { return _num_regions - _front_idx; }

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -76,8 +76,8 @@ public:
 
   // Remove collection set candidates which would reclaim at most prune_total_bytes
   // bytes and keeping at least keep_min_regions. Removes the least efficient
-  // collection set candidate regions first.
-  void prune(uint keep_min_regions, size_t prune_total_bytes);
+  // collection set candidate regions first. Applies cl on the pruned regions.
+  void prune(uint keep_min_regions, size_t prune_total_bytes, HeapRegionClosure* cl);
 
   // Remove num_regions from the front of the collection set candidate list.
   void remove(uint num_regions);

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -74,11 +74,6 @@ public:
     return res;
   }
 
-  // Remove collection set candidates which would reclaim at most prune_total_bytes
-  // bytes and keeping at least keep_min_regions. Removes the least efficient
-  // collection set candidate regions first. Applies cl on the pruned regions.
-  void prune(uint keep_min_regions, size_t prune_total_bytes, HeapRegionClosure* cl);
-
   // Remove num_regions from the front of the collection set candidate list.
   void remove(uint num_regions);
   // Remove num_remove regions from the back of the collection set candidate list.

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -74,6 +74,12 @@ public:
     return res;
   }
 
+  // Remove collection set candidates which would reclaim at most prune_total_bytes
+  // bytes and keeping at least keep_min_regions beginning the least efficient
+  // collection set candidates regions.
+  void prune(uint keep_min_regions, size_t prune_total_bytes);
+
+  // Remove num_regions from the front of the collection set candidate list.
   void remove(uint num_regions);
 
   // Iterate over all remaining collection set candidate regions.

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -265,6 +265,8 @@ G1CollectionSetCandidates* G1CollectionSetChooser::build(WorkGang* workers, uint
   workers->run_task(&cl, num_workers);
 
   G1CollectionSetCandidates* result = cl.get_sorted_candidates();
+  G1Policy* p = G1CollectedHeap::heap()->policy();
+  p->prune_collection_set(result);
   result->verify();
   return result;
 }

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -273,12 +273,13 @@ public:
     _num_pruned(0), _cur_wasted(0), _max_pruned(max_pruned), _max_wasted(max_wasted) { }
 
   virtual bool do_heap_region(HeapRegion* r) {
+    size_t const reclaimable = r->reclaimable_bytes();
     if (_num_pruned > _max_pruned ||
-        _cur_wasted + r->reclaimable_bytes() > _max_wasted) {
+        _cur_wasted + reclaimable > _max_wasted) {
       return true;
     }
     r->rem_set()->clear(true /* cardset_only */);
-    _cur_wasted += r->reclaimable_bytes();
+    _cur_wasted += reclaimable;
     _num_pruned++;
     return false;
   }
@@ -306,7 +307,7 @@ void G1CollectionSetChooser::prune(G1CollectionSetCandidates* candidates) {
                               prune_cl.wasted(),
                               allowed_waste);
 
-    candidates->remove_from_end(prune_cl.num_pruned());
+    candidates->remove_from_end(prune_cl.num_pruned(), prune_cl.wasted());
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,11 @@ class WorkGang;
 // methods.
 class G1CollectionSetChooser : public AllStatic {
   static uint calculate_work_chunk_size(uint num_workers, uint num_regions);
+
+  // Remove regions in the collection set candidates as long as the G1HeapWastePercent
+  // criteria is met. Keep at least the minimum amount of old regions to guarantee
+  // some progress.
+  static void prune(G1CollectionSetCandidates* candidates);
 public:
 
   static size_t mixed_gc_live_threshold_bytes() {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1278,22 +1278,27 @@ bool G1Policy::next_gc_should_be_mixed(const char* true_action_str,
     log_debug(gc, ergo)("%s (candidate old regions not available)", false_action_str);
     return false;
   }
-
-  // Is the amount of uncollected reclaimable space above G1HeapWastePercent?
-  size_t reclaimable_bytes = candidates->remaining_reclaimable_bytes();
-  double reclaimable_percent = reclaimable_bytes_percent(reclaimable_bytes);
-  double threshold = (double) G1HeapWastePercent;
-  if (reclaimable_percent <= threshold) {
-    log_debug(gc, ergo)("%s (reclaimable percentage not over threshold). candidate old regions: %u reclaimable: " SIZE_FORMAT " (%1.2f) threshold: " UINTX_FORMAT,
-                        false_action_str, candidates->num_remaining(), reclaimable_bytes, reclaimable_percent, G1HeapWastePercent);
-    return false;
-  }
-  log_debug(gc, ergo)("%s (candidate old regions available). candidate old regions: %u reclaimable: " SIZE_FORMAT " (%1.2f) threshold: " UINTX_FORMAT,
-                      true_action_str, candidates->num_remaining(), reclaimable_bytes, reclaimable_percent, G1HeapWastePercent);
+  // Go through all regions - we already pruned regions not worth collecting
+  // during candidate selection.
   return true;
 }
 
-uint G1Policy::calc_min_old_cset_length() const {
+void G1Policy::prune_collection_set(G1CollectionSetCandidates* candidates) {
+  uint num_candidates_before = candidates->num_remaining();
+  size_t reclaimable_bytes_before = candidates->remaining_reclaimable_bytes();
+
+  size_t accepted_waste = G1HeapWastePercent * _g1h->capacity() / 100;
+
+  candidates->prune(calc_min_old_cset_length(candidates), accepted_waste);
+
+  log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving " SIZE_FORMAT " bytes waste (accepted " SIZE_FORMAT ")",
+                            num_candidates_before - candidates->num_remaining(),
+                            candidates->num_regions(),
+                            reclaimable_bytes_before - candidates->remaining_reclaimable_bytes(),
+                            accepted_waste);
+}
+
+uint G1Policy::calc_min_old_cset_length(G1CollectionSetCandidates* candidates) const {
   // The min old CSet region bound is based on the maximum desired
   // number of mixed GCs after a cycle. I.e., even if some old regions
   // look expensive, we should add them to the CSet anyway to make
@@ -1304,7 +1309,7 @@ uint G1Policy::calc_min_old_cset_length() const {
   // to the CSet candidates in the first place, not how many remain, so
   // that the result is the same during all mixed GCs that follow a cycle.
 
-  const size_t region_num = _collection_set->candidates()->num_regions();
+  const size_t region_num = candidates->num_regions();
   const size_t gc_num = (size_t) MAX2(G1MixedGCCountTarget, (uintx) 1);
   size_t result = region_num / gc_num;
   // emulate ceiling
@@ -1347,7 +1352,7 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
 
   double optional_threshold_ms = time_remaining_ms * optional_prediction_fraction();
 
-  const uint min_old_cset_length = calc_min_old_cset_length();
+  const uint min_old_cset_length = calc_min_old_cset_length(candidates);
   const uint max_old_cset_length = MAX2(min_old_cset_length, calc_max_old_cset_length());
   const uint max_optional_regions = max_old_cset_length - min_old_cset_length;
   bool check_time_remaining = use_adaptive_young_list_length();

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1283,19 +1283,8 @@ bool G1Policy::next_gc_should_be_mixed(const char* true_action_str,
   return true;
 }
 
-void G1Policy::prune_collection_set(G1CollectionSetCandidates* candidates, HeapRegionClosure* cl) {
-  uint num_candidates_before = candidates->num_remaining();
-  size_t reclaimable_bytes_before = candidates->remaining_reclaimable_bytes();
-
-  size_t accepted_waste = G1HeapWastePercent * _g1h->capacity() / 100;
-
-  candidates->prune(calc_min_old_cset_length(candidates), accepted_waste, cl);
-
-  log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving " SIZE_FORMAT " bytes waste (accepted " SIZE_FORMAT ")",
-                            num_candidates_before - candidates->num_remaining(),
-                            candidates->num_regions(),
-                            reclaimable_bytes_before - candidates->remaining_reclaimable_bytes(),
-                            accepted_waste);
+size_t G1Policy::allowed_waste_in_collection_set() const {
+  return G1HeapWastePercent * _g1h->capacity() / 100;
 }
 
 uint G1Policy::calc_min_old_cset_length(G1CollectionSetCandidates* candidates) const {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1283,13 +1283,13 @@ bool G1Policy::next_gc_should_be_mixed(const char* true_action_str,
   return true;
 }
 
-void G1Policy::prune_collection_set(G1CollectionSetCandidates* candidates) {
+void G1Policy::prune_collection_set(G1CollectionSetCandidates* candidates, HeapRegionClosure* cl) {
   uint num_candidates_before = candidates->num_remaining();
   size_t reclaimable_bytes_before = candidates->remaining_reclaimable_bytes();
 
   size_t accepted_waste = G1HeapWastePercent * _g1h->capacity() / 100;
 
-  candidates->prune(calc_min_old_cset_length(candidates), accepted_waste);
+  candidates->prune(calc_min_old_cset_length(candidates), accepted_waste, cl);
 
   log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving " SIZE_FORMAT " bytes waste (accepted " SIZE_FORMAT ")",
                             num_candidates_before - candidates->num_remaining(),

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -349,8 +349,9 @@ public:
 
   // Prune collection set candidates according to G1HeapWastePercent heuristics
   // during selection. Guarantee some forward progress by always keeping a minimum
-  // of old collection set candidates for a single GC.
-  void prune_collection_set(G1CollectionSetCandidates* candidates);
+  // of old collection set candidates for a single GC. Applies cl onto the pruned
+  // regions.
+  void prune_collection_set(G1CollectionSetCandidates* candidates, HeapRegionClosure* cl);
   // Calculate and return the number of initial and optional old gen regions from
   // the given collection set candidates and the remaining time.
   void calculate_old_collection_set_regions(G1CollectionSetCandidates* candidates,

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -246,7 +246,7 @@ public:
 
   // Calculate the minimum number of old regions we'll add to the CSet
   // during a mixed GC.
-  uint calc_min_old_cset_length() const;
+  uint calc_min_old_cset_length(G1CollectionSetCandidates* candidates) const;
 
   // Calculate the maximum number of old regions we'll add to the CSet
   // during a mixed GC.
@@ -347,6 +347,10 @@ public:
   bool next_gc_should_be_mixed(const char* true_action_str,
                                const char* false_action_str) const;
 
+  // Prune collection set candidates according to G1HeapWastePercent heuristics
+  // during selection. Guarantee some forward progress by always keeping a minimum
+  // of old collection set candidates for a single GC.
+  void prune_collection_set(G1CollectionSetCandidates* candidates);
   // Calculate and return the number of initial and optional old gen regions from
   // the given collection set candidates and the remaining time.
   void calculate_old_collection_set_regions(G1CollectionSetCandidates* candidates,

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,11 +347,8 @@ public:
   bool next_gc_should_be_mixed(const char* true_action_str,
                                const char* false_action_str) const;
 
-  // Prune collection set candidates according to G1HeapWastePercent heuristics
-  // during selection. Guarantee some forward progress by always keeping a minimum
-  // of old collection set candidates for a single GC. Applies cl onto the pruned
-  // regions.
-  void prune_collection_set(G1CollectionSetCandidates* candidates, HeapRegionClosure* cl);
+  // Amount of allowed waste in bytes in the collection set.
+  size_t allowed_waste_in_collection_set() const;
   // Calculate and return the number of initial and optional old gen regions from
   // the given collection set candidates and the remaining time.
   void calculate_old_collection_set_regions(G1CollectionSetCandidates* candidates,


### PR DESCRIPTION
Hello,

  can I have reviews for this change to the collection candidate selection procedure, moving the G1HeapWastePercent exclusion criteria right after candidate selection instead of at the end of mixed gcs?

This can save lots of memory with negligible other impact.

Long version:
Currently G1 maintains collection set candidates from the marking phase (where it determines those) until the end of the mixed gc phase.

Mixed gc phase ends when the amount of space that can be reclaimed in the java heap with the remaining collection set candidates is smaller than G1HeapWastePercent of the (current) heap capacity.

This means that in some cases a significant amount of memory is used for regions that will never be evacuated. In addition to that, maintaining the remembered sets for these never evacuated regions uses execution time and more memory for the remembered set.

In fact, in some cases, it can happen that in the first few mixed gcs of a mixed gc phase, remembered set memory consumption *increases* even though the remembered sets of recently evacuated old gen regions are freed.

The proposed alternative is to prune the collection set candidates as early as possible, filtering out regions that are never going to be evacuated (or have a very low probability).

In some cases doing this can save half of peak remembered set memory usage. 

There are a few drawbacks here that should be considered during evaluation, also comparing against the old heuristic.

* In the old heuristic, G1 checks *at the end* of gc whether the remaining collection set candidates are worth collecting (remaining collectible space < G1HeapWastePercent means: stop). Which helps with ensuring at least some forward progress in evacuating the heap because (assuming there are candidates) at least some space will be reclaimed.
(I do not know whether this behavior as is is intentional for that reason, but it has been there since initial implementation; then it did not really matter because G1 has been maintaining the old gen remembered sets for all regions all the time anyway).
This is approximated by not removing all of the candidates to have at least one "minimal" mixed collection in this change.

* In some cases in the old heuristic G1 would just evacuate all candidate regions (in the extreme in a single gc) if the pause time permitted, reclaiming a bit more space (i.e. that amount < G1HeapWastePercent of the total heap).
You would expect (given the default value of 5), there will be more mixed cycles because of that with the new heuristic. 

Testing: tier1-5, Oracle internal performance test suite

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262185](https://bugs.openjdk.java.net/browse/JDK-8262185): G1: Prune collection set candidates early


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 66736efaf2f7eb001dd92802500113205c608c28
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 62b498df5621b9a75edfa9b447e4c81c85c23b0a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2693/head:pull/2693`
`$ git checkout pull/2693`
