### PR TITLE
8262935: Add missing logging to sun.net.httpserver.ServerImpl

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -667,14 +667,16 @@ class ServerImpl implements TimeSource {
             } catch (IOException e1) {
                 logger.log (Level.TRACE, "ServerImpl.Exchange (1)", e1);
                 closeConnection(connection);
-            } catch (NumberFormatException e3) {
+            } catch (NumberFormatException e2) {
+                logger.log (Level.TRACE, "ServerImpl.Exchange (2)", e2);
                 reject (Code.HTTP_BAD_REQUEST,
                         requestLine, "NumberFormatException thrown");
-            } catch (URISyntaxException e) {
+            } catch (URISyntaxException e3) {
+                logger.log (Level.TRACE, "ServerImpl.Exchange (3)", e3);
                 reject (Code.HTTP_BAD_REQUEST,
                         requestLine, "URISyntaxException thrown");
             } catch (Exception e4) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (2)", e4);
+                logger.log (Level.TRACE, "ServerImpl.Exchange (4)", e4);
                 closeConnection(connection);
             }
         }


### PR DESCRIPTION
Small fix to add logging to catch blocks where it was previously missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262935](https://bugs.openjdk.java.net/browse/JDK-8262935): Add missing logging to sun.net.httpserver.ServerImpl


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2808/head:pull/2808`
`$ git checkout pull/2808`
