### PR TITLE
JDK-8262509: JSSE Server should check the legacy version in TLSv1.3 ClientHello

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -1149,6 +1149,11 @@ final class ClientHello {
                         "Received unexpected renegotiation handshake message");
             }
 
+            if (clientHello.clientVersion != ProtocolVersion.TLS12.id) {
+                throw shc.conContext.fatal(Alert.PROTOCOL_VERSION,
+                        "The ClientHello.legacy_version field is not TLS 1.2");
+            }
+
             // The client may send a dummy change_cipher_spec record
             // immediately after the first ClientHello.
             shc.conContext.consumers.putIfAbsent(


### PR DESCRIPTION
Per RFC 8446, section 4.1.2, the legacy_version field in ClientHello message MUST be set to 0x0303 (TLSv1.2).
T13ClientHelloConsumer should do this check like that T13ServerHelloConsumer does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262509](https://bugs.openjdk.java.net/browse/JDK-8262509): JSSE Server should check the legacy version in TLSv1.3 ClientHello


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2772/head:pull/2772`
`$ git checkout pull/2772`
