### PR TITLE
JDK-8262326: MaxMetaspaceSize does not have to be aligned to metaspace commit alignment

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -625,9 +625,6 @@ void Metaspace::ergo_initialize() {
   // We still adjust CompressedClassSpaceSize to reasonable limits, mainly to
   //  save on reserved space, and to make ergnonomics less confusing.
 
-  // (aligned just for cleanliness:)
-  MaxMetaspaceSize = MAX2(align_down(MaxMetaspaceSize, commit_alignment()), commit_alignment());
-
   if (UseCompressedClassPointers) {
     // Let CCS size not be larger than 80% of MaxMetaspaceSize. Note that is
     // grossly over-dimensioned for most usage scenarios; typical ratio of

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -95,7 +95,7 @@ static void print_vs(outputStream* out, size_t scale) {
 
 static void print_settings(outputStream* out, size_t scale) {
   out->print("MaxMetaspaceSize: ");
-  if (MaxMetaspaceSize >= (max_uintx) - (2 * os::vm_page_size())) {
+  if (MaxMetaspaceSize == max_uintx) {
     // aka "very big". Default is max_uintx, but due to rounding in arg parsing the real
     // value is smaller.
     out->print("unlimited");

--- a/src/hotspot/share/services/allocationSite.hpp
+++ b/src/hotspot/share/services/allocationSite.hpp
@@ -36,7 +36,6 @@ class AllocationSite {
   const MEMFLAGS         _flag;
  public:
   AllocationSite(const NativeCallStack& stack, MEMFLAGS flag) : _call_stack(stack), _flag(flag) { }
-  int hash() const { return _call_stack.hash(); }
 
   bool equals(const NativeCallStack& stack) const {
     return _call_stack.equals(stack);

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -57,12 +57,13 @@ class MallocSite : public AllocationSite {
 class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
  private:
   MallocSite                         _malloc_site;
+  const unsigned                     _hash;
   MallocSiteHashtableEntry* volatile _next;
 
  public:
 
   MallocSiteHashtableEntry(NativeCallStack stack, MEMFLAGS flags):
-    _malloc_site(stack, flags), _next(NULL) {
+    _malloc_site(stack, flags), _hash(stack.calculate_hash()), _next(NULL) {
     assert(flags != mtNone, "Expect a real memory type");
   }
 
@@ -74,6 +75,8 @@ class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
   // Return true if the entry is inserted successfully.
   // The operation can be failed due to contention from other thread.
   bool atomic_insert(MallocSiteHashtableEntry* entry);
+
+  unsigned hash() const { return _hash; }
 
   inline const MallocSite* peek() const { return &_malloc_site; }
   inline MallocSite* data()             { return &_malloc_site; }

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -57,7 +57,7 @@ class MallocSite : public AllocationSite {
 class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
  private:
   MallocSite                         _malloc_site;
-  const unsigned                     _hash;
+  const unsigned int                 _hash;
   MallocSiteHashtableEntry* volatile _next;
 
  public:
@@ -76,7 +76,7 @@ class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
   // The operation can be failed due to contention from other thread.
   bool atomic_insert(MallocSiteHashtableEntry* entry);
 
-  unsigned hash() const { return _hash; }
+  unsigned int hash() const { return _hash; }
 
   inline const MallocSite* peek() const { return &_malloc_site; }
   inline MallocSite* data()             { return &_malloc_site; }

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -30,16 +30,7 @@
 
 const NativeCallStack NativeCallStack::_empty_stack; // Uses default ctor
 
-static unsigned int calculate_hash(address stack[NMT_TrackingStackDepth]) {
-  uintptr_t hash = 0;
-  for (int i = 0; i < NMT_TrackingStackDepth; i++) {
-    hash += (uintptr_t)stack[i];
-  }
-  return hash;
-}
-
-NativeCallStack::NativeCallStack(int toSkip) :
-  _hash_value(0) {
+NativeCallStack::NativeCallStack(int toSkip) {
 
   // We need to skip the NativeCallStack::NativeCallStack frame if a tail call is NOT used
   // to call os::get_native_stack. A tail call is used if _NMT_NOINLINE_ is not defined
@@ -55,7 +46,6 @@ NativeCallStack::NativeCallStack(int toSkip) :
 #endif // Special-case for BSD.
 #endif // Not a tail call.
   os::get_native_stack(_stack, NMT_TrackingStackDepth, toSkip);
-  _hash_value = calculate_hash(_stack);
 }
 
 NativeCallStack::NativeCallStack(address* pc, int frameCount) {
@@ -68,7 +58,6 @@ NativeCallStack::NativeCallStack(address* pc, int frameCount) {
   for (; index < NMT_TrackingStackDepth; index ++) {
     _stack[index] = NULL;
   }
-  _hash_value = calculate_hash(_stack);
 }
 
 // number of stack frames captured

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -56,12 +56,11 @@ class MemTracker;
 class NativeCallStack : public StackObj {
 private:
   address       _stack[NMT_TrackingStackDepth];
-  unsigned int  _hash_value;
   static const NativeCallStack _empty_stack;
 public:
   // Default ctor creates an empty stack.
   // (it may make sense to remove this altogether but its used in a few places).
-  NativeCallStack() : _hash_value(0) {
+  NativeCallStack() {
     memset(_stack, 0, sizeof(_stack));
   }
 
@@ -83,9 +82,6 @@ public:
   }
 
   inline bool equals(const NativeCallStack& other) const {
-    // compare hash values
-    if (hash() != other.hash()) return false;
-    // compare each frame
     return compare(other) == 0;
   }
 
@@ -94,7 +90,14 @@ public:
     return _stack[index];
   }
 
-  unsigned int hash() const { return _hash_value; }
+  // Helper; calculates a hash value over the stack frames in this stack
+  unsigned int calculate_hash() const {
+    uintptr_t hash = 0;
+    for (int i = 0; i < NMT_TrackingStackDepth; i++) {
+      hash += (uintptr_t)_stack[i];
+    }
+    return hash;
+  }
 
   void print_on(outputStream* out) const;
   void print_on(outputStream* out, int indent) const;

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -85,7 +85,6 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/NMT/CheckForProperDetailStackTrace.java 8261520 generic-all
 runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 containers/docker/TestJFRWithJMX.java 8256417 linux-5.4.17-2011.5.3.el8uek.x86_64
 


### PR DESCRIPTION
Currently MaxMetaspaceSize is aligned to commit alignment in Metaspace::ergo_initialize().

That is unnecessary. MaxMetaspaceSize is just a number to compare the metaspace commit charge against. The fact that we commit in discrete uniform steps (since JEP-387, the size of a commit granule) makes no difference to that comparison.

This alignment introduced subtle display errors where the default value of max_uintx was aligned down, and that not-quite-max_uintx was not recognized to mean "infinite" (see JDK-8262099).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262326](https://bugs.openjdk.java.net/browse/JDK-8262326): MaxMetaspaceSize does not have to be aligned to metaspace commit alignment


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2713/head:pull/2713`
`$ git checkout pull/2713`
