### PR TITLE
JDK-8262428: doclint warnings in java.xml module

### DIFF
--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -41,7 +41,7 @@
  * <h3>Naming Convention</h3>
  * The names of the features and properties are fully qualified, composed of a
  * prefix and name.
- * <p>
+ *
  * <h4>Prefix</h4>
  * The prefix for JDK properties is defined as:
  * <pre>
@@ -57,7 +57,7 @@
  * <pre>
  *     {@code jdk.xml.}
  * </pre>
- * <p>
+ *
  * <h4>Name</h4>
  * A name may consist of one or multiple words that are case-sensitive.
  * All letters of the first word are in lowercase, while the first letter of
@@ -114,12 +114,10 @@
  * JAXP properties specified through JAXP factories or processors (e.g. SAXParser)
  * take preference over system properties, the jaxp.properties file, as well as
  * secure processing.
- * <p>
  *
  * <h3 id="Processor">Processor Support</h3>
  * Features and properties may be supported by one or more processors. The
  * following table lists the processors by IDs that can be used for reference.
- * <p>
  *
  * <table class="plain" id="Processors">
  * <caption>Processors</caption>
@@ -165,7 +163,6 @@
  * {@code schemaFactory.setProperty(name, value);}
  * </td>
  * </tr>
- * </tr>
  * <tr>
  * <th scope="row" style="font-weight:normal" id="Transform">Transform</th>
  * <td>XML Transform API</td>
@@ -193,11 +190,9 @@
  * </tbody>
  * </table>
  *
- * <p>
  * <h3>Implementation Specific Features and Properties</h3>
  * This section lists features and properties supported by the JDK implementation.
  *
- * <p>
  * <table class="plain" id="FeaturesAndProperties">
  * <caption>Features and Properties</caption>
  * <thead>


### PR DESCRIPTION
Please review a small doc fix to remove some superfluous `<p>` tags and an erroneous `</tr>` tag, all reported by doclint..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262428](https://bugs.openjdk.java.net/browse/JDK-8262428): doclint warnings in java.xml module


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2733/head:pull/2733`
`$ git checkout pull/2733`
