### PR TITLE
8262504: Some CLHSDB command cannot know they run on remote debugger

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1128,7 +1128,7 @@ public class CommandProcessor {
         },
         new Command("pmap", "pmap", false) {
             public void doit(Tokens t) {
-                PMap pmap = new PMap();
+                PMap pmap = new PMap(debugger.getAgent());
                 pmap.run(out, debugger.getAgent().getDebugger());
             }
         },
@@ -1138,7 +1138,7 @@ public class CommandProcessor {
                 if (t.countTokens() > 0 && t.nextToken().equals("-v")) {
                     verbose = true;
                 }
-                PStack pstack = new PStack(verbose, true);
+                PStack pstack = new PStack(verbose, true, debugger.getAgent());
                 pstack.run(out, debugger.getAgent().getDebugger());
             }
         },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,9 +72,9 @@ public class HotSpotAgent {
     //  - Starting debug server for core file
 
     // These are options for the "client" side of things
-    private static final int PROCESS_MODE   = 0;
-    private static final int CORE_FILE_MODE = 1;
-    private static final int REMOTE_MODE    = 2;
+    public static final int PROCESS_MODE   = 0;
+    public static final int CORE_FILE_MODE = 1;
+    public static final int REMOTE_MODE    = 2;
     private int startupMode;
 
     // This indicates whether we are really starting a server or not
@@ -115,7 +115,7 @@ public class HotSpotAgent {
     // Accessors (once the system is set up)
     //
 
-    public synchronized Debugger getDebugger() {
+    public synchronized JVMDebugger getDebugger() {
         return debugger;
     }
 
@@ -646,5 +646,9 @@ public class HotSpotAgent {
         } else {
             throw new DebuggerException("Should not call attach() for startupMode == " + startupMode);
         }
+    }
+
+    public int getStartupMode() {
+        return startupMode;
     }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package sun.jvm.hotspot.tools;
 
 import java.io.*;
 import java.util.*;
+import sun.jvm.hotspot.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
 import sun.jvm.hotspot.utilities.PlatformInfo;
@@ -38,6 +39,10 @@ public class PMap extends Tool {
 
    public PMap(JVMDebugger d) {
        super(d);
+   }
+
+   public PMap(HotSpotAgent agent) {
+       super(agent);
    }
 
    @Override

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package sun.jvm.hotspot.tools;
 
 import java.io.*;
 import java.util.*;
+import sun.jvm.hotspot.*;
 import sun.jvm.hotspot.code.*;
 import sun.jvm.hotspot.interpreter.*;
 import sun.jvm.hotspot.debugger.*;
@@ -36,13 +37,18 @@ import sun.jvm.hotspot.utilities.PlatformInfo;
 
 public class PStack extends Tool {
     // in non-verbose mode, Method*s are not printed in java frames
-   public PStack(boolean v, boolean concurrentLocks) {
+   public PStack(boolean v, boolean concurrentLocks, HotSpotAgent agent) {
+      super(agent);
       this.verbose = v;
       this.concurrentLocks = concurrentLocks;
    }
 
+   public PStack(boolean v, boolean concurrentLocks) {
+      this(v, concurrentLocks, null);
+   }
+
    public PStack() {
-      this(true, true);
+      this(true, true, null);
    }
 
    public PStack(JVMDebugger d) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/Tool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/Tool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,22 @@ public abstract class Tool implements Runnable {
 
    public Tool(JVMDebugger d) {
       jvmDebugger = d;
+   }
+
+   public Tool(HotSpotAgent agent) {
+      this.agent = agent;
+      if (agent == null) {
+          jvmDebugger = null;
+          debugeeType = -1;
+      } else {
+          jvmDebugger = agent.getDebugger();
+          debugeeType = switch (agent.getStartupMode()) {
+              case HotSpotAgent.PROCESS_MODE   -> DEBUGEE_PID;
+              case HotSpotAgent.CORE_FILE_MODE -> DEBUGEE_CORE;
+              case HotSpotAgent.REMOTE_MODE    -> DEBUGEE_REMOTE;
+              default -> throw new IllegalStateException("Invalid attach mode");
+          };
+      }
    }
 
    public String getName() {


### PR DESCRIPTION
`pmap` and `pstack` CLHSDB command do not work on remote debugger, we can see following error message:

```
hsdb> pmap
not yet implemented (debugger does not support CDebugger)!
```

However, SA has different message for this purpose:

https://github.com/openjdk/jdk/blob/03d888f463c0a6e3fee70ed8ad606fc0a3082636/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java#L74-L78

SA should show "remote configuration is not yet implemented" when it works on remote debugger.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262504](https://bugs.openjdk.java.net/browse/JDK-8262504): Some CLHSDB command cannot know they run on remote debugger


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2766/head:pull/2766`
`$ git checkout pull/2766`
