### PR TITLE
8262819: gc/shenandoah/compiler/TestLinkToNativeRBP.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -32,7 +32,8 @@
  *
  * @modules jdk.incubator.foreign
  *
- * @run main/othervm -Dforeign.restricted=permit -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestLinkToNativeRBP
+ * @run main/othervm -Dforeign.restricted=permit -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestLinkToNativeRBP
  *
  */
 


### PR DESCRIPTION
Hi all,

Please review this trivial fix to the failure of TestLinkToNativeRBP.java with release VMs.

Only -XX:+UnlockDiagnosticVMOptions is added for the test.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262819](https://bugs.openjdk.java.net/browse/JDK-8262819): gc/shenandoah/compiler/TestLinkToNativeRBP.java fails with release VMs


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2786/head:pull/2786`
`$ git checkout pull/2786`
