### PR TITLE
8262227: Change SystemDictionary::find() to return an InstanceKlass*.

### DIFF
--- a/src/hotspot/share/aot/aotCodeHeap.cpp
+++ b/src/hotspot/share/aot/aotCodeHeap.cpp
@@ -112,8 +112,7 @@ Klass* AOTCodeHeap::lookup_klass(const char* name, int len, const Method* method
     log_debug(aot, class, resolve)("Probe failed for AOT class %s", name);
     return NULL;
   }
-  Klass* k = SystemDictionary::find_instance_or_array_klass(sym, loader, protection_domain, thread);
-  assert(!thread->has_pending_exception(), "should not throw");
+  Klass* k = SystemDictionary::find_instance_or_array_klass(sym, loader, protection_domain);
 
   if (k != NULL) {
     log_info(aot, class, resolve)("%s %s (lookup)", caller->method_holder()->external_name(), k->external_name());

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -304,10 +304,10 @@ ciInstance* ciEnv::get_or_create_exception(jobject& handle, Symbol* name) {
   VM_ENTRY_MARK;
   if (handle == NULL) {
     // Cf. universe.cpp, creation of Universe::_null_ptr_exception_instance.
-    Klass* k = SystemDictionary::find(name, Handle(), Handle(), THREAD);
+    InstanceKlass* ik = SystemDictionary::find_instance_klass(name, Handle(), Handle());
     jobject objh = NULL;
-    if (!HAS_PENDING_EXCEPTION && k != NULL) {
-      oop obj = InstanceKlass::cast(k)->allocate_instance(THREAD);
+    if (ik != NULL) {
+      oop obj = ik->allocate_instance(THREAD);
       if (!HAS_PENDING_EXCEPTION)
         objh = JNIHandles::make_global(Handle(THREAD, obj));
     }
@@ -448,8 +448,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
       kls = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader,
                                                                        CHECK_AND_CLEAR_(fail_type));
     } else {
-      kls = SystemDictionary::find_instance_or_array_klass(sym, loader, domain,
-                                                           CHECK_AND_CLEAR_(fail_type));
+      kls = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }
     found_klass = kls;
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -899,16 +899,15 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
 // _dictionary->bucket(index) is read here, so the caller will not see
 // the new entry.
 
-Klass* SystemDictionary::find(Symbol* class_name,
-                              Handle class_loader,
-                              Handle protection_domain,
-                              TRAPS) {
+InstanceKlass* SystemDictionary::find_instance_klass(Symbol* class_name,
+                                                     Handle class_loader,
+                                                     Handle protection_domain) {
 
   // The result of this call should be consistent with the result
   // of the call to resolve_instance_class_or_null().
   // See evaluation 6790209 and 4474172 for more details.
-  class_loader = Handle(THREAD, java_lang_ClassLoader::non_reflection_class_loader(class_loader()));
-  ClassLoaderData* loader_data = ClassLoaderData::class_loader_data_or_null(class_loader());
+  oop class_loader_oop = java_lang_ClassLoader::non_reflection_class_loader(class_loader());
+  ClassLoaderData* loader_data = ClassLoaderData::class_loader_data_or_null(class_loader_oop);
 
   if (loader_data == NULL) {
     // If the ClassLoaderData has not been setup,
@@ -918,16 +917,14 @@ Klass* SystemDictionary::find(Symbol* class_name,
 
   Dictionary* dictionary = loader_data->dictionary();
   unsigned int name_hash = dictionary->compute_hash(class_name);
-  return dictionary->find(name_hash, class_name,
-                          protection_domain);
+  return dictionary->find(name_hash, class_name, protection_domain);
 }
 
 // Look for a loaded instance or array klass by name.  Do not do any loading.
 // return NULL in case of error.
 Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
                                                       Handle class_loader,
-                                                      Handle protection_domain,
-                                                      TRAPS) {
+                                                      Handle protection_domain) {
   Klass* k = NULL;
   assert(class_name != NULL, "class name must be non NULL");
 
@@ -941,13 +938,13 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
     if (t != T_OBJECT) {
       k = Universe::typeArrayKlassObj(t);
     } else {
-      k = SystemDictionary::find(ss.as_symbol(), class_loader, protection_domain, THREAD);
+      k = SystemDictionary::find_instance_klass(ss.as_symbol(), class_loader, protection_domain);
     }
     if (k != NULL) {
       k = k->array_klass_or_null(ndims);
     }
   } else {
-    k = find(class_name, class_loader, protection_domain, THREAD);
+    k = find_instance_klass(class_name, class_loader, protection_domain);
   }
   return k;
 }
@@ -1219,7 +1216,7 @@ bool SystemDictionary::check_shared_class_super_type(InstanceKlass* klass, Insta
   if (!super_type->is_shared_unregistered_class() && super_type->class_loader_data() != NULL) {
     // Check if the super class is loaded by the current class_loader
     Symbol* name = super_type->name();
-    Klass* check = find(name, class_loader, protection_domain, CHECK_0);
+    InstanceKlass* check = find_instance_klass(name, class_loader, protection_domain);
     if (check == super_type) {
       return true;
     }
@@ -1897,7 +1894,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
   // Force the protection domain to be null.  (This removes protection checks.)
   Handle no_protection_domain;
   Klass* klass = find_instance_or_array_klass(class_name, class_loader,
-                                              no_protection_domain, CHECK_NULL);
+                                              no_protection_domain);
   if (klass != NULL)
     return klass;
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -139,15 +139,14 @@ class SystemDictionary : AllStatic {
                                             TRAPS);
 
   // Lookup an already loaded class. If not found NULL is returned.
-  static Klass* find(Symbol* class_name, Handle class_loader, Handle protection_domain, TRAPS);
+  static InstanceKlass* find_instance_klass(Symbol* class_name, Handle class_loader, Handle protection_domain);
 
   // Lookup an already loaded instance or array class.
   // Do not make any queries to class loaders; consult only the cache.
   // If not found NULL is returned.
   static Klass* find_instance_or_array_klass(Symbol* class_name,
                                              Handle class_loader,
-                                             Handle protection_domain,
-                                             TRAPS);
+                                             Handle protection_domain);
 
   // Lookup an instance or array class that has already been loaded
   // either into the given class loader, or else into another class

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -1513,7 +1513,7 @@ static bool is_retransforming(const InstanceKlass* ik, TRAPS) {
   assert(name != NULL, "invariant");
   Handle class_loader(THREAD, ik->class_loader());
   Handle protection_domain(THREAD, ik->protection_domain());
-  return SystemDictionary::find(name, class_loader, protection_domain, THREAD) != NULL;
+  return SystemDictionary::find_instance_klass(name, class_loader, protection_domain) != NULL;
 }
 
 // target for JFR_ON_KLASS_CREATION hook

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -547,16 +547,17 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, jcla
       // This is a name from a signature.  Strip off the trimmings.
       // Call recursive to keep scope of strippedsym.
       TempNewSymbol strippedsym = Signature::strip_envelope(class_name);
-      resolved_klass = SystemDictionary::find(strippedsym, class_loader, protection_domain, CHECK_NULL);
+      resolved_klass = SystemDictionary::find_instance_klass(strippedsym,
+                                                             class_loader,
+                                                             protection_domain);
     } else if (Signature::is_array(class_name)) {
       SignatureStream ss(class_name, false);
       int ndim = ss.skip_array_prefix();
       if (ss.type() == T_OBJECT) {
         Symbol* strippedsym = ss.as_symbol();
-        resolved_klass = SystemDictionary::find(strippedsym,
-                                                class_loader,
-                                                protection_domain,
-                                                CHECK_NULL);
+        resolved_klass = SystemDictionary::find_instance_klass(strippedsym,
+                                                               class_loader,
+                                                               protection_domain);
         if (!resolved_klass.is_null()) {
           resolved_klass = resolved_klass->array_klass(ndim, CHECK_NULL);
         }
@@ -564,7 +565,9 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, jcla
         resolved_klass = TypeArrayKlass::cast(Universe::typeArrayKlassObj(ss.type()))->array_klass(ndim, CHECK_NULL);
       }
     } else {
-      resolved_klass = SystemDictionary::find(class_name, class_loader, protection_domain, CHECK_NULL);
+      resolved_klass = SystemDictionary::find_instance_klass(class_name,
+                                                             class_loader,
+                                                             protection_domain);
     }
   }
   JVMCIObject result = JVMCIENV->get_jvmci_type(resolved_klass, JVMCI_CHECK_NULL);

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1162,7 +1162,7 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
     if (!require_local) {
       found_klass = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader, CHECK_NULL);
     } else {
-      found_klass = SystemDictionary::find_instance_or_array_klass(sym, loader, domain, CHECK_NULL);
+      found_klass = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }
   }
 

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -582,7 +582,7 @@ Klass* ConstantPool::klass_at_if_loaded(const constantPoolHandle& this_cp, int w
     oop protection_domain = this_cp->pool_holder()->protection_domain();
     Handle h_prot (thread, protection_domain);
     Handle h_loader (thread, loader);
-    Klass* k = SystemDictionary::find(name, h_loader, h_prot, thread);
+    Klass* k = SystemDictionary::find_instance_klass(name, h_loader, h_prot);
 
     // Avoid constant pool verification at a safepoint, which takes the Module_lock.
     if (k != NULL && !SafepointSynchronize::is_at_safepoint()) {

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -891,7 +891,7 @@ bool Method::is_klass_loaded_by_klass_index(int klass_index) const {
     Symbol* klass_name = constants()->klass_name_at(klass_index);
     Handle loader(thread, method_holder()->class_loader());
     Handle prot  (thread, method_holder()->protection_domain());
-    return SystemDictionary::find(klass_name, loader, prot, thread) != NULL;
+    return SystemDictionary::find_instance_klass(klass_name, loader, prot) != NULL;
   } else {
     return true;
   }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1070,8 +1070,7 @@ JVM_ENTRY(jclass, JVM_FindLoadedClass(JNIEnv *env, jobject loader, jstring name)
   Handle h_loader(THREAD, JNIHandles::resolve(loader));
   Klass* k = SystemDictionary::find_instance_or_array_klass(klass_name,
                                                               h_loader,
-                                                              Handle(),
-                                                              CHECK_NULL);
+                                                              Handle());
 #if INCLUDE_CDS
   if (k == NULL) {
     // If the class is not already loaded, try to see if it's in the shared

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -903,12 +903,11 @@ Deoptimization::DeoptAction Deoptimization::_unloaded_action
 template<typename CacheType>
 class BoxCacheBase : public CHeapObj<mtCompiler> {
 protected:
-  static InstanceKlass* find_cache_klass(Symbol* klass_name, TRAPS) {
+  static InstanceKlass* find_cache_klass(Symbol* klass_name) {
     ResourceMark rm;
     char* klass_name_str = klass_name->as_C_string();
-    Klass* k = SystemDictionary::find(klass_name, Handle(), Handle(), THREAD);
-    guarantee(k != NULL, "%s must be loaded", klass_name_str);
-    InstanceKlass* ik = InstanceKlass::cast(k);
+    InstanceKlass* ik = SystemDictionary::find_instance_klass(klass_name, Handle(), Handle());
+    guarantee(ik != NULL, "%s must be loaded", klass_name_str);
     guarantee(ik->is_initialized(), "%s must be initialized", klass_name_str);
     CacheType::compute_offsets(ik);
     return ik;
@@ -922,7 +921,7 @@ template<typename PrimitiveType, typename CacheType, typename BoxType> class Box
 protected:
   static BoxCache<PrimitiveType, CacheType, BoxType> *_singleton;
   BoxCache(Thread* thread) {
-    InstanceKlass* ik = BoxCacheBase<CacheType>::find_cache_klass(CacheType::symbol(), thread);
+    InstanceKlass* ik = BoxCacheBase<CacheType>::find_cache_klass(CacheType::symbol());
     objArrayOop cache = CacheType::cache(ik);
     assert(cache->length() > 0, "Empty cache");
     _low = BoxType::value(cache->obj_at(0));
@@ -978,7 +977,7 @@ class BooleanBoxCache : public BoxCacheBase<java_lang_Boolean> {
 protected:
   static BooleanBoxCache *_singleton;
   BooleanBoxCache(Thread *thread) {
-    InstanceKlass* ik = find_cache_klass(java_lang_Boolean::symbol(), thread);
+    InstanceKlass* ik = find_cache_klass(java_lang_Boolean::symbol());
     _true_cache = JNIHandles::make_global(Handle(thread, java_lang_Boolean::get_TRUE(ik)));
     _false_cache = JNIHandles::make_global(Handle(thread, java_lang_Boolean::get_FALSE(ik)));
   }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,7 @@ Klass* SignatureStream::as_klass(Handle class_loader, Handle protection_domain,
   } else if (failure_mode == CachedOrNull) {
     NoSafepointVerifier nsv;  // no loading, now, we mean it!
     assert(!HAS_PENDING_EXCEPTION, "");
-    k = SystemDictionary::find(name, class_loader, protection_domain, CHECK_NULL);
+    k = SystemDictionary::find_instance_klass(name, class_loader, protection_domain);
     // SD::find does not trigger loading, so there should be no throws
     // Still, bad things can happen, so we CHECK_NULL and ask callers
     // to do likewise.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -903,15 +903,13 @@ char java_runtime_vendor_version[128] = "";
 char java_runtime_vendor_vm_bug_url[128] = "";
 
 // extract the JRE version string from java.lang.VersionProps.java_version
-static const char* get_java_version(TRAPS) {
-  Klass* k = SystemDictionary::find(vmSymbols::java_lang_VersionProps(),
-                                    Handle(), Handle(), CHECK_AND_CLEAR_NULL);
+static const char* get_java_version(InstanceKlass* ik) {
   fieldDescriptor fd;
-  bool found = k != NULL &&
-               InstanceKlass::cast(k)->find_local_field(vmSymbols::java_version_name(),
-                                                        vmSymbols::string_signature(), &fd);
+  bool found = ik != NULL &&
+               ik->find_local_field(vmSymbols::java_version_name(),
+                                    vmSymbols::string_signature(), &fd);
   if (found) {
-    oop name_oop = k->java_mirror()->obj_field(fd.offset());
+    oop name_oop = ik->java_mirror()->obj_field(fd.offset());
     if (name_oop == NULL) {
       return NULL;
     }
@@ -925,15 +923,13 @@ static const char* get_java_version(TRAPS) {
 }
 
 // extract the JRE name from java.lang.VersionProps.java_runtime_name
-static const char* get_java_runtime_name(TRAPS) {
-  Klass* k = SystemDictionary::find(vmSymbols::java_lang_VersionProps(),
-                                    Handle(), Handle(), CHECK_AND_CLEAR_NULL);
+static const char* get_java_runtime_name(InstanceKlass* ik) {
   fieldDescriptor fd;
-  bool found = k != NULL &&
-               InstanceKlass::cast(k)->find_local_field(vmSymbols::java_runtime_name_name(),
-                                                        vmSymbols::string_signature(), &fd);
+  bool found = ik != NULL &&
+               ik->find_local_field(vmSymbols::java_runtime_name_name(),
+                                    vmSymbols::string_signature(), &fd);
   if (found) {
-    oop name_oop = k->java_mirror()->obj_field(fd.offset());
+    oop name_oop = ik->java_mirror()->obj_field(fd.offset());
     if (name_oop == NULL) {
       return NULL;
     }
@@ -947,15 +943,13 @@ static const char* get_java_runtime_name(TRAPS) {
 }
 
 // extract the JRE version from java.lang.VersionProps.java_runtime_version
-static const char* get_java_runtime_version(TRAPS) {
-  Klass* k = SystemDictionary::find(vmSymbols::java_lang_VersionProps(),
-                                    Handle(), Handle(), CHECK_AND_CLEAR_NULL);
+static const char* get_java_runtime_version(InstanceKlass* ik) {
   fieldDescriptor fd;
-  bool found = k != NULL &&
-               InstanceKlass::cast(k)->find_local_field(vmSymbols::java_runtime_version_name(),
-                                                        vmSymbols::string_signature(), &fd);
+  bool found = ik != NULL &&
+               ik->find_local_field(vmSymbols::java_runtime_version_name(),
+                                    vmSymbols::string_signature(), &fd);
   if (found) {
-    oop name_oop = k->java_mirror()->obj_field(fd.offset());
+    oop name_oop = ik->java_mirror()->obj_field(fd.offset());
     if (name_oop == NULL) {
       return NULL;
     }
@@ -969,15 +963,13 @@ static const char* get_java_runtime_version(TRAPS) {
 }
 
 // extract the JRE vendor version from java.lang.VersionProps.VENDOR_VERSION
-static const char* get_java_runtime_vendor_version(TRAPS) {
-  Klass* k = SystemDictionary::find(vmSymbols::java_lang_VersionProps(),
-                                    Handle(), Handle(), CHECK_AND_CLEAR_NULL);
+static const char* get_java_runtime_vendor_version(InstanceKlass* ik) {
   fieldDescriptor fd;
-  bool found = k != NULL &&
-               InstanceKlass::cast(k)->find_local_field(vmSymbols::java_runtime_vendor_version_name(),
-                                                        vmSymbols::string_signature(), &fd);
+  bool found = ik != NULL &&
+               ik->find_local_field(vmSymbols::java_runtime_vendor_version_name(),
+                                    vmSymbols::string_signature(), &fd);
   if (found) {
-    oop name_oop = k->java_mirror()->obj_field(fd.offset());
+    oop name_oop = ik->java_mirror()->obj_field(fd.offset());
     if (name_oop == NULL) {
       return NULL;
     }
@@ -991,15 +983,13 @@ static const char* get_java_runtime_vendor_version(TRAPS) {
 }
 
 // extract the JRE vendor VM bug URL from java.lang.VersionProps.VENDOR_URL_VM_BUG
-static const char* get_java_runtime_vendor_vm_bug_url(TRAPS) {
-  Klass* k = SystemDictionary::find(vmSymbols::java_lang_VersionProps(),
-                                    Handle(), Handle(), CHECK_AND_CLEAR_NULL);
+static const char* get_java_runtime_vendor_vm_bug_url(InstanceKlass* ik) {
   fieldDescriptor fd;
-  bool found = k != NULL &&
-               InstanceKlass::cast(k)->find_local_field(vmSymbols::java_runtime_vendor_vm_bug_url_name(),
-                                                        vmSymbols::string_signature(), &fd);
+  bool found = ik != NULL &&
+               ik->find_local_field(vmSymbols::java_runtime_vendor_vm_bug_url_name(),
+                                    vmSymbols::string_signature(), &fd);
   if (found) {
-    oop name_oop = k->java_mirror()->obj_field(fd.offset());
+    oop name_oop = ik->java_mirror()->obj_field(fd.offset());
     if (name_oop == NULL) {
       return NULL;
     }
@@ -3022,11 +3012,13 @@ void Threads::initialize_java_lang_classes(JavaThread* main_thread, TRAPS) {
   call_initPhase1(CHECK);
 
   // get the Java runtime name, version, and vendor info after java.lang.System is initialized
-  JDK_Version::set_java_version(get_java_version(THREAD));
-  JDK_Version::set_runtime_name(get_java_runtime_name(THREAD));
-  JDK_Version::set_runtime_version(get_java_runtime_version(THREAD));
-  JDK_Version::set_runtime_vendor_version(get_java_runtime_vendor_version(THREAD));
-  JDK_Version::set_runtime_vendor_vm_bug_url(get_java_runtime_vendor_vm_bug_url(THREAD));
+  InstanceKlass* ik = SystemDictionary::find_instance_klass(vmSymbols::java_lang_VersionProps(),
+                                                            Handle(), Handle());
+  JDK_Version::set_java_version(get_java_version(ik));
+  JDK_Version::set_runtime_name(get_java_runtime_name(ik));
+  JDK_Version::set_runtime_version(get_java_runtime_version(ik));
+  JDK_Version::set_runtime_vendor_version(get_java_runtime_vendor_version(ik));
+  JDK_Version::set_runtime_vendor_vm_bug_url(get_java_runtime_vendor_vm_bug_url(ik));
 
   // an instance of OutOfMemory exception has been allocated earlier
   initialize_class(vmSymbols::java_lang_OutOfMemoryError(), CHECK);


### PR DESCRIPTION
Please review this fix for JDK-8262227.  This fix changes SystemDictionary::find() to return an InstanceKlass* to reduce InstanceKlass casts, it renames find() to find_instance_klass(), removes its unneeded TRAP parameter, and changes its callers as appropriate.

It also changed the get_java_...() methods, in thread.cpp, to take an InstanceKlass* parameter and removed their now unneeded TRAPS parameter.

The fix was tested with mach5 tiers 1 and 2 on Linux, Windows, and Mac OS, and tiers 3-5 on Linux x64 (still in progress).

Thanks to Coleen and David for their helpful suggestions.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262227](https://bugs.openjdk.java.net/browse/JDK-8262227): Change SystemDictionary::find() to return an InstanceKlass*.


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2712/head:pull/2712`
`$ git checkout pull/2712`
