### PR TITLE
8139348: Deprecate 3DES and RC4 in Kerberos

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/EType.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/EType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,8 +236,8 @@ public abstract class EType {
             result = BUILTIN_ETYPES;
         }
         if (!allowWeakCrypto) {
-            // The last 2 etypes are now weak ones
-            return Arrays.copyOfRange(result, 0, result.length - 2);
+            // The last 4 etypes are now weak ones
+            return Arrays.copyOfRange(result, 0, result.length - 4);
         }
         return result;
     }

--- a/test/jdk/sun/security/krb5/auto/NewSalt.java
+++ b/test/jdk/sun/security/krb5/auto/NewSalt.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6960894 8194486 8139348
+ * @bug 6960894 8194486
  * @summary Better AS-REQ creation and processing
  * @library /test/lib
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts

--- a/test/jdk/sun/security/krb5/auto/NewSalt.java
+++ b/test/jdk/sun/security/krb5/auto/NewSalt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6960894 8194486
+ * @bug 6960894 8194486 8139348
  * @summary Better AS-REQ creation and processing
  * @library /test/lib
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
@@ -45,7 +45,7 @@ public class NewSalt {
         KDC kdc = new OneKDC(null);
         if (System.getProperty("onlyonepreauth") != null) {
             KDC.saveConfig(OneKDC.KRB5_CONF, kdc,
-                    "default_tgs_enctypes=des3-cbc-sha1");
+                    "default_tgs_enctypes=aes128-sha1");
             Config.refresh();
             kdc.setOption(KDC.Option.ONLY_ONE_PREAUTH, true);
         }

--- a/test/jdk/sun/security/krb5/auto/W83.java
+++ b/test/jdk/sun/security/krb5/auto/W83.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6932525 6951366 6959292 8194486 8139348
+ * @bug 6932525 6951366 6959292 8194486
  * @summary kerberos login failure on win2008 with AD set to win2000 compat mode
  * and cannot login if session key and preauth does not use the same etype
  * @library /test/lib

--- a/test/jdk/sun/security/krb5/auto/W83.java
+++ b/test/jdk/sun/security/krb5/auto/W83.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,16 @@
 
 /*
  * @test
- * @bug 6932525 6951366 6959292 8194486
+ * @bug 6932525 6951366 6959292 8194486 8139348
  * @summary kerberos login failure on win2008 with AD set to win2000 compat mode
  * and cannot login if session key and preauth does not use the same etype
  * @library /test/lib
+ * @compile -XDignore.symbol.file W83.java
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm -D6932525 -Djdk.net.hosts.file=TestHosts W83
  * @run main/othervm -D6959292 -Djdk.net.hosts.file=TestHosts W83
  */
 import com.sun.security.auth.module.Krb5LoginModule;
-import java.io.File;
 import sun.security.krb5.Config;
 import sun.security.krb5.EncryptedData;
 import sun.security.krb5.PrincipalName;
