### PR TITLE
8262438: sun/security/ssl/SSLLogger/LoggingFormatConsistency.java failed with "SocketException: Socket is closed"

### DIFF
--- a/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
+++ b/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
@@ -77,6 +77,7 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
             var incorrectTLSVersionsFormat = new String[]{"TLS10", "TLS11", "TLS12", "TLS13"};
 
             for (var i = 0; i < correctTlsVersionsFormat.length; i++) {
+                Thread.sleep(1000);
                 var expectedTLSVersion = correctTlsVersionsFormat[i];
                 var incorrectTLSVersion = incorrectTLSVersionsFormat[i];
 
@@ -90,7 +91,11 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
                         "runTest"); // Ensuring args.length is greater than 0 when test JVM starts
 
                 if (output.getExitValue() != 0) {
-                    throw new RuntimeException("Test JVM process failed. JVM stderr= " + output.getStderr());
+                    System.out.println("Process output = ");
+                    for (String line : output.asLines()) {
+                        System.out.println(line);
+                    }
+                    throw new RuntimeException("Test JVM process failed");
                 }
 
                 output.shouldContain(expectedTLSVersion);
@@ -132,11 +137,11 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
 
         var host = serverAddress == null ? "localhost" : serverAddress.getHostAddress();
         var url = new URL("https://" + host + ":" + serverPort + "/");
-        var httpsConnection = (HttpsURLConnection) url.openConnection();
-        httpsConnection.disconnect();
-        try (var in = new BufferedReader(new InputStreamReader(httpsConnection.getInputStream()))) {
-            // Getting the input stream from the BufferedReader is sufficient to generate the desired debug output
-            // We don't need to process the data
+        System.out.println("Connecting to " + url);
+
+        try (var in = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            // Opening the connection and getting the input stream is sufficient
+            // to generate debug logs
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
+++ b/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
@@ -89,7 +89,11 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
                         "LoggingFormatConsistency",
                         "runTest"); // Ensuring args.length is greater than 0 when test JVM starts
 
-                output.asLines().stream().filter(line -> line.startsWith("Connecting to")).forEach(System.out::println); // prints connection info from test jvm output
+                output.asLines()
+                        .stream()
+                        .filter(line -> line.startsWith("Connecting to"))
+                        .forEach(System.out::println); // prints connection info from test jvm output
+
                 if (output.getExitValue() != 0) {
                     output.asLines().forEach(System.out::println);
                     throw new RuntimeException("Test JVM process failed");


### PR DESCRIPTION
Hi all,

Please review my test fix relating to JDK-8262438

This patch introduces as Thread.sleep at the start of each iteration which creates a new test jvm. 
This allows the server socket sufficient time to release the previous connection and allows the port to be used again.

I also refactored the behaviour for when the exitCode is not 0, allowing for an easier to read output.
An incorrect HttpsUrlConnection.disconnect() was also removed.

The test was ran 100 times on all platforms and no failures were seen. 

Thanks,
Evan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262438](https://bugs.openjdk.java.net/browse/JDK-8262438): sun/security/ssl/SSLLogger/LoggingFormatConsistency.java failed with "SocketException: Socket is closed"


### Reviewers
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2749/head:pull/2749`
`$ git checkout pull/2749`
