### PR TITLE
8262266: JDK-8262049 fails validate-source

### DIFF
--- a/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial copyright header fix.
Now passes "make CONF=macosx-x86_64-normal-server-release validate-headers".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262266](https://bugs.openjdk.java.net/browse/JDK-8262266): JDK-8262049 fails validate-source


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2699/head:pull/2699`
`$ git checkout pull/2699`
