### PR TITLE
8261532: Archived superinterface class cannot be accessed

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1677,7 +1677,7 @@ InstanceKlass* SystemDictionaryShared::prepare_shared_lambda_proxy_class(Instanc
                                                                          InstanceKlass* caller_ik, TRAPS) {
   Handle class_loader(THREAD, caller_ik->class_loader());
   Handle protection_domain;
-  PackageEntry* pkg_entry = get_package_entry_from_class(caller_ik, class_loader);
+  PackageEntry* pkg_entry = caller_ik->package();
   if (caller_ik->class_loader() != NULL) {
     protection_domain = SystemDictionaryShared::init_security_info(class_loader, caller_ik, pkg_entry, CHECK_NULL);
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2857,9 +2857,10 @@ void InstanceKlass::set_package(ClassLoaderData* loader_data, PackageEntry* pkg_
     check_prohibited_package(name(), loader_data, CHECK);
   }
 
-  if (is_shared() && _package_entry == pkg_entry) {
-    if (MetaspaceShared::use_full_module_graph()) {
+  if (is_shared() && _package_entry != NULL) {
+    if (MetaspaceShared::use_full_module_graph() && _package_entry == pkg_entry) {
       // we can use the saved package
+      assert(MetaspaceShared::is_in_shared_metaspace(_package_entry), "must be");
       return;
     } else {
       _package_entry = NULL;

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
@@ -31,7 +31,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
- * @build sun.hotspot.WhiteBox ArchivedSuperIfApp Bar Baz 
+ * @build sun.hotspot.WhiteBox ArchivedSuperIfApp Bar Baz
  * @run driver ClassFileInstaller -jar archived_super_if.jar pkg.ArchivedSuperIfApp pkg.Bar pkg.Baz
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8261532
+ * @summary An archived super interface should be accessible by the class which
+ *          implements the interface during runtime although the class itself
+ *          is not in the CDS archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
+ * @build sun.hotspot.WhiteBox ArchivedSuperIfApp Bar Baz 
+ * @run driver ClassFileInstaller -jar archived_super_if.jar pkg.ArchivedSuperIfApp pkg.Bar pkg.Baz
+ * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. ArchivedSuperIf
+ */
+
+public class ArchivedSuperIf extends DynamicArchiveTestBase {
+    public static void main(String[] args) throws Exception {
+        runTest(ArchivedSuperIf::test);
+    }
+
+    static void test() throws Exception {
+        String topArchiveName = getNewArchiveName();
+        String appJar = ClassFileInstaller.getJarPath("archived_super_if.jar");
+        String mainClass = "pkg.ArchivedSuperIfApp";
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+
+        dump(topArchiveName,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-Xlog:class+load=debug,cds+dynamic=info",
+            use_whitebox_jar,
+            "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                // Only the inteface Bar is loaded during dump time.
+                output.shouldMatch(".class.load. pkg.Bar source:.*archived_super_if.jar")
+                      .shouldNotMatch(".class.load. pkg.Baz source:.*archived_super_if.jar")
+                      .shouldHaveExitValue(0);
+            });
+
+        run(topArchiveName,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            use_whitebox_jar,
+            "-Xlog:class+load=debug",
+            "-cp", appJar, mainClass, "Baz")
+            .assertNormalExit(output -> {
+                // The interface Bar will be loaded from the archive.
+                // The class (Baz) which implements Bar will be loaded from jar.
+                output.shouldContain("[class,load] pkg.Bar source: shared objects file (top)")
+                      .shouldMatch(".class.load. pkg.Baz source:.*archived_super_if.jar")
+                      .shouldHaveExitValue(0);
+            });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/ArchivedSuperIfApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/ArchivedSuperIfApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package pkg;
+
+public class ArchivedSuperIfApp {
+
+    public static void main(String ... args) throws Exception {
+        Class.forName("pkg.Bar");
+        System.out.println(Bar.class.getName());
+        if (args.length > 0 && args[0].equals("Baz")) {
+            Class.forName("pkg.Baz");
+
+            Baz baz = new Baz();
+            baz.foo();
+            System.out.println(Baz.class.getName());
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/Bar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/Bar.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package pkg;
+
+interface Bar {
+
+    void foo();
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/Baz.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/Baz.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package pkg;
+
+class Baz implements Bar {
+
+    public void foo() { System.out.println("OK"); }
+
+}


### PR DESCRIPTION
Problem: If an interface is in the CDS archive but not the class which implements the interface. During runtime, IllegalAccessError will result when the class is being loaded.

Fix:
In `InstanceKlass::set_packge()` when checking if we can use a saved copy of the` _package_entry`, add a NULL check for `_package_entry` before returning. In `SystemDictionaryShared::prepare_shared_lambda_proxy_class()`, we can obtain the `_package_entry` directly from the `caller_ik` instead of calling `get_package_entry_from_class()`.

Testing: passed mach5 tiers 1 - 4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261532](https://bugs.openjdk.java.net/browse/JDK-8261532): Archived superinterface class cannot be accessed


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2820/head:pull/2820`
`$ git checkout pull/2820`
