### PR TITLE
8262793: Shenandoah: Need to restore reference marking strength after mark through subgraph

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -30,6 +30,7 @@
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahMark.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
+#include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahStringDedup.inline.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
@@ -53,8 +54,8 @@ void ShenandoahMark::do_task(ShenandoahObjToScanQueue* q, T* cl, ShenandoahLiveD
   shenandoah_assert_not_in_cset_except(NULL, obj, ShenandoahHeap::heap()->cancelled_gc());
 
   // Are we in weak subgraph scan?
-  bool weak = task->is_weak();
-  cl->set_weak(weak);
+  bool weak = cl->is_weak();
+  ShenandoahRefStrengthScope<T> scope(cl, weak);
 
   if (task->is_not_chunked()) {
     if (obj->is_instance()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -337,14 +337,12 @@ bool ShenandoahReferenceProcessor::discover(oop reference, ReferenceType type, u
 
   if (type == REF_FINAL) {
     ShenandoahMarkRefsSuperClosure* cl = _ref_proc_thread_locals[worker_id].mark_closure();
-    bool weak = cl->is_weak();
-    cl->set_weak(true);
+    ShenandoahRefStrengthScope<ShenandoahMarkRefsSuperClosure> scope(cl, true);
     if (UseCompressedOops) {
       cl->do_oop(reinterpret_cast<narrowOop*>(java_lang_ref_Reference::referent_addr_raw(reference)));
     } else {
       cl->do_oop(reinterpret_cast<oop*>(java_lang_ref_Reference::referent_addr_raw(reference)));
     }
-    cl->set_weak(weak);
   }
 
   // Add reference to discovered list

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
@@ -127,6 +127,22 @@ public:
   }
 };
 
+template <typename T>
+class ShenandoahRefStrengthScope : public StackObj {
+private:
+  T* const   _cl;
+  bool const _was_weak;
+public:
+  ShenandoahRefStrengthScope(T* cl, bool weak) :
+    _cl(cl), _was_weak(cl->is_weak()) {
+    _cl->set_weak(weak);
+  }
+
+  ~ShenandoahRefStrengthScope() {
+    _cl->set_weak(_was_weak);
+  }
+};
+
 class ShenandoahReferenceProcessor : public ReferenceDiscoverer {
 private:
   ReferencePolicy* _soft_reference_policy;


### PR DESCRIPTION
During marking phase, wavefront may switch to weak marking, but need to restore back to original wavefront after mark through the subgraph.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262793](https://bugs.openjdk.java.net/browse/JDK-8262793): Shenandoah: Need to restore reference marking strength after mark through subgraph


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2784/head:pull/2784`
`$ git checkout pull/2784`
