### PR TITLE
8263041: Shenandoah: Cleanup C1 keep alive barrier check

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
@@ -221,26 +221,21 @@ void ShenandoahBarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result)
   }
 
   // 3: apply keep-alive barrier if ShenandoahSATBBarrier is set
-  if (ShenandoahSATBBarrier) {
-    bool is_weak = (decorators & ON_WEAK_OOP_REF) != 0;
-    bool is_phantom = (decorators & ON_PHANTOM_OOP_REF) != 0;
+  if (ShenandoahSATBBarrier && ShenandoahBarrierSet::need_keep_alive_barrier(decorators, type)) {
     bool is_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
-    bool keep_alive = (decorators & AS_NO_KEEPALIVE) == 0;
 
-    if ((is_weak || is_phantom || is_anonymous) && keep_alive) {
-      // Register the value in the referent field with the pre-barrier
-      LabelObj *Lcont_anonymous;
-      if (is_anonymous) {
-        Lcont_anonymous = new LabelObj();
-        generate_referent_check(access, Lcont_anonymous);
-      }
-      pre_barrier(gen, access.access_emit_info(), decorators, LIR_OprFact::illegalOpr /* addr_opr */,
-                  result /* pre_val */);
-      if (is_anonymous) {
-        __ branch_destination(Lcont_anonymous->label());
-      }
+    // Register the value in the referent field with the pre-barrier
+    LabelObj *Lcont_anonymous;
+    if (is_anonymous) {
+      Lcont_anonymous = new LabelObj();
+      generate_referent_check(access, Lcont_anonymous);
     }
- }
+    pre_barrier(gen, access.access_emit_info(), decorators, LIR_OprFact::illegalOpr /* addr_opr */,
+                result /* pre_val */);
+    if (is_anonymous) {
+      __ branch_destination(Lcont_anonymous->label());
+    }
+  }
 }
 
 class C1ShenandoahPreBarrierCodeGenClosure : public StubAssemblerCodeGenClosure {

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
@@ -220,8 +220,8 @@ void ShenandoahBarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result)
     BarrierSetC1::load_at_resolved(access, result);
   }
 
-  // 3: apply keep-alive barrier if ShenandoahSATBBarrier is set
-  if (ShenandoahSATBBarrier && ShenandoahBarrierSet::need_keep_alive_barrier(decorators, type)) {
+  // 3: apply keep-alive barrier for java.lang.ref.Reference if needed
+  if (ShenandoahBarrierSet::need_keep_alive_barrier(decorators, type)) {
     bool is_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
 
     // Register the value in the referent field with the pre-barrier

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -551,7 +551,7 @@ Node* ShenandoahBarrierSetC2::load_at_resolved(C2Access& access, const Type* val
     }
   }
 
-  // 3: apply keep-alive barrier if needed
+  // 3: apply keep-alive barrier for java.lang.ref.Reference if needed
   if (ShenandoahBarrierSet::need_keep_alive_barrier(decorators, type)) {
     Node* top = Compile::current()->top();
     Node* adr = access.addr().node();

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -537,7 +537,7 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
     enqueue_references_locked();
   } else {
     // Heap_lock protects external pending list
-    MonitorLocker ml(Heap_lock, Mutex::_no_safepoint_check_flag);
+    MonitorLocker ml(Heap_lock);
 
     enqueue_references_locked();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -155,7 +155,6 @@ static void soft_reference_update_clock() {
 
 ShenandoahRefProcThreadLocal::ShenandoahRefProcThreadLocal() :
   _discovered_list(NULL),
-  _mark_closure(NULL),
   _encountered_count(),
   _discovered_count(),
   _enqueued_count() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -155,6 +155,7 @@ static void soft_reference_update_clock() {
 
 ShenandoahRefProcThreadLocal::ShenandoahRefProcThreadLocal() :
   _discovered_list(NULL),
+  _mark_closure(NULL),
   _encountered_count(),
   _discovered_count(),
   _enqueued_count() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -537,7 +537,7 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
     enqueue_references_locked();
   } else {
     // Heap_lock protects external pending list
-    MonitorLocker ml(Heap_lock);
+    MonitorLocker ml(Heap_lock, Mutex::_no_safepoint_check_flag);
 
     enqueue_references_locked();
 


### PR DESCRIPTION
Please review this cleanup. It appears that JDK-8233339 missed C1 change.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263041](https://bugs.openjdk.java.net/browse/JDK-8263041): Shenandoah: Cleanup C1 keep alive barrier check


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2834/head:pull/2834`
`$ git checkout pull/2834`
