### PR TITLE
JDK-8263050: move HtmlDocletWriter.verticalSeparator to IndexWriter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -2165,10 +2165,6 @@ public class HtmlDocletWriter {
         return localStylesheets;
     }
 
-    Content getVerticalSeparator() {
-        return HtmlTree.SPAN(HtmlStyle.verticalSeparator, Text.of("|"));
-    }
-
     public void addPreviewSummary(Element forWhat, Content target) {
         if (utils.isPreviewAPI(forWhat)) {
             Content div = HtmlTree.DIV(HtmlStyle.block);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -370,4 +370,8 @@ public class IndexWriter extends HtmlDocletWriter {
                 .collect(Collectors.toList());
         contentTree.add(contents.join(getVerticalSeparator(), pageLinks));
     }
+
+    private Content getVerticalSeparator() {
+        return HtmlTree.SPAN(HtmlStyle.verticalSeparator, Text.of("|"));
+    }
 }


### PR DESCRIPTION
Please review a tiny change to move a small utility method from a superclass into the one subclass where it is actually used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263050](https://bugs.openjdk.java.net/browse/JDK-8263050): move HtmlDocletWriter.verticalSeparator to IndexWriter


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2837/head:pull/2837`
`$ git checkout pull/2837`
