### PR TITLE
8260403: javap should be more robust in the face of invalid class files

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -229,6 +229,8 @@ public class ClassWriter extends BasicWriter {
                 }
             } catch (ConstantPoolException e) {
                 print(report(e));
+            } catch (IllegalStateException e) {
+                report("Invalid value for Signature attribute: " + e.getMessage());
             }
         }
 
@@ -500,7 +502,7 @@ public class ClassWriter extends BasicWriter {
                 methodExceptions = methodType.throwsTypes;
                 if (methodExceptions != null && methodExceptions.isEmpty())
                     methodExceptions = null;
-            } catch (ConstantPoolException e) {
+            } catch (ConstantPoolException | IllegalStateException e) {
                 // report error?
                 // fall back on standard descriptor
                 methodType = null;

--- a/test/langtools/tools/javap/8260403/InvalidSignature.jcod
+++ b/test/langtools/tools/javap/8260403/InvalidSignature.jcod
@@ -1,0 +1,120 @@
+class InvalidSignature {
+  0xCAFEBABE;
+  0; // minor version
+  52; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #4 #14; // #1
+    String #15; // #2
+    class #16; // #3
+    class #17; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "()V"; // #6
+    Utf8 "Code"; // #7
+    Utf8 "LineNumberTable"; // #8
+    Utf8 "m"; // #9
+    Utf8 "m2"; // #10
+    Utf8 "()Ljava/lang/String;"; // #11
+    Utf8 "SourceFile"; // #12
+    Utf8 "InvalidSignature.java"; // #13
+    NameAndType #5 #6; // #14
+    Utf8 "Hello"; // #15
+    Utf8 "InvalidSignature"; // #16
+    Utf8 "java/lang/Object"; // #17
+    Utf8 "Signature"; // #18
+    Utf8 "', '"; // #19
+  } // Constant Pool
+
+  0x0020; // access
+  #3;// this_cpx
+  #4;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0000; // access
+      #5; // name_cpx
+      #6; // sig_cpx
+      [] { // Attributes
+        Attr(#7) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#8) { // LineNumberTable
+              [] { // LineNumberTable
+                0  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0000; // access
+      #9; // name_cpx
+      #6; // sig_cpx
+      [] { // Attributes
+        Attr(#7) { // Code
+          0; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#8) { // LineNumberTable
+              [] { // LineNumberTable
+                0  2;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0000; // access
+      #9; // name_cpx
+      #11; // sig_cpx
+      [] { // Attributes
+        Attr(#7) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x1202B0;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#8) { // LineNumberTable
+              [] { // LineNumberTable
+                0  3;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#12) { // SourceFile
+      #13;
+    }; // end SourceFile
+    Attr(#18) { // Signature
+      #19;
+    } // end Signature
+  } // Attributes
+} // end class InvalidSignature

--- a/test/langtools/tools/javap/8260403/T8260403.java
+++ b/test/langtools/tools/javap/8260403/T8260403.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8260403
+ * @summary javap should be more robust in the face of invalid class files
+ * @build InvalidSignature
+ * @run main T8260403
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+import java.io.PrintWriter;
+
+public class T8260403 {
+
+    public static void main(String args[]) throws Exception {
+        if (com.sun.tools.javap.Main.run(new String[]{"-c", System.getProperty("test.classes") + "/InvalidSignature.class"},
+                new PrintWriter(System.out)) != 0) {
+            throw new AssertionError();
+        }
+    }
+}


### PR DESCRIPTION
Please review javap fix to handle java.lang.IllegalStateException for classes with invalid Signature attribute.
New test (T8260403) parsing class with invalid Signature attribute (as described in the bug) is included.
Fix wraps java.lang.IllegalStateException, reports "Error: Invalid value for Signature attribute: <signature debug info>" and continues.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260403](https://bugs.openjdk.java.net/browse/JDK-8260403): javap should be more robust in the face of invalid class files


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2724/head:pull/2724`
`$ git checkout pull/2724`
