### PR TITLE
8262402: Make CATCH macro assert not fatal

### DIFF
--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -321,8 +321,8 @@ class Exceptions {
   THREAD); if (HAS_PENDING_EXCEPTION) {    \
     oop ex = PENDING_EXCEPTION;            \
     CLEAR_PENDING_EXCEPTION;               \
-    ex->print();                           \
-    ShouldNotReachHere();                  \
+    DEBUG_ONLY(ex->print();)               \
+    assert(false, "CATCH");                \
   } (void)(0
 
 // ExceptionMark is a stack-allocated helper class for local exception handling.


### PR DESCRIPTION
Hopefully, this is a trivial change.   Tested with tier1 on linux, macosx, and windows, product and debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262402](https://bugs.openjdk.java.net/browse/JDK-8262402): Make CATCH macro assert not fatal


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2736/head:pull/2736`
`$ git checkout pull/2736`
