### PR TITLE
JDK-8261203: Incorrectly escaped javadoc html with type annotations

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -767,14 +767,20 @@ public class Utils {
             }
 
             @Override
-            public StringBuilder visitTypeVariable(javax.lang.model.type.TypeVariable t, Void p) {
+            public StringBuilder visitPrimitive(PrimitiveType t, Void p) {
+                sb.append(t.getKind().toString().toLowerCase(Locale.ROOT));
+                return sb;
+            }
+
+            @Override
+            public StringBuilder visitTypeVariable(TypeVariable t, Void p) {
                 Element e = t.asElement();
                 sb.append(qualifiedName ? getFullyQualifiedName(e, false) : getSimpleName(e));
                 return sb;
             }
 
             @Override
-            public StringBuilder visitWildcard(javax.lang.model.type.WildcardType t, Void p) {
+            public StringBuilder visitWildcard(WildcardType t, Void p) {
                 sb.append("?");
                 TypeMirror upperBound = t.getExtendsBound();
                 if (upperBound != null) {

--- a/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8261203
+ * @summary  Incorrectly escaped javadoc html with type annotations
+ * @library  /tools/lib ../../lib/
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestMethodId
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestMethodId extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestMethodId tester = new TestMethodId();
+        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+    }
+
+    private ToolBox tb = new ToolBox();
+
+    @Test
+    public void testMethodId(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    public class C {
+                        public void m(@A("anno-text") int i) { }
+                    }
+                    """,
+                """
+                    package p;
+                    public @interface A {
+                        String value();
+                    }
+                    """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-Xdoclint:none",
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html",
+                true,
+                """
+                    <code><a href="#m(int)" class="member-name-link">m</a>&#8203;(int&nbsp;i)</code>""",
+                """
+                    <section class="detail" id="m(int)">
+                    <h3>m</h3>""");
+    }
+}


### PR DESCRIPTION
Please review a simple change to exclude type annotations from primitive types in the id generated for a method signature.

There's a latent secondary issue, not addressed here, that quotes (`"`) in an attribute value are not escaped correctly. That could be fixed, separately, at the cost of checking every generated attribute value. For now, at least for ids, we can avoid this issue by constraining the set of attribute values, which for ids, is now easier, in the recently-new `HtmlIds` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261203](https://bugs.openjdk.java.net/browse/JDK-8261203): Incorrectly escaped javadoc html with type annotations


### Reviewers
 * @liach (no known github.com user name / role)
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2719/head:pull/2719`
`$ git checkout pull/2719`
