### PR TITLE
8264896: Remove redundant '& 0xFF' from int-to-byte cast

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -170,7 +170,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      */
     public final void writeShort(int v) throws IOException {
         writeBuffer[0] = (byte)(v >>> 8);
-        writeBuffer[1] = (byte)(v >>> 0);
+        writeBuffer[1] = (byte) v;
         out.write(writeBuffer, 0, 2);
         incCount(2);
     }
@@ -186,7 +186,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      */
     public final void writeChar(int v) throws IOException {
         writeBuffer[0] = (byte)(v >>> 8);
-        writeBuffer[1] = (byte)(v >>> 0);
+        writeBuffer[1] = (byte) v;
         out.write(writeBuffer, 0, 2);
         incCount(2);
     }
@@ -204,7 +204,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         writeBuffer[0] = (byte)(v >>> 24);
         writeBuffer[1] = (byte)(v >>> 16);
         writeBuffer[2] = (byte)(v >>>  8);
-        writeBuffer[3] = (byte)(v >>>  0);
+        writeBuffer[3] = (byte) v;
         out.write(writeBuffer, 0, 4);
         incCount(4);
     }
@@ -226,7 +226,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         writeBuffer[4] = (byte)(v >>> 24);
         writeBuffer[5] = (byte)(v >>> 16);
         writeBuffer[6] = (byte)(v >>>  8);
-        writeBuffer[7] = (byte)(v >>>  0);
+        writeBuffer[7] = (byte) v;
         out.write(writeBuffer, 0, 8);
         incCount(8);
     }
@@ -301,7 +301,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         for (int i = 0 ; i < len ; i++) {
             int v = s.charAt(i);
             writeBuffer[0] = (byte)(v >>> 8);
-            writeBuffer[1] = (byte)(v >>> 0);
+            writeBuffer[1] = (byte) v;
             out.write(writeBuffer, 0, 2);
         }
         incCount(len * 2);
@@ -379,8 +379,8 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         }
 
         int count = 0;
-        bytearr[count++] = (byte) ((utflen >>> 8) & 0xFF);
-        bytearr[count++] = (byte) ((utflen >>> 0) & 0xFF);
+        bytearr[count++] = (byte) (utflen >>> 8);
+        bytearr[count++] = (byte) utflen;
 
         int i = 0;
         for (i = 0; i < strlen; i++) { // optimized for initial run of ASCII
@@ -396,10 +396,10 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
             } else if (c >= 0x800) {
                 bytearr[count++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
                 bytearr[count++] = (byte) (0x80 | ((c >>  6) & 0x3F));
-                bytearr[count++] = (byte) (0x80 | ((c >>  0) & 0x3F));
+                bytearr[count++] = (byte) (0x80 | (c & 0x3F));
             } else {
                 bytearr[count++] = (byte) (0xC0 | ((c >>  6) & 0x1F));
-                bytearr[count++] = (byte) (0x80 | ((c >>  0) & 0x3F));
+                bytearr[count++] = (byte) (0x80 | (c & 0x3F));
             }
         }
         out.write(bytearr, 0, utflen + 2);

--- a/src/java.base/share/classes/java/io/PipedInputStream.java
+++ b/src/java.base/share/classes/java/io/PipedInputStream.java
@@ -206,7 +206,7 @@ public class PipedInputStream extends InputStream {
             in = 0;
             out = 0;
         }
