### PR TITLE
8262500: HostName entry in VM.info should be a new line

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1700,9 +1700,9 @@ void os::print_os_info(outputStream* st) {
   char buffer[1024];
   st->print("HostName: ");
   if (get_host_name(buffer, sizeof(buffer))) {
-    st->print("%s ", buffer);
+    st->print_cr(buffer);
   } else {
-    st->print("N/A ");
+    st->print_cr("N/A");
   }
 #endif
   st->print_cr("OS:");


### PR DESCRIPTION
We can get host name from VM.info dcmd (and also hs_err log) on fastdebug build as below. It affects (fast)debug build for Windows only.

```
--------------- S Y S T E M ---------------

HostName: Xelvis OS:
 Windows 10 , 64 bit Build 19041 (10.0.19041.804)
OS uptime: 1 days 1:33 hours
Hyper-V role detected
```

`OS` label is available within HostName entry. It should be in a new line.

After this change, we can get VM.info output as below:

```
---------------  S Y S T E M  ---------------

HostName: Xelvis
OS:
 Windows 10 , 64 bit Build 19041 (10.0.19041.804)
OS uptime: 1 days 1:44 hours
Hyper-V role detected
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262500](https://bugs.openjdk.java.net/browse/JDK-8262500): HostName entry in VM.info should be a new line


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2763/head:pull/2763`
`$ git checkout pull/2763`
