### PR TITLE
8262862: Harden tests sun/security/x509/URICertStore/ExtensionsWithLDAP.java and krb5/canonicalize/Test.java

### DIFF
--- a/test/jdk/sun/security/krb5/canonicalize/Test.java
+++ b/test/jdk/sun/security/krb5/canonicalize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,15 @@
  * @bug 6682516 8149521
  * @summary SPNEGO_HTTP_AUTH/WWW_KRB and SPNEGO_HTTP_AUTH/WWW_SPNEGO failed on all non-windows platforms
  * @modules java.security.jgss/sun.security.krb5
- * @run main/othervm  -Djava.security.krb5.conf=krb5.conf Test
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts
+ *                   -Djava.security.krb5.conf=krb5.conf Test
  */
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import sun.security.krb5.PrincipalName;
 
 public class Test {
     public static void main(String[] args) throws Exception {
         // This config file is generated using Kerberos.app on a Mac
-        String hostsFileName = System.getProperty("test.src", ".") + "/TestHosts";
-        System.setProperty("jdk.net.hosts.file", hostsFileName);
         System.setProperty("java.security.krb5.realm", "THIS.REALM");
         System.setProperty("java.security.krb5.kdc", "localhost");
 

--- a/test/jdk/sun/security/krb5/canonicalize/Test.java
+++ b/test/jdk/sun/security/krb5/canonicalize/Test.java
@@ -26,7 +26,7 @@
  * @summary SPNEGO_HTTP_AUTH/WWW_KRB and SPNEGO_HTTP_AUTH/WWW_SPNEGO failed on all non-windows platforms
  * @modules java.security.jgss/sun.security.krb5
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts
- *                   -Djava.security.krb5.conf=krb5.conf Test
+ *      -Djava.security.krb5.conf=krb5.conf Test
  */
 
 import sun.security.krb5.PrincipalName;

--- a/test/jdk/sun/security/krb5/canonicalize/Test.java
+++ b/test/jdk/sun/security/krb5/canonicalize/Test.java
@@ -26,6 +26,8 @@
  * @summary SPNEGO_HTTP_AUTH/WWW_KRB and SPNEGO_HTTP_AUTH/WWW_SPNEGO failed on all non-windows platforms
  * @modules java.security.jgss/sun.security.krb5
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts
+ *      -Djava.security.krb5.realm=THIS.REALM
+ *      -Djava.security.krb5.kdc=localhost
  *      -Djava.security.krb5.conf=krb5.conf Test
  */
 
@@ -33,10 +35,6 @@ import sun.security.krb5.PrincipalName;
 
 public class Test {
     public static void main(String[] args) throws Exception {
-        // This config file is generated using Kerberos.app on a Mac
-        System.setProperty("java.security.krb5.realm", "THIS.REALM");
-        System.setProperty("java.security.krb5.kdc", "localhost");
-
         // add using canonicalized name
         check("c1", "c1.this.domain");
         check("c1.this", "c1.this.domain");

--- a/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
+++ b/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
@@ -28,9 +28,11 @@
  * @bug 8134708
  * @summary Check if LDAP resources from CRLDP and AIA extensions can be loaded
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/CRLDP
+ *      -Dcom.sun.security.enableCRLDP=true
  *      ExtensionsWithLDAP CRLDP ldap.host.for.crldp
  * @modules jdk.security.auth
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/AIA
+ *      -Dcom.sun.security.enableAIAcaIssuers=true
  *      ExtensionsWithLDAP AIA ldap.host.for.aia
  */
 
@@ -130,10 +132,6 @@ public class ExtensionsWithLDAP {
     public static void main(String[] args) throws Exception {
         String extension = args[0];
         String targetHost = args[1];
-
-        // enable CRLDP and AIA extensions
-        System.setProperty("com.sun.security.enableCRLDP", "true");
-        System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
 
         X509Certificate trustedCert = loadCertificate(CA_CERT);
         X509Certificate eeCert = loadCertificate(EE_CERT);

--- a/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
+++ b/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,17 @@
  * @test
  * @bug 8134708
  * @summary Check if LDAP resources from CRLDP and AIA extensions can be loaded
- * @run main/othervm ExtensionsWithLDAP CRLDP ldap.host.for.crldp
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/CRLDP
+ *      ExtensionsWithLDAP CRLDP ldap.host.for.crldp
  * @modules jdk.security.auth
- * @run main/othervm ExtensionsWithLDAP AIA ldap.host.for.aia
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/AIA
+ *      ExtensionsWithLDAP AIA ldap.host.for.aia
  */
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
@@ -135,11 +134,6 @@ public class ExtensionsWithLDAP {
         // enable CRLDP and AIA extensions
         System.setProperty("com.sun.security.enableCRLDP", "true");
         System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
-
-        Path hostsFilePath = Paths.get(System.getProperty("test.src", ".")
-                + File.separator + extension);
-        System.setProperty("jdk.net.hosts.file",
-                hostsFilePath.toFile().getAbsolutePath());
 
         X509Certificate trustedCert = loadCertificate(CA_CERT);
         X509Certificate eeCert = loadCertificate(EE_CERT);


### PR DESCRIPTION
Certain JVM tools may access and initialise InetAddress class and its static fields during start up resulting in a NameService implementation being already set to the default **PlatformNameService**, causing intermittent failures in some tests that expect the use of **HostsFileNameService** instead by setting the system property jdk.net.hosts.file in the test main body, which has no effect in this scenario

By setting the property **jdk.net.hosts.file** in the @run tag, there is certainty that it will be properly configured at the time that a [NameService](https://github.com/openjdk/jdk/blob/382e38dd246596ec94a1f1ce0e0f9e87f53366c7/src/java.base/share/classes/java/net/InetAddress.java#L1155) is created

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262862](https://bugs.openjdk.java.net/browse/JDK-8262862): Harden tests sun/security/x509/URICertStore/ExtensionsWithLDAP.java and krb5/canonicalize/Test.java


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2809/head:pull/2809`
`$ git checkout pull/2809`
