### PR TITLE
8262508: Vector API's ergonomics is incorrect

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4078,7 +4078,7 @@ jint Arguments::apply_ergo() {
     UseOptoBiasInlining = false;
   }
 
-  if (!EnableVectorSupport) {
+  if (!FLAG_IS_DEFAULT(EnableVectorSupport) && !EnableVectorSupport) {
     if (!FLAG_IS_DEFAULT(EnableVectorReboxing) && EnableVectorReboxing) {
       warning("Disabling EnableVectorReboxing since EnableVectorSupport is turned off.");
     }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
@@ -26,6 +26,7 @@ package compiler.vectorapi;
 /*
  * @test TestVectorErgonomics
  * @bug 8262508
+ * @requires vm.compiler2.enabled
  * @summary Check ergonomics for Vector API
  * @library /test/lib
  * @run main/othervm compiler.vectorapi.TestVectorErgonomics

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+/*
+ * @test TestVectorErgonomics
+ * @bug 8262508
+ * @summary Check ergonomics for Vector API
+ * @library /test/lib
+ * @run main/othervm compiler.vectorapi.TestVectorErgonomics
+ */
+
+import jdk.test.lib.process.ProcessTools;
+
+public class TestVectorErgonomics {
+
+    public static void main(String[] args) throws Throwable {
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorReboxing=true");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorAggressiveReboxing=true");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:-EnableVectorReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorReboxing=false")
+                    .shouldContain("EnableVectorAggressiveReboxing=false");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:-EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorAggressiveReboxing=false");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:-EnableVectorSupport", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorSupport=false")
+                    .shouldContain("EnableVectorReboxing=false")
+                    .shouldContain("EnableVectorAggressiveReboxing=false");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorSupport=false")
+                    .shouldContain("EnableVectorReboxing=false")
+                    .shouldContain("EnableVectorAggressiveReboxing=false");
+
+        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
+                    .shouldHaveExitValue(0)
+                    .shouldContain("EnableVectorSupport=false")
+                    .shouldContain("EnableVectorReboxing=false")
+                    .shouldContain("EnableVectorAggressiveReboxing=false");
+    }
+}


### PR DESCRIPTION
Hi all,

The ergonomics (e.g., EnableVectorReboxing/EnableVectorAggressiveReboxing) for Vector API doesn't work as expected.

There are two sets of rules for Vector API.
One is in Arguments::apply_ergo() [1], which sets the flags to be false.
And the other is in Modules::define_module() [2], which sets the flags to be true.

The value of EnableVectorReboxing and EnableVectorAggressiveReboxing may be changed (from specified true to false) in [1] if EnableVectorSupport=false (which is the default value).
It would be wrong when EnableVectorSupport isn't specified in the command line since it will be set true later in [2]
So rules in [1] should not be executed if EnableVectorSupport isn't specified.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/arguments.cpp#L4081
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/classfile/modules.cpp#L462

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262508](https://bugs.openjdk.java.net/browse/JDK-8262508): Vector API's ergonomics is incorrect


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2771/head:pull/2771`
`$ git checkout pull/2771`
