### PR TITLE
8261670: Add javadoc for the XML processing limits

### DIFF
--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -191,7 +191,12 @@
  * </table>
  *
  * <h3>Implementation Specific Features and Properties</h3>
- * The table below lists Implementation Specific Properties supported by the JDK.
+ * The Implementation Specific Features and Properties reflect JDK's choice to
+ * manage the limitations on resources while complying with the API specification,
+ * or allow applications to alter behaviors beyond those required by the standards.
+ * <p>
+ * The table below lists the Implementation Specific Properties currently supported
+ * by the JDK. More properties may be added in the future if necessary.
  *
  * <table class="striped" id="Properties">
  * <caption>Implementation Specific Properties</caption>

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -94,7 +94,7 @@
  * (hereafter referred to as secure processing) is required for XML processors
  * including DOM, SAX, Schema Validation, XSLT, and XPath. Any properties flagged
  * as {@code "security: yes"} (hereafter referred to as security properties) in
- * table <a href="#FeaturesAndProperties">Features And Properties</a>
+ * table <a href="#Properties">Implementation Specific Properties</a>
  * are enforced when secure processing is set to true. Such enforcement includes
  * setting security features to true and limits to the defined values shown in
  * the table. The property values will not be affected, however, when setting
@@ -195,11 +195,10 @@
  *
  * <p>
  * <h3>Implementation Specific Features and Properties</h3>
- * This section lists features and properties supported by the JDK implementation.
- *
+ * The table below lists Implementation Specific Properties supported by the JDK.
  * <p>
- * <table class="plain" id="FeaturesAndProperties">
- * <caption>Features and Properties</caption>
+ * <table class="striped" id="Properties">
+ * <caption>Implementation Specific Properties</caption>
  * <thead>
  * <tr>
  * <th scope="col" rowspan="2">Name [1]</th>
@@ -219,6 +218,85 @@
  * </thead>
  *
  * <tbody>
+ *
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="EELimit">entityExpansionLimit</th>
+ * <td>Limits the number of entity expansions.
+ * </td>
+ * <td rowspan="9">yes</td>
+ * <td rowspan="9">yes</td>
+ * <td rowspan="9">Integer</td>
+ * <th id="Value" scope="row" style="font-weight:normal" rowspan="9">
+ * A positive integer. A value less than or equal to 0 indicates no limit.
+ * If the value is not an integer, a NumericFormatException is thrown.
+ * </th>
+ * <th id="Default" scope="row" style="font-weight:normal">64000</th>
+ * <td rowspan="9">Yes</td>
+ * <td rowspan="9">
+ *     <a href="#DOM">DOM</a><br>
+ *     <a href="#SAX">SAX</a><br>
+ *     <a href="#StAX">StAX</a><br>
+ *     <a href="#Validation">Validation</a><br>
+ *     <a href="#Transform">Transform</a>
+ * </td>
+ * <td rowspan="6">7u45, 8</td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="EALimit">elementAttributeLimit</th>
+ * <td>Limits the number of attributes an element can have.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">10000</th>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="OccurLimit">maxOccurLimit</th>
+ * <td>Limits the number of content model nodes that may be created when building
+ * a grammar for a W3C XML Schema that contains maxOccurs attributes with values
+ * other than "unbounded".
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">5000</th>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="SizeLimit">totalEntitySizeLimit</th>
+ * <td>Limits the total size of all entities that include general and parameter
+ * entities. The size is calculated as an aggregation of all entities.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">5x10^7</th>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="GELimit">maxGeneralEntitySizeLimit</th>
+ * <td>Limits the maximum size of any general entities.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">0</th>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="PELimit">maxParameterEntitySizeLimit</th>
+ * <td>Limits the maximum size of any parameter entities, including the result
+ * of nesting multiple parameter entities.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">10^6</th>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="ERLimit">entityReplacementLimit</th>
+ * <td>Limits the total number of nodes in all entity references.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">3x10^6</th>
+ * <td>7u111, 8u101</td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="ElementDepth">maxElementDepth</th>
+ * <td>Limits the maximum element depth.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">0</th>
+ * <td>7u65, 8u11</td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="NameLimit">maxXMLNameLimit</th>
+ * <td>Limits the maximum size of XML names, including element name, attribute
+ * name and namespace prefix and URI.
+ * </td>
+ * <th id="Default" scope="row" style="font-weight:normal">1000</th>
+ * <td>7u91, 8u65</td>
+ * </tr>
  *
  * <tr>
  * <th scope="row" style="font-weight:normal" id="ISSTANDALONE">isStandalone</th>
