### PR TITLE
8262300: jpackage app-launcher fails on linux when using JDK11 based runtime

### DIFF
--- a/src/jdk.jpackage/linux/native/libapplauncher/LinuxLauncherLib.cpp
+++ b/src/jdk.jpackage/linux/native/libapplauncher/LinuxLauncherLib.cpp
@@ -55,6 +55,8 @@ void launchApp() {
 
     AppLauncher appLauncher;
     appLauncher.addJvmLibName(_T("lib/libjli.so"));
+    // add backup - older version such as JDK11 have it in jli sub-dir
+    appLauncher.addJvmLibName(_T("lib/jli/libjli.so"));
 
     if (ownerPackage.name().empty()) {
         // Launcher should be in "bin" subdirectory of app image.


### PR DESCRIPTION
Fix jpackage app launcher to also look for JLI lib in "lib/jli/libjli.so" subdirectory of runtime

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262300](https://bugs.openjdk.java.net/browse/JDK-8262300): jpackage app-launcher fails on linux when using JDK11 based runtime


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2827/head:pull/2827`
`$ git checkout pull/2827`
