### PR TITLE
JDK-8262326: MaxMetaspaceSize does not have to be aligned to metaspace commit alignment

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -607,9 +607,8 @@ void Metaspace::ergo_initialize() {
   //  to commit for the Metaspace.
   //  It is just a number; a limit we compare against before committing. It
   //  does not have to be aligned to anything.
-  //  It gets used as compare value in class CommitLimiter.
-  //  It is set to max_uintx in globals.hpp by default, so by default it does
-  //  not limit anything.
+  //  It gets used as compare value before attempting to increase the metaspace
+  //  commit charge. It defaults to max_uintx (unlimited).
   //
   // CompressedClassSpaceSize is the size, in bytes, of the address range we
   //  pre-reserve for the compressed class space (if we use class space).
@@ -626,8 +625,7 @@ void Metaspace::ergo_initialize() {
   // We still adjust CompressedClassSpaceSize to reasonable limits, mainly to
   //  save on reserved space, and to make ergnonomics less confusing.
 
-  // (aligned just for cleanliness:)
-  MaxMetaspaceSize = MAX2(align_down(MaxMetaspaceSize, commit_alignment()), commit_alignment());
+  MaxMetaspaceSize = MAX2(MaxMetaspaceSize, commit_alignment());
 
   if (UseCompressedClassPointers) {
     // Let CCS size not be larger than 80% of MaxMetaspaceSize. Note that is

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -96,10 +96,7 @@ static void print_vs(outputStream* out, size_t scale) {
 
 static void print_settings(outputStream* out, size_t scale) {
   out->print("MaxMetaspaceSize: ");
-  // See Metaspace::ergo_initialize() for how MaxMetaspaceSize is rounded
-  if (MaxMetaspaceSize >= align_down(max_uintx, Metaspace::commit_alignment())) {
-    // aka "very big". Default is max_uintx, but due to rounding in arg parsing the real
-    // value is smaller.
+  if (MaxMetaspaceSize == max_uintx) {
     out->print("unlimited");
   } else {
     print_human_readable_size(out, MaxMetaspaceSize, scale);


### PR DESCRIPTION
Currently MaxMetaspaceSize is aligned to commit alignment in Metaspace::ergo_initialize(). 

That is unnecessary. MaxMetaspaceSize is just a number to compare the metaspace commit charge against. The fact that we commit in discrete uniform steps (since JEP-387, the size of a commit granule) makes no difference to that comparison.

This alignment introduced subtle display errors where the default value of max_uintx was aligned down, and that not-quite-max_uintx was not recognized to mean "infinite" (see JDK-8262099).

-----------

Tests: GA, nightlies at SAP

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262326](https://bugs.openjdk.java.net/browse/JDK-8262326): MaxMetaspaceSize does not have to be aligned to metaspace commit alignment


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2721/head:pull/2721`
`$ git checkout pull/2721`
