### PR TITLE
JDK-8262461: handle wcstombsdmp return value correctly in unix awt_InputMethod.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1235,8 +1235,12 @@ StatusDrawCallback(XIC ic, XPointer client_data,
                 statusWindow->status[MAX_STATUS_LEN - 1] = '\0';
             } else {
                 char *mbstr = wcstombsdmp(text->string.wide_char, text->length);
+                if (mbstr == NULL) {
+                    goto finally;
+                }
                 strncpy(statusWindow->status, mbstr, MAX_STATUS_LEN);
                 statusWindow->status[MAX_STATUS_LEN - 1] = '\0';
+                free(mbstr);
             }
             statusWindow->on = True;
             onoffStatusWindow(pX11IMData, statusWindow->parent, True);


### PR DESCRIPTION
The function wcstombsdmp is called at a few places in awt_InputMethod.c.
This function needs checking of a NULL return value and freeing of the memory allocated by this function. However this is missing at one place in the file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262461](https://bugs.openjdk.java.net/browse/JDK-8262461): handle wcstombsdmp return value correctly in unix awt_InputMethod.c


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2747/head:pull/2747`
`$ git checkout pull/2747`
