### PR TITLE
JDK-8157682: @inheritDoc doesn't work with @exception

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -97,7 +97,12 @@ public class TagletManager {
     public static final char SIMPLE_TAGLET_OPT_SEPARATOR = ':';
 
     /**
-     * All taglets, keyed by their {@link Taglet#getName() name}.
+     * All taglets, keyed either by their {@link Taglet#getName() name},
+     * or by an alias.
+     *
+     * In general, taglets do <i>not</i> provide aliases;
+     * the one instance that does is {@code ThrowsTaglet}, which handles
+     * both {@code @throws} tags and {@code @exception} tags.
      */
     private final LinkedHashMap<String, Taglet> allTaglets;
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -576,20 +576,15 @@ public class TagletManager {
 
         inlineTags = new LinkedHashMap<>();
 
-        for (Taglet t : allTaglets.values()) {
+        allTaglets.forEach((name, t) -> {
             if (t.isInlineTag()) {
                 inlineTags.put(t.getName(), t);
             }
 
-            if (t.isBlockTag()) {
-                for (Location l : t.getAllowedLocations()) {
-                    List<Taglet> list = blockTagletsByLocation.get(l);
-                    if (!list.contains(t)) {
-                        list.add(t);
-                    }
-                }
+            if (t.isBlockTag() && t.getName().equals(name)) {
+                t.getAllowedLocations().forEach(l -> blockTagletsByLocation.get(l).add(t));
             }
-        }
+        });
 
         // init the serialized form tags for the serialized form page
         serializedFormTags = new ArrayList<>();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -737,8 +736,7 @@ public class TagletManager {
      * a need for a corresponding update to the spec.
      */
     private void showTaglets(PrintStream out) {
-        Map<String, Taglet> taglets = new TreeMap<String, Taglet>();
-        taglets.putAll(allTaglets);
+        Map<String, Taglet> taglets = new TreeMap<>(allTaglets);
 
         taglets.forEach((n, t) -> {
             // give preference to simpler block form if a tag can be either

--- a/test/langtools/jdk/javadoc/doclet/testExceptionInheritance/TestExceptionInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testExceptionInheritance/TestExceptionInheritance.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8157682
+ * @summary at-inheritDoc doesn't work with at-exception
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestExceptionInheritance
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+
+import toolbox.ToolBox;
+
+public class TestExceptionInheritance extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestExceptionInheritance tester = new TestExceptionInheritance();
+        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testExceptionException(Path base) throws Exception {
+        test(base, "exception", "exception");
+    }
+
+    @Test
+    public void testExceptionThrows(Path base) throws Exception {
+        test(base, "exception", "throws");
+    }
+
+    @Test
+    public void testThrowsException(Path base) throws Exception {
+        test(base, "throws", "exception");
+    }
+
+    @Test
+    public void testThrowsThrows(Path base) throws Exception {
+        test(base, "throws", "throws");
+    }
+
+    void test(Path base, String a, String b) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    public class A {
+                        /**
+                         * @param x a number
+                         * @##A## NullPointerException if x is null
+                         * @##A## IllegalArgumentException if {@code x < 0}
+                         */
+                        public void m(Integer x) { }
+                    }
+                    """.replace("##A##", a),
+                """
+                    package p;
+                    public class A_Sub extends A {
+                        /**
+                         * @param x {@inheritDoc}
+                         * @##B## NullPointerException {@inheritDoc}
+                         * @##B## IllegalArgumentException {@inheritDoc}
+                         */
+                        @Override
+                        public void m(Integer x) { }
+                    }
+                    """.replace("##B##", b)
+                );
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/A_Sub.html", true,
+                "<code>java.lang.NullPointerException</code> - if x is null");
+
+        checkOutput("p/A_Sub.html", true,
+                "<code>java.lang.IllegalArgumentException</code> - if <code>x &lt; 0</code>");
+    }
+}


### PR DESCRIPTION
Please review a fix to improve the handling of the legacy `@exception` tag.

A patch for this was [previously submitted](https://mail.openjdk.java.net/pipermail/javadoc-dev/2019-September/001139.html). However, that patch introduced an explicit new `ExceptionTaglet` class, whereas the fix here just reuses the existing `ThrowsTaglet`, registering it under an additional name.

The test in the original patch is enhanced to check all 4 combinations of (throws, exception) in the base class and (throws, exception) in the subclass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8157682](https://bugs.openjdk.java.net/browse/JDK-8157682): @inheritDoc doesn't work with @exception


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Contributors
 * Yano, Masanori `<yano-masanori@jp.fujitsu.com>`
 * Jonathan Gibbons `<jjg@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2818/head:pull/2818`
`$ git checkout pull/2818`
