### PR TITLE
8262520: Add SA Command Line Debugger support to connect to debug server

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -36,7 +36,7 @@ Each CLHSDB command can have zero or more arguments and optionally end with outp
 <code>
 Available commands:
   assert true | false <font color="red">turn on/off asserts in SA code</font>
-  attach pid | exec core | remote_server  <font color="red">attach SA to a process, core, or remote debug server</font>
+  attach pid | exec core | debugserver  <font color="red">attach SA to a process, core, or remote debug server</font>
   buildreplayjars [all | boot | app] <font color="red">build jars for replay, boot.jar for bootclasses, app.jar for application classes</font>
   class name <font color="red">find a Java class from debuggee and print oop</font>
   classes <font color="red">print all loaded Java classes with Klass*</font>

--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -36,7 +36,7 @@ Each CLHSDB command can have zero or more arguments and optionally end with outp
 <code>
 Available commands:
   assert true | false <font color="red">turn on/off asserts in SA code</font>
-  attach pid | exec core  <font color="red">attach SA to a process or core</font>
+  attach pid | exec core | remote_server  <font color="red">attach SA to a process, core, or remote debug server</font>
   buildreplayjars [all | boot | app] <font color="red">build jars for replay, boot.jar for bootclasses, app.jar for application classes</font>
   class name <font color="red">find a Java class from debuggee and print oop</font>
   classes <font color="red">print all loaded Java classes with Klass*</font>

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,6 +77,9 @@ public class CLHSDB {
                 public void attach(String java, String core) {
                     attachDebugger(java, core);
                 }
+                public void connect(String remoteServer) {
+                    CLHSDB.this.connect(remoteServer);
+                }
                 public void detach() {
                     detachDebugger();
                 }
@@ -86,8 +89,10 @@ public class CLHSDB {
                     }
                     if (pidText != null) {
                         attach(pidText);
-                    } else {
+                    } else if (execPath != null) {
                         attach(execPath, coreFilename);
+                    } else if (remoteServer != null) {
+                        connect(remoteServer);
                     }
                 }
             };
