### PR TITLE
8250804: Can't set the application icon image for Unity WM on Linux.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -852,7 +852,6 @@ java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html 8080185 macosx-a
 javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
 java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java 8163086 macosx-all
-java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java 8250804 macosx-all,linux-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/print/Dialog/RestoreActiveWindowTest/RestoreActiveWindowTest.java 8185429 macosx-all

--- a/test/jdk/java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,12 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8147648 8163160
  * @summary [hidpi] multiresolution image: wrong resolution variant is used as
  * icon in the Unity panel
+ * @requires os.family == "linux"
  * @run main/manual/othervm -Dsun.java2d.uiScale=2 IconTest
  */
 import java.awt.Color;
@@ -33,7 +34,6 @@ import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BaseMultiResolutionImage;
@@ -58,6 +58,8 @@ public class IconTest {
     private static JButton testButton;
     private static JFrame f;
     private static CountDownLatch latch;
+
+    private static volatile boolean failed;
 
     private static BufferedImage generateImage(int scale, Color c) {
         int x = SZ * scale;
@@ -91,8 +93,10 @@ public class IconTest {
                 GridBagConstraints gbc = new GridBagConstraints();
                 String instructions
                         = "<html>INSTRUCTIONS:<br>"
-                        + "Check if test button icon and unity icon are both "
-                        + "blue with green border.<br><br>"
+                        + "Check if test button icon and unity icon<br>"
+                        + "(icon in a side dock, if present)<br>"
+                        + "are both blue with green border.<br><br>"
+                        + "NB: Icon in the top bar may be presented in grayscale.<br><br>"
                         + "If Icon color is blue press pass"
                         + " else press fail.<br><br></html>";
 
@@ -120,13 +124,10 @@ public class IconTest {
                 });
                 failButton = new JButton("Fail");
                 failButton.setActionCommand("Fail");
-                failButton.addActionListener(new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        latch.countDown();
-                        f.dispose();
-                        throw new RuntimeException("Test Failed");
-                    }
+                failButton.addActionListener(e -> {
+                    failed = true;
+                    latch.countDown();
+                    f.dispose();
                 });
                 gbc.gridx = 1;
                 gbc.gridy = 0;
@@ -159,6 +160,10 @@ public class IconTest {
         latch = new CountDownLatch(1);
         createUI();
         latch.await();
+
+        if (failed) {
+            throw new RuntimeException("Test Failed");
+        }
     }
 }
 


### PR DESCRIPTION
As of now we can have two icons: on the side dock and on the top bar.
But this test was written for an old time Unity with an icon in the side dock only. 

Icon at the top by default is displayed as grayscale(the actual reason of submitting bug report).
BTW it may not be presented depending on Gnome Shell settings.

`setIconImage()` seems to be working as expected in this case, but we need to clarify the test's instruction.

Besides that the test has another issue: it does not fail on pressing "Fail" button. It is also fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250804](https://bugs.openjdk.java.net/browse/JDK-8250804): Can't set the application icon image for Unity WM on Linux.


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2838/head:pull/2838`
`$ git checkout pull/2838`
