### PR TITLE
8260923: Add more tests for SSLSocket input/output shutdown

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8184328 8253368
+ * @bug 8184328 8253368 8260923
  * @summary JDK8u131-b34-socketRead0 hang at SSL read
  * @run main/othervm SSLSocketCloseHang TLSv1.2
  * @run main/othervm SSLSocketCloseHang TLSv1.2 shutdownInput
@@ -182,7 +182,6 @@ public class SSLSocketCloseHang {
         try {
             sslSocket.shutdownInput();
         } catch (SSLException e) {
-            System.out.println("----------- Hello: ");
             if (!e.getMessage().contains
                     ("closing inbound before receiving peer's close_notify")) {
                 throw new RuntimeException("expected different exception "

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
@@ -25,9 +25,14 @@
  * @test
  * @bug 8184328 8253368
  * @summary JDK8u131-b34-socketRead0 hang at SSL read
- * @run main/othervm SSLSocketCloseHang
- * @run main/othervm SSLSocketCloseHang shutdownInputTest
+ * @run main/othervm SSLSocketCloseHang TLSv1.2
+ * @run main/othervm SSLSocketCloseHang TLSv1.2 shutdownInput
+ * @run main/othervm SSLSocketCloseHang TLSv1.2 shutdownOutput
+ * @run main/othervm SSLSocketCloseHang TLSv1.3
+ * @run main/othervm SSLSocketCloseHang TLSv1.3 shutdownInput
+ * @run main/othervm SSLSocketCloseHang TLSv1.3 shutdownOutput
  */
+
 
 import java.io.*;
 import java.net.*;
@@ -36,7 +41,6 @@ import java.security.*;
 import javax.net.ssl.*;
 
 public class SSLSocketCloseHang {
-
     /*
      * =============================================================
      * Set the various variables needed for the tests, then
@@ -73,7 +77,7 @@ public class SSLSocketCloseHang {
      */
     static boolean debug = false;
 
-    static boolean shutdownInputTest = false;
+    static String socketCloseType;
 
     /*
      * If the client or server is doing some kind of object creation
@@ -148,28 +152,46 @@ public class SSLSocketCloseHang {
         Thread.sleep(500);
         System.err.println("Client closing: " + System.nanoTime());
 
-        if (shutdownInputTest) {
-            try {
-                sslSocket.shutdownInput();
-            } catch (SSLException e) {
-                if (!e.getMessage().contains
-                        ("closing inbound before receiving peer's close_notify")) {
-                    throw new RuntimeException("expected different exception message. " +
-                        e.getMessage());
-                }
-            }
-            if (!sslSocket.getSession().isValid()) {
-                throw new RuntimeException("expected session to remain valid");
-            }
-
-        } else {
-            sslSocket.close();
-        }
-
-
+        closeConnection(sslSocket);
 
         clientClosed = true;
         System.err.println("Client closed: " + System.nanoTime());
+    }
+
+    private void closeConnection(SSLSocket sslSocket) throws IOException {
+        if ("shutdownInput".equals(socketCloseType)) {
+            shutdownInput(sslSocket);
+            // second call to shutdownInput() should just return,
+            // shouldn't throw any exception
+            sslSocket.shutdownInput();
+            // invoking shutdownOutput() just after shutdownInput()
+            sslSocket.shutdownOutput();
+        } else if ("shutdownOutput".equals(socketCloseType)) {
+            sslSocket.shutdownOutput();
+            // second call to shutdownInput() should just return,
+            // shouldn't throw any exception
+            sslSocket.shutdownOutput();
+            // invoking shutdownInput() just after shutdownOutput()
+            shutdownInput(sslSocket);
+        } else {
+            sslSocket.close();
+        }
+    }
+
+    private void shutdownInput(SSLSocket sslSocket) throws IOException {
+        try {
+            sslSocket.shutdownInput();
+        } catch (SSLException e) {
+            System.out.println("----------- Hello: ");
+            if (!e.getMessage().contains
+                    ("closing inbound before receiving peer's close_notify")) {
+                throw new RuntimeException("expected different exception "
+                        + "message. " + e.getMessage());
+            }
+        }
+        if (!sslSocket.getSession().isValid()) {
+            throw new RuntimeException("expected session to remain valid");
+        }
     }
 
     /*
@@ -197,11 +219,13 @@ public class SSLSocketCloseHang {
         System.setProperty("javax.net.ssl.keyStorePassword", passwd);
         System.setProperty("javax.net.ssl.trustStore", trustFilename);
         System.setProperty("javax.net.ssl.trustStorePassword", passwd);
+        System.setProperty("jdk.tls.client.protocols", args[0]);
 
         if (debug)
             System.setProperty("javax.net.debug", "all");
 
-        shutdownInputTest = args.length > 0 ? true : false;
+        socketCloseType = args.length > 1 ? args[1] : "";
+
 
         /*
          * Start the tests.


### PR DESCRIPTION
There is a lack of tests in the area of  java.net.Socket.shutdownInput() and java.net.Socket.shutdownOutput() , so added more tests in this area of with different TLS versions. Please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260923](https://bugs.openjdk.java.net/browse/JDK-8260923): Add more tests for SSLSocket input/output shutdown


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2745/head:pull/2745` \
`$ git checkout pull/2745`

Update a local copy of the PR: \
`$ git checkout pull/2745` \
`$ git pull https://git.openjdk.java.net/jdk pull/2745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2745`

View PR using the GUI difftool: \
`$ git pr show -t 2745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2745.diff">https://git.openjdk.java.net/jdk/pull/2745.diff</a>

</details>