@@ -111,6 +116,7 @@ public class CLHSDB {
     private int pid;
     private String execPath;
     private String coreFilename;
+    private String remoteServer;
 
     private void doUsage() {
         System.out.println("Usage:  java CLHSDB [[pid] | [path-to-java-executable [path-to-corefile]] | help ]");
@@ -217,8 +223,9 @@ public class CLHSDB {
     private void connect(final String remoteMachineName) {
         // Try to open this core file
         try {
-            System.err.println("Connecting to debug server, please wait...");
+            System.out.println("Connecting to debug server, please wait...");
             agent.attach(remoteMachineName);
+            remoteServer = remoteMachineName;
             attached = true;
         }
         catch (DebuggerException e) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -233,7 +233,7 @@ public class CLHSDB {
         }
         catch (DebuggerException e) {
             final String errMsg = formatMessage(e.getMessage(), 80);
-            System.err.println("Unable to connect to machine \"" + debugServerName + "\":\n\n" + errMsg);
+            System.err.println("Unable to connect to debug server \"" + debugServerName + "\":\n\n" + errMsg);
             agent.detach();
             e.printStackTrace();
             return;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -179,15 +179,9 @@ public class CLHSDB {
         thread or the Swing/AWT event handler thread, so we must be very
         careful when creating or removing widgets */
     private void attachDebugger(int pid) {
+        this.pid = pid;
         try {
-            this.pid = pid;
-        }
-        catch (NumberFormatException e) {
-            System.err.print("Unable to parse process ID \"" + Integer.toString(pid) + "\".\nPlease enter a number.");
-        }
-
-        try {
-            System.err.println("Attaching to process " + pid + ", please wait...");
+            System.out.println("Attaching to process " + pid + ", please wait...");
 
             // FIXME: display exec'd debugger's output messages during this
             // lengthy call

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -36,7 +36,7 @@ public class CLHSDB {
         pid = -1;
         execPath = null;
         coreFilename = null;
-        remoteMachineName = null;
+        debugServerName = null;
         jvmDebugger = d;
     }
 
@@ -50,7 +50,8 @@ public class CLHSDB {
         // If execPath != null, it is the path of a jdk/bin/java
         // and coreFilename is the pathname of a core file we are
         // supposed to attach to.
-        // Finally, if remoteMachineName != null, we are supposed to connect to remote debug server.
+        // Finally, if debugServerName != null, we are supposed to
+        // connect to remote debug server.
 
         agent = new HotSpotAgent();
 
@@ -66,8 +67,8 @@ public class CLHSDB {
             attachDebugger(pid);
         } else if (execPath != null) {
             attachDebugger(execPath, coreFilename);
-        } else if (remoteMachineName != null) {
-            connect(remoteMachineName);
+        } else if (debugServerName != null) {
+            connect(debugServerName);
         }
 
 
@@ -84,8 +85,8 @@ public class CLHSDB {
                 public void attach(String java, String core) {
                     attachDebugger(java, core);
                 }
-                public void attach(String remoteMachineName) {
-                    connect(remoteMachineName);
+                public void attach(String debugServerName) {
+                    connect(debugServerName);
                 }
                 public void detach() {
                     detachDebugger();
@@ -96,8 +97,8 @@ public class CLHSDB {
                     }
                     if (pid != -1) {
                         attach(pid);
-                    } else if (remoteMachineName != null) {
-                        connect(remoteMachineName);
+                    } else if (debugServerName != null) {
+                        connect(debugServerName);
                     } else {
                         attach(execPath, coreFilename);
                     }
@@ -122,7 +123,7 @@ public class CLHSDB {
     private int pid;
     private String execPath;
     private String coreFilename;
-    private String remoteMachineName;
+    private String debugServerName;
 
     private void doUsage() {
         System.out.println("Usage:  java CLHSDB [[pid] | [path-to-java-executable [path-to-corefile]] | help ]");
@@ -137,7 +138,7 @@ public class CLHSDB {
         pid = -1;
         execPath = null;
         coreFilename = null;
-        remoteMachineName = null;
+        debugServerName = null;
 
         switch (args.length) {
         case (0):
@@ -222,17 +223,17 @@ public class CLHSDB {
     /** NOTE we are in a different thread here than either the main
         thread or the Swing/AWT event handler thread, so we must be very
         careful when creating or removing widgets */
-    private void connect(final String remoteMachineName) {
+    private void connect(final String debugServerName) {
         // Try to open this core file
         try {
             System.out.println("Connecting to debug server, please wait...");
-            agent.attach(remoteMachineName);
-            this.remoteMachineName = remoteMachineName;
+            agent.attach(debugServerName);
+            this.debugServerName = debugServerName;
             attached = true;
         }
         catch (DebuggerException e) {
             final String errMsg = formatMessage(e.getMessage(), 80);
-            System.err.println("Unable to connect to machine \"" + remoteMachineName + "\":\n\n" + errMsg);
+            System.err.println("Unable to connect to machine \"" + debugServerName + "\":\n\n" + errMsg);
             agent.detach();
             e.printStackTrace();
             return;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -114,9 +114,9 @@ public class CommandProcessor {
     public abstract static class DebuggerInterface {
         public abstract HotSpotAgent getAgent();
         public abstract boolean isAttached();
-        public abstract void attach(String pid);
+        public abstract void attach(int pid);
         public abstract void attach(String java, String core);
-        public abstract void connect(String remoteServer);
+        public abstract void attach(String remoteMachineName);
         public abstract void detach();
         public abstract void reattach();
     }
@@ -383,28 +383,23 @@ public class CommandProcessor {
                 postAttach();
             }
         },
-        new Command("attach", "attach pid | exec core", true) {
+        new Command("attach", "attach pid | exec core | remote_server", true) {
             public void doit(Tokens t) {
                 int tokens = t.countTokens();
                 if (tokens == 1) {
                     preAttach();
-                    debugger.attach(t.nextToken());
+                    String arg = t.nextToken();
+                    try {
+                        // Attempt to attach as a PID
+                        debugger.attach(Integer.parseInt(arg));
+                    } catch (NumberFormatException e) {
+                        // Attempt to connect to remote debug server
+                        debugger.attach(arg);
+                    }
                     postAttach();
                 } else if (tokens == 2) {
                     preAttach();
                     debugger.attach(t.nextToken(), t.nextToken());
-                    postAttach();
-                } else {
-                    usage();
-                }
-            }
-        },
-        new Command("connect", "connect remote_server", true) {
-            public void doit(Tokens t) {
-                int tokens = t.countTokens();
-                if (tokens == 1) {
-                    preAttach();
-                    debugger.connect(t.nextToken());
                     postAttach();
                 } else {
                     usage();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -116,7 +116,7 @@ public class CommandProcessor {
         public abstract boolean isAttached();
         public abstract void attach(int pid);
         public abstract void attach(String java, String core);
-        public abstract void attach(String remoteMachineName);
+        public abstract void attach(String debugServerName);
         public abstract void detach();
         public abstract void reattach();
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -116,6 +116,7 @@ public class CommandProcessor {
         public abstract boolean isAttached();
         public abstract void attach(String pid);
         public abstract void attach(String java, String core);
+        public abstract void connect(String remoteServer);
         public abstract void detach();
         public abstract void reattach();
     }
@@ -392,6 +393,18 @@ public class CommandProcessor {
                 } else if (tokens == 2) {
                     preAttach();
                     debugger.attach(t.nextToken(), t.nextToken());
+                    postAttach();
+                } else {
+                    usage();
+                }
+            }
+        },
+        new Command("connect", "connect remote_server", true) {
+            public void doit(Tokens t) {
+                int tokens = t.countTokens();
+                if (tokens == 1) {
+                    preAttach();
+                    debugger.connect(t.nextToken());
                     postAttach();
                 } else {
                     usage();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
   private int pid;
   private String execPath;
   private String coreFilename;
+  private String remoteServer;
 
   private void doUsage() {
     System.out.println("Usage:  java HSDB [[pid] | [path-to-java-executable [path-to-corefile]] | help ]");
@@ -1317,6 +1318,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
       if (agent.getDebugger().hasConsole()) {
         showDbgConsoleMenuItem.setEnabled(true);
       }
+      remoteServer = remoteMachineName;
       attached = true;
       SwingUtilities.invokeLater(remover);
     }
@@ -1504,6 +1506,9 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
               }
               public void attach(String java, String core) {
               }
+              public void connect(String remoteServer) {
+                  HSDB.this.connect(remoteServer);
+              }
               public void detach() {
                   detachDebugger();
               }
@@ -1513,8 +1518,10 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
                   }
                   if (pidText != null) {
                       attach(pidText);
-                  } else {
+                  } else if (execPath != null) {
                       attach(execPath, coreFilename);
+                  } else if (remoteServer != null) {
+                      connect(remoteServer);
                   }
               }
           };

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -81,7 +81,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
   private int pid;
   private String execPath;
   private String coreFilename;
-  private String remoteMachineName;
+  private String debugServerName;
 
   private void doUsage() {
     System.out.println("Usage:  java HSDB [[pid] | [path-to-java-executable [path-to-corefile]] | help ]");
@@ -97,7 +97,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
     pid = -1;
     execPath = null;
     coreFilename = null;
-    remoteMachineName = null;
+    debugServerName = null;
     jvmDebugger = d;
   }
 
@@ -105,7 +105,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
     pid = -1;
     execPath = null;
     coreFilename = null;
-    remoteMachineName = null;
+    debugServerName = null;
 
     switch (args.length) {
     case (0):
@@ -433,7 +433,8 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
     // If execPath != null, it is the path of a jdk/bin/java
     // and coreFilename is the pathname of a core file we are
     // supposed to attach to.
-    // Finally, if remoteMachineName != null, we are supposed to connect to remote debug server.
+    // Finally, if debugServerName != null, we are supposed to
+    // connect to remote debug server.
 
     if (jvmDebugger != null) {
       attach(jvmDebugger);
@@ -441,8 +442,8 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
       attach(pid);
     } else if (execPath != null) {
       attach(execPath, coreFilename);
-    } else if (remoteMachineName != null) {
-      connect(remoteMachineName);
+    } else if (debugServerName != null) {
+      connect(debugServerName);
     }
   }
 
@@ -1287,7 +1288,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
   /** NOTE we are in a different thread here than either the main
       thread or the Swing/AWT event handler thread, so we must be very
       careful when creating or removing widgets */
-  private void connect(final String remoteMachineName) {
+  private void connect(final String debugServerName) {
     // Try to open this core file
     Runnable remover = new Runnable() {
           public void run() {
@@ -1307,7 +1308,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
           }
         });
 
-      agent.attach(remoteMachineName);
+      agent.attach(debugServerName);
       if (agent.getDebugger().hasConsole()) {
         showDbgConsoleMenuItem.setEnabled(true);
       }
@@ -1321,7 +1322,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
           public void run() {
             setMenuItemsEnabled(attachMenuItems, true);
             JOptionPane.showInternalMessageDialog(desktop,
-                                                  "Unable to connect to machine \"" + remoteMachineName + "\":\n\n" + errMsg,
+                                                  "Unable to connect to machine \"" + debugServerName + "\":\n\n" + errMsg,
                                                   "Unable to Connect",
                                                   JOptionPane.WARNING_MESSAGE);
           }
@@ -1498,8 +1499,8 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
               }
               public void attach(String java, String core) {
               }
-              public void attach(String remoteMachineName) {
-                  HSDB.this.connect(remoteMachineName);
+              public void attach(String debugServerName) {
+                  HSDB.this.connect(debugServerName);
               }
               public void detach() {
                   detachDebugger();
@@ -1510,8 +1511,8 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
                   }
                   if (pid != -1) {
                       attach(pid);
-                  } else if (remoteMachineName != null) {
-                      connect(remoteMachineName);
+                  } else if (debugServerName != null) {
+                      connect(debugServerName);
                   } else {
                       attach(execPath, coreFilename);
                   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1183,22 +1183,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
       thread or the Swing/AWT event handler thread, so we must be very
       careful when creating or removing widgets */
   private void attach(int pid) {
-      try {
-      this.pid = pid;
-    }
-    catch (NumberFormatException e) {
-      SwingUtilities.invokeLater(new Runnable() {
-          public void run() {
-            setMenuItemsEnabled(attachMenuItems, true);
-            JOptionPane.showInternalMessageDialog(desktop,
-                                                  "Unable to parse process ID \"" + Integer.toString(HSDB.this.pid) + "\".\nPlease enter a number.",
-                                                  "Parse error",
-                                                  JOptionPane.WARNING_MESSAGE);
-          }
-        });
-      return;
-    }
-
+    this.pid = pid;
     // Try to attach to this process
     Runnable remover = new Runnable() {
           public void run() {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
@@ -78,10 +78,10 @@ public class ClhsdbAttachToDebugServer {
                 console.println("echo true");
                 console.println("verbose true");
                 console.println("attach localhost");
-                console.println("universe");
+                console.println("class java.lang.Object");
                 console.println("detach");
                 console.println("reattach");
-                console.println("universe");
+                console.println("class java.lang.String");
                 console.println("quit");
             }
 
@@ -90,6 +90,8 @@ public class ClhsdbAttachToDebugServer {
             System.err.println(out.getStderr());
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+            out.shouldMatch("^java/lang/Object @0x[0-9a-f]+$"); // for "class java.lang.Object"
+            out.shouldMatch("^java/lang/String @0x[0-9a-f]+$"); // for "class java.lang.String"
             out.shouldHaveExitValue(0);
         } catch (SkippedException se) {
             throw se;

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
@@ -93,6 +93,12 @@ public class ClhsdbAttachToDebugServer {
             out.shouldMatch("^java/lang/Object @0x[0-9a-f]+$"); // for "class java.lang.Object"
             out.shouldMatch("^java/lang/String @0x[0-9a-f]+$"); // for "class java.lang.String"
             out.shouldHaveExitValue(0);
+
+            // This will detect most SA failures, including during the attach.
+            out.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
+            // This will detect unexpected exceptions, like NPEs and asserts, that are caught
+            // by sun.jvm.hotspot.CommandProcessor.
+            out.shouldNotMatch("^Error: .*$");
         } catch (SkippedException se) {
             throw se;
         } catch (Exception ex) {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
@@ -38,10 +38,10 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main/othervm ClhsdbConnect
+ * @run main/othervm ClhsdbAttachToDebugServer
  */
 
-public class ClhsdbConnect {
+public class ClhsdbAttachToDebugServer {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
@@ -58,7 +58,7 @@ public class ClhsdbConnect {
             throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
         }
 
-        System.out.println("Starting ClhsdbConnect test");
+        System.out.println("Starting ClhsdbAttachToDebugServer test");
 
         LingeredApp theApp = null;
         DebugdUtils debugd = null;
@@ -77,7 +77,7 @@ public class ClhsdbConnect {
             try (PrintStream console = new PrintStream(jhsdb.getOutputStream(), true)) {
                 console.println("echo true");
                 console.println("verbose true");
-                console.println("connect localhost");
+                console.println("attach localhost");
                 console.println("universe");
                 console.println("detach");
                 console.println("reattach");

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbConnect.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbConnect.java
@@ -45,6 +45,19 @@ public class ClhsdbConnect {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+
+        if (SATestUtils.needsPrivileges()) {
+            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
+            // be killed if you do this (because it is a root process and the test is not), so the destroy()
+            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
+            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
+            // attached to in a stuck state for some unknown reason, causing the stopApp() call
+            // to timeout. For that reason we don't run this test when privileges are needed. Note
+            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
+            // are not required.
+            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
+        }
+
         System.out.println("Starting ClhsdbConnect test");
 
         LingeredApp theApp = null;

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbConnect.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbConnect.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.PrintStream;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
+
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8262520
+ * @summary Test clhsdb connect, detach, reattach commands
+ * @requires vm.hasSA
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm ClhsdbConnect
+ */
+
+public class ClhsdbConnect {
+
+    public static void main(String[] args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+        System.out.println("Starting ClhsdbConnect test");
+
+        LingeredApp theApp = null;
+        DebugdUtils debugd = null;
+        try {
+            theApp = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+            debugd = new DebugdUtils(null);
+            debugd.attach(theApp.getPid());
+
+            JDKToolLauncher jhsdbLauncher = JDKToolLauncher.createUsingTestJDK("jhsdb");
+            jhsdbLauncher.addToolArg("clhsdb");
+
+            Process jhsdb = (SATestUtils.createProcessBuilder(jhsdbLauncher)).start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            try (PrintStream console = new PrintStream(jhsdb.getOutputStream(), true)) {
+                console.println("echo true");
+                console.println("verbose true");
+                console.println("connect localhost");
+                console.println("universe");
+                console.println("detach");
+                console.println("reattach");
+                console.println("universe");
+                console.println("quit");
+            }
+
+            jhsdb.waitFor();
+            System.out.println(out.getStdout());
+            System.err.println(out.getStderr());
+
+            out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+            out.shouldHaveExitValue(0);
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            if (debugd != null) {
+                debugd.detach();
+            }
+            LingeredApp.stopApp(theApp);
+        }
+        System.out.println("Test PASSED");
+    }
+}


### PR DESCRIPTION
`attach` command on CLHSDB supports to attach live process (PID) and coredump, but it cannot connect to debug server. CLHSDB does not have a command to connect to debug server.

Other jhsdb commands (jstack, jmap, etc...) can connect debug server via `--connect` option, so CLHSDB should connect to it.

After this change, you can connect to debug server with 'connect <hostname>'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262520](https://bugs.openjdk.java.net/browse/JDK-8262520): Add SA Command Line Debugger support to connect to debug server


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2773/head:pull/2773`
`$ git checkout pull/2773`
