### PR TITLE
8261636: The test mapping in hugetlbfs_sanity_check should consider LargePageSizeInBytes

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3529,14 +3529,18 @@ bool os::Linux::transparent_huge_pages_sanity_check(bool warn,
   return result;
 }
 
+int os::Linux::hugetlbfs_page_size_flag(size_t page_size) {
+  if (page_size != default_large_page_size()) {
+    return (exact_log2(page_size) << MAP_HUGE_SHIFT);
+  }
+  return 0;
+}
+
 bool os::Linux::hugetlbfs_sanity_check(bool warn, size_t page_size) {
   bool result = false;
 
-  int flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB;
-  if (page_size != default_large_page_size()) {
-    flags |= (exact_log2(page_size) << MAP_HUGE_SHIFT);
-  }
-
+  // Include the page size flag to ensure we sanity check the correct page size.
+  int flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB | hugetlbfs_page_size_flag(page_size);
   void *p = mmap(NULL, page_size, PROT_READ|PROT_WRITE, flags, -1, 0);
 
   if (p != MAP_FAILED) {
@@ -3984,10 +3988,9 @@ char* os::Linux::reserve_memory_special_huge_tlbfs_only(size_t bytes,
 
   int prot = exec ? PROT_READ|PROT_WRITE|PROT_EXEC : PROT_READ|PROT_WRITE;
   int flags = MAP_PRIVATE|MAP_ANONYMOUS|MAP_HUGETLB;
+  // Ensure the correct page size flag is used when needed.
+  flags |= hugetlbfs_page_size_flag(os::large_page_size());
 
-  if (os::large_page_size() != default_large_page_size()) {
-    flags |= (exact_log2(os::large_page_size()) << MAP_HUGE_SHIFT);
-  }
   char* addr = (char*)::mmap(req_addr, bytes, prot, flags, -1, 0);
 
   if (addr == MAP_FAILED) {
@@ -4057,11 +4060,7 @@ char* os::Linux::reserve_memory_special_huge_tlbfs_mixed(size_t bytes,
   }
 
   // Commit large-paged area.
-  flags |= MAP_HUGETLB;
-
-  if (os::large_page_size() != default_large_page_size()) {
-    flags |= (exact_log2(os::large_page_size()) << MAP_HUGE_SHIFT);
-  }
+  flags |= MAP_HUGETLB | hugetlbfs_page_size_flag(os::large_page_size());
 
   result = ::mmap(lp_start, lp_bytes, prot, flags, -1, 0);
   if (result == MAP_FAILED) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3531,9 +3531,13 @@ bool os::Linux::transparent_huge_pages_sanity_check(bool warn,
 
 bool os::Linux::hugetlbfs_sanity_check(bool warn, size_t page_size) {
   bool result = false;
-  void *p = mmap(NULL, page_size, PROT_READ|PROT_WRITE,
-                 MAP_ANONYMOUS|MAP_PRIVATE|MAP_HUGETLB,
-                 -1, 0);
+
+  int flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB;
+  if (page_size != default_large_page_size()) {
+    flags |= (exact_log2(page_size) << MAP_HUGE_SHIFT);
+  }
+
+  void *p = mmap(NULL, page_size, PROT_READ|PROT_WRITE, flags, -1, 0);
 
   if (p != MAP_FAILED) {
     // We don't know if this really is a huge page or not.

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -87,6 +87,8 @@ class Linux {
   static bool hugetlbfs_sanity_check(bool warn, size_t page_size);
   static bool shm_hugetlbfs_sanity_check(bool warn, size_t page_size);
 
+  static int hugetlbfs_page_size_flag(size_t page_size);
+
   static char* reserve_memory_special_shm(size_t bytes, size_t alignment, char* req_addr, bool exec);
   static char* reserve_memory_special_huge_tlbfs(size_t bytes, size_t alignment, char* req_addr, bool exec);
   static char* reserve_memory_special_huge_tlbfs_only(size_t bytes, char* req_addr, bool exec);


### PR DESCRIPTION
When explicit large pages are enabled we do a sanity check to test if there are large pages configured. This sanity check just tests if there are any pages available of the systems default large page size. When the flag `LargePageSizeInBytes` is specified the JVM will try to use this large page size for all its mapping, except for the first sanity mapping. This can lead to large pages being disabled because the sanity mapping failed, while there are still plenty of pages available of the size specified by `LargePageSizeInBytes`.

The fix is to simply take the large page size into consideration in the sanity-check, making sure the correct flags are passed when needed.

**Testing**
* Manual testing verifying the problem when for example only 1g pages are available. Before the fix these large pages could not be used (unless the default large page size was changed to 1g or there were also 2m pages configured).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261636](https://bugs.openjdk.java.net/browse/JDK-8261636): The test mapping in hugetlbfs_sanity_check should consider LargePageSizeInBytes


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2695/head:pull/2695`
`$ git checkout pull/2695`