@@ -49,7 +49,8 @@ public class W83 {
         KDC kdc = new KDC(OneKDC.REALM, "127.0.0.1", 0, true);
         kdc.addPrincipal(OneKDC.USER, OneKDC.PASS);
         kdc.addPrincipalRandKey("krbtgt/" + OneKDC.REALM);
-        KDC.saveConfig(OneKDC.KRB5_CONF, kdc);
+        KDC.saveConfig(OneKDC.KRB5_CONF, kdc,
+                "allow_weak_crypto = true");
         System.setProperty("java.security.krb5.conf", OneKDC.KRB5_CONF);
         Config.refresh();
 

--- a/test/jdk/sun/security/krb5/etype/weakcrypto.conf
+++ b/test/jdk/sun/security/krb5/etype/weakcrypto.conf
@@ -1,2 +1,0 @@
-[libdefaults]
-allow_weak_crypto = false

--- a/test/jdk/sun/security/krb5/tools/KtabCheck.java
+++ b/test/jdk/sun/security/krb5/tools/KtabCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import sun.security.krb5.internal.ktab.KeyTabEntry;
 
 /*
  * @test
- * @bug 6950546
+ * @bug 6950546 8139348
  * @summary "ktab -d name etype" to "ktab -d name [-e etype] [kvno | all | old]"
  * @requires os.family == "windows"
  * @library /test/lib
@@ -49,39 +49,42 @@ public class KtabCheck {
 
         Files.deleteIfExists(Path.of(KEYTAB));
 
+        // This test uses a krb5.conf file that only permits
+        // 3 etypes: aes128-cts(17) aes256-cts(18) aes128-sha2(19).
+
         ktab("-a me mine");
-        check(1,16,1,23,1,17);
+        check(1,17,1,18,1,19);
         ktab("-a me mine -n 0");
-        check(0,16,0,23,0,17);
+        check(0,17,0,18,0,19);
         ktab("-a me mine -n 1 -append");
-        check(0,16,0,23,0,17,1,16,1,23,1,17);
+        check(0,17,0,18,0,19,1,17,1,18,1,19);
         ktab("-a me mine -append");
-        check(0,16,0,23,0,17,1,16,1,23,1,17,2,16,2,23,2,17);
+        check(0,17,0,18,0,19,1,17,1,18,1,19,2,17,2,18,2,19);
         ktab("-a me mine");
-        check(3,16,3,23,3,17);
+        check(3,17,3,18,3,19);
         ktab("-a me mine -n 4 -append");
-        check(3,16,3,23,3,17,4,16,4,23,4,17);
+        check(3,17,3,18,3,19,4,17,4,18,4,19);
         ktab("-a me mine -n 5 -append");
-        check(3,16,3,23,3,17,4,16,4,23,4,17,5,16,5,23,5,17);
+        check(3,17,3,18,3,19,4,17,4,18,4,19,5,17,5,18,5,19);
         ktab("-a me mine -n 6 -append");
-        check(3,16,3,23,3,17,4,16,4,23,4,17,5,16,5,23,5,17,6,16,6,23,6,17);
+        check(3,17,3,18,3,19,4,17,4,18,4,19,5,17,5,18,5,19,6,17,6,18,6,19);
         ktab("-d me 3");
-        check(4,16,4,23,4,17,5,16,5,23,5,17,6,16,6,23,6,17);
-        ktab("-d me -e 16 6");
-        check(4,16,4,23,4,17,5,16,5,23,5,17,6,23,6,17);
+        check(4,17,4,18,4,19,5,17,5,18,5,19,6,17,6,18,6,19);
         ktab("-d me -e 17 6");
-        check(4,16,4,23,4,17,5,16,5,23,5,17,6,23);
-        ktab("-d me -e 16 5");
-        check(4,16,4,23,4,17,5,23,5,17,6,23);
+        check(4,17,4,18,4,19,5,17,5,18,5,19,6,18,6,19);
+        ktab("-d me -e 19 6");
+        check(4,17,4,18,4,19,5,17,5,18,5,19,6,18);
+        ktab("-d me -e 17 5");
+        check(4,17,4,18,4,19,5,18,5,19,6,18);
         ktab("-d me old");
-        check(4,16,5,17,6,23);
+        check(4,17,5,19,6,18);
         try {
             ktab("-d me old");
             throw new Exception("Should fail");
         } catch (Exception e) {
             // no-op
         }
-        check(4,16,5,17,6,23);
+        check(4,17,5,19,6,18);
         ktab("-d me");
         check();
     }

--- a/test/jdk/sun/security/krb5/tools/KtabCheck.java
+++ b/test/jdk/sun/security/krb5/tools/KtabCheck.java
@@ -49,8 +49,9 @@ public class KtabCheck {
 
         Files.deleteIfExists(Path.of(KEYTAB));
 
-        // This test uses a krb5.conf file that only permits
-        // 3 etypes: aes128-cts(17) aes256-cts(18) aes128-sha2(19).
+        // This test uses a krb5.conf file (onlythree.conf) in which
+        // only 3 etypes in the default_tkt_enctypes setting are enabled
+        // by default: aes128-cts(17), aes256-cts(18), and aes128-sha2(19).
 
         ktab("-a me mine");
         check(1,17,1,18,1,19);

--- a/test/jdk/sun/security/krb5/tools/onlythree.conf
+++ b/test/jdk/sun/security/krb5/tools/onlythree.conf
@@ -1,6 +1,6 @@
 [libdefaults]
 default_realm = LOCAL.COM
-default_tkt_enctypes = des3-cbc-sha1 rc4-hmac aes128-cts
+default_tkt_enctypes = aes128-cts aes256-cts aes128-sha2
 
 [realms]
 LOCAL.COM = {

--- a/test/jdk/sun/security/krb5/tools/onlythree.conf
+++ b/test/jdk/sun/security/krb5/tools/onlythree.conf
@@ -1,6 +1,6 @@
 [libdefaults]
 default_realm = LOCAL.COM
-default_tkt_enctypes = aes128-cts aes256-cts aes128-sha2
+default_tkt_enctypes = des-cbc-crc des-cbc-md5 des3-cbc-sha1 rc4-hmac aes128-cts aes256-cts aes128-sha2
 
 [realms]
 LOCAL.COM = {


### PR DESCRIPTION
Deprecate des3-hmac-sha1 (etype 16) and rc4-hmac (etype 23). User can add "allow_weak_crypto = true" in krb5.conf to re-enable them (plus the DES-based etypes deprecated long ago).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8139348](https://bugs.openjdk.java.net/browse/JDK-8139348): Deprecate 3DES and RC4 in Kerberos


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 146bc47a2170fd2452d26fee863f7d344f9dd746


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2701/head:pull/2701`
`$ git checkout pull/2701`
