### PR TITLE
JDK-8262466: linux libsaproc/DwarfParser.cpp delete DwarfParser object in early return

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/DwarfParser.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/DwarfParser.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, NTT DATA.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,14 +99,13 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_linux_amd64_DwarfParser_ini
 extern "C"
 JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_amd64_DwarfParser_createDwarfContext
   (JNIEnv *env, jclass this_cls, jlong lib) {
-  jlong result = 0L;
-
   DwarfParser *parser = new DwarfParser(reinterpret_cast<lib_info *>(lib));
   if (!parser->is_parseable()) {
     jclass ex_cls = env->FindClass("sun/jvm/hotspot/debugger/DebuggerException");
     if (!env->ExceptionOccurred()) {
         env->ThrowNew(ex_cls, "DWARF not found");
     }
+    delete parser;
     return 0L;
   }
 


### PR DESCRIPTION
There is an early return in Java_sun_jvm_hotspot_debugger_linux_amd64_DwarfParser_createDwarfContext that misses to delete the non-parsable parser object.
see also the Sonar finding :
https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=cpp&open=AXck8Ca-BBG2CXpcnimn&resolved=false&severities=BLOCKER&types=BUG

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262466](https://bugs.openjdk.java.net/browse/JDK-8262466): linux libsaproc/DwarfParser.cpp delete DwarfParser object in early return


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2793/head:pull/2793`
`$ git checkout pull/2793`
