### PR TITLE
JDK-8262926 JDK-8260966 broke AIX build

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/AixFileStore.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixFileStore.java
@@ -88,9 +88,8 @@ class AixFileStore
         throw new IOException("Mount point not found");
     }
 
-    // returns true if extended attributes enabled on file system where given
-    // file resides, returns false if disabled or unable to determine.
-    private boolean isExtendedAttributesEnabled(UnixPath path) {
+    @Override
+    protected boolean isExtendedAttributesEnabled(UnixPath path) {
         return false;
     }
 


### PR DESCRIPTION
Fixed access modifier of `isExtendedAttributesEnabled` which has been moved to super class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262926](https://bugs.openjdk.java.net/browse/JDK-8262926): JDK-8260966 broke AIX build


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2805/head:pull/2805`
`$ git checkout pull/2805`
