### PR TITLE
JDK-8263043: Add test to verify order of tag output

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
@@ -75,8 +75,8 @@ public class TestTagOrder extends JavadocTester {
                          * @since 1.0
                          * @see <a href="http://example.com">example</a>
                          */
-                        public int m(int p1, int p2) throws IllegalArgumentException { 
-                            return 0; 
+                        public int m(int p1, int p2) throws IllegalArgumentException {
+                            return 0;
                         }
                     }
                     """);

--- a/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
@@ -83,14 +83,14 @@ public class TestTagOrder extends JavadocTester {
                     }
                     """, """
                     package p;
-                    /** 
+                    /**
                      * Class C2.
                      * @since 1.0
                      * @author J. Duke.
-                     * @version 2.0 
+                     * @version 2.0
                      * @see <a href="http://example.com">example</a>
                      */
-                    public class C2 { } 
+                    public class C2 { }
                     """);
 
         // The following add map entries in the default order of appearance in the output.

--- a/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8263043
+ * @summary Add test to verify order of tag output
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestTagOrder
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+/**
+ * Tests the order of the output of block tags in the generated output.
+ * There is a default order, embodies in the order of declaration of tags in
+ * {@code Tagl;etManager}, but this can be overridden on the command line by
+ * specifying {@code -tag} options in the desired order.
+ */
+public class TestTagOrder extends JavadocTester {
+    public static void main(String... args) throws Exception {
+        TestTagOrder tester = new TestTagOrder();
+        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+    }
+
+    ToolBox tb = new ToolBox();
+    Path src = Path.of("src");
+    Map<String, String> expect = new LinkedHashMap<>();
+
+    TestTagOrder() throws IOException {
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    /** Class C. */
+                    public class C {
+                        /**
+                         * This is method m.
+                         * @param p1 first parameter
+                         * @param p2 second parameter
+                         * @return zero
+                         * @throws IllegalArgumentException well, never
+                         * @since 1.0
+                         * @see <a href="http://example.com">example</a>
+                         */
+                        public int m(int p1, int p2) throws IllegalArgumentException { 
+                            return 0; 
+                        }
+                    }
+                    """);
+
+        // The following adds map entries in the default order of appearance in the output.
+        // Note that the list is not otherwise ordered, such as alphabetically.
+
+        expect.put("@param", """
+                <dt>Parameters:</dt>
+                <dd><code>p1</code> - first parameter</dd>
+                <dd><code>p2</code> - second parameter</dd>
+                """);
+
+        expect.put("@return", """
+                <dt>Returns:</dt>
+                <dd>zero</dd>
+                """);
+
+        expect.put("@throws", """
+                <dt>Throws:</dt>
+                <dd><code>java.lang.IllegalArgumentException</code> - well, never</dd>
+                """);
+
+        expect.put("@since", """
+                <dt>Since:</dt>
+                <dd>1.0</dd>
+                """);
+
+        expect.put("@see", """
+                <dt>See Also:</dt>
+                <dd><a href="http://example.com">example</a></dd>
+                """);
+    }
+
+    @Test
+    public void testDefault(Path base) {
+        javadoc("-d", base.resolve("out").toString(),
+                "--source-path", src.toString(),
+                "--no-platform-links",
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                "<dl class=\"notes\">\n"
+                + String.join("", expect.values())
+                + "</dl>");
+    }
+
+    @Test
+    public void testAlpha(Path base) {
+        List<String> args = new ArrayList<>();
+        args.addAll(List.of(
+                "-d", base.resolve("out").toString(),
+                "--source-path", src.toString(),
+                "--no-platform-links"));
+
+        SortedMap<String, String> e = new TreeMap<>(Comparator.naturalOrder());
+        e.putAll(expect);
+        e.keySet().forEach(t -> { args.add("-tag"); args.add(t.substring(1)); });
+        args.add("p");
+
+        javadoc(args.toArray(new String[args.size()]));
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                "<dl class=\"notes\">\n"
+                        + String.join("", e.values())
+                        + "</dl>");
+    }
+
+    @Test
+    public void testReverse(Path base) {
+        List<String> args = new ArrayList<>();
+        args.addAll(List.of(
+                "-d", base.resolve("out").toString(),
+                "--source-path", src.toString(),
+                "--no-platform-links"));
+
+        SortedMap<String, String> e = new TreeMap<>(Comparator.reverseOrder());
+        e.putAll(expect);
+        e.keySet().forEach(t -> { args.add("-tag"); args.add(t.substring(1)); });
+        args.add("p");
+
+        javadoc(args.toArray(new String[args.size()]));
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                "<dl class=\"notes\">\n"
+                        + String.join("", e.values())
+                        + "</dl>");
+    }
+}


### PR DESCRIPTION
Please review a new test to verify that the output of block tags is generated in the expected order.

The code in the standard doclet to generate the output is the same for all use sites (modules, packages, class, members) and so just the richest site is tested.

The test checks that tags appear in the expected order by default, but can be reordered in a couple of different ways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263043](https://bugs.openjdk.java.net/browse/JDK-8263043): Add test to verify order of tag output


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 395cca1ba954db3fc8e12fe74bf2c969c8aced10


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2835/head:pull/2835`
`$ git checkout pull/2835`