@@ -274,7 +352,9 @@
  * the property value. If the type is boolean, the system property is true only
  * if it is "true"; If the type is String, the system property is true only if
  * it is exactly the same string representing the positive value (e.g. "yes" for
- * {@code xsltcIsStandalone}); The system property is false otherwise.
+ * {@code xsltcIsStandalone}); The system property is false otherwise. If the type
+ * is Integer, the value of the System Property is the String representation of
+ * the value (e.g. "64000" for {@code entityExpansionLimit}).
  *
  * <p>
  * <b>[4]</b> A value "yes" indicates the property is a Security Property. Refer

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -192,7 +192,7 @@
  *
  * <h3>Implementation Specific Features and Properties</h3>
  * The table below lists Implementation Specific Properties supported by the JDK.
- * 
+ *
  * <table class="striped" id="Properties">
  * <caption>Implementation Specific Properties</caption>
  * <thead>
@@ -222,11 +222,11 @@
  * <td rowspan="9">yes</td>
  * <td rowspan="9">yes</td>
  * <td rowspan="9">Integer</td>
- * <th id="Value" scope="row" style="font-weight:normal" rowspan="9">
+ * <th scope="row" style="font-weight:normal" rowspan="9">
  * A positive integer. A value less than or equal to 0 indicates no limit.
- * If the value is not an integer, a NumericFormatException is thrown.
+ * If the value is not an integer, a NumberFormatException is thrown.
  * </th>
- * <th id="Default" scope="row" style="font-weight:normal">64000</th>
+ * <th scope="row" style="font-weight:normal">64000</th>
  * <td rowspan="9">Yes</td>
  * <td rowspan="9">
  *     <a href="#DOM">DOM</a><br>
@@ -235,13 +235,13 @@
  *     <a href="#Validation">Validation</a><br>
  *     <a href="#Transform">Transform</a>
  * </td>
- * <td rowspan="6">7u45, 8</td>
+ * <td rowspan="9">8</td>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="EALimit">elementAttributeLimit</th>
  * <td>Limits the number of attributes an element can have.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">10000</th>
+ * <th scope="row" style="font-weight:normal">10000</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="OccurLimit">maxOccurLimit</th>
@@ -249,49 +249,46 @@
  * a grammar for a W3C XML Schema that contains maxOccurs attributes with values
  * other than "unbounded".
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">5000</th>
+ * <th scope="row" style="font-weight:normal">5000</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="SizeLimit">totalEntitySizeLimit</th>
  * <td>Limits the total size of all entities that include general and parameter
  * entities. The size is calculated as an aggregation of all entities.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">5x10^7</th>
+ * <th scope="row" style="font-weight:normal">5x10^7</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="GELimit">maxGeneralEntitySizeLimit</th>
  * <td>Limits the maximum size of any general entities.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">0</th>
+ * <th scope="row" style="font-weight:normal">0</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="PELimit">maxParameterEntitySizeLimit</th>
  * <td>Limits the maximum size of any parameter entities, including the result
  * of nesting multiple parameter entities.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">10^6</th>
+ * <th scope="row" style="font-weight:normal">10^6</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="ERLimit">entityReplacementLimit</th>
  * <td>Limits the total number of nodes in all entity references.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">3x10^6</th>
- * <td>7u111, 8u101</td>
+ * <th scope="row" style="font-weight:normal">3x10^6</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="ElementDepth">maxElementDepth</th>
  * <td>Limits the maximum element depth.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">0</th>
- * <td>7u65, 8u11</td>
+ * <th scope="row" style="font-weight:normal">0</th>
  * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="NameLimit">maxXMLNameLimit</th>
  * <td>Limits the maximum size of XML names, including element name, attribute
  * name and namespace prefix and URI.
  * </td>
- * <th id="Default" scope="row" style="font-weight:normal">1000</th>
- * <td>7u91, 8u65</td>
+ * <th scope="row" style="font-weight:normal">1000</th>
  * </tr>
  *
  * <tr>
@@ -305,8 +302,8 @@
  * <td>yes</td>
  * <td>yes</td>
  * <td>boolean</td>
- * <th id="Value" scope="row" style="font-weight:normal">true/false</th>
- * <th id="Default" scope="row" style="font-weight:normal">false</th>
+ * <th scope="row" style="font-weight:normal">true/false</th>
+ * <th scope="row" style="font-weight:normal">false</th>
  * <td>No</td>
  * <td><a href="#DOMLS">DOMLS</a></td>
  * <td>17</td>
@@ -327,8 +324,8 @@
  * <td>yes</td>
  * <td>yes</td>
  * <td>String</td>
- * <th id="Value" scope="row" style="font-weight:normal">yes/no</th>
- * <th id="Default" scope="row" style="font-weight:normal">no</th>
+ * <th scope="row" style="font-weight:normal">yes/no</th>
+ * <th scope="row" style="font-weight:normal">no</th>
  * <td>No</td>
  * <td><a href="#XSLTCSerializer">XSLTC Serializer</a></td>
  * <td>17</td>


### PR DESCRIPTION
Add the documentation for XML processing limits to module summary. The limits were previously documented in Java tutorial and guide.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261670](https://bugs.openjdk.java.net/browse/JDK-8261670): Add javadoc for the XML processing limits


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2732/head:pull/2732`
`$ git checkout pull/2732`
