### PR TITLE
8262519: AArch64: Unnecessary acquire semantics of memory-order-conservative atomics in C++ Hotspot code

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5654,7 +5654,7 @@ class StubGenerator: public StubCodeGenerator {
         release = false;
         break;
       default:
-        acquire = true;
+        acquire = false;
         release = true;
         break;
     }
@@ -5673,7 +5673,7 @@ class StubGenerator: public StubCodeGenerator {
 
   void gen_ldaddal_entry(Assembler::operand_size size) {
     Register prev = r2, addr = c_rarg0, incr = c_rarg1;
-    __ ldaddal(size, incr, prev, addr);
+    __ ldaddl(size, incr, prev, addr);
     __ membar(Assembler::StoreStore|Assembler::StoreLoad);
     if (size == Assembler::xword) {
       __ mov(r0, prev);
@@ -5685,7 +5685,7 @@ class StubGenerator: public StubCodeGenerator {
 
   void gen_swpal_entry(Assembler::operand_size size) {
     Register prev = r2, addr = c_rarg0, incr = c_rarg1;
-    __ swpal(size, incr, prev, addr);
+    __ swpl(size, incr, prev, addr);
     __ membar(Assembler::StoreStore|Assembler::StoreLoad);
     if (size == Assembler::xword) {
       __ mov(r0, prev);

--- a/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.S
+++ b/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.S
@@ -27,7 +27,7 @@
         .align 5
 aarch64_atomic_fetch_add_8_default_impl:
         prfm    pstl1strm, [x0]
-0:      ldaxr   x2, [x0]
+0:      ldxr    x2, [x0]
         add     x8, x2, x1
         stlxr   w9, x8, [x0]
         cbnz    w9, 0b
@@ -39,7 +39,7 @@ aarch64_atomic_fetch_add_8_default_impl:
         .align 5
 aarch64_atomic_fetch_add_4_default_impl:
         prfm    pstl1strm, [x0]
-0:      ldaxr   w2, [x0]
+0:      ldxr    w2, [x0]
         add     w8, w2, w1
         stlxr   w9, w8, [x0]
         cbnz    w9, 0b
@@ -51,7 +51,7 @@ aarch64_atomic_fetch_add_4_default_impl:
         .align 5
 aarch64_atomic_xchg_4_default_impl:
         prfm    pstl1strm, [x0]
-0:      ldaxr   w2, [x0]
+0:      ldxr    w2, [x0]
         stlxr   w8, w1, [x0]
         cbnz    w8, 0b
         dmb     ish
@@ -62,7 +62,7 @@ aarch64_atomic_xchg_4_default_impl:
         .align 5
 aarch64_atomic_xchg_8_default_impl:
         prfm    pstl1strm, [x0]
-0:      ldaxr   x2, [x0]
+0:      ldxr    x2, [x0]
         stlxr   w8, x1, [x0]
         cbnz    w8, 0b
         dmb     ish


### PR DESCRIPTION
The aarch64 LSE atomic operations are introduced to C++ hotspot code in JDK-8261027 and optimized in JDK-8261649.
For memory_order_conservative, the acquire semantics in atomic instructions, i.e. ldaddal, swpal, casal, ensure that no subsequent accesses can pass the atomic operations.
We also have a trailing dmb to ensure barrier-ordered-after relationship, it can ensure what the acquire does. So the acquire semantics is no longer needed, {ldaddl, swpl, casl} would be enough.

Checked by using the herd7 consistency model simulator with the test in comments before `gen_cas_entry`:
```
AArch64 LseCasAfter
{ 0:X1=x; 0:X2=y; 1:X1=x; 1:X2=y; }
P0           | P1                ;
LDR W4, [X2] | MOV W3, #0        ;
DMB LD       | MOV W4, #1        ;
LDR W3, [X1] | CASL W3, W4, [X1] ;
             | DMB ISH           ;
             | STR W4, [X2]      ;
exists
 (0:X3=0 /\ 0:X4=1)
```
No `X3 == 0 && X4 == 1` witnessed.

Remove the acquire semantics does not allow prior accesses to pass the atomic operations, because the release semantics are still there.
Just in case, checked by herd7 with the testcase below:
```
AArch64 LseCasPrior
{ 0:X1=x; 0:X2=y; 1:X1=x; 1:X2=y; }
P0           | P1                ;
LDR W3, [X1] | MOV W3, #0        ;
DMB LD       | MOV W4, #1        ;
LDR W4, [X2] | STR W4, [X2]      ;
             | CASL W3, W4, [X1] ;
             | DMB ISH           ;
exists
 (0:X3=1 /\ 0:X4=0)
```
No `X3 == 1 && X4 == 0` witnessed.

Similarly, the default implementations of `atomic_fetch_add` and `atomic_xchg` via `ldaxr+stlxr+dmb` can be replaced by `ldxr+stlxr+dmb`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262519](https://bugs.openjdk.java.net/browse/JDK-8262519): AArch64: Unnecessary acquire semantics of memory-order-conservative atomics in C++ Hotspot code


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2788/head:pull/2788`
`$ git checkout pull/2788`
