### PR TITLE
8262000: jdk/jfr/event/gc/detailed/TestPromotionFailedEventWithParallelScavenge.java failed with "OutOfMemoryError: Java heap space"

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/ExecuteOOMApp.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/ExecuteOOMApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class ExecuteOOMApp {
         OutputAnalyzer out = AppExecutorHelper.executeAndRecord(settings, jfrFilename, additionalVmFlagsList.toArray(new String[0]),
                                                                 OOMApp.class.getName(), String.valueOf(bytesToAllocate));
 
-        if ((out.getExitValue() == 1 && out.getOutput().contains("Exception: java.lang.OutOfMemoryError"))) {
+        if ((out.getExitValue() == 1 && out.getOutput().contains("java.lang.OutOfMemoryError"))) {
             return false;
         }
 


### PR DESCRIPTION
By relaxing the matching of OOM error slightly, the test case can catch OOM errors not starting with "Exception: "

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262000](https://bugs.openjdk.java.net/browse/JDK-8262000): jdk/jfr/event/gc/detailed/TestPromotionFailedEventWithParallelScavenge.java failed with "OutOfMemoryError: Java heap space" 


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2806/head:pull/2806`
`$ git checkout pull/2806`
