### PR TITLE
JDK-8262420: typo: @implnote in java.desktop module

### DIFF
--- a/src/java.desktop/share/classes/java/awt/TrayIcon.java
+++ b/src/java.desktop/share/classes/java/awt/TrayIcon.java
@@ -71,17 +71,16 @@ import java.security.AccessController;
  * a {@code TrayIcon}. Otherwise the constructor will throw a
  * SecurityException.
  *
- * <p>
- * @implnote
+ * <p> See the {@link SystemTray} class overview for an example on how
+ * to use the {@code TrayIcon} API.
+ *
+ * @implNote
  * When the {@systemProperty apple.awt.enableTemplateImages} property is
  * set, all images associated with instances of this class are treated
  * as template images by the native desktop system. This means all color
  * information is discarded, and the image is adapted automatically to
  * be visible when desktop theme and/or colors change. This property
  * only affects MacOSX.
- *
- * <p> See the {@link SystemTray} class overview for an example on how
- * to use the {@code TrayIcon} API.
  *
  * @since 1.6
  * @see SystemTray#add


### PR DESCRIPTION
Please review some doc changes in `java.awt.TrayIcon`.

Note, the fix is more than the 1-character fix for the typo detected by doclint. The changes are:

1. Fix the name of the `@implNote` tag
2. Remove the redundant `<p>` before the `@implNote` tag
3. Move the `@implNote` tag and its immediate content to after the following paragraph, (beginning _See the ..._) which was originally part of the main description, and does not appear that it should be part of the implementation note.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262420](https://bugs.openjdk.java.net/browse/JDK-8262420): typo: @implnote in java.desktop module


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2735/head:pull/2735`
`$ git checkout pull/2735`
