### PR TITLE
8260869: Test java/foreign/TestHandshake.java fails intermittently

### DIFF
--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -56,6 +56,8 @@ public class TestHandshake {
     static final int MAX_EXECUTOR_WAIT_SECONDS = 10;
     static final int MAX_THREAD_SPIN_WAIT_MILLIS = 200;
 
+    static final int NUM_ACCESSORS = Math.max(10, Runtime.getRuntime().availableProcessors());
+
     static final AtomicLong start = new AtomicLong();
 
     @Test(dataProvider = "accessors")
@@ -65,7 +67,7 @@ public class TestHandshake {
             System.out.println("ITERATION " + it);
             ExecutorService accessExecutor = Executors.newCachedThreadPool();
             start.set(System.currentTimeMillis());
-            for (int i = 0; i < Runtime.getRuntime().availableProcessors() ; i++) {
+            for (int i = 0; i < NUM_ACCESSORS ; i++) {
                 accessExecutor.execute(accessorFactory.make(i, segment));
             }
             int delay = ThreadLocalRandom.current().nextInt(MAX_DELAY_MILLIS);

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -56,7 +56,7 @@ public class TestHandshake {
     static final int MAX_EXECUTOR_WAIT_SECONDS = 10;
     static final int MAX_THREAD_SPIN_WAIT_MILLIS = 200;
 
-    static final int NUM_ACCESSORS = Math.max(10, Runtime.getRuntime().availableProcessors());
+    static final int NUM_ACCESSORS = Math.min(10, Runtime.getRuntime().availableProcessors());
 
     static final AtomicLong start = new AtomicLong();
 


### PR DESCRIPTION
This simple fix reduces the amount of concurrency on the foreign memory TestHandshake test. As this test spins a new accessor thread for each available processors, on machines which feature an high number of available processors (because of multi-threading), and which are slower in forking new threads (e.g. Windows), the test can sometimes timeout.

The sensible step, for now, is to introduce an hard limit on the number of concurrent accessor threads being created. I've looked at the test logs quite in depth, and there's nothing suggesting that something else is amiss - the number of concurrent threads just seem to be too high in some instances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260869](https://bugs.openjdk.java.net/browse/JDK-8260869): Test java/foreign/TestHandshake.java fails intermittently


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2748/head:pull/2748`
`$ git checkout pull/2748`
