### PR TITLE
8255859: Incorrect comments in log.hpp

### DIFF
--- a/src/hotspot/share/logging/log.hpp
+++ b/src/hotspot/share/logging/log.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,16 +72,16 @@ class LogMessageBuffer;
 // Log class for more advanced logging scenarios.
 // Has printf-style member functions for each log level (trace(), debug(), etc).
 //
-// Also has outputStream compatible API for the different log-levels.
-// The streams are resource allocated when requested and are accessed through
-// calls to <level>_stream() functions (trace_stream(), debug_stream(), etc).
+// The (trace(), debug(), etc) functions can also be used along with the LogStream
+// class to obtain an outputStream object, to be passed to various printing
+// functions that accept an outputStream:
 //
 // Example usage:
-//   Log(logging) log;
+//   Log(codecache, sweep) log;
 //   if (log.is_debug()) {
-//     ...
 //     log.debug("result = %d", result).trace(" tracing info");
-//     obj->print_on(log.debug_stream());
+//     LogStream ls(log.debug());
+//     CodeCache::print_summary(&ls, false);
 //   }
 //
 #define Log(...)  LogImpl<LOG_TAGS(__VA_ARGS__)>
@@ -93,13 +93,11 @@ class LogMessageBuffer;
 // so that redundant specification of tags or levels can be avoided.
 //
 // Example usage:
-//   LogTarget(Debug, gc) out;
+//   LogTarget(Debug, codecache, sweep) out;
 //   if (out.is_enabled()) {
-//     ...
-//     out.print("Worker: %u", i);
-//     out.print(" data: %d", x);
-//     ...
-//     print_stats(out.stream());
+//     out.print("result = %d", result);
+//     LogStream ls(out);
+//     CodeCache::print_summary(&ls, false);
 //   }
 //
 #define LogTarget(level, ...) LogTargetImpl<LogLevel::level, LOG_TAGS(__VA_ARGS__)>


### PR DESCRIPTION
Please review this trivial, comment-only change. I updated the comments to match the current usage for `Log` and `LogTarget`. I also tried to make the examples consistent so you can easily see the difference between `Log` and `LogTarget`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255859](https://bugs.openjdk.java.net/browse/JDK-8255859): Incorrect comments in log.hpp


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2785/head:pull/2785`
`$ git checkout pull/2785`
