### PR TITLE
8262424: Change multiple get_java_xxx() functions in thread.cpp into one function

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -896,11 +896,11 @@ static void create_initial_thread(Handle thread_group, JavaThread* thread,
                                       JavaThreadStatus::RUNNABLE);
 }
 
-char java_version[64] = "";
-char java_runtime_name[128] = "";
-char java_runtime_version[128] = "";
-char java_runtime_vendor_version[128] = "";
-char java_runtime_vendor_vm_bug_url[128] = "";
+static char java_version[64] = "";
+static char java_runtime_name[128] = "";
+static char java_runtime_version[128] = "";
+static char java_runtime_vendor_version[128] = "";
+static char java_runtime_vendor_vm_bug_url[128] = "";
 
 // Extract version and vendor specific information.
 static const char* get_java_version_info(InstanceKlass* ik,


### PR DESCRIPTION
Please review this small fix to change the multiple get_java_xxx() functions in thread.cpp into a single function.

The fix was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, and tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262424](https://bugs.openjdk.java.net/browse/JDK-8262424): Change multiple get_java_xxx() functions in thread.cpp into one function


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 2d8f10ccaaf31126455253eadeef3b07454796a4
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2750/head:pull/2750`
`$ git checkout pull/2750`
