### PR TITLE
8262332: serviceability/sa/ClhsdbJhisto.java fails with Test ERROR java.lang.RuntimeException: 'ParselTongue' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 import jdk.test.lib.apps.LingeredApp;
+
+import java.lang.ref.Reference;
 
 interface Language {
     static final long nbrOfWords = 99999;
@@ -54,5 +56,6 @@ public class LingeredAppWithInterface extends LingeredApp {
         System.out.println(lang.getNbrOfWords() + muggleSpeak.getNbrOfWords());
 
         LingeredApp.main(args);
+        Reference.reachabilityFence(lang);
     }
 }


### PR DESCRIPTION
…va.lang.RuntimeException: 'ParselTongue' missing from stdout/stderr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262332](https://bugs.openjdk.java.net/browse/JDK-8262332): serviceability/sa/ClhsdbJhisto.java fails with Test ERROR java.lang.RuntimeException: 'ParselTongue' missing from stdout/stderr 


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2717/head:pull/2717`
`$ git checkout pull/2717`
