### PR TITLE
8262885: Shenandoah: FullGC prologue does not need to save/restore heap has_forwarded_object flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -185,7 +185,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     // The rest of prologue:
     BiasedLocking::preserve_marks();
     _preserved_marks->init(heap->workers()->active_workers());
-    
+
     assert(heap->has_forwarded_objects() == has_forwarded_objects, "Not expect to change");
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -186,7 +186,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     BiasedLocking::preserve_marks();
     _preserved_marks->init(heap->workers()->active_workers());
 
-    assert(heap->has_forwarded_objects() == has_forwarded_objects, "Not expect to change");
+    assert(heap->has_forwarded_objects() == has_forwarded_objects, "This should not change");
   }
 
   if (UseTLAB) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -143,9 +143,6 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     ShenandoahGCPhase prepare_phase(ShenandoahPhaseTimings::full_gc_prepare);
     // Full GC is supposed to recover from any GC state:
 
-    // a0. Remember if we have forwarded objects
-    bool has_forwarded_objects = heap->has_forwarded_objects();
-
     // a1. Cancel evacuation, if in progress
     if (heap->is_evacuation_in_progress()) {
       heap->set_evacuation_in_progress(false);
@@ -166,7 +163,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     assert(!heap->is_concurrent_mark_in_progress(), "sanity");
 
     // c. Update roots if this full GC is due to evac-oom, which may carry from-space pointers in roots.
-    if (has_forwarded_objects) {
+    if (heap->has_forwarded_objects()) {
       update_roots(true /*full_gc*/);
     }
 
@@ -179,10 +176,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     ShenandoahReferenceProcessor* rp = heap->ref_processor();
     rp->abandon_partial_discovery();
 
-    // f. Set back forwarded objects bit back, in case some steps above dropped it.
-    heap->set_has_forwarded_objects(has_forwarded_objects);
-
-    // g. Sync pinned region status from the CP marks
+    // f. Sync pinned region status from the CP marks
     heap->sync_pinned_region_status();
 
     // The rest of prologue:


### PR DESCRIPTION
Another trivial cleanup. FullGC prologue code does not change heap's has_forwarded_objects flag, there is no point to save/restore it.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262885](https://bugs.openjdk.java.net/browse/JDK-8262885): Shenandoah: FullGC prologue does not need to save/restore heap has_forwarded_object flag


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to e22fe9df6d1975543c91053252a4343806ab5dde


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2797/head:pull/2797`
`$ git checkout pull/2797`
