### PR TITLE
8257500: Drawing MultiResolutionImage with ImageObserver "leaks" memory

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
+++ b/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
@@ -126,6 +126,10 @@ public class MultiResolutionToolkitImage extends ToolkitImage implements MultiRe
             ImageObserver observer = observerRef.get();
             Image image = imageRef.get();
 
+            if (observer == null || image == null) {
+                return false;
+            }
+
             if ((infoflags & (ImageObserver.WIDTH | BITS_INFO)) != 0) {
                 width = (width + 1) / 2;
             }

--- a/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
+++ b/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
+++ b/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
@@ -95,14 +95,14 @@ public class MultiResolutionToolkitImage extends ToolkitImage implements MultiRe
             final int imgWidth, final int imgHeight,
             final int rvWidth, final int rvHeight, boolean concatenateInfo) {
 
-//        if (observer == null) {
+        if (observer == null) {
             return null;
-//        }
-//
-//        synchronized (ObserverCache.INSTANCE) {
-//            return ObserverCache.INSTANCE.computeIfAbsent(observer,
-//                    key -> new ObserverCache(key, concatenateInfo, image));
-//        }
+        }
+
+        synchronized (ObserverCache.INSTANCE) {
+            return ObserverCache.INSTANCE.computeIfAbsent(observer,
+                    key -> new ObserverCache(key, concatenateInfo, image));
+        }
     }
 
     private static final class ObserverCache implements ImageObserver {

--- a/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
+++ b/src/java.desktop/share/classes/sun/awt/image/MultiResolutionToolkitImage.java
@@ -22,15 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package sun.awt.image;
 
 import java.awt.Image;
 import java.awt.image.ImageObserver;
 import java.awt.image.MultiResolutionImage;
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.function.Function;
-import sun.awt.SoftCache;
 
 public class MultiResolutionToolkitImage extends ToolkitImage implements MultiResolutionImage {
 
@@ -79,12 +82,6 @@ public class MultiResolutionToolkitImage extends ToolkitImage implements MultiRe
     private static final int BITS_INFO = ImageObserver.SOMEBITS
             | ImageObserver.FRAMEBITS | ImageObserver.ALLBITS;
 
-    private static class ObserverCache {
-
-        @SuppressWarnings("deprecation")
-        static final SoftCache INSTANCE = new SoftCache();
-    }
-
     public static ImageObserver getResolutionVariantObserver(
             final Image image, final ImageObserver observer,
             final int imgWidth, final int imgHeight,
@@ -98,43 +95,54 @@ public class MultiResolutionToolkitImage extends ToolkitImage implements MultiRe
             final int imgWidth, final int imgHeight,
             final int rvWidth, final int rvHeight, boolean concatenateInfo) {
 
-        if (observer == null) {
+//        if (observer == null) {
             return null;
+//        }
+//
+//        synchronized (ObserverCache.INSTANCE) {
+//            return ObserverCache.INSTANCE.computeIfAbsent(observer,
+//                    key -> new ObserverCache(key, concatenateInfo, image));
+//        }
+    }
+
+    private static final class ObserverCache implements ImageObserver {
+
+        private static final Map<ImageObserver, ImageObserver> INSTANCE =
+                new WeakHashMap<>();
+
+        private final boolean concat;
+        private final WeakReference<Image> imageRef;
+        private final WeakReference<ImageObserver> observerRef;
+
+        private ObserverCache(ImageObserver obs, boolean concat, Image img) {
+            this.concat = concat;
+            imageRef = new WeakReference<>(img);
+            observerRef = new WeakReference<>(obs);
         }
 
-        synchronized (ObserverCache.INSTANCE) {
-            ImageObserver o = (ImageObserver) ObserverCache.INSTANCE.get(observer);
+        @Override
+        public boolean imageUpdate(Image img, int infoflags,
+                                   int x, int y, int width, int height) {
+            ImageObserver observer = observerRef.get();
+            Image image = imageRef.get();
 
-            if (o == null) {
-
-                o = (Image resolutionVariant, int flags,
-                        int x, int y, int width, int height) -> {
-
-                            if ((flags & (ImageObserver.WIDTH | BITS_INFO)) != 0) {
-                                width = (width + 1) / 2;
-                            }
-
-                            if ((flags & (ImageObserver.HEIGHT | BITS_INFO)) != 0) {
-                                height = (height + 1) / 2;
-                            }
-
-                            if ((flags & BITS_INFO) != 0) {
-                                x /= 2;
-                                y /= 2;
-                            }
-
-                            if(concatenateInfo){
-                                flags &= ((ToolkitImage) image).
-                                        getImageRep().check(null);
-                            }
-
-                            return observer.imageUpdate(
-                                    image, flags, x, y, width, height);
-                        };
-
-                ObserverCache.INSTANCE.put(observer, o);
+            if ((infoflags & (ImageObserver.WIDTH | BITS_INFO)) != 0) {
+                width = (width + 1) / 2;
             }
-            return o;
+
+            if ((infoflags & (ImageObserver.HEIGHT | BITS_INFO)) != 0) {
+                height = (height + 1) / 2;
+            }
+
+            if ((infoflags & BITS_INFO) != 0) {
+                x /= 2;
+                y /= 2;
+            }
+
+            if (concat) {
+                infoflags &= ((ToolkitImage) image).getImageRep().check(null);
+            }
+            return observer.imageUpdate(image, infoflags, x, y, width, height);
         }
     }
 }

--- a/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
+++ b/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BaseMultiResolutionImage;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+
+/*
+ * @test
+ * @bug 8257500
+ * @summary Drawing MultiResolutionImage with ImageObserver may "leaks" memory
+ */
+public final class ImageObserverLeak {
+
+    public static void main(String[] args) throws Exception {
+        Reference<ImageObserver> ref = test();
+
+        while (!ref.refersTo(null)) {
+            Thread.sleep(500);
+            System.gc();
+        }
+    }
+
+    private static Reference<ImageObserver> test() throws Exception {
+        BufferedImage src = new BufferedImage(200, 200, TYPE_INT_RGB);
+        Image mri = new BaseMultiResolutionImage(src);
+        ImageObserver observer = new ImageObserver() {
+            @Override
+            public boolean imageUpdate(Image img, int infoflags, int x, int y,
+                                       int width, int height) {
+                return false;
+            }
+        };
+        Reference<ImageObserver> ref = new WeakReference<>(observer);
+
+        BufferedImage dst = new BufferedImage(200, 300, TYPE_INT_RGB);
+        Graphics2D g2d = dst.createGraphics();
+        g2d.drawImage(mri, 0, 0, observer);
+        g2d.dispose();
+        return ref;
+    }
+}

--- a/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
+++ b/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
@@ -43,6 +43,7 @@ public final class ImageObserverLeak {
 
         while (!ref.refersTo(null)) {
             Thread.sleep(500);
+            // Cannot generate OOM here, it will clear the SoftRefs as well
             System.gc();
         }
     }

--- a/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
+++ b/test/jdk/java/awt/image/multiresolution/ImageObserverLeak.java
@@ -31,7 +31,7 @@ import java.lang.ref.WeakReference;
 
 import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
-/*
+/**
  * @test
  * @bug 8257500
  * @summary Drawing MultiResolutionImage with ImageObserver may "leaks" memory

--- a/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
@@ -36,7 +36,7 @@ import sun.awt.image.MultiResolutionToolkitImage;
 /**
  * @test
  * @key headful
- * @bug 8040291
+ * @bug 8040291 8257500
  * @requires os.family == "mac"
  * @summary [macosx] Http-Images are not fully loaded when using ImageIcon
  * @modules java.desktop/sun.awt

--- a/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,21 @@
 
 import java.awt.Color;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
+import static java.awt.image.ImageObserver.ALLBITS;
 import java.io.File;
-
 import javax.imageio.ImageIO;
-
 import sun.awt.OSInfo;
 import sun.awt.SunToolkit;
 import sun.awt.image.MultiResolutionToolkitImage;
-
-import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
 /**
  * @test
  * @key headful
  * @bug 8040291
- * @requires os.family == "mac"
  * @author Alexander Scherbatiy
  * @summary [macosx] Http-Images are not fully loaded when using ImageIcon
  * @modules java.desktop/sun.awt
@@ -59,6 +54,8 @@ public class MultiResolutionToolkitImageTest {
     private static final String IMAGE_NAME_1X = "image.png";
     private static final String IMAGE_NAME_2X = "image@2x.png";
     private static final int WAIT_TIME = 400;
+    private static volatile boolean isImageLoaded = false;
+    private static volatile boolean isRVObserverCalled = false;
 
     public static void main(String[] args) throws Exception {
 
@@ -67,33 +64,6 @@ public class MultiResolutionToolkitImageTest {
         }
         generateImages();
         testToolkitMultiResolutionImageLoad();
-        testToolkitMultiResolutionImageLoadOnDraw();
-    }
-
-    static void testToolkitMultiResolutionImageLoadOnDraw() throws Exception {
-        File imageFile = new File(IMAGE_NAME_1X);
-        String fileName = imageFile.getAbsolutePath();
-        Image src = Toolkit.getDefaultToolkit().getImage(fileName);
-        System.out.println("src = " + src);
-        LoadImageObserver observer = new LoadImageObserver();
-        BufferedImage dst = new BufferedImage(200, 300, TYPE_INT_RGB);
-        Graphics2D g2d = dst.createGraphics();
-        g2d.drawImage(src, 0, 0, observer);
-        g2d.dispose();
-
-        final long time = WAIT_TIME + System.currentTimeMillis();
-        while ((!observer.isImageLoaded || !observer.isRVObserverCalled)
-                && System.currentTimeMillis() < time) {
-            Thread.sleep(50);
-        }
-
-        if(!observer.isImageLoaded){
-            throw new RuntimeException("Image is not loaded!");
-        }
-
-        if(!observer.isRVObserverCalled){
-            throw new RuntimeException("Resolution Variant observer is not called!");
-        }
     }
 
     static void testToolkitMultiResolutionImageLoad() throws Exception {
@@ -101,20 +71,19 @@ public class MultiResolutionToolkitImageTest {
         String fileName = imageFile.getAbsolutePath();
         Image image = Toolkit.getDefaultToolkit().getImage(fileName);
         SunToolkit toolkit = (SunToolkit) Toolkit.getDefaultToolkit();
-        LoadImageObserver observer = new LoadImageObserver();
-        toolkit.prepareImage(image, -1, -1, observer);
+        toolkit.prepareImage(image, -1, -1, new LoadImageObserver());
 
         final long time = WAIT_TIME + System.currentTimeMillis();
-        while ((!observer.isImageLoaded || !observer.isRVObserverCalled)
+        while ((!isImageLoaded || !isRVObserverCalled)
                 && System.currentTimeMillis() < time) {
             Thread.sleep(50);
         }
 
-        if(!observer.isImageLoaded){
+        if(!isImageLoaded){
             throw new RuntimeException("Image is not loaded!");
         }
 
-        if(!observer.isRVObserverCalled){
+        if(!isRVObserverCalled){
             throw new RuntimeException("Resolution Variant observer is not called!");
         }
     }
@@ -145,9 +114,6 @@ public class MultiResolutionToolkitImageTest {
 
     static class LoadImageObserver implements ImageObserver {
 
-        volatile boolean isImageLoaded;
-        volatile boolean isRVObserverCalled;
-
         @Override
         public boolean imageUpdate(Image img, int infoflags, int x, int y,
                 int width, int height) {
@@ -174,7 +140,7 @@ public class MultiResolutionToolkitImageTest {
         Exception e = new Exception();
 
         for (StackTraceElement elem : e.getStackTrace()) {
-            if (elem.getClassName().endsWith("MultiResolutionToolkitImage")) {
+            if (elem.getClassName().endsWith("ObserverCache")) {
                 return true;
             }
         }

--- a/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiResolutionToolkitImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
-import static java.awt.image.ImageObserver.ALLBITS;
 import java.io.File;
 import javax.imageio.ImageIO;
 import sun.awt.OSInfo;
@@ -38,13 +37,12 @@ import sun.awt.image.MultiResolutionToolkitImage;
  * @test
  * @key headful
  * @bug 8040291
- * @author Alexander Scherbatiy
+ * @requires os.family == "mac"
  * @summary [macosx] Http-Images are not fully loaded when using ImageIcon
  * @modules java.desktop/sun.awt
  *          java.desktop/sun.awt.image
  * @run main MultiResolutionToolkitImageTest
  */
-
 public class MultiResolutionToolkitImageTest {
 
     private static final int IMAGE_WIDTH = 300;


### PR DESCRIPTION
This bug was reported as a leak of the ImageObserver when the user draws a multiresolution image.

The multiresolution image is an image that contains a few images inside, when the app uses the observer to get notifications about image loading we create a special internal observer and use it to track loading resolution-variants. This internal observer forwards notification from the resolution variant to the application observer.

The mapping from the application observer to the internal observer is done via "SoftCache" which is a kind of HashMap that uses soft references to the key and value.

Here the bug comes, the soft references are cleared only under memory pressure, and unused objects may sit hours in memory before being cleaned. Moreover, the internal observer was implemented using a strong reference to the application observer(it is not obvious since the lambda is used). So the key object refers to the application's observer cannot be clear fast. This causes an even longer delay of the memory cleanup, which was considered by the use as a "leak".

The fix changes the usage of SoftCache to the WeakHashMap, so the key(the application observer) will be cleared when the application lost the reference to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257500](https://bugs.openjdk.java.net/browse/JDK-8257500): Drawing MultiResolutionImage with ImageObserver "leaks" memory


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2711/head:pull/2711`
`$ git checkout pull/2711`
