### PR TITLE
JDK-8262315: missing ';' in generated entities

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/JSpec.java
+++ b/make/jdk/src/classes/build/tools/taglet/JSpec.java
@@ -206,7 +206,7 @@ public class JSpec implements Taglet  {
             private String escape(String s) {
                 return s.replace("&", "&amp;")
                         .replace("<", "&lt;")
-                        .replace(">", "&gt");
+                        .replace(">", "&gt;");
             }
         }).visit(trees, new StringBuilder()).toString();
     }


### PR DESCRIPTION
Fix  typo-by-omission.  A `;` is missing after `&gt`.

This is in the build tools, in the code for the `@jls` taglet, used to generate docs. No change to JDK product code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262315](https://bugs.openjdk.java.net/browse/JDK-8262315): missing ';' in generated entities


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2709/head:pull/2709`
`$ git checkout pull/2709`
