### PR TITLE
8261450: JShell crashes with SIOOBE in tab completion

### DIFF
--- a/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocFormatter.java
+++ b/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -593,6 +593,7 @@ public class JavadocFormatter {
         private void reflowTillNow() {
             while (result.length() > 0 && result.charAt(result.length() - 1) == ' ')
                 result.delete(result.length() - 1, result.length());
+            reflownTo = Math.min(reflownTo, result.length());
             reflow(result, reflownTo, indent, limit);
             reflownTo = result.length();
         }

--- a/test/langtools/jdk/internal/shellsupport/doc/JavadocFormatterTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/JavadocFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8131019 8169561
+ * @bug 8131019 8169561 8261450
  * @summary Test JavadocFormatter
  * @library /tools/lib
  * @modules jdk.compiler/jdk.internal.shellsupport.doc
@@ -399,6 +399,18 @@ public class JavadocFormatterTest {
         if (!Objects.equals(actual, expected)) {
             throw new AssertionError("Incorrect output: " + actual);
         }
+    }
+
+    public void testSpaceAtEndOfLine() {
+        String header = "Class<?> Class<T>.forName(Module module, String name)";
+        String javadoc = """
+                         @throws SecurityException
+                                 <ul>
+                                 <li> test </li>
+                                 </ul>
+                         """;
+
+            new JavadocFormatter(60, true).formatJavadoc(header, javadoc);
     }
 
 }


### PR DESCRIPTION
`reflowTillNow` will strip trailing spaces, but then `reflownTo` may point after the full content of `result`. Need to fix `reflownTo` to not point after the full content of `result`, otherwise a `StringIndexOutOfBoundsException` may occur.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261450](https://bugs.openjdk.java.net/browse/JDK-8261450): JShell crashes with SIOOBE in tab completion


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2812/head:pull/2812`
`$ git checkout pull/2812`
