### PR TITLE
8263030: Remove Shenandoah leftovers from ReferenceProcessor

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1157,8 +1157,7 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
       // Check assumption that an object is not potentially
       // discovered twice except by concurrent collectors that potentially
       // trace the same Reference object twice.
-      assert(UseG1GC || UseShenandoahGC,
-             "Only possible with a concurrent marking collector");
+      assert(UseG1GC, "Only possible with a concurrent marking collector");
       return true;
     }
   }


### PR DESCRIPTION
Shenandoah is no longer using the shared ReferenceProcessor. We can remove remaining Shenandoah leftovers there.

Testing:
 - [x] hotspot_gc_shenandoah
 - [x] hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263030](https://bugs.openjdk.java.net/browse/JDK-8263030): Remove Shenandoah leftovers from ReferenceProcessor


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2829/head:pull/2829`
`$ git checkout pull/2829`
