### PR TITLE
JDK-8262875: doccheck: empty paragraphs, etc in java.base module

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -264,7 +264,7 @@ public final class Integer extends Number
      * <blockquote>
      *  {@code Integer.toHexString(n).toUpperCase()}
      * </blockquote>
-     * <p>
+     *
      * @apiNote
      * The {@link java.util.HexFormat} class provides formatting and parsing
      * of byte arrays and primitives to return a string or adding to an {@link Appendable}.

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -299,7 +299,7 @@ public final class Long extends Number
      * <blockquote>
      *  {@code Long.toHexString(n).toUpperCase()}
      * </blockquote>
-     * <p>
+     *
      * @apiNote
      * The {@link java.util.HexFormat} class provides formatting and parsing
      * of byte arrays and primitives to return a string or adding to an {@link Appendable}.

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1681,7 +1681,7 @@ public class MethodHandles {
          * (used during {@link #findClass} invocations)
          * are determined by the lookup class' loader,
          * which may change due to this operation.
-         * <p>
+         *
          * @param requestedLookupClass the desired lookup class for the new lookup object
          * @return a lookup object which reports the desired lookup class, or the same object
          * if there is no change

--- a/src/java.base/share/classes/java/util/Comparator.java
+++ b/src/java.base/share/classes/java/util/Comparator.java
@@ -131,14 +131,14 @@ public interface Comparator<T> {
      *
      * Finally, the implementor must ensure that {@code compare(x,
      * y)==0} implies that {@code signum(compare(x,
-     * z))==signum(compare(y, z))} for all {@code z}.<p>
+     * z))==signum(compare(y, z))} for all {@code z}.
      *
      * @apiNote
      * It is generally the case, but <i>not</i> strictly required that
      * {@code (compare(x, y)==0) == (x.equals(y))}.  Generally speaking,
      * any comparator that violates this condition should clearly indicate
      * this fact.  The recommended language is "Note: this comparator
-     * imposes orderings that are inconsistent with equals."<p>
+     * imposes orderings that are inconsistent with equals."
      *
      * @param o1 the first object to be compared.
      * @param o2 the second object to be compared.

--- a/src/java.base/share/classes/java/util/jar/package-info.java
+++ b/src/java.base/share/classes/java/util/jar/package-info.java
@@ -37,7 +37,7 @@
  * <ul>
  *   <li><b>Info-ZIP file format</b> - The JAR format is based on the Info-ZIP
  *       file format. See
- *       <a href="../zip/package-summary.html#package.description">java.util.zip
+ *       <a href="../zip/package-summary.html#package-description">java.util.zip
  *       package description.</a> <p>
  *       In JAR files, all file names must be encoded in the UTF-8 encoding.
  *   <li><a href="{@docRoot}/../specs/jar/jar.html">

--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -39,7 +39,7 @@ import sun.nio.ch.DirectBuffer;
  * popular ZLIB compression library. The ZLIB compression library was
  * initially developed as part of the PNG graphics standard and is not
  * protected by patents. It is fully described in the specifications at
- * the <a href="package-summary.html#package.description">java.util.zip
+ * the <a href="package-summary.html#package-description">java.util.zip
  * package description</a>.
  * <p>
  * This class deflates sequences of bytes into ZLIB compressed data format.

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -39,7 +39,7 @@ import sun.nio.ch.DirectBuffer;
  * popular ZLIB compression library. The ZLIB compression library was
  * initially developed as part of the PNG graphics standard and is not
  * protected by patents. It is fully described in the specifications at
- * the <a href="package-summary.html#package.description">java.util.zip
+ * the <a href="package-summary.html#package-description">java.util.zip
  * package description</a>.
  * <p>
  * This class inflates sequences of ZLIB compressed bytes. The input byte

--- a/src/java.base/share/classes/javax/net/ssl/SSLSessionContext.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSessionContext.java
@@ -76,7 +76,6 @@ public interface SSLSessionContext {
      * <code>SSLSessionContext</code>.
      * <p>Session contexts may not contain all sessions. For example,
      * stateless sessions are not stored in the session context.
-     * <p>
      *
      * @return an enumeration of all the Session id's
      */


### PR DESCRIPTION
Please review some minor doc fixes, for issues found by _doccheck_.    There are two kinds of errors that are addressed.

1. Incorrect use of `<p>`. In HTML, `<p>` marks the *beginning* of a paragraph. It is not a terminator, to mark the end of a paragraph, or a separator to mark the boundary between paragraphs.  In particular, it should not be used at the end of a description before a javadoc block tag, such as `@param` or before other HTML block tags, like `<ul>` or `<table>`.

2. References to the id `package-description`, following the recent standardization of all ids generated by javadoc,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262875](https://bugs.openjdk.java.net/browse/JDK-8262875): doccheck: empty paragraphs, etc in java.base module


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2795/head:pull/2795`
`$ git checkout pull/2795`
