### PR TITLE
8262486: Merge trivial JDWP agent changes from the loom repo to the jdk repo

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -942,7 +942,6 @@ eventFilter_setStepFilter(HandlerNode *node, jint index,
     return JVMTI_ERROR_NONE;
 }
 
-
 jvmtiError
 eventFilter_setSourceNameMatchFilter(HandlerNode *node,
                                     jint index,

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -518,8 +518,7 @@ eventFilterRestricted_passesFilter(JNIEnv *env,
 
           case JDWP_REQUEST_MODIFIER(SourceNameMatch): {
               char* desiredNamePattern = filter->u.SourceNameOnly.sourceNamePattern;
-              if (searchAllSourceNames(env, clazz,
-                           desiredNamePattern) != 1) {
+              if (searchAllSourceNames(env, clazz, desiredNamePattern) != 1) {
                   /* The name isn't in the SDE; try the sourceName in the ref
                    * type
                    */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -534,7 +534,8 @@ synthesizeUnloadEvent(void *signatureVoid, void *envVoid)
 /* Garbage Collection Happened */
 static unsigned int garbageCollected = 0;
 
-/* The JVMTI generic event callback. Each event is passed to a sequence of
+/*
+ * The JVMTI generic event callback. Each event is passed to a sequence of
  * handlers in a chain until the chain ends or one handler
  * consumes the event.
  */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -269,7 +269,7 @@ eventHandlerRestricted_iterator(EventIndex ei,
 
 /* BREAKPOINT, METHOD_ENTRY and SINGLE_STEP events are covered by
  * the co-location of events policy. Of these three co-located
- * events, METHOD_ENTRY is  always reported first and BREAKPOINT
+ * events, METHOD_ENTRY is always reported first and BREAKPOINT
  * is always reported last. Here are the possible combinations and
  * their order:
  *
@@ -545,8 +545,9 @@ event_callback(JNIEnv *env, EventInfo *evinfo)
     jbyte eventSessionID = currentSessionID; /* session could change */
     jthrowable currentException;
     jthread thread;
+    EventIndex ei = evinfo->ei;
 
-    LOG_MISC(("event_callback(): ei=%s", eventText(evinfo->ei)));
+    LOG_MISC(("event_callback(): ei=%s", eventText(ei)));
     log_debugee_location("event_callback()", evinfo->thread, evinfo->method, evinfo->location);
 
     /* We want to preserve any current exception that might get
@@ -602,8 +603,7 @@ event_callback(JNIEnv *env, EventInfo *evinfo)
          * resources can be allocated.  This must be done before
          * grabbing any locks.
          */
-        eventBag = threadControl_onEventHandlerEntry(eventSessionID,
-                                 evinfo->ei, thread, currentException);
+        eventBag = threadControl_onEventHandlerEntry(eventSessionID, evinfo, currentException);
         if ( eventBag == NULL ) {
             jboolean invoking;
             do {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1045,12 +1045,12 @@ eventHelper_reportEvents(jbyte sessionID, struct bag *eventBag)
 
 void
 eventHelper_recordEvent(EventInfo *evinfo, jint id, jbyte suspendPolicy,
-                         struct bag *eventBag)
+                        struct bag *eventBag)
 {
     JNIEnv *env = getEnv();
     CommandSingle *command = bagAdd(eventBag);
     if (command == NULL) {
-        EXIT_ERROR(AGENT_ERROR_OUT_OF_MEMORY,"badAdd(eventBag)");
+        EXIT_ERROR(AGENT_ERROR_OUT_OF_MEMORY,"bagAdd(eventBag)");
     }
 
     command->singleKind = COMMAND_SINGLE_EVENT;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/standardHandlers.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/standardHandlers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@
 
 #include "standardHandlers.h"
 
+/* HandlerFunction - Invoked from event_callback() */
 static void
 handleClassPrepare(JNIEnv *env, EventInfo *evinfo,
                    HandlerNode *node,
@@ -75,6 +76,7 @@ handleClassPrepare(JNIEnv *env, EventInfo *evinfo,
                             node->suspendPolicy, eventBag);
 }
 
+/* HandlerFunction - Invoked from event_callback() */
 static void
 handleGarbageCollectionFinish(JNIEnv *env, EventInfo *evinfo,
                   HandlerNode *node,
@@ -83,6 +85,7 @@ handleGarbageCollectionFinish(JNIEnv *env, EventInfo *evinfo,
     JDI_ASSERT_MSG(JNI_FALSE, "Should never call handleGarbageCollectionFinish");
 }
 
+/* HandlerFunction - Invoked from event_callback() for METHOD_ENTRY and METHOD_EXIT. */
 static void
 handleFrameEvent(JNIEnv *env, EventInfo *evinfo,
                  HandlerNode *node,
@@ -122,6 +125,7 @@ handleFrameEvent(JNIEnv *env, EventInfo *evinfo,
                                  eventBag);
 }
 
+/* HandlerFunction - Invoked from event_callback() */
 static void
 genericHandler(JNIEnv *env, EventInfo *evinfo,
                HandlerNode *node,

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -39,6 +39,8 @@
  * If the ei field is non-zero, then one of the possible
  * co-located events has been posted and the other fields describe
  * the event's location.
+ *
+ * See comment above deferEventReport() for an explanation of co-located events.
  */
 typedef struct CoLocatedEventInfo_ {
     EventIndex ei;
@@ -63,27 +65,28 @@ typedef struct CoLocatedEventInfo_ {
  */
 typedef struct ThreadNode {
     jthread thread;
-    unsigned int toBeResumed : 1;
-    unsigned int pendingInterrupt : 1;
-    unsigned int isDebugThread : 1;
-    unsigned int suspendOnStart : 1;
-    unsigned int isStarted : 1;
+    unsigned int toBeResumed : 1;      /* true if this thread was successfully suspended. */
+    unsigned int pendingInterrupt : 1; /* true if thread is interrupted while handling an event. */
+    unsigned int isDebugThread : 1;    /* true if this is one of our debug agent threads. */
+    unsigned int suspendOnStart : 1;   /* true for new threads if we are currently in a VM.suspend(). */
+    unsigned int isStarted : 1;        /* THREAD_START or VIRTUAL_THREAD_SCHEDULED event received. */
     unsigned int popFrameEvent : 1;
     unsigned int popFrameProceed : 1;
     unsigned int popFrameThread : 1;
-    EventIndex current_ei;
-    jobject pendingStop;
+    EventIndex current_ei; /* Used to determine if we are currently handling an event on this thread. */
+    jobject pendingStop;   /* Object we are throwing to stop the thread (ThreadReferenceImpl.stop). */
     jint suspendCount;
     jint resumeFrameDepth; /* !=0 => This thread is in a call to Thread.resume() */
     jvmtiEventMode instructionStepMode;
     StepRequest currentStep;
     InvokeRequest currentInvoke;
-    struct bag *eventBag;
-    CoLocatedEventInfo cleInfo;
+    struct bag *eventBag;       /* Accumulation of JDWP events to be sent as a reply. */
+    CoLocatedEventInfo cleInfo; /* See comment above deferEventReport() for an explanation. */
     struct ThreadNode *next;
     struct ThreadNode *prev;
-    jlong frameGeneration;
-    struct ThreadList *list;  /* Tells us what list this thread is in */
+    jlong frameGeneration;    /* used to generate a unique frameID. Incremented whenever existing frameID
+                                 needs to be invalidated, such as when the thread is resumed. */
+    struct ThreadList *list;  /* Tells us what list this thread is in. */
 #ifdef DEBUG_THREADNAME
     char name[256];
 #endif
@@ -228,7 +231,10 @@ nonTlsSearch(JNIEnv *env, ThreadList *list, jthread thread)
 /*
  * These functions maintain the linked list of currently running threads.
  * All assume that the threadLock is held before calling.
- * If list==NULL, search both lists.
+ */
+
+/*
+ * Search for a thread on the list. If list==NULL, search all lists.
  */
 static ThreadNode *
 findThread(ThreadList *list, jthread thread)
@@ -672,6 +678,10 @@ notifyAppResumeComplete(void)
     }
 }
 
+/*
+ * Event handler for FRAME_POP and EXCEPTION_CATCH when in Thread.resume()
+ * so we can detect its completion.
+ */
 static void
 handleAppResumeCompletion(JNIEnv *env, EventInfo *evinfo,
                           HandlerNode *handlerNode,
@@ -756,6 +766,7 @@ trackAppResume(jthread thread)
     }
 }
 
+/* Global breakpoint handler for Thread.resume() */
 static void
 handleAppResumeBreakpoint(JNIEnv *env, EventInfo *evinfo,
                           HandlerNode *handlerNode,
@@ -927,7 +938,7 @@ deferredSuspendThreadByNode(ThreadNode *node)
          * happens when suspendOnStart is set to true.
          */
         if (error != JVMTI_ERROR_NONE) {
-          node->suspendCount--;
+            node->suspendCount--;
         }
     }
 
@@ -1080,6 +1091,9 @@ commonSuspend(JNIEnv *env, jthread thread, jboolean deferred)
      * to a separate list of threads so that we'll resume it later.
      */
     node = findThread(&runningThreads, thread);
+#if 0
+    tty_message("commonSuspend: node(%p) suspendCount(%d) %s", node, node->suspendCount, node->name);
+#endif
     if (node == NULL) {
         node = insertThread(env, &otherThreads, thread);
     }
@@ -1387,7 +1401,6 @@ commonSuspendList(JNIEnv *env, jint initCount, jthread *initList)
     return error;
 }
 
-
 static jvmtiError
 commonResume(jthread thread)
 {
@@ -1399,6 +1412,9 @@ commonResume(jthread thread)
      * not, check the auxiliary list used by threadControl_suspendThread.
      */
     node = findThread(NULL, thread);
+#if 0
+    tty_message("commonResume: node(%p) suspendCount(%d) %s", node, node->suspendCount, node->name);
+#endif
 
     /*
      * If the node is in neither list, the debugger never suspended
@@ -1520,6 +1536,9 @@ threadControl_suspendAll(void)
 {
     jvmtiError error;
     JNIEnv    *env;
+#if 0
+    tty_message("threadControl_suspendAll: suspendAllCount(%d)", suspendAllCount);
+#endif
 
     env = getEnv();
 
@@ -1593,6 +1612,9 @@ threadControl_resumeAll(void)
 {
     jvmtiError error;
     JNIEnv    *env;
+#if 0
+    tty_message("threadControl_resumeAll: suspendAllCount(%d)", suspendAllCount);
+#endif
 
     env = getEnv();
 
@@ -2050,13 +2072,15 @@ checkForPopFrameEvents(JNIEnv *env, EventIndex ei, jthread thread)
 }
 
 struct bag *
-threadControl_onEventHandlerEntry(jbyte sessionID, EventIndex ei, jthread thread, jobject currentException)
+threadControl_onEventHandlerEntry(jbyte sessionID, EventInfo *evinfo, jobject currentException)
 {
     ThreadNode *node;
     JNIEnv     *env;
     struct bag *eventBag;
     jthread     threadToSuspend;
     jboolean    consumed;
+    EventIndex  ei = evinfo->ei;
+    jthread     thread = evinfo->thread;
 
     env             = getEnv();
     threadToSuspend = NULL;
@@ -2483,7 +2507,8 @@ threadControl_setEventMode(jvmtiEventMode mode, EventIndex ei, jthread thread)
  * Returns the current thread, if the thread has generated at least
  * one event, and has not generated a thread end event.
  */
-jthread threadControl_currentThread(void)
+jthread
+threadControl_currentThread(void)
 {
     jthread thread;
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
@@ -40,8 +40,7 @@ void threadControl_onDisconnect(void);
 
 jvmtiError threadControl_popFrames(jthread thread, FrameNumber fnum);
 
-struct bag *threadControl_onEventHandlerEntry(jbyte sessionID,
-                  EventIndex ei, jthread thread, jobject currentException);
+struct bag *threadControl_onEventHandlerEntry(jbyte sessionID, EventInfo *evinfo, jobject currentException);
 void threadControl_onEventHandlerExit(EventIndex ei, jthread thread, struct bag *);
 
 


### PR DESCRIPTION
In the loom repo there are a number of trivial changes to the JDWP agent that are not loom specific. Moving them to the jdk repo will make future merges simpler, along with making it easier to get a diff of the important differences between the loom and jdk repos, without the clutter of these trivial changes. The changes I'd like to merge are:

1. Very minor code refactoring.
2. Comment additions, fixes, and improvements.
3. Minor indentation and whitespace changes.
4. Added a trivial assert

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262486](https://bugs.openjdk.java.net/browse/JDK-8262486): Merge trivial JDWP agent changes from the loom repo to the jdk repo


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to e2c9a4512806bd2ef50519959328cd70bd266015
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2815/head:pull/2815`
`$ git checkout pull/2815`
