### PR TITLE
JDK-8262269: javadoc test TestGeneratedClasses.java fails on Windows

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -27,8 +27,6 @@
 #
 # javadoc
 
-jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java 8262260 windows-all
-
 ###########################################################################
 #
 # jshell

--- a/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
@@ -63,6 +63,7 @@ public class TestGeneratedClasses extends JavadocTester {
                 """
                     Building tree for all the packages and classes...
                     Generating testClasses/out/m/p/C.html...
-                    Generating testClasses/out/m/p/package-summary.html...""");
+                    Generating testClasses/out/m/p/package-summary.html..."""
+                    .replace("/", FS));
     }
 }


### PR DESCRIPTION
Fix test to work on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262269](https://bugs.openjdk.java.net/browse/JDK-8262269): javadoc test TestGeneratedClasses.java fails on Windows


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2702/head:pull/2702`
`$ git checkout pull/2702`
