### PR TITLE
8261862: Expand discussion of rationale for BigDecimal equals/compareTo semantics

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -215,7 +215,7 @@ import java.util.Objects;
  * @apiNote Care should be exercised if {@code BigDecimal} objects
  * are used as keys in a {@link java.util.SortedMap SortedMap} or
  * elements in a {@link java.util.SortedSet SortedSet} since
- * {@code BigDecimal}'s <i>natural ordering</i> is <em>inconsistent
+ * {@code BigDecimal}'s <i>{@linkplain compareTo(BigDecimal) natural ordering}</i> is <em>inconsistent
  * with equals</em>.  See {@link Comparable}, {@link
  * java.util.SortedMap} or {@link java.util.SortedSet} for more
  * information.
@@ -3141,7 +3141,17 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * compareTo}, this method considers two {@code BigDecimal}
      * objects equal only if they are equal in value and
      * scale. Therefore 2.0 is not equal to 2.00 when compared by this
-     * method.
+     * method since the former has [{@code BigInteger},
+     * {@code scale}] components equal to [20, 1] while the latter has
+     * components equals to [200, 2].
+     *
+     * <p>One example that shows how 2.0 and 2.00 are <em>not</em>
+     * substitutable for each other under some arithmetic operations
+     * either are the two expressions:<br>
+     * {@code new BigDecimal("2.0" ).divide(BigDecimal.valueOf(3),
+     * HALF_UP)} which evaluates to 0.7 and <br>
+     * {@code new BigDecimal("2.00").divide(BigDecimal.valueOf(3),
+     * HALF_UP)} which evaluates to 0.<b>6</b>7.
      *
      * @param  x {@code Object} to which this {@code BigDecimal} is
      *         to be compared.

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -212,13 +212,13 @@ import java.util.Objects;
  * {@code NullPointerException} when passed a {@code null} object
  * reference for any input parameter.
  *
- * @apiNote Care should be exercised if {@code BigDecimal} objects
- * are used as keys in a {@link java.util.SortedMap SortedMap} or
- * elements in a {@link java.util.SortedSet SortedSet} since
- * {@code BigDecimal}'s <i>{@linkplain compareTo(BigDecimal) natural ordering}</i> is <em>inconsistent
- * with equals</em>.  See {@link Comparable}, {@link
- * java.util.SortedMap} or {@link java.util.SortedSet} for more
- * information.
+ * @apiNote Care should be exercised if {@code BigDecimal} objects are
+ * used as keys in a {@link java.util.SortedMap SortedMap} or elements
+ * in a {@link java.util.SortedSet SortedSet} since {@code
+ * BigDecimal}'s <i>{@linkplain compareTo(BigDecimal) natural
+ * ordering}</i> is <em>inconsistent with equals</em>.  See {@link
+ * Comparable}, {@link java.util.SortedMap} or {@link
+ * java.util.SortedSet} for more information.
  *
  * @see     BigInteger
  * @see     MathContext
@@ -3141,17 +3141,18 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * compareTo}, this method considers two {@code BigDecimal}
      * objects equal only if they are equal in value and
      * scale. Therefore 2.0 is not equal to 2.00 when compared by this
-     * method since the former has [{@code BigInteger},
-     * {@code scale}] components equal to [20, 1] while the latter has
-     * components equals to [200, 2].
+     * method since the former has [{@code BigInteger}, {@code scale}]
+     * components equal to [20, 1] while the latter has components
+     * equal to [200, 2].
      *
-     * <p>One example that shows how 2.0 and 2.00 are <em>not</em>
+     * @apiNote
+     * One example that shows how 2.0 and 2.00 are <em>not</em>
      * substitutable for each other under some arithmetic operations
-     * either are the two expressions:<br>
+     * are the two expressions:<br>
      * {@code new BigDecimal("2.0" ).divide(BigDecimal.valueOf(3),
      * HALF_UP)} which evaluates to 0.7 and <br>
      * {@code new BigDecimal("2.00").divide(BigDecimal.valueOf(3),
-     * HALF_UP)} which evaluates to 0.<b>6</b>7.
+     * HALF_UP)} which evaluates to 0.67.
      *
      * @param  x {@code Object} to which this {@code BigDecimal} is
      *         to be compared.


### PR DESCRIPTION
I considered @stuart-marks previous suggestion during the code review of JDK-8261123 to include a more explicit discussion of why, say, different representations of 2 should not be regarded as equivalent. After contemplating several alternatives, I didn't find anything simpler than Stuart's 2/3 example so I used that as seen in the diff.

A short digression, BigDecimal supports both fixed-point style and floating-point style rounding. Floating-point rounding primarily replies on the number of precision digits, regards of their scale, while fixed-point style rounding prioritizes the scale. The number of digits of eventual output is a function of number number of digits in the inputs and the number of precision digits in a floating-point style rounding. A floating-point style rounding has a preferred scale, rather than a fixed scale based on the inputs. The fixed-point style divide method used in the example has a scale based on the dividend, allowing a relatively simple expression to show a distinction between 2.0 and 2.00.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261862](https://bugs.openjdk.java.net/browse/JDK-8261862): Expand discussion of rationale for BigDecimal equals/compareTo semantics


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 48b49386bd49fc387d309483f299d8c4fa7eb994
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 48b49386bd49fc387d309483f299d8c4fa7eb994


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2804/head:pull/2804`
`$ git checkout pull/2804`
