### PR TITLE
8262299: C2 compilation fails with "modified node was not processed by IGVN.transform_old()"

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -183,13 +183,15 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
   Node* in_mem = in(TypeFunc::Memory);
 
   const Type* src_type = phase->type(base_src);
-
-  MergeMemNode* mem = phase->transform(MergeMemNode::make(in_mem))->as_MergeMem();
-
   const TypeInstPtr* inst_src = src_type->isa_instptr();
-
   if (inst_src == NULL) {
     return NULL;
+  }
+
+  MergeMemNode* mem = phase->transform(MergeMemNode::make(in_mem))->as_MergeMem();
+  PhaseIterGVN* igvn = phase->is_IterGVN();
+  if (igvn != NULL) {
+    igvn->_worklist.push(mem);
   }
 
   if (!inst_src->klass_is_exact()) {


### PR DESCRIPTION
We hit an assert because a dead `MergeMemNode` was not removed. Make sure it's added to the IGVN worklist to give it a chance to be removed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262299](https://bugs.openjdk.java.net/browse/JDK-8262299): C2 compilation fails with "modified node was not processed by IGVN.transform_old()"


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2705/head:pull/2705`
`$ git checkout pull/2705`
