### PR TITLE
JDK-8262957 (fs) Fail fast in UnixFileStore.isExtendedAttributesEnabled

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -179,6 +179,11 @@ abstract class UnixFileStore
      * @return <code>true</code> if enabled, <code>false</code> if disabled or unable to determine
      */
     protected boolean isExtendedAttributesEnabled(UnixPath path) {
+        if (!UnixNativeDispatcher.xattrSupported()) {
+            // avoid I/O if native code doesn't support xattr
+            return false;
+        }
+
         int fd = -1;
         try {
             fd = path.openForAttributeAccess(false);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -614,8 +614,9 @@ class UnixNativeDispatcher {
      */
     private static final int SUPPORTS_OPENAT        = 1 << 1;  // syscalls
     private static final int SUPPORTS_FUTIMES       = 1 << 2;
-    private static final int SUPPORTS_FUTIMENS      = 1 << 4;
-    private static final int SUPPORTS_LUTIMES       = 1 << 8;
+    private static final int SUPPORTS_FUTIMENS      = 1 << 3;
+    private static final int SUPPORTS_LUTIMES       = 1 << 4;
+    private static final int SUPPORTS_XATTR         = 1 << 5;
     private static final int SUPPORTS_BIRTHTIME     = 1 << 16; // other features
     private static final int capabilities;
 
@@ -652,6 +653,13 @@ class UnixNativeDispatcher {
      */
     static boolean birthtimeSupported() {
         return (capabilities & SUPPORTS_BIRTHTIME) != 0;
+    }
+
+    /**
+     * Supports extended attributes
+     */
+    static boolean xattrSupported() {
+        return (capabilities & SUPPORTS_XATTR) != 0;
     }
 
     private static native int init();

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -315,6 +315,12 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
     capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_BIRTHTIME;
 #endif
 
+    /* supports extended attributes */
+
+#ifdef _SYS_XATTR_H_
+    capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_XATTR;
+#endif
+
     return capabilities;
 }
 


### PR DESCRIPTION
Added new capability flag `UnixNativeDispatcher.SUPPORTS_XATTR`, which gets set `#ifdef _SYS_XATTR_H_`.

Note that `_SYS_XATTR_H_` is defined in `xattr.h` in both [macOS/Darwin](https://github.com/apple/darwin-xnu/blob/main/bsd/sys/xattr.h), [Linux and GNU-based BSD systems using glibc](https://github.com/bminor/glibc/blob/master/misc/sys/xattr.h). It might not be defined for other operating systems that still support xattr. So if OpenJDK eventually adds support for further platforms, this might need to be adjusted as well.

If xattr capabilities are missing, `UnixFileStore.isExtendedAttributesEnabled` will return false immediately, avoiding any I/O.

As a side effect of this change, I redefined some other (private) capabilities. Strictly speaking, this change is not required but keeps the code consistent, as [previously discussed in the mailing list](https://mail.openjdk.java.net/pipermail/nio-dev/2021-February/008133.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262957](https://bugs.openjdk.java.net/browse/JDK-8262957): (fs) Fail fast in UnixFileStore.isExtendedAttributesEnabled


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2816/head:pull/2816` \
`$ git checkout pull/2816`

Update a local copy of the PR: \
`$ git checkout pull/2816` \
`$ git pull https://git.openjdk.java.net/jdk pull/2816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2816`

View PR using the GUI difftool: \
`$ git pr show -t 2816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2816.diff">https://git.openjdk.java.net/jdk/pull/2816.diff</a>

</details>
