### PR TITLE
8263138: Initialization of sun.font.SunFontManager.platformFontMap is not thread safe

### DIFF
--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -1433,6 +1433,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         public String boldFileName;
         public String italicFileName;
         public String boldItalicFileName;
+        boolean failed;
     }
 
     static HashMap<String, FamilyDescription> platformFontMap;
@@ -1445,8 +1446,10 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
     }
 
     Font2D findFontFromPlatformMap(String lcName, int style) {
+        HashMap<String, FamilyDescription> platformFontMap = SunFontManager.platformFontMap;
         if (platformFontMap == null) {
             platformFontMap = populateHardcodedFileNameMap();
+            SunFontManager.platformFontMap = platformFontMap;
         }
 
         if (platformFontMap == null || platformFontMap.size() == 0) {
@@ -1460,7 +1463,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         }
 
         FamilyDescription fd = platformFontMap.get(firstWord);
-        if (fd == null) {
+        if (fd == null || fd.failed) {
             return null;
         }
         /* Once we've established that its at least the first word,
@@ -1527,7 +1530,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
             if (FontUtilities.isLogging()) {
                 FontUtilities.logInfo("Hardcoded file missing looking for " + lcName);
             }
-            platformFontMap.remove(firstWord);
+            fd.failed = true;
             return null;
         }
 
@@ -1554,7 +1557,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
             if (FontUtilities.isLogging()) {
                 FontUtilities.logInfo("Hardcoded file missing looking for " + lcName);
             }
-            platformFontMap.remove(firstWord);
+            fd.failed = true;
             return null;
         }
 

--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -1436,7 +1436,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         boolean failed;
     }
 
-    static HashMap<String, FamilyDescription> platformFontMap;
+    static volatile HashMap<String, FamilyDescription> platformFontMap;
 
     /**
      * default implementation does nothing.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263138](https://bugs.openjdk.java.net/browse/JDK-8263138): Initialization of sun.font.SunFontManager.platformFontMap is not thread safe


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2762/head:pull/2762`
`$ git checkout pull/2762`
