### PR TITLE
8262491: AArch64: CPU description should contain compatible board list

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -130,6 +130,8 @@ public:
 
   static bool supports_fast_class_init_checks() { return true; }
   constexpr static bool supports_stack_watermark_barrier() { return true; }
+
+  static void get_compatible_board(char *buf, int buflen);
 };
 
 #endif // CPU_AARCH64_VM_VERSION_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
@@ -52,26 +52,9 @@ void VM_Version_Ext::initialize_cpu_information(void) {
   _no_of_sockets = _no_of_cores;
   snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "AArch64");
 
-  int fd = open("/proc/device-tree/compatible", O_RDONLY);
-  if (fd != -1) {
-    struct stat statbuf;
-    fstat(fd, &statbuf);
-    char* tmp = NEW_C_HEAP_ARRAY(char, statbuf.st_size, mtInternal);
-    if (read(fd, tmp, statbuf.st_size) != -1) {
-      // Replace '\0' to ' '
-      char *tok = tmp;
-      while ((tok = (char*)memchr(tok, 0, statbuf.st_size - (tok - tmp) - 1)) != NULL) {
-        *tok = ' ';
-      }
-      snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s %s", tmp, _features_string);
-    } else {
-      snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 %s", _features_string);
-    }
-    FREE_C_HEAP_ARRAY(char, tmp);
-    close(fd);
-  } else {
-    snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 %s", _features_string);
-  }
+  VM_Version::get_compatible_board(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE);
+  size_t desc_len = strlen(_cpu_desc);
+  snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
 
   _initialized = true;
 }

