### PR TITLE
8259577: Dangling reference to temp_path in Java_sun_tools_attach_VirtualMachineImpl_getTempDir

### DIFF
--- a/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
@@ -314,17 +314,14 @@ JNIEXPORT jstring JNICALL Java_sun_tools_attach_VirtualMachineImpl_getTempDir(JN
     // directory not the java application's temp directory, ala java.io.tmpdir.
 
 #ifdef __APPLE__
-    // macosx has a secure per-user temporary directory
-    static char *temp_path = NULL;
-    char temp_path_storage[PATH_MAX];
-    if (temp_path == NULL) {
-        int pathSize = confstr(_CS_DARWIN_USER_TEMP_DIR, temp_path_storage, PATH_MAX);
-        if (pathSize == 0 || pathSize > PATH_MAX) {
-            strlcpy(temp_path_storage, "/tmp", sizeof(temp_path_storage));
-        }
-        temp_path = temp_path_storage;
+    // macosx has a secure per-user temporary directory.
+    // Don't cache the result as this is only called once.
+    char path[PATH_MAX];
+    int pathSize = confstr(_CS_DARWIN_USER_TEMP_DIR, path, PATH_MAX);
+    if (pathSize == 0 || pathSize > PATH_MAX) {
+        strlcpy(path, "/tmp", sizeof(path));
     }
-    return JNU_NewStringPlatform(env, temp_path);
+    return JNU_NewStringPlatform(env, path);
 #else /* __APPLE__ */
     return (*env)->NewStringUTF(env, "/tmp");
 #endif /* __APPLE__ */

--- a/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi,
This is a pull request for 8259577, which points out that Java_sun_tools_attach_VirtualMachineImpl_getTempDir
caches a local variable from a previous call, so could return garbage.
However as noted in the bug, we have been safe so far because this method is only called once, so the caching is not required.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259577](https://bugs.openjdk.java.net/browse/JDK-8259577): Dangling reference to temp_path in Java_sun_tools_attach_VirtualMachineImpl_getTempDir


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 7eb29e4d6475edb9ef0063f52ea60a302410220c
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2832/head:pull/2832`
`$ git checkout pull/2832`