-        buffer[in++] = (byte)(b & 0xFF);
+        buffer[in++] = (byte) b;
         if (in >= buffer.length) {
             in = 0;
         }

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -227,7 +227,7 @@ final class StringConcatHelper {
      */
     private static long prepend(long indexCoder, byte[] buf, char value) {
         if (indexCoder < UTF16) {
-            buf[(int)(--indexCoder)] = (byte) (value & 0xFF);
+            buf[(int)(--indexCoder)] = (byte) value;
         } else {
             StringUTF16.putChar(buf, (int)(--indexCoder), value);
         }

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -303,10 +303,10 @@ class Inet4Address extends InetAddress {
         int address = holder().getAddress();
         byte[] addr = new byte[INADDRSZ];
 
-        addr[0] = (byte) ((address >>> 24) & 0xFF);
-        addr[1] = (byte) ((address >>> 16) & 0xFF);
-        addr[2] = (byte) ((address >>> 8) & 0xFF);
-        addr[3] = (byte) (address & 0xFF);
+        addr[0] = (byte) (address >>> 24);
+        addr[1] = (byte) (address >>> 16);
+        addr[2] = (byte) (address >>> 8);
+        addr[3] = (byte) address;
         return addr;
     }
 

--- a/src/java.base/share/classes/java/text/RuleBasedCollationKey.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollationKey.java
@@ -104,9 +104,9 @@ final class RuleBasedCollationKey extends CollationKey {
         char[] src = key.toCharArray();
         byte[] dest = new byte[ 2*src.length ];
         int j = 0;
-        for( int i=0; i<src.length; i++ ) {
-            dest[j++] = (byte)(src[i] >>> 8);
-            dest[j++] = (byte)(src[i] & 0x00ff);
+        for (char c : src) {
+            dest[j++] = (byte) (c >>> 8);
+            dest[j++] = (byte) c;
         }
         return dest;
     }

--- a/src/java.base/share/classes/java/util/Base64.java
+++ b/src/java.base/share/classes/java/util/Base64.java
@@ -908,7 +908,7 @@ public class Base64 {
         @Override
         public void write(int b) throws IOException {
             byte[] buf = new byte[1];
-            buf[0] = (byte)(b & 0xff);
+            buf[0] = (byte) b;
             write(buf, 0, 1);
         }
 

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -308,7 +308,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
         for (int i = 0; i < n - 1; i++)
             bb.putLong(words[i]);
         for (long x = words[n - 1]; x != 0; x >>>= 8)
-            bb.put((byte) (x & 0xff));
+            bb.put((byte) x);
         return bytes;
     }
 

--- a/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
@@ -183,7 +183,7 @@ public class DeflaterOutputStream extends FilterOutputStream {
      */
     public void write(int b) throws IOException {
         byte[] buf = new byte[1];
-        buf[0] = (byte)(b & 0xff);
+        buf[0] = (byte) b;
         write(buf, 0, 1);
     }
 

--- a/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
@@ -219,7 +219,7 @@ public class GZIPOutputStream extends DeflaterOutputStream {
      * at a given offset
      */
     private void writeShort(int s, byte[] buf, int offset) throws IOException {
-        buf[offset] = (byte)(s & 0xff);
-        buf[offset + 1] = (byte)((s >> 8) & 0xff);
+        buf[offset] = (byte) s;
+        buf[offset + 1] = (byte) (s >> 8);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
@@ -54,20 +54,20 @@ class ClassFileAssembler implements ClassFileConstants {
 
     public void emitInt(int val) {
         emitByte((byte) (val >> 24));
-        emitByte((byte) ((val >> 16) & 0xFF));
-        emitByte((byte) ((val >> 8) & 0xFF));
-        emitByte((byte) (val & 0xFF));
+        emitByte((byte) (val >> 16));
+        emitByte((byte) (val >> 8));
+        emitByte((byte) val);
     }
 
     public void emitShort(short val) {
-        emitByte((byte) ((val >> 8) & 0xFF));
-        emitByte((byte) (val & 0xFF));
+        emitByte((byte) (val >> 8));
+        emitByte((byte) val);
     }
 
     // Support for labels; package-private
     void emitShort(short bci, short val) {
-        vec.put(bci,     (byte) ((val >> 8) & 0xFF));
-        vec.put(bci + 1, (byte) (val & 0xFF));
+        vec.put(bci,     (byte) (val >> 8));
+        vec.put(bci + 1, (byte) val);
     }
 
     public void emitByte(byte val) {

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -115,13 +115,13 @@ public class IPAddressUtil {
         }
         switch (currByte) {
             case 0:
-                res[0] = (byte) ((tmpValue >> 24) & 0xff);
+                res[0] = (byte) ((tmpValue >> 24));
             case 1:
-                res[1] = (byte) ((tmpValue >> 16) & 0xff);
+                res[1] = (byte) ((tmpValue >> 16));
             case 2:
-                res[2] = (byte) ((tmpValue >>  8) & 0xff);
+                res[2] = (byte) ((tmpValue >>  8));
             case 3:
-                res[3] = (byte) ((tmpValue >>  0) & 0xff);
+                res[3] = (byte) tmpValue;
         }
         return res;
     }
@@ -192,8 +192,8 @@ public class IPAddressUtil {
                 }
                 if (j + INT16SZ > INADDR16SZ)
                     return null;
-                dst[j++] = (byte) ((val >> 8) & 0xff);
-                dst[j++] = (byte) (val & 0xff);
+                dst[j++] = (byte) (val >> 8);
+                dst[j++] = (byte) val;
                 saw_xdigit = false;
                 val = 0;
                 continue;
@@ -224,8 +224,8 @@ public class IPAddressUtil {
         if (saw_xdigit) {
             if (j + INT16SZ > INADDR16SZ)
                 return null;
-            dst[j++] = (byte) ((val >> 8) & 0xff);
-            dst[j++] = (byte) (val & 0xff);
+            dst[j++] = (byte) (val >> 8);
+            dst[j++] = (byte) val;
         }
 
         if (colonp != -1) {

--- a/src/java.base/share/classes/sun/nio/ch/NativeSocketAddress.java
+++ b/src/java.base/share/classes/sun/nio/ch/NativeSocketAddress.java
@@ -243,8 +243,8 @@ class NativeSocketAddress {
      * port is stored in network order.
      */
     private void putPort(int family, int port) {
-        byte b1 = (byte) ((port >> 8) & 0xff);
-        byte b2 = (byte) ((port >> 0) & 0xff);
+        byte b1 = (byte) (port >> 8);
+        byte b2 = (byte) (port >> 0);
         if (family == AF_INET) {
             UNSAFE.putByte(address + OFFSET_SIN4_PORT, b1);
             UNSAFE.putByte(address + OFFSET_SIN4_PORT + 1, b2);
@@ -316,10 +316,10 @@ class NativeSocketAddress {
     private static void putAddress(long address, Inet4Address ia) {
         int ipAddress = JNINA.addressValue(ia);
         // network order
-        UNSAFE.putByte(address + 0, (byte) ((ipAddress >>> 24) & 0xFF));
-        UNSAFE.putByte(address + 1, (byte) ((ipAddress >>> 16) & 0xFF));
-        UNSAFE.putByte(address + 2, (byte) ((ipAddress >>> 8) & 0xFF));
-        UNSAFE.putByte(address + 3, (byte) (ipAddress & 0xFF));
+        UNSAFE.putByte(address + 0, (byte) (ipAddress >>> 24));
+        UNSAFE.putByte(address + 1, (byte) (ipAddress >>> 16));
+        UNSAFE.putByte(address + 2, (byte) (ipAddress >>> 8));
+        UNSAFE.putByte(address + 3, (byte) ipAddress);
     }
 
     private static void putAddress(long address, Inet6Address ia) {

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -344,10 +344,10 @@ public class Net {
      */
     static InetAddress inet4FromInt(int address) {
         byte[] addr = new byte[4];
-        addr[0] = (byte) ((address >>> 24) & 0xFF);
-        addr[1] = (byte) ((address >>> 16) & 0xFF);
-        addr[2] = (byte) ((address >>> 8) & 0xFF);
-        addr[3] = (byte) (address & 0xFF);
+        addr[0] = (byte) (address >>> 24);
+        addr[1] = (byte) (address >>> 16);
+        addr[2] = (byte) (address >>> 8);
+        addr[3] = (byte) address;
         try {
             return InetAddress.getByAddress(addr);
         } catch (UnknownHostException uhe) {

--- a/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/UnicodeEncoder.java
@@ -58,9 +58,9 @@ public abstract class UnicodeEncoder extends CharsetEncoder {
     private void put(char c, ByteBuffer dst) {
         if (byteOrder == BIG) {
             dst.put((byte)(c >> 8));
-            dst.put((byte)(c & 0xff));
+            dst.put((byte)(c));
         } else {
-            dst.put((byte)(c & 0xff));
+            dst.put((byte)(c));
             dst.put((byte)(c >> 8));
         }
     }


### PR DESCRIPTION
When we do
```java
byte b1 = (byte) (value & 0xFF);
```
we keep from int only 1 lower byte and exactly the same can be achieved with plain cast. See the test below:
```java
public class Main {
  public static void main(String[] args) throws Exception {
    IntStream.range(Integer.MIN_VALUE, Integer.MAX_VALUE).forEach(value -> {
      byte b1 = (byte) (value & 0xFF);
      byte b2 = (byte) value;
      if (b1 != b2) {
        throw new RuntimeException("" + value);
      }
    });
}
```

Also tier1 and tier2 are both OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264896](https://bugs.openjdk.java.net/browse/JDK-8264896): Remove redundant '& 0xFF' from int-to-byte cast


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2826/head:pull/2826` \
`$ git checkout pull/2826`

Update a local copy of the PR: \
`$ git checkout pull/2826` \
`$ git pull https://git.openjdk.java.net/jdk pull/2826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2826`

View PR using the GUI difftool: \
`$ git pr show -t 2826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2826.diff">https://git.openjdk.java.net/jdk/pull/2826.diff</a>

</details>
