### PR TITLE
8262507: OS label and information should be in same line

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1265,7 +1265,7 @@ void os::print_os_info_brief(outputStream* st) {
 }
 
 void os::print_os_info(outputStream* st) {
-  st->print_cr("OS:");
+  st->print("OS: ");
 
   os::Posix::print_uname_info(st);
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1990,7 +1990,7 @@ void os::print_os_info_brief(outputStream* st) {
 }
 
 void os::print_os_info(outputStream* st) {
-  st->print_cr("OS:");
+  st->print("OS: ");
 
   os::Linux::print_distro_info(st);
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1705,7 +1705,7 @@ void os::print_os_info(outputStream* st) {
     st->print("N/A ");
   }
 #endif
-  st->print_cr("OS:");
+  st->print("OS: ");
   os::win32::print_windows_version(st);
 
   os::win32::print_uptime_info(st);


### PR DESCRIPTION
We can see OS information in VM.info dcmd and hs_err log as following. Most of information and its label are in same line, but just OS is not so.

```
OS:
 Windows 10 , 64 bit Build 19041 (10.0.19041.804)
OS uptime: 1 days 23:40 hours
Hyper-V role detected

CPU: total 8 (initial active 8) (8 cores per cpu, 2 threads per core) family 23 model 113 stepping 0 microcode 0x0, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, hv

Memory: 4k page, system-wide physical 16309M (11935M free)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262507](https://bugs.openjdk.java.net/browse/JDK-8262507): OS label and information should be in same line


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2770/head:pull/2770`
`$ git checkout pull/2770`
