### PR TITLE
8262085: Hovering Metal HTML Tooltips in different windows cause IllegalArgExc on Linux

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolTipUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolTipUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import sun.swing.SwingUtilities2;
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
-import javax.swing.BorderFactory;
-import javax.swing.border.Border;
 import javax.swing.plaf.*;
 import javax.swing.plaf.basic.BasicToolTipUI;
 import javax.swing.plaf.basic.BasicHTML;
@@ -120,6 +118,11 @@ public class MetalToolTipUI extends BasicToolTipUI {
             insets.top,
             size.width - (insets.left + insets.right) - 6 - accelSpacing,
             size.height - (insets.top + insets.bottom));
+
+        if (paintTextR.width <= 0 || paintTextR.height <= 0) {
+            return;
+        }
+
         View v = (View) c.getClientProperty(BasicHTML.propertyKey);
         if (v != null) {
             v.paint(g, paintTextR);

--- a/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
+++ b/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
@@ -56,8 +56,9 @@ public class FastTooltipSwitchIAE {
         try {
             System.out.println("LookAndFeel: " + laf.getClassName());
             UIManager.setLookAndFeel(laf.getClassName());
-        } catch (ClassNotFoundException | InstantiationException |
-                UnsupportedLookAndFeelException | IllegalAccessException e) {
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.err.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }

--- a/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
+++ b/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
@@ -115,7 +115,7 @@ public class FastTooltipSwitchIAE {
 
         boolean moveToDialog = true;
 
-        int timeoutMs = 60_000;
+        int timeoutMs = 40_000;
         long endTime = System.currentTimeMillis() + timeoutMs;
 
         while (

--- a/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
+++ b/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8262085
+ * @summary Tests tooltip for not throwing IllegalArgumentException on fast switching between frames.
+ * @run main FastTooltipSwitchIAE
+ */
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.WindowConstants;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Window;
+
+public class FastTooltipSwitchIAE {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                UIManager.setLookAndFeel(new MetalLookAndFeel());
+            } catch (UnsupportedLookAndFeelException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        FastTooltipSwitchIAE fastTooltipSwitchIAE = new FastTooltipSwitchIAE();
+        fastTooltipSwitchIAE.doTest();
+    }
+
+    Robot robot = new Robot();
+    JFrame frame;
+    JDialog dialog;
+
+    public FastTooltipSwitchIAE() throws AWTException {
+        SwingUtilities.invokeLater(() -> {
+            frame = new JFrame("Frame");
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            frame.setSize(250, 250);
+            frame.setLocation(100, 100);
+
+            frame.add(createLabel("Frame label", Color.RED, "frame tooltip"));
+            frame.setVisible(true);
+
+            dialog = new JDialog(frame, "Dialog");
+            dialog.add(createLabel("Dialog label", Color.YELLOW, "dialog tooltip"));
+            dialog.pack();
+            dialog.setLocation(350, 100);
+            dialog.setVisible(true);
+        });
+    }
+
+    private Point getCenter(Window window) {
+        Rectangle bounds = window.getBounds();
+        Insets insets = window.getInsets();
+        int width = bounds.width - insets.right - insets.left;
+        int height = bounds.height - insets.top - insets.bottom;
+
+        return new Point(
+                bounds.x + insets.left + width / 2,
+                bounds.y + insets.top + height / 2
+        );
+    }
+
+    private volatile Throwable unexpectedThrowable = null;
+
+    private void doTest() throws InterruptedException {
+        robot.waitForIdle();
+
+        Point frameCenter = getCenter(frame);
+        Point dialogCenter = getCenter(dialog);
+
+
+        robot.mouseMove(frameCenter.x, frameCenter.y);
+
+        // waiting for tooltip to show up
+        Thread.sleep(3000);
+
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            // Let's catch all exceptions, not only IllegalArgumentException
+            unexpectedThrowable = e;
+            e.printStackTrace();
+        });
+
+        boolean moveToDialog = true;
+
+        int timeoutMs = 60_000;
+        long endTime = System.currentTimeMillis() + timeoutMs;
+
+        while (
+                unexpectedThrowable == null
+                        && System.currentTimeMillis() <= endTime
+        ) {
+            if (moveToDialog) {
+                robot.mouseMove(dialogCenter.x, dialogCenter.y);
+            } else {
+                robot.mouseMove(frameCenter.x, frameCenter.y);
+            }
+            robot.waitForIdle();
+            moveToDialog = !moveToDialog;
+        }
+        frame.dispose();
+        if (unexpectedThrowable == null) {
+            System.out.println("Test passed, no exception thrown in " + timeoutMs + "ms");
+        } else {
+            throw new RuntimeException("Test failed due to exception thrown:", unexpectedThrowable);
+        }
+    }
+
+    private static JLabel createLabel(
+            final String labelText,
+            final Color bgColor,
+            final String tooltipContent
+    ) {
+        final JLabel label = new JLabel(labelText);
+        label.setOpaque(true);
+        label.setBackground(bgColor);
+        label.setToolTipText("<html><h1>" + tooltipContent + "</h1></html>");
+        return label;
+    }
+}


### PR DESCRIPTION
This issue occurs only under `MetalLookAndFeel` on Linux. 

It was introduced by [JDK-8040630](https://bugs.openjdk.java.net/browse/JDK-8040630) fix.

> component.setBounds(ownerX, ownerY, 1, 1);

This line adds an extra reshape call with `1x1` size right before getting another one with correct sizes.

If `MetalToolTipUI#paint()` call happens before getting correct sizes,  it calculates `paintTextR` with negative sizes for component with `1x1` size,  thus IAE is thrown.

The fix is to do not proceed with `paint()` for negative sizes.
The provided test fails for me in 0-30s interval(before the fix), other testing(client-tier1,2,3) looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262085](https://bugs.openjdk.java.net/browse/JDK-8262085): Hovering Metal HTML Tooltips in different windows cause IllegalArgExc on Linux


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 034425b06b3efa4c6426e3c0b77c83ce8596b2ea
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2761/head:pull/2761`
`$ git checkout pull/2761`
