### PR TITLE
8262893: Enable more doclint checks in javadoc build

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -99,7 +99,7 @@ JAVADOC_TAGS := \
 REFERENCE_TAGS := $(JAVADOC_TAGS)
 
 # Which doclint checks to ignore
-JAVADOC_DISABLED_DOCLINT := accessibility html missing syntax reference
+JAVADOC_DISABLED_DOCLINT := missing
 
 # The initial set of options for javadoc
 JAVADOC_OPTIONS := -use -keywords -notimestamp \


### PR DESCRIPTION
With recent cleanups, several doclint categories have been cleared across the JDK and should be enabled in the javadoc build to make sure they stay clean.

Local docs build completes with this stricter set of checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262893](https://bugs.openjdk.java.net/browse/JDK-8262893): Enable more doclint checks in javadoc build


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2799/head:pull/2799`
`$ git checkout pull/2799`
