### PR TITLE
8262296 Fix remaining doclint warnings in jdk.httpserver

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -151,7 +151,7 @@ public abstract class Authenticator {
      *     is required. Any response headers needing to be sent back to the client are set
      *     in the given {@code HttpExchange}. The response code to be returned must be
      *     provided in the {@code Retry} object. {@code Retry} may occur multiple times.
-     * <ul/>
+     * </ul>
      *
      * @param exch the {@code HttpExchange} upon which authenticate is called
      * @return the result

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpHandler.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpHandler.java
@@ -42,6 +42,7 @@ public interface HttpHandler {
      * @param exchange the exchange containing the request from the
      *                 client and used to send the response
      * @throws NullPointerException if exchange is {@code null}
+     * @throws IOException if an I/O error occurs
      */
     public abstract void handle (HttpExchange exchange) throws IOException;
 }

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
@@ -26,6 +26,7 @@
 package com.sun.net.httpserver;
 
 import java.net.InetSocketAddress;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 
 /**

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsServer.java
@@ -58,6 +58,7 @@ public abstract class HttpsServer extends HttpServer {
      * must also have a {@code HttpsConfigurator} established with
      * {@link #setHttpsConfigurator(HttpsConfigurator)}.
      *
+     * @return an instance of {@code HttpsServer}
      * @throws IOException if an I/O error occurs
      */
     public static HttpsServer create() throws IOException {
@@ -80,6 +81,7 @@ public abstract class HttpsServer extends HttpServer {
      *             the address
      * @param backlog the socket backlog. If this value is less than or equal to
      *               zero, then a system default value is used.
+     * @return an instance of {@code HttpsServer}
      * @throws BindException if the server cannot bind to the requested address,
      *          or if the server is already bound
      * @throws IOException if an I/O error occurs

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/package-info.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/package-info.java
@@ -26,8 +26,8 @@
 /**
    Provides a simple high-level Http server API, which can be used to build
    embedded HTTP servers. Both "http" and "https" are supported. The API provides
-   a partial implementation of RFC <a href="http://www.ietf.org/rfc/rfc2616.txt">2616</a> (HTTP 1.1)
-   and RFC <a href="http://www.ietf.org/rfc/rfc2818.txt">2818</a> (HTTP over TLS).
+   a partial implementation of RFC <a href="https://www.ietf.org/rfc/rfc2616.txt">2616</a> (HTTP 1.1)
+   and RFC <a href="https://www.ietf.org/rfc/rfc2818.txt">2818</a> (HTTP over TLS).
    Any HTTP functionality not provided by this API can be implemented by application code
    using the API.
    <p>


### PR DESCRIPTION
Trivial clean up of remaining doclint warnings in jdk.httpserver. 

The minor spec clarifications do not amount to a normative change, so no CSR is required (they're documented the obvious and only possible behaviour).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262296](https://bugs.openjdk.java.net/browse/JDK-8262296): Fix remaining doclint warnings in jdk.httpserver


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2706/head:pull/2706`
`$ git checkout pull/2706`