--- a/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
@@ -54,7 +54,7 @@ void VM_Version_Ext::initialize_cpu_information(void) {
 
   int desc_len = snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 ");
   VM_Version::get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
-  desc_len = strlen(_cpu_desc);
+  desc_len = (int)strlen(_cpu_desc);
   snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
 
   _initialized = true;

--- a/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
@@ -52,8 +52,9 @@ void VM_Version_Ext::initialize_cpu_information(void) {
   _no_of_sockets = _no_of_cores;
   snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "AArch64");
 
-  VM_Version::get_compatible_board(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE);
-  size_t desc_len = strlen(_cpu_desc);
+  int desc_len = snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "AArch64 ");
+  VM_Version::get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
+  desc_len = strlen(_cpu_desc);
   snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
 
   _initialized = true;

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -175,14 +175,16 @@ void VM_Version::get_compatible_board(char *buf, int buflen) {
   int fd = open("/proc/device-tree/compatible", O_RDONLY);
   if (fd != -1) {
     ssize_t read_sz = read(fd, buf, buflen - 1);
-    buf[buflen - 1] = '\0';
     if (read_sz > 0) {
+      buf[read_sz] = '\0';
       // Replace '\0' to ' '
       for (char *ch = buf; ch < buf + read_sz; ch++) {
         if (*ch == '\0') {
           *ch = ' ';
         }
       }
+    } else {
+      *buf = '\0';
     }
     close(fd);
   }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -171,15 +171,12 @@ void VM_Version::get_os_cpu_info() {
 void VM_Version::get_compatible_board(char *buf, int buflen) {
   const char *aarch64_label = "AArch64";
   assert((buf != NULL) && ((size_t)buflen >= (strlen(aarch64_label) + 1)), "invalid argument");
+  strncpy(buf, aarch64_label, buflen);
 
   int fd = open("/proc/device-tree/compatible", O_RDONLY);
   if (fd != -1) {
     struct stat statbuf;
     fstat(fd, &statbuf);
-    if (buflen < statbuf.st_size) {
-      strncpy(buf, aarch64_label, buflen);
-      return;
-    }
     ssize_t read_sz = read(fd, buf, statbuf.st_size);
     if (read_sz != -1) {
       // Replace '\0' to ' '
@@ -187,11 +184,7 @@ void VM_Version::get_compatible_board(char *buf, int buflen) {
       while ((tok = (char*)memchr(tok, 0, statbuf.st_size - (tok - buf) - 1)) != NULL) {
         *tok = ' ';
       }
-    } else {
-      strncpy(buf, aarch64_label, buflen);
     }
     close(fd);
-  } else {
-    strncpy(buf, aarch64_label, buflen);
   }
 }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -165,5 +165,33 @@ void VM_Version::get_os_cpu_info() {
       }
     }
     fclose(f);
+  }
+}
+
+void VM_Version::get_compatible_board(char *buf, int buflen) {
+  const char *aarch64_label = "AArch64";
+  assert((buf != NULL) && ((size_t)buflen >= (strlen(aarch64_label) + 1)), "invalid argument");
+
+  int fd = open("/proc/device-tree/compatible", O_RDONLY);
+  if (fd != -1) {
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    if (buflen < statbuf.st_size) {
+      strncpy(buf, aarch64_label, buflen);
+      return;
+    }
+    ssize_t read_sz = read(fd, buf, statbuf.st_size);
+    if (read_sz != -1) {
+      // Replace '\0' to ' '
+      char *tok = buf;
+      while ((tok = (char*)memchr(tok, 0, statbuf.st_size - (tok - buf) - 1)) != NULL) {
+        *tok = ' ';
+      }
+    } else {
+      strncpy(buf, aarch64_label, buflen);
+    }
+    close(fd);
+  } else {
+    strncpy(buf, aarch64_label, buflen);
   }
 }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -170,17 +170,18 @@ void VM_Version::get_os_cpu_info() {
 
 void VM_Version::get_compatible_board(char *buf, int buflen) {
   assert(buf != NULL, "invalid argument");
+  assert(buflen >= 1, "invalid argument");
   *buf = '\0';
   int fd = open("/proc/device-tree/compatible", O_RDONLY);
   if (fd != -1) {
-    struct stat statbuf;
-    fstat(fd, &statbuf);
-    ssize_t read_sz = read(fd, buf, statbuf.st_size);
+    ssize_t read_sz = read(fd, buf, buflen);
+    buf[buflen - 1] = '\0';
     if (read_sz != -1) {
       // Replace '\0' to ' '
-      char *tok = buf;
-      while ((tok = (char*)memchr(tok, 0, statbuf.st_size - (tok - buf) - 1)) != NULL) {
-        *tok = ' ';
+      for (char *ch = buf; ch < buf + read_sz; ch++) {
+        if (*ch == '\0') {
+          *ch = ' ';
+        }
       }
     }
     close(fd);

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -169,10 +169,8 @@ void VM_Version::get_os_cpu_info() {
 }
 
 void VM_Version::get_compatible_board(char *buf, int buflen) {
-  const char *aarch64_label = "AArch64";
-  assert((buf != NULL) && ((size_t)buflen >= (strlen(aarch64_label) + 1)), "invalid argument");
-  strncpy(buf, aarch64_label, buflen);
-
+  assert(buf != NULL, "invalid argument");
+  *buf = '\0';
   int fd = open("/proc/device-tree/compatible", O_RDONLY);
   if (fd != -1) {
     struct stat statbuf;

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -174,9 +174,9 @@ void VM_Version::get_compatible_board(char *buf, int buflen) {
   *buf = '\0';
   int fd = open("/proc/device-tree/compatible", O_RDONLY);
   if (fd != -1) {
-    ssize_t read_sz = read(fd, buf, buflen);
+    ssize_t read_sz = read(fd, buf, buflen - 1);
     buf[buflen - 1] = '\0';
-    if (read_sz != -1) {
+    if (read_sz > 0) {
       // Replace '\0' to ' '
       for (char *ch = buf; ch < buf + read_sz; ch++) {
         if (*ch == '\0') {

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -99,7 +99,6 @@ void VM_Version::get_os_cpu_info() {
 }
 
 void VM_Version::get_compatible_board(char *buf, int buflen) {
-  const char *aarch64_label = "AArch64";
-  assert((buf != NULL) && ((size_t)buflen >= (strlen(aarch64_label) + 1)), "invalid argument");
-  strncpy(buf, aarch64_label, buflen);
+  assert(buf != NULL, "invalid argument");
+  *buf = '\0';
 }

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -100,5 +100,6 @@ void VM_Version::get_os_cpu_info() {
 
 void VM_Version::get_compatible_board(char *buf, int buflen) {
   assert(buf != NULL, "invalid argument");
+  assert(buflen >= 1, "invalid argument");
   *buf = '\0';
 }

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2020, 2021, Microsoft Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,4 +96,10 @@ void VM_Version::get_os_cpu_info() {
       _revision = si.wProcessorRevision & 0xFF;
     }
   }
+}
+
+void VM_Version::get_compatible_board(char *buf, int buflen) {
+  const char *aarch64_label = "AArch64";
+  assert((buf != NULL) && ((size_t)buflen >= (strlen(aarch64_label) + 1)), "invalid argument");
+  strncpy(buf, aarch64_label, buflen);
 }


### PR DESCRIPTION
HotSpot generates CPU description when it is started. We can see it `jdk.CPUInformation` JFR event as below:

```
$ jfr print --events jdk.CPUInformation raspi4.jfr
jdk.CPUInformation {
  startTime = 22:57:13.521
  cpu = "AArch64"
  description = "AArch64 0x41:0x0:0xd08:3, simd, crc"
  sockets = 4
  cores = 4
  hwThreads = 4
}
```

`description` contains "AArch64", it is fixed value, we cannot guess the process was run on what machine (SoC).

In Linux, we can use `compatible`property in device tree to guess the machine. The 'compatible' property contains a sorted list of strings starting with the exact name of the machine, followed by an optional list of boards it is compatible with sorted from most compatible to least.

After this change, we can get the description as below:

```
jdk.CPUInformation {
  startTime = 00:32:49.767
  cpu = "AArch64"
  description = "raspberrypi,4-model-b brcm,bcm2711 0x41:0x0:0xd08:3, simd, crc"
  sockets = 4
  cores = 4
  hwThreads = 4
}
```

In Linux on AMD64, we can see as following, then we can guess the CPU model from it. The same should do for AArch64.

```
jdk.CPUInformation {
  startTime = 17:28:03.907
  cpu = "AMD (null) (HT) SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 SSE4A AMD64"
  description = "Brand: AMD Ryzen 3 3300X 4-Core Processor , Vendor: AuthenticAMD
Family: <unknown> (0x17), Model: <unknown> (0x71), Stepping: 0x0
Ext. family: 0x8, Ext. model: 0x7, Type: 0x0, Signature: 0x00870f10
Features: ebx: 0x01020800, ecx: 0xfed83203, edx: 0x178bfbff
Ext. features: eax: 0x00870f10, ebx: 0x20000000, ecx: 0x004003f3, edx: 0x2fd3fbff
Supports: On-Chip FPU, Virtual Mode Extensions, Debugging Extensions, Page Size Extensions, Time Stamp Counter, Model Specific Registers, Physical Address Extension, Machine Check Exceptions, CMPXCHG8B Instruction, On-Chip APIC, Fast System Call, Memory Type Range Registers, Page Global Enable, Machine Check Architecture, Conditional Mov Instruction, Page Attribute Table, 36-bit Page Size Extension, CLFLUSH Instruction, Intel Architecture MMX Technology, Fast Float Point Save and Restore, Streaming SIMD extensions, Streaming SIMD extensions 2, Hyper Threading, Streaming SIMD Extensions 3, PCLMULQDQ, Supplemental Streaming SIMD Extensions 3, Fused Multiply-Add, CMPXCHG16B, Streaming SIMD extensions 4.1, Streaming SIMD extensions 4.2, MOVBE, Popcount instruction, AESNI, XSAVE, OSXSAVE, AVX, F16C, LAHF/SAHF instruction support, Core multi-processor leagacy mode, Advanced Bit Manipulations: LZCNT, SSE4A: MOVNTSS, MOVNTSD, EXTRQ, INSERTQ, Misaligned SSE mode, SYSCALL/SYSRET, Execute Disable Bit, RDTSCP, Intel 64 Architecture"
  sockets = 1
  cores = 2
  hwThreads = 2
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262491](https://bugs.openjdk.java.net/browse/JDK-8262491): AArch64: CPU description should contain compatible board list


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role) ⚠️ Review applies to 8c8953613426326a1fbcdbacb4488691a1156329
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2759/head:pull/2759`
`$ git checkout pull/2759`
