### PR TITLE
8262828: Format of OS information is different on macOS

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1411,7 +1411,7 @@ void os::print_os_info_brief(outputStream* st) {
 }
 
 void os::print_os_info(outputStream* st) {
-  st->print("OS:");
+  st->print_cr("OS:");
 
   os::Posix::print_uname_info(st);
 


### PR DESCRIPTION
This pull request derives from [JDK-8262507](https://github.com/openjdk/jdk/pull/2770). Unlike Windows and Linux, there isn't a newline after the OS label in os information of a hs_error log file and jcmd VM.info on macOS. So this adds the newline.

I checked output in a hs_err log and jcmd VM.info. 
```
OS:
uname: Darwin MacBook-Pro.local 19.6.0 Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64 x86_64
OS uptime: 2 days 5:13 hours
rlimit (soft/hard): STACK 8192k/65532k , CORE 0k/infinity , NPROC 5568/8352 , NOFILE 10240/65535 , AS infinity/infinity , CPU infinity/infinity , DATA infinity/infinity , FSIZE infinity/infinity , MEMLOCK infinity/infinity , RSS infinity/infinity
load average: 1.69 1.75 1.76
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262828](https://bugs.openjdk.java.net/browse/JDK-8262828): Format of OS information is different on macOS


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2824/head:pull/2824`
`$ git checkout pull/2824`
