### PR TITLE
JDK-8262430: doclint warnings in java.base module

### DIFF
--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -255,7 +255,6 @@ bytes (depending on the platform), it is important to ensure that the temporary 
 together with the filename used for the socket (currently a name similar to
 {@code socket_1679697142}) does not exceed this limit. The following properties
 can be used to control the selection of this directory:
-<p>
 <ul>
 	<li><p><b>{@systemProperty jdk.net.unixdomain.tmpdir}</b> This can be set as 
 	a networking property in {@code conf/net.properties} If set, this specifies the 

--- a/src/java.base/share/classes/java/nio/channels/ServerSocketChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/ServerSocketChannel.java
@@ -26,6 +26,7 @@
 package java.nio.channels;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.NetPermission;
 import java.net.ProtocolFamily;
 import java.net.ServerSocket;
@@ -234,7 +235,7 @@ public abstract class ServerSocketChannel
      * <p> The {@code backlog} parameter is the maximum number of pending
      * connections on the socket. Its exact semantics are implementation specific.
      * In particular, an implementation may impose a maximum length or may choose
-     * to ignore the parameter altogther. If the {@code backlog} parameter has
+     * to ignore the parameter altogether. If the {@code backlog} parameter has
      * the value {@code 0}, or a negative value, then an implementation specific
      * default is used.
      *


### PR DESCRIPTION
Please review some simple doc fixes in the `java.base` module.  Two were reported by doclint; the spelling error was detected by the IDE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262430](https://bugs.openjdk.java.net/browse/JDK-8262430): doclint warnings in java.base module


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2734/head:pull/2734`
`$ git checkout pull/2734`
