### PR TITLE
8262726: AArch64: C1 StubAssembler::call_RT can corrupt stack

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -147,7 +147,7 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   if (arg1 == c_rarg2 || arg1 == c_rarg3 ||
       arg2 == c_rarg1 || arg2 == c_rarg3 ||
       arg3 == c_rarg1 || arg3 == c_rarg2) {
-    stp(arg3, arg2, Address(pre(sp, 2 * wordSize)));
+    stp(arg3, arg2, Address(pre(sp, -2 * wordSize)));
     stp(arg1, zr, Address(pre(sp, -2 * wordSize)));
     ldp(c_rarg1, zr, Address(post(sp, 2 * wordSize)));
     ldp(c_rarg3, c_rarg2, Address(post(sp, 2 * wordSize)));


### PR DESCRIPTION
StubAssembler::call_RT() has some code to shuffle arguments using the
stack as temporary storage. But there's a typo: the first pre(sp, 2 *
wordSize) should be pre(sp, -2 * wordSize) otherwise the pushes and pops
are unbalanced.

I think this was exposed by JDK-8259619 which fixed the conflict check
but AFAIK it only causes a problem on the Valhalla lworld branch and is
not used otherwise.

I would rather replace this code with an assert that the conflict never
occurs as we are in full control of the argument registers passed to
call_RT (the PPC port does this, for example).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262726](https://bugs.openjdk.java.net/browse/JDK-8262726): AArch64: C1 StubAssembler::call_RT can corrupt stack


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2787/head:pull/2787`
`$ git checkout pull/2787`
