### PR TITLE
8261689: javax/swing/JComponent/7154030/bug7154030.java still fails with "Exception: Failed to hide opaque button"

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -31,8 +31,11 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import java.io.File;
@@ -81,18 +84,24 @@ public class bug7154030 {
                     button.setOpaque(true);
                     button.setVisible(false);
                     desktop.add(button);
+                    desktop.setMinimumSize(new Dimension(300, 300));
+                    desktop.setMaximumSize(new Dimension(300, 300));
 
                     frame.setContentPane(desktop);
-                    frame.setSize(300, 300);
+                    frame.setMinimumSize(new Dimension(350, 350));
+                    frame.setMaximumSize(new Dimension(350, 350));
+                    frame.pack();
                     frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 }
             });
 
-            robot.delay(1000);
             robot.waitForIdle(1000);
+            robot.delay(1000);
 
+            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
             Rectangle bounds = frame.getBounds();
             Insets insets = frame.getInsets();
             locx = bounds.x + insets.left;
@@ -100,6 +109,11 @@ public class bug7154030 {
             frw = bounds.width - insets.left - insets.right;
             frh = bounds.height - insets.top - insets.bottom;
 
+            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
+            BufferedImage fullScreen = robot.createScreenCapture(screen);
+            Graphics g = fullScreen.getGraphics();
+            g.setColor(Color.RED);
+            g.drawRect(locx-1, locy-1, frw+1, frh+1);
             imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -115,6 +129,7 @@ public class bug7154030 {
             if (Util.compareBufferedImages(imageInit, imageShow)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageShow, "png", new File("imageShow.png"));
+                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
                 throw new Exception("Failed to show opaque button");
             }
 
@@ -133,6 +148,7 @@ public class bug7154030 {
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageHide, "png", new File("imageHide.png"));
+                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
                 throw new Exception("Failed to hide opaque button");
             }
 
@@ -171,6 +187,7 @@ public class bug7154030 {
             if (Util.compareBufferedImages(imageInit, imageShow)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageShow, "png", new File("imageShow.png"));
+                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
                 throw new Exception("Failed to show non-opaque button");
             }
 
@@ -180,6 +197,7 @@ public class bug7154030 {
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageHide, "png", new File("imageHide.png"));
+                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
                 throw new Exception("Failed to hide non-opaque button");
             }
         } finally {

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -109,11 +109,10 @@ public class bug7154030 {
             frw = bounds.width - insets.left - insets.right;
             frh = bounds.height - insets.top - insets.bottom;
 
-            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
             BufferedImage fullScreen = robot.createScreenCapture(screen);
             Graphics g = fullScreen.getGraphics();
             g.setColor(Color.RED);
-            g.drawRect(locx-1, locy-1, frw+1, frh+1);
+            g.drawRect(locx - 1, locy - 1, frw + 1, frh + 1);
             imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             SwingUtilities.invokeAndWait(new Runnable() {

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -175,6 +175,13 @@ public class bug7154030 {
             robot.waitForIdle(500);
             imageShow = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
+            if (Util.compareBufferedImages(imageInit, imageShow)) {
+                ImageIO.write(imageInit, "png", new File("imageInit.png"));
+                ImageIO.write(imageShow, "png", new File("imageShow.png"));
+                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
+                throw new Exception("Failed to show non-opaque button");
+            }
+
             SwingUtilities.invokeAndWait(new Runnable() {
 
                 @Override
@@ -182,13 +189,6 @@ public class bug7154030 {
                     button.hide();
                 }
             });
-
-            if (Util.compareBufferedImages(imageInit, imageShow)) {
-                ImageIO.write(imageInit, "png", new File("imageInit.png"));
-                ImageIO.write(imageShow, "png", new File("imageShow.png"));
-                ImageIO.write(fullScreen, "png", new File("fullScreenInit.png"));
-                throw new Exception("Failed to show non-opaque button");
-            }
 
             robot.waitForIdle(500);
             imageHide = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261689](https://bugs.openjdk.java.net/browse/JDK-8261689): javax/swing/JComponent/7154030/bug7154030.java still fails with "Exception: Failed to hide opaque button"


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2790/head:pull/2790`
`$ git checkout pull/2790`
