### PR TITLE
Update ArrayBlockingQueue.java

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -301,12 +301,10 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
         try {
             final Object[] items = this.items;
             int i = 0;
-            try {
-                for (E e : c)
-                    items[i++] = Objects.requireNonNull(e);
-            } catch (ArrayIndexOutOfBoundsException ex) {
-                throw new IllegalArgumentException();
-            }
+            if(c.size()>capacity)
+                 throw new IllegalArgumentException();
+            for (E e : c)
+                 items[i++] = Objects.requireNonNull(e);
             count = i;
             putIndex = (i == capacity) ? 0 : i;
         } finally {


### PR DESCRIPTION
i think should decide whether the parameter set is larger than the queue capacity before copy the data, as unwanted replication can be a waste of time，Or we can  add a constructor with a boolean parameter that determines whether to add elements to the queue if the container size exceeds the queue capacity

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2807/head:pull/2807`
`$ git checkout pull/2807`
