### PR TITLE
8263040: fix for JDK-8262122 fails validate-source

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial fix for a bad copyright line in test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263040](https://bugs.openjdk.java.net/browse/JDK-8263040): fix for JDK-8262122 fails validate-source


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2831/head:pull/2831`
`$ git checkout pull/2831`
