### PR TITLE
8262927: Explicitly state fields examined for BigDecimal.hashCode

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -3215,8 +3215,13 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
     // Hash Function
 
     /**
-     * Returns the hash code for this {@code BigDecimal}.  Note that
-     * two {@code BigDecimal} objects that are numerically equal but
+     * Returns the hash code for this {@code BigDecimal}.
+     * The hash code is computed as a function of the {@linkplain
+     * unscaledValue() unscaled value} and the {@linkplain scale()
+     * scale} of this {@code BigDecimal}.
+     *
+     * @apiNote
+     * Two {@code BigDecimal} objects that are numerically equal but
      * differ in scale (like 2.0 and 2.00) will generally <em>not</em>
      * have the same hash code.
      *


### PR DESCRIPTION
The class BigDecimal can be and sometimes is subclassed. The spec of BigDecimal.hashCode is improved slightly by explicitly stating it is a function of the unscaled value and the scale of the BigDecimal, the same fields examined by equals.

It is a conscious choice to *not* explicitly state what the exact hash function is.

As the behavior of hashCode is mostly implied from equals, I don't think a CSR is necessary in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262927](https://bugs.openjdk.java.net/browse/JDK-8262927): Explicitly state fields examined for BigDecimal.hashCode


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2817/head:pull/2817`
`$ git checkout pull/2817`
