### PR TITLE
8261804: Remove field _processing_is_mt, calculate it instead

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1794,12 +1794,9 @@ void G1CollectedHeap::ref_processing_init() {
   //     * Discovery is atomic - i.e. not concurrent.
   //     * Reference discovery will not need a barrier.
 
-  bool mt_processing = ParallelRefProcEnabled && (ParallelGCThreads > 1);
-
   // Concurrent Mark ref processor
   _ref_processor_cm =
     new ReferenceProcessor(&_is_subject_to_discovery_cm,
-                           mt_processing,                                  // mt processing
                            ParallelGCThreads,                              // degree of mt processing
                            (ParallelGCThreads > 1) || (ConcGCThreads > 1), // mt discovery
                            MAX2(ParallelGCThreads, ConcGCThreads),         // degree of mt discovery
@@ -1810,7 +1807,6 @@ void G1CollectedHeap::ref_processing_init() {
   // STW ref processor
   _ref_processor_stw =
     new ReferenceProcessor(&_is_subject_to_discovery_stw,
-                           mt_processing,                        // mt processing
                            ParallelGCThreads,                    // degree of mt processing
                            (ParallelGCThreads > 1),              // mt discovery
                            ParallelGCThreads,                    // degree of mt discovery

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -858,7 +858,6 @@ public:
     BoolObjectClosure* is_subject_to_discovery,
     BoolObjectClosure* is_alive_non_header) :
       ReferenceProcessor(is_subject_to_discovery,
-      ParallelRefProcEnabled && (ParallelGCThreads > 1), // mt processing
       ParallelGCThreads,   // mt processing degree
       true,                // mt discovery
       ParallelGCThreads,   // mt discovery degree

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -822,7 +822,6 @@ void PSScavenge::initialize() {
   _span_based_discoverer.set_span(young_gen->reserved());
   _ref_processor =
     new ReferenceProcessor(&_span_based_discoverer,
-                           ParallelRefProcEnabled && (ParallelGCThreads > 1), // mt processing
                            ParallelGCThreads,          // mt processing degree
                            true,                       // mt discovery
                            ParallelGCThreads,          // mt discovery degree

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -26,9 +26,9 @@
 #include "classfile/javaClasses.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
-#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/referencePolicy.hpp"
 #include "gc/shared/referenceProcessor.inline.hpp"
 #include "gc/shared/referenceProcessorPhaseTimes.hpp"
@@ -137,6 +137,10 @@ void ReferenceProcessor::verify_no_references_recorded() {
   }
 }
 #endif
+
+bool ReferenceProcessor::processing_is_mt() const {
+  return ParallelRefProcEnabled && _num_queues > 1;
+}
 
 void ReferenceProcessor::weak_oops_do(OopClosure* f) {
   for (uint i = 0; i < _max_num_queues * number_of_subclasses_of_ref(); i++) {

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -93,7 +93,6 @@ void ReferenceProcessor::enable_discovery(bool check_no_refs) {
 }
 
 ReferenceProcessor::ReferenceProcessor(BoolObjectClosure* is_subject_to_discovery,
-                                       bool      mt_processing,
                                        uint      mt_processing_degree,
                                        bool      mt_discovery,
                                        uint      mt_discovery_degree,
@@ -103,7 +102,6 @@ ReferenceProcessor::ReferenceProcessor(BoolObjectClosure* is_subject_to_discover
   _is_subject_to_discovery(is_subject_to_discovery),
   _discovering_refs(false),
   _enqueuing_is_done(false),
-  _processing_is_mt(mt_processing),
   _next_id(0),
   _adjust_no_of_processing_threads(adjust_no_of_processing_threads),
   _is_alive_non_header(is_alive_non_header)
@@ -657,7 +655,7 @@ void ReferenceProcessor::set_active_mt_degree(uint v) {
 }
 
 bool ReferenceProcessor::need_balance_queues(DiscoveredList refs_lists[]) {
-  assert(_processing_is_mt, "why balance non-mt processing?");
+  assert(processing_is_mt(), "why balance non-mt processing?");
   // _num_queues is the processing degree.  Only list entries up to
   // _num_queues will be processed, so any non-empty lists beyond
   // that must be redistributed to lists in that range.  Even if not
@@ -679,7 +677,7 @@ bool ReferenceProcessor::need_balance_queues(DiscoveredList refs_lists[]) {
 }
 
 void ReferenceProcessor::maybe_balance_queues(DiscoveredList refs_lists[]) {
-  assert(_processing_is_mt, "Should not call this otherwise");
+  assert(processing_is_mt(), "Should not call this otherwise");
   if (need_balance_queues(refs_lists)) {
     balance_queues(refs_lists);
   }
@@ -774,11 +772,11 @@ void ReferenceProcessor::process_soft_ref_reconsider(BoolObjectClosure* is_alive
                                                      VoidClosure* complete_gc,
                                                      AbstractRefProcTaskExecutor* task_executor,
                                                      ReferenceProcessorPhaseTimes* phase_times) {
-  assert(!_processing_is_mt || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
+  assert(!processing_is_mt() || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
 
   size_t const num_soft_refs = total_count(_discoveredSoftRefs);
   phase_times->set_ref_discovered(REF_SOFT, num_soft_refs);
-  phase_times->set_processing_is_mt(_processing_is_mt);
+  phase_times->set_processing_is_mt(processing_is_mt());
 
   if (num_soft_refs == 0) {
     log_debug(gc, ref)("Skipped phase 1 of Reference Processing: no references");
@@ -792,7 +790,7 @@ void ReferenceProcessor::process_soft_ref_reconsider(BoolObjectClosure* is_alive
 
   RefProcMTDegreeAdjuster a(this, RefPhase1, num_soft_refs);
 
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(RefPhase1, phase_times);
     maybe_balance_queues(_discoveredSoftRefs);
   }
@@ -800,7 +798,7 @@ void ReferenceProcessor::process_soft_ref_reconsider(BoolObjectClosure* is_alive
   RefProcPhaseTimeTracker tt(RefPhase1, phase_times);
 
   log_reflist("Phase 1 Soft before", _discoveredSoftRefs, _max_num_queues);
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcPhase1Task phase1(*this, phase_times, _current_soft_ref_policy);
     task_executor->execute(phase1, num_queues());
   } else {
@@ -822,7 +820,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(BoolObjectClosure* is_aliv
                                                       VoidClosure* complete_gc,
                                                       AbstractRefProcTaskExecutor*  task_executor,
                                                       ReferenceProcessorPhaseTimes* phase_times) {
-  assert(!_processing_is_mt || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
+  assert(!processing_is_mt() || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
 
   size_t const num_soft_refs = total_count(_discoveredSoftRefs);
   size_t const num_weak_refs = total_count(_discoveredWeakRefs);
@@ -831,7 +829,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(BoolObjectClosure* is_aliv
   phase_times->set_ref_discovered(REF_WEAK, num_weak_refs);
   phase_times->set_ref_discovered(REF_FINAL, num_final_refs);
 
-  phase_times->set_processing_is_mt(_processing_is_mt);
+  phase_times->set_processing_is_mt(processing_is_mt());
 
   if (num_total_refs == 0) {
     log_debug(gc, ref)("Skipped phase 2 of Reference Processing: no references");
@@ -840,7 +838,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(BoolObjectClosure* is_aliv
 
   RefProcMTDegreeAdjuster a(this, RefPhase2, num_total_refs);
 
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(RefPhase2, phase_times);
     maybe_balance_queues(_discoveredSoftRefs);
     maybe_balance_queues(_discoveredWeakRefs);
@@ -852,7 +850,7 @@ void ReferenceProcessor::process_soft_weak_final_refs(BoolObjectClosure* is_aliv
   log_reflist("Phase 2 Soft before", _discoveredSoftRefs, _max_num_queues);
   log_reflist("Phase 2 Weak before", _discoveredWeakRefs, _max_num_queues);
   log_reflist("Phase 2 Final before", _discoveredFinalRefs, _max_num_queues);
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcPhase2Task phase2(*this, phase_times);
     task_executor->execute(phase2, num_queues());
   } else {
@@ -898,11 +896,11 @@ void ReferenceProcessor::process_final_keep_alive(OopClosure* keep_alive,
                                                   VoidClosure* complete_gc,
                                                   AbstractRefProcTaskExecutor*  task_executor,
                                                   ReferenceProcessorPhaseTimes* phase_times) {
-  assert(!_processing_is_mt || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
+  assert(!processing_is_mt() || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
 
   size_t const num_final_refs = total_count(_discoveredFinalRefs);
 
-  phase_times->set_processing_is_mt(_processing_is_mt);
+  phase_times->set_processing_is_mt(processing_is_mt());
 
   if (num_final_refs == 0) {
     log_debug(gc, ref)("Skipped phase 3 of Reference Processing: no references");
@@ -911,7 +909,7 @@ void ReferenceProcessor::process_final_keep_alive(OopClosure* keep_alive,
 
   RefProcMTDegreeAdjuster a(this, RefPhase3, num_final_refs);
 
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(RefPhase3, phase_times);
     maybe_balance_queues(_discoveredFinalRefs);
   }
@@ -920,7 +918,7 @@ void ReferenceProcessor::process_final_keep_alive(OopClosure* keep_alive,
   // . Traverse referents of final references and keep them and followers alive.
   RefProcPhaseTimeTracker tt(RefPhase3, phase_times);
 
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcPhase3Task phase3(*this, phase_times);
     task_executor->execute(phase3, num_queues());
   } else {
@@ -937,12 +935,12 @@ void ReferenceProcessor::process_phantom_refs(BoolObjectClosure* is_alive,
                                               VoidClosure* complete_gc,
                                               AbstractRefProcTaskExecutor* task_executor,
                                               ReferenceProcessorPhaseTimes* phase_times) {
-  assert(!_processing_is_mt || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
+  assert(!processing_is_mt() || task_executor != NULL, "Task executor must not be NULL when mt processing is set.");
 
   size_t const num_phantom_refs = total_count(_discoveredPhantomRefs);
-  phase_times->set_ref_discovered(REF_PHANTOM, num_phantom_refs);
 
-  phase_times->set_processing_is_mt(_processing_is_mt);
+  phase_times->set_ref_discovered(REF_PHANTOM, num_phantom_refs);
+  phase_times->set_processing_is_mt(processing_is_mt());
 
   if (num_phantom_refs == 0) {
     log_debug(gc, ref)("Skipped phase 4 of Reference Processing: no references");
@@ -951,7 +949,7 @@ void ReferenceProcessor::process_phantom_refs(BoolObjectClosure* is_alive,
 
   RefProcMTDegreeAdjuster a(this, RefPhase4, num_phantom_refs);
 
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcBalanceQueuesTimeTracker tt(RefPhase4, phase_times);
     maybe_balance_queues(_discoveredPhantomRefs);
   }
@@ -960,7 +958,7 @@ void ReferenceProcessor::process_phantom_refs(BoolObjectClosure* is_alive,
   RefProcPhaseTimeTracker tt(RefPhase4, phase_times);
 
   log_reflist("Phase 4 Phantom before", _discoveredPhantomRefs, _max_num_queues);
-  if (_processing_is_mt) {
+  if (processing_is_mt()) {
     RefProcPhase4Task phase4(*this, phase_times);
     task_executor->execute(phase4, num_queues());
   } else {
@@ -987,7 +985,7 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
   } else {
     // single-threaded discovery, we save in round-robin
     // fashion to each of the lists.
-    if (_processing_is_mt) {
+    if (processing_is_mt()) {
       id = next_id();
     }
   }
@@ -1371,7 +1369,6 @@ RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,
                                                  RefProcPhases phase,
                                                  size_t ref_count):
     _rp(rp),
-    _saved_mt_processing(_rp->processing_is_mt()),
     _saved_num_queues(_rp->num_queues()) {
   if (!_rp->processing_is_mt() || !_rp->adjust_no_of_processing_threads() || (ReferencesPerThread == 0)) {
     return;
@@ -1379,12 +1376,10 @@ RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,
 
   uint workers = ergo_proc_thread_count(ref_count, _rp->num_queues(), phase);
 
-  _rp->set_mt_processing(workers > 1);
   _rp->set_active_mt_degree(workers);
 }
 
 RefProcMTDegreeAdjuster::~RefProcMTDegreeAdjuster() {
   // Revert to previous status.
-  _rp->set_mt_processing(_saved_mt_processing);
   _rp->set_active_mt_degree(_saved_num_queues);
 }

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHARED_REFERENCEPROCESSOR_HPP
 #define SHARE_GC_SHARED_REFERENCEPROCESSOR_HPP
 
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/referenceDiscoverer.hpp"
 #include "gc/shared/referencePolicy.hpp"
 #include "gc/shared/referenceProcessorStats.hpp"
@@ -201,8 +202,6 @@ private:
   bool        _discovery_is_mt;         // true if reference discovery is MT.
 
   bool        _enqueuing_is_done;       // true if all weak references enqueued
-  bool        _processing_is_mt;        // true during phases when
-                                        // reference processing is MT.
   uint        _next_id;                 // round-robin mod _num_queues counter in
                                         // support of work distribution
 
@@ -374,7 +373,7 @@ private:
 public:
   // Default parameters give you a vanilla reference processor.
   ReferenceProcessor(BoolObjectClosure* is_subject_to_discovery,
-                     bool mt_processing = false, uint mt_processing_degree = 1,
+                     uint mt_processing_degree = 1,
                      bool mt_discovery  = false, uint mt_discovery_degree  = 1,
                      bool atomic_discovery = true,
                      BoolObjectClosure* is_alive_non_header = NULL,
@@ -415,8 +414,7 @@ public:
   void set_mt_discovery(bool mt) { _discovery_is_mt = mt; }
 
   // Whether we are in a phase when _processing_ is MT.
-  bool processing_is_mt() const { return _processing_is_mt; }
-  void set_mt_processing(bool mt) { _processing_is_mt = mt; }
+  bool processing_is_mt() const { return ParallelRefProcEnabled && _num_queues > 1; }
 
   // whether all enqueueing of weak references is complete
   bool enqueuing_is_done()  { return _enqueuing_is_done; }
@@ -643,7 +641,6 @@ class RefProcMTDegreeAdjuster : public StackObj {
   typedef ReferenceProcessor::RefProcPhases RefProcPhases;
 
   ReferenceProcessor* _rp;
-  bool                _saved_mt_processing;
   uint                _saved_num_queues;
 
   // Calculate based on total of references.

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_GC_SHARED_REFERENCEPROCESSOR_HPP
 #define SHARE_GC_SHARED_REFERENCEPROCESSOR_HPP
 
-#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/referenceDiscoverer.hpp"
 #include "gc/shared/referencePolicy.hpp"
 #include "gc/shared/referenceProcessorStats.hpp"
@@ -414,7 +413,7 @@ public:
   void set_mt_discovery(bool mt) { _discovery_is_mt = mt; }
 
   // Whether we are in a phase when _processing_ is MT.
-  bool processing_is_mt() const { return ParallelRefProcEnabled && _num_queues > 1; }
+  bool processing_is_mt() const;
 
   // whether all enqueueing of weak references is complete
   bool enqueuing_is_done()  { return _enqueuing_is_done; }


### PR DESCRIPTION
In the reference processor, remove _processing_is_mt. Instead calculate its value in its accessor, processing_is_mt().

This change will remove some state, make RefProcMTDegreeAdjuster a bit simpler and make it much easier to derive when processing is indeed multi threaded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261804](https://bugs.openjdk.java.net/browse/JDK-8261804): Remove field _processing_is_mt, calculate it instead


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 5b80656f00d750378881a832dcbcc8f8815e05b5
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 5b80656f00d750378881a832dcbcc8f8815e05b5


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2704/head:pull/2704`
`$ git checkout pull/2704`
