### PR TITLE
JDK-8262064: Make compiler/ciReplay tests ignore lambdas in compilation replay

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -727,7 +727,7 @@ void ciInstanceKlass::dump_replay_data(outputStream* out) {
   // Try to record related loaded classes
   Klass* sub = ik->subklass();
   while (sub != NULL) {
-    if (sub->is_instance_klass()) {
+    if (sub->is_instance_klass() && !sub->is_hidden() && !InstanceKlass::cast(sub)->is_unsafe_anonymous()) {
       out->print_cr("instanceKlass %s", sub->name()->as_quoted_ascii());
     }
     sub = sub->next_sibling();


### PR DESCRIPTION
Don't include hidden classes in replay file.  I consider this a temporary fix because I plan to remove the dumping of subclassses in a later RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262064](https://bugs.openjdk.java.net/browse/JDK-8262064): Make compiler/ciReplay tests ignore lambdas in compilation replay


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2821/head:pull/2821`
`$ git checkout pull/2821`
