### PR TITLE
JDK-8261839: Error creating runtime package on macos without mac-package-identifier

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -110,11 +110,13 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                         // Get identifier from app image if user provided
                         // app image and did not provide the identifier via CLI.
                         String identifier = extractBundleIdentifier(params);
-                        if (identifier != null) {
-                            return identifier;
+                        if (identifier == null) {
+                            identifier =  MacAppBundler.getIdentifier(params);
                         }
-
-                        return MacAppBundler.getIdentifier(params);
+                        if (identifier == null) {
+                            identifier = APP_NAME.fetchFrom(params);
+                        }
+                        return identifier;
                     },
                     (s, p) -> s);
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -723,7 +723,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
                         .filter(path -> path.getFileName().equals(appImageFileName))
                         .map(Path::toString)
                         .collect(Collectors.toList());
-                if (isImagePackageType() || TKit.isOSX()) {
+                if (isImagePackageType() || (TKit.isOSX() && !isRuntime())) {
                     List<String> expected = List.of(
                             AppImageFile.getPathInAppImage(rootDir).toString());
                     TKit.assertStringListEquals(expected, appImageFiles,
@@ -750,11 +750,11 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         if (!isRuntime()) {
             TKit.assertExecutableFileExists(appLauncherPath());
             TKit.assertFileExists(appLauncherCfgPath(null));
-        }
 
-        if (TKit.isOSX()) {
-            TKit.assertFileExists(appRuntimeDirectory().resolve(
-                    "Contents/MacOS/libjli.dylib"));
+            if (TKit.isOSX()) {
+                TKit.assertFileExists(appRuntimeDirectory().resolve(
+                        "Contents/MacOS/libjli.dylib"));
+            }
         }
 
         return this;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -62,7 +62,8 @@ public class MacHelper {
 
         final Path mountPoint = Path.of(plist.queryValue("mount-point"));
         try {
-            Path dmgImage = mountPoint.resolve(cmd.name() + ".app");
+            Path dmgImage = mountPoint.resolve(cmd.name() +
+                    (cmd.isRuntime() ? "" : ".app"));
             TKit.trace(String.format("Exploded [%s] in [%s] directory",
                     cmd.outputBundle(), dmgImage));
             ThrowingConsumer.toConsumer(consumer).accept(dmgImage);
@@ -215,7 +216,7 @@ public class MacHelper {
     static Path getInstallationDirectory(JPackageCommand cmd) {
         cmd.verifyIsOfType(PackageType.MAC);
         return Path.of(cmd.getArgumentValue("--install-dir", () -> "/Applications"))
-                .resolve(cmd.name() + ".app");
+                .resolve(cmd.name() + (cmd.isRuntime() ? "" : ".app"));
     }
 
     private static String getPackageName(JPackageCommand cmd) {

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -53,8 +53,6 @@ import jdk.jpackage.test.Annotations.Test;
  * @library ../helpers
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
- * @comment Temporary disable for OSX until functionality implemented
- * @requires (os.family != "mac")
  * @requires (jpackage.test.SQETest == null)
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile RuntimePackageTest.java
@@ -68,8 +66,6 @@ import jdk.jpackage.test.Annotations.Test;
  * @library ../helpers
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
- * @comment Temporary disable for OSX until functionality implemented
- * @requires (os.family != "mac")
  * @requires (jpackage.test.SQETest != null)
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile RuntimePackageTest.java
@@ -111,7 +107,11 @@ public class RuntimePackageTest {
         })
         .addInstallVerifier(cmd -> {
             Set<Path> srcRuntime = listFiles(Path.of(cmd.getArgumentValue("--runtime-image")));
-            Set<Path> dstRuntime = listFiles(cmd.appRuntimeDirectory());
+            Path dest = cmd.appRuntimeDirectory();
+            if (TKit.isOSX()) {
+                dest = dest.resolve("Contents/Home");
+            }
+            Set<Path> dstRuntime = listFiles(dest);
 
             Set<Path> intersection = new HashSet<>(srcRuntime);
             intersection.retainAll(dstRuntime);


### PR DESCRIPTION
…age-identifier

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261839](https://bugs.openjdk.java.net/browse/JDK-8261839): Error creating runtime package on macos without mac-package-identifier


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2730/head:pull/2730`
`$ git checkout pull/2730`
