### PR TITLE
8262368: wrong verifier message for bogus return type

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -1675,7 +1675,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
         case Bytecodes::_return :
           if (return_type != VerificationType::bogus_type()) {
             verify_error(ErrorContext::bad_code(bci),
-                         "Method expects a return value");
+                         "Method descriptor has a non-void return type");
             return;
           }
           // Make sure "this" has been initialized if current method is an
@@ -3149,7 +3149,7 @@ void ClassVerifier::verify_return_value(
   if (return_type == VerificationType::bogus_type()) {
     verify_error(ErrorContext::bad_type(bci,
         current_frame->stack_top_ctx(), TypeOrigin::signature(return_type)),
-        "Method expects a return value");
+        "Method descriptor has a void return type");
     return;
   }
   bool match = return_type.is_assignable_from(type, this, false, CHECK_VERIFY(this));

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -1675,7 +1675,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
         case Bytecodes::_return :
           if (return_type != VerificationType::bogus_type()) {
             verify_error(ErrorContext::bad_code(bci),
-                         "Method descriptor has a non-void return type");
+                         "Method expects a return value");
             return;
           }
           // Make sure "this" has been initialized if current method is an
@@ -3149,7 +3149,7 @@ void ClassVerifier::verify_return_value(
   if (return_type == VerificationType::bogus_type()) {
     verify_error(ErrorContext::bad_type(bci,
         current_frame->stack_top_ctx(), TypeOrigin::signature(return_type)),
-        "Method descriptor has a void return type");
+        "Method does not expect a return value");
     return;
   }
   bool match = return_type.is_assignable_from(type, this, false, CHECK_VERIFY(this));

--- a/test/hotspot/jtreg/runtime/verifier/ReturnMsgs.java
+++ b/test/hotspot/jtreg/runtime/verifier/ReturnMsgs.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8262368
+ * @summary Test that VerifyError messages are correct when return bytecodes
+ *          andd method signatures do not match.
+ * @compile Returns.jasm
+ * @run main/othervm -Xverify ReturnMsgs
+ */
+
+public class ReturnMsgs {
+
+    public static void main(String args[]) throws Throwable {
+        System.out.println("Regression test for bug 8262368");
+
+        try {
+            // Test message for class with a void return type in its method
+            // descriptor, containing an 'ireturn' bytecode.
+            Class newClass = Class.forName("VoidReturnSignature");
+            throw new RuntimeException("Expected VerifyError exception not thrown");
+        } catch (java.lang.VerifyError e) {
+            String eMsg = e.getMessage();
+            if (!eMsg.contains("Method descriptor has a void return type")) {
+                throw new RuntimeException("Unexpected exception message: " + eMsg);
+            }
+        }
+
+        try {
+            // Test message for class with a non-void return type in its
+            // method descriptor, containing a 'return' bytecode.
+            Class newClass = Class.forName("NonVoidReturnSignature");
+            throw new RuntimeException("Expected VerifyError exception not thrown");
+        } catch (java.lang.VerifyError e) {
+            String eMsg = e.getMessage();
+            if (!eMsg.contains("Method descriptor has a non-void return type")) {
+                throw new RuntimeException("Unexpected exception message: " + eMsg);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/ReturnMsgs.java
+++ b/test/hotspot/jtreg/runtime/verifier/ReturnMsgs.java
@@ -42,7 +42,7 @@ public class ReturnMsgs {
             throw new RuntimeException("Expected VerifyError exception not thrown");
         } catch (java.lang.VerifyError e) {
             String eMsg = e.getMessage();
-            if (!eMsg.contains("Method descriptor has a void return type")) {
+            if (!eMsg.contains("Method does not expect a return value")) {
                 throw new RuntimeException("Unexpected exception message: " + eMsg);
             }
         }
@@ -54,7 +54,7 @@ public class ReturnMsgs {
             throw new RuntimeException("Expected VerifyError exception not thrown");
         } catch (java.lang.VerifyError e) {
             String eMsg = e.getMessage();
-            if (!eMsg.contains("Method descriptor has a non-void return type")) {
+            if (!eMsg.contains("Method expects a return value")) {
                 throw new RuntimeException("Unexpected exception message: " + eMsg);
             }
         }

--- a/test/hotspot/jtreg/runtime/verifier/Returns.jasm
+++ b/test/hotspot/jtreg/runtime/verifier/Returns.jasm
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// This class should fail verification because method voidRetSig has a void
+// return signature and an ireturn bytecode.
+super public class VoidReturnSignature version 61:0 {
+    public Method "<init>":"()V" stack 1 locals 1 {
+        aload_0;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    static Method voidRetSig:"(I)V" stack 1 locals 1 {
+        iconst_5;
+        ireturn;
+    }
+
+    public static Method main:"([Ljava/lang/String;)V" throws java/lang/Throwable stack 0 locals 1 {
+        return;
+    }
+
+} // end Class VoidReturnSignature
+
+
+
+// This class should fail verification because method nonVoidReturnSig has
+// a non-void return signature and a return bytecode.
+super public class NonVoidReturnSignature version 61:0 {
+    public Method "<init>":"()V" stack 1 locals 1 {
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    static Method nonVoidReturnSig:"(I)I" stack 1 locals 1 {
+        iconst_5;
+        return;
+    }
+
+    public static Method main:"([Ljava/lang/String;)V" throws java/lang/Throwable stack 0 locals 1 {
+        return;
+    }
+
+} // end Class NonVoidReturnSignature


### PR DESCRIPTION
Please review this small change to fix some verifier error messages.  If a method's descriptor has a void return signature, but contains a bytecode such as 'ireturn' or 'areturn'. then it will get a VerifyError exception with the message "Method descriptor has a void return type".   Conversely, if a method's descriptor has a non-void return signature, but contains a 'return' bytecode then it will get a VerifyError exception with the message "Method descriptor has a non-void return type".

A sample error message looks like:
Error: Unable to initialize main class Hi
Caused by: java.lang.VerifyError: Method descriptor has a void return type
Exception Details:
  Location:
    Hi.noRet(I)V @1: ireturn
  Reason:
    Type integer (current frame, stack[0]) is not assignable to top (from method signature)
  Current Frame:
    bci: @1
    flags: { }
    locals: { integer }
    stack: { integer }
  Bytecode:
    0000000: 08ac

The fix was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, tiers 3-5 on Linux x64. and the JCK Lang and VM tests on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262368](https://bugs.openjdk.java.net/browse/JDK-8262368): wrong verifier message for bogus return type


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2757/head:pull/2757`
`$ git checkout pull/2757`
