### PR TITLE
8252831: Correct "no comment" warnings in jdk.net module

### DIFF
--- a/src/jdk.net/share/classes/jdk/net/Sockets.java
+++ b/src/jdk.net/share/classes/jdk/net/Sockets.java
@@ -78,6 +78,7 @@ public class Sockets {
      * @param name The socket option
      * @param value The value of the socket option. May be null for some
      *              options.
+     * @param <T> The type of the socket option
      *
      * @throws UnsupportedOperationException if the socket does not support
      *         the option.
@@ -107,6 +108,7 @@ public class Sockets {
      *
      * @param s the socket
      * @param name The socket option
+     * @param <T> The type of the socket option
      *
      * @return The value of the socket option.
      *
@@ -135,7 +137,8 @@ public class Sockets {
      *
      * @param s the socket
      * @param name The socket option
-     * @param value The value of the socket option.
+     * @param value The value of the socket option
+     * @param <T> The type of the socket option
      *
      * @throws UnsupportedOperationException if the socket does not support
      *         the option.
@@ -165,6 +168,7 @@ public class Sockets {
      *
      * @param s the socket
      * @param name The socket option
+     * @param <T> The type of the socket option
      *
      * @return The value of the socket option.
      *
@@ -194,7 +198,8 @@ public class Sockets {
      *
      * @param s the socket
      * @param name The socket option
-     * @param value The value of the socket option.
+     * @param value The value of the socket option
+     * @param <T> The type of the socket option
      *
      * @throws UnsupportedOperationException if the socket does not support
      *         the option.
@@ -225,6 +230,7 @@ public class Sockets {
      *
      * @param s the socket
      * @param name The socket option
+     * @param <T> The type of the socket option
      *
      * @return The value of the socket option.
      *
@@ -254,6 +260,8 @@ public class Sockets {
      * non standard extended options.
      *
      * @param socketType the type of java.net socket
+     *
+     * @return A set of socket options
      *
      * @throws IllegalArgumentException if socketType is not a valid
      *         socket type from the java.net package.


### PR DESCRIPTION
Hi,

Could someone please review my changeset that fixes the "no comment" warnings generated by `javadoc -Xdoclint` for `java.base/jdk.net`?

CSR: https://bugs.openjdk.java.net/browse/JDK-8262938

Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252831](https://bugs.openjdk.java.net/browse/JDK-8252831): Correct "no comment" warnings in jdk.net module


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2792/head:pull/2792`
`$ git checkout pull/2792`
