### PR TITLE
8262973: Verify ParCompactionManager instance in PCAdjustPointerClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -179,3 +179,19 @@ void ParCompactionManager::push_shadow_region(size_t shadow_region) {
 void ParCompactionManager::remove_all_shadow_regions() {
   _shadow_region_array->clear();
 }
+
+#ifdef ASSERT
+void ParCompactionManager::verify_all_marking_stack_empty() {
+  uint parallel_gc_threads = ParallelGCThreads;
+  for (uint i=0; i<=parallel_gc_threads; i++) {
+    assert(_manager_array[i]->marking_stacks_empty(), "Marking stack should be empty");
+  }
+}
+
+void ParCompactionManager::verify_all_region_stack_empty() {
+  uint parallel_gc_threads = ParallelGCThreads;
+  for (uint i=0; i<=parallel_gc_threads; i++) {
+    assert(_manager_array[i]->region_stack()->is_empty(), "Region stack should be empty");
+  }
+}
+#endif

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -183,14 +183,14 @@ void ParCompactionManager::remove_all_shadow_regions() {
 #ifdef ASSERT
 void ParCompactionManager::verify_all_marking_stack_empty() {
   uint parallel_gc_threads = ParallelGCThreads;
-  for (uint i=0; i<=parallel_gc_threads; i++) {
+  for (uint i = 0; i <= parallel_gc_threads; i++) {
     assert(_manager_array[i]->marking_stacks_empty(), "Marking stack should be empty");
   }
 }
 
 void ParCompactionManager::verify_all_region_stack_empty() {
   uint parallel_gc_threads = ParallelGCThreads;
-  for (uint i=0; i<=parallel_gc_threads; i++) {
+  for (uint i = 0; i <= parallel_gc_threads; i++) {
     assert(_manager_array[i]->region_stack()->is_empty(), "Region stack should be empty");
   }
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2620,9 +2620,9 @@ void PSParallelCompact::compact() {
 
   {
     GCTraceTime(Trace, gc, phases) tm("Deferred Updates", &_gc_timer);
-    // Update the deferred objects, if any. Any compaction manager can be used.
-    // However, since the current thread is VM thread, we use the rightful one
-    // to keep the verification logic happy.
+    // Update the deferred objects, if any. In principle, any compaction
+    // manager can be used. However, since the current thread is VM thread, we
+    // use the rightful one to keep the verification logic happy.
     ParCompactionManager* cm = ParCompactionManager::get_vmthread_cm();
     for (unsigned int id = old_space_id; id < last_space_id; ++id) {
       update_deferred_objects(cm, SpaceId(id));

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -126,7 +126,7 @@ inline void PSParallelCompact::adjust_pointer(T* p, ParCompactionManager* cm) {
 class PCAdjustPointerClosure: public BasicOopIterateClosure {
 public:
   PCAdjustPointerClosure(ParCompactionManager* cm) {
-    assert(cm != NULL, "associate ParCompactionManage should not be NULL");
+    verify_cm(cm);
     _cm = cm;
   }
   template <typename T> void do_oop_nv(T* p) { PSParallelCompact::adjust_pointer(p, _cm); }
@@ -136,6 +136,8 @@ public:
   virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
 private:
   ParCompactionManager* _cm;
+
+  static void verify_cm(ParCompactionManager* cm) NOT_DEBUG_RETURN;
 };
 
 #endif // SHARE_GC_PARALLEL_PSPARALLELCOMPACT_INLINE_HPP

--- a/test/hotspot/gtest/gc/parallel/test_psParallelCompact.cpp
+++ b/test/hotspot/gtest/gc/parallel/test_psParallelCompact.cpp
@@ -49,8 +49,6 @@ TEST_VM(PSParallelCompact, print_generic_summary_data) {
   // end region.  The end region should not be printed because it
   // corresponds to the space after the end of the heap.
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  ParCompactionManager* const vmthread_cm =
-    ParCompactionManager::manager_array(ParallelGCThreads);
   HeapWord* begin_heap =
     (HeapWord*) heap->old_gen()->virtual_space()->low_boundary();
   HeapWord* end_heap =


### PR DESCRIPTION
Verify the correct ParCompactionManager instance is used by VM/GC threads and some general cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262973](https://bugs.openjdk.java.net/browse/JDK-8262973): Verify ParCompactionManager instance in PCAdjustPointerClosure


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 4a426d289be334731806b64985b9e553afe9ddf4


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2813/head:pull/2813`
`$ git checkout pull/2813`
