### PR TITLE
8262389: Use permitted_enctypes if default_tkt_enctypes or default_tgs_enctypes is not present

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -979,6 +979,9 @@ public class Config {
     public int[] defaultEtype(String configName) throws KrbException {
         String default_enctypes;
         default_enctypes = get("libdefaults", configName);
+        if (default_enctypes == null && !configName.equals("permitted_enctypes")) {
+            default_enctypes = get("libdefaults", "permitted_enctypes");
+        }
         int[] etype;
         if (default_enctypes == null) {
             if (DEBUG) {

--- a/test/jdk/sun/security/krb5/etype/Permitted.java
+++ b/test/jdk/sun/security/krb5/etype/Permitted.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8262389
+ * @modules java.security.jgss/sun.security.krb5
+ * @library /test/lib
+ * @summary Use permitted_enctypes if default_tkt_enctypes or default_tgs_enctypes is not present
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.krb5.Config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class Permitted {
+    public static void main(String[] args) throws Exception {
+
+        System.setProperty("java.security.krb5.conf", "permitted.conf");
+
+        Files.write(Path.of("permitted.conf"), List.of("[libdefaults]",
+                "permitted_enctypes = aes128-cts"));
+        Config.refresh();
+        Asserts.assertEQ(Config.getInstance().defaultEtype("default_tkt_enctypes").length, 1);
+        Asserts.assertEQ(Config.getInstance().defaultEtype("default_tgs_enctypes").length, 1);
+
+        Files.write(Path.of("permitted.conf"), List.of("[libdefaults]",
+                "default_tkt_enctypes = aes128-cts aes256-cts",
+                "default_tgs_enctypes = aes128-cts aes256-cts aes256-sha2",
+                "permitted_enctypes = aes128-cts"));
+        Config.refresh();
+        Asserts.assertEQ(Config.getInstance().defaultEtype("default_tkt_enctypes").length, 2);
+        Asserts.assertEQ(Config.getInstance().defaultEtype("default_tgs_enctypes").length, 3);
+    }
+}


### PR DESCRIPTION
When default_tkt_enctypes or default_tgs_enctypes, use the value of permitted_enctypes if it exists.

Please also review the CSR at https://bugs.openjdk.java.net/browse/JDK-8262391 and release note at https://bugs.openjdk.java.net/browse/JDK-8262401.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262389](https://bugs.openjdk.java.net/browse/JDK-8262389): Use permitted_enctypes if default_tkt_enctypes or default_tgs_enctypes is not present


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2729/head:pull/2729` \
`$ git checkout pull/2729`

Update a local copy of the PR: \
`$ git checkout pull/2729` \
`$ git pull https://git.openjdk.java.net/jdk pull/2729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2729`

View PR using the GUI difftool: \
`$ git pr show -t 2729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2729.diff">https://git.openjdk.java.net/jdk/pull/2729.diff</a>

</details>
