### PR TITLE
JDK-8262421: doclint warnings in jdk.compiler module

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeFactory.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeFactory.java
@@ -269,13 +269,17 @@ public interface DocTreeFactory {
      * Creates a new {@code ReturnTree} object, to represent a {@code @return} tag
      * or {@code {@return}} tag.
      *
+     * @param isInline    {@code true} if this instance is as an inline tag,
+     *                    and {@code false} otherwise
+     * @param description the description of the return value of a method
+     *
+     * @return a {@code ReturnTree} object
+     * @throws UnsupportedOperationException if inline {@code {@return}} tags are
+     *                                       not supported
+     *
      * @implSpec This implementation throws {@code UnsupportedOperationException} if
      * {@code isInline} is {@code true}, and calls {@link #newReturnTree(List)} otherwise.
      *
-     * @param description the description of the return value of a method
-     * @return a {@code ReturnTree} object
-     * @throws UnsupportedOperationException if inline {@code {@return}} tags are
-     *      not supported
      * @since 16
      */
     default ReturnTree newReturnTree(boolean isInline, List<? extends DocTree> description) {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
@@ -232,6 +232,7 @@ public abstract class DocTrees extends Trees {
      * <a href="https://www.w3.org/TR/html52/syntax.html#character-references">8.1.4. Character references</a>
      * in the HTML 5.2 specification.</p>
      *
+     * @param tree the tree containing the entity
      * @return a string containing the characters
      */
     public abstract String getCharacters(EntityTree tree);


### PR DESCRIPTION
Please review this doc fix to provide a couple of missing `@param` tags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262421](https://bugs.openjdk.java.net/browse/JDK-8262421): doclint warnings in jdk.compiler module


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2731/head:pull/2731`
`$ git checkout pull/2731`
