### PR TITLE
8261845: File permissions of packages built by jpackage

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinExeBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinExeBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,6 +140,8 @@ public class WinExeBundler extends AbstractBundler {
         Files.deleteIfExists(dstExePath);
 
         Files.copy(exePath, dstExePath);
+
+        dstExePath.toFile().setWritable(true, true);
 
         Log.verbose(MessageFormat.format(
                 I18N.getString("message.output-location"),


### PR DESCRIPTION
- Fixed by adding write permissions to .exe package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261845](https://bugs.openjdk.java.net/browse/JDK-8261845): File permissions of packages built by jpackage


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2822/head:pull/2822`
`$ git checkout pull/2822`
