### PR TITLE
JDK-8261518: jpackage looks for main module in current dir when there is no module-path

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -306,10 +306,11 @@ final class LauncherData {
     private static List<Path> getPathListParameter(String paramName,
             Map<String, ? super Object> params) throws ConfigException {
         return getPathParam(params, paramName, () -> {
-            String value = params.getOrDefault(paramName, "").toString();
-        return List.of(value.split(File.pathSeparator)).stream()
-                .map(Path::of)
-                .collect(Collectors.toUnmodifiableList());
+            String value = (String) params.get(paramName);
+            return (value == null) ? List.of() :
+                    List.of(value.split(File.pathSeparator)).stream()
+                    .map(Path::of)
+                    .collect(Collectors.toUnmodifiableList()); 
         });
     }
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -310,7 +310,7 @@ final class LauncherData {
             return (value == null) ? List.of() :
                     List.of(value.split(File.pathSeparator)).stream()
                     .map(Path::of)
-                    .collect(Collectors.toUnmodifiableList()); 
+                    .collect(Collectors.toUnmodifiableList());
         });
     }
 

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
@@ -109,7 +109,7 @@ public final class NoMPathRuntimeTest {
                 TKit.deleteIfExists(junkJar);
             }
         }
-            
+
     }
 
     @Parameters

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.tests;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import java.nio.file.Path;
+import jdk.jpackage.test.Annotations.Parameters;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JavaAppDesc;
+import jdk.jpackage.test.JavaTool;
+import jdk.jpackage.test.TKit;
+
+
+/*
+ * @test
+ * @summary test '--runtime-image' option of jpackage
+ * @library ../../../../helpers
+ * @build jdk.jpackage.test.*
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @compile NoMPathRuntimeTest.java
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=jdk.jpackage.tests.NoMPathRuntimeTest
+ */
+
+public final class NoMPathRuntimeTest {
+
+    public NoMPathRuntimeTest(String javaAppDesc, String jlinkOutputSubdir,
+            String runtimeSubdir) {
+        this.javaAppDesc = javaAppDesc;
+        this.jlinkOutputSubdir = Path.of(jlinkOutputSubdir);
+        this.runtimeSubdir = Path.of(runtimeSubdir);
+    }
+
+    @Test
+    public void test() throws IOException {
+        final Path tmpdir = TKit.createTempDirectory("tmpdir");
+        try {
+            Files.createFile(tmpdir.resolve("tmpfile"));
+        } catch (IOException ioe) {
+            // ignore
+        }
+        JavaAppDesc appDesc = JavaAppDesc.parse(javaAppDesc);
+
+        JPackageCommand cmd = JPackageCommand.helloAppImage(appDesc);
+
+        final String moduleName = appDesc.moduleName();
+
+        if (moduleName != null) {
+            // Build module jar.
+            cmd.executePrerequisiteActions();
+        }
+
+        final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
+        final Path jlinkOutputDir = workDir.resolve(jlinkOutputSubdir);
+        Files.createDirectories(jlinkOutputDir.getParent());
+
+        // List of modules required for test app.
+        final var modules = new String[] {
+            "java.base",
+            "java.desktop"
+        };
+
+        Executor jlink = new Executor()
+        .setToolProvider(JavaTool.JLINK)
+        .dumpOutput()
+        .addArguments(
+                "--add-modules", String.join(",", modules),
+                "--output", jlinkOutputDir.toString(),
+                "--strip-debug",
+                "--no-header-files",
+                "--no-man-pages");
+
+        if (moduleName != null) {
+            jlink.addArguments("--add-modules", moduleName, "--module-path",
+                    Path.of(cmd.getArgumentValue("--module-path")).resolve(
+                            "hello.jar").toString());
+        }
+
+        jlink.execute();
+
+        ArrayList<Path> paths = new ArrayList<Path>();
+        paths.add(TKit.TEST_SRC_ROOT.resolve("apps/image/Hello.java"));
+
+        // compile Hello.java again putting classes in tmpdir
+        new Executor()
+                .setToolProvider(JavaTool.JAVAC)
+                .addArguments("-d", tmpdir.toString())
+                .addPathArguments(paths)
+                .execute();
+
+        // make raw jar of just Hello.class from tmpdir.
+        new Executor()
+                .setToolProvider(JavaTool.JAR)
+                .dumpOutput()
+                .addArguments("-cvf", "junk.jar",
+                        "-C", tmpdir.toString(), "Hello.class")
+                .execute();
+
+        // non-modular jar in current dir caused error whe no module-path given
+        cmd.removeArgumentWithValue("--module-path");
+
+        cmd.setArgumentValue("--runtime-image", workDir.resolve(runtimeSubdir));
+        cmd.executeAndAssertHelloAppImageCreated();
+    }
+
+    @Parameters
+    public static Collection data() {
+        final List<String> javaAppDescs = List.of("Hello",
+                "com.foo/com.foo.main.Aloha");
+
+        final List<String[]> paths = new ArrayList<>();
+        paths.add(new String[] { "", "" });
+        if (TKit.isOSX()) {
+            // On OSX jpackage should accept both runtime root and runtime home
+            // directories.
+            paths.add(new String[] { "Contents/Home", "" });
+        }
+
+        List<Object[]> data = new ArrayList<>();
+        for (var javaAppDesc : javaAppDescs) {
+            for (var pathCfg : paths) {
+                data.add(new Object[] { javaAppDesc, pathCfg[0], pathCfg[1] });
+            }
+        }
+
+        return data;
+    }
+
+    private final String javaAppDesc;
+    private final Path jlinkOutputSubdir;
+    private final Path runtimeSubdir;
+}

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
@@ -37,6 +37,7 @@ import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.JavaAppDesc;
 import jdk.jpackage.test.JavaTool;
 import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.HelloApp;
 
 
 /*
@@ -106,23 +107,8 @@ public final class NoMPathRuntimeTest {
 
         jlink.execute();
 
-        ArrayList<Path> paths = new ArrayList<Path>();
-        paths.add(TKit.TEST_SRC_ROOT.resolve("apps/image/Hello.java"));
-
-        // compile Hello.java again putting classes in tmpdir
-        new Executor()
-                .setToolProvider(JavaTool.JAVAC)
-                .addArguments("-d", tmpdir.toString())
-                .addPathArguments(paths)
-                .execute();
-
-        // make raw jar of just Hello.class from tmpdir.
-        new Executor()
-                .setToolProvider(JavaTool.JAR)
-                .dumpOutput()
-                .addArguments("-cvf", "junk.jar",
-                        "-C", tmpdir.toString(), "Hello.class")
-                .execute();
+        // create a non-modular jar in the current directory
+        HelloApp.createBundle(JavaAppDesc.parse("junk.jar:Hello"), Path.of("."));
 
         // non-modular jar in current dir caused error whe no module-path given
         cmd.removeArgumentWithValue("--module-path");

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/NoMPathRuntimeTest.java
@@ -62,12 +62,6 @@ public final class NoMPathRuntimeTest {
 
     @Test
     public void test() throws IOException {
-        final Path tmpdir = TKit.createTempDirectory("tmpdir");
-        try {
-            Files.createFile(tmpdir.resolve("tmpfile"));
-        } catch (IOException ioe) {
-            // ignore
-        }
         JavaAppDesc appDesc = JavaAppDesc.parse(javaAppDesc);
 
         JPackageCommand cmd = JPackageCommand.helloAppImage(appDesc);


### PR DESCRIPTION
when the app modules have already been jlinked with the runtime, and there is no need for module-path, jpackage was acting as if the module-path was "." and picking up jars in the current directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261518](https://bugs.openjdk.java.net/browse/JDK-8261518): jpackage looks for main module in current dir when there is no module-path


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer) ⚠️ Review applies to afd59c25fdbce9de4f0b35a32d9e02ee5a5a0807
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer) ⚠️ Review applies to c09775d9336dacedb0070cc572a6c68d2432de91
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to afd59c25fdbce9de4f0b35a32d9e02ee5a5a0807


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2781/head:pull/2781`
`$ git checkout pull/2781`
