### PR TITLE
8239386: handle ContendedPaddingWidth in vm_version_aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -95,6 +95,9 @@ void VM_Version::initialize() {
     SoftwarePrefetchHintDistance &= ~7;
   }
 
+  if (FLAG_IS_DEFAULT(ContendedPaddingWidth) && (dcache_line > ContendedPaddingWidth)) {
+      ContendedPaddingWidth = dcache_line;
+  }
 
   if (os::supports_map_sync()) {
     // if dcpop is available publish data cache line flush size via


### PR DESCRIPTION
Handle ContendedPaddingWidth the same way other architectures do

Passes Hotspot Tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239386](https://bugs.openjdk.java.net/browse/JDK-8239386): handle ContendedPaddingWidth in vm_version_aarch64


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2814/head:pull/2814`
`$ git checkout pull/2814`
