### PR TITLE
8261914: IfNode::fold_compares_helper faces non-canonicalized bool when running JRuby JSON workload

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -981,6 +981,7 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
       assert(igvn->_worklist.member(in(1)) && in(1)->Value(igvn) != igvn->type(in(1)), "unhandled lo_test: %d", lo_test);
       return false;
     }
+    // this test was canonicalized
     assert(this_bool->_test.is_less() && !fail->_con, "incorrect test");
   } else {
     const TypeInt* failtype = filtered_int_type(igvn, n, proj);

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -884,8 +884,6 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
       hi_type->_hi == max_jint && lo_type->_lo == min_jint && lo_test != BoolTest::ne) {
     assert((dom_bool->_test.is_less() && !proj->_con) ||
            (dom_bool->_test.is_greater() && proj->_con), "incorrect test");
-    // this test was canonicalized
-    assert(this_bool->_test.is_less() && fail->_con, "incorrect test");
 
     // this_bool = <
     //   dom_bool = >= (proj = True) or dom_bool = < (proj = False)
@@ -922,9 +920,11 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
         return false;
       }
     } else {
-      assert(false, "unhandled hi_test: %d", hi_test);
+      assert(igvn->_worklist.member(in(1)) && in(1)->Value(igvn) != igvn->type(in(1)), "unhandled hi_test: %d", hi_test);
       return false;
     }
+    // this test was canonicalized
+    assert(this_bool->_test.is_less() && fail->_con, "incorrect test");
   } else if (lo_type != NULL && hi_type != NULL && lo_type->_lo > hi_type->_hi &&
              lo_type->_hi == max_jint && hi_type->_lo == min_jint && lo_test != BoolTest::ne) {
 
@@ -951,8 +951,6 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
 
     assert((dom_bool->_test.is_less() && proj->_con) ||
            (dom_bool->_test.is_greater() && !proj->_con), "incorrect test");
-    // this test was canonicalized
-    assert(this_bool->_test.is_less() && !fail->_con, "incorrect test");
 
     cond = (hi_test == BoolTest::le || hi_test == BoolTest::gt) ? BoolTest::gt : BoolTest::ge;
 
@@ -980,9 +978,10 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
         return false;
       }
     } else {
-      assert(false, "unhandled lo_test: %d", lo_test);
+      assert(igvn->_worklist.member(in(1)) && in(1)->Value(igvn) != igvn->type(in(1)), "unhandled lo_test: %d", lo_test);
       return false;
     }
+    assert(this_bool->_test.is_less() && !fail->_con, "incorrect test");
   } else {
     const TypeInt* failtype = filtered_int_type(igvn, n, proj);
     if (failtype != NULL) {


### PR DESCRIPTION
The assert fires because the current IfNode's condition was not
canonicalized when it's being folded with a dominating
IfNode. idealize_test() should have taken care of that because it
executed before fold_compares() but it didn't because:

  Node* new_b = phase->transform( new BoolNode(b->in(1), bt.negate()) );
  if( !new_b->is_Bool() ) return NULL;

caused it to bail out. new_b is a constant. This happens because of
the order in which nodes are processed by IGVN. The If's current Bool
would also constant fold but it's in the IGVN worklist and hasn't been
processed yet.

The fix I propose is to keep Aleksey's defensive fix but to check that
the Bool input is indeed about to be transformed by IGVN and that that
would cause the IfNode to be reprocessed.

I tried to write a test case but didn't succeed. The 2 If nodes come
from a tableswitch that's transformed into a series of If based on
profile data. I couldn't reproduce the profile data with a simple test
case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261914](https://bugs.openjdk.java.net/browse/JDK-8261914): IfNode::fold_compares_helper faces non-canonicalized bool when running JRuby JSON workload


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to aa598fb9fae671cf1ebe89a97b128560e5312b36
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to aa598fb9fae671cf1ebe89a97b128560e5312b36


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2707/head:pull/2707`
`$ git checkout pull/2707`
