### PR TITLE
8263054: [testbug] SharedArchiveConsistency.java reuses jsa files

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -289,7 +289,6 @@ public class SharedArchiveConsistency {
                 throw new IOException("Could not delete file " + newJsaFile);
             }
         }
-        newJsaFile.createNewFile();
         Files.copy(orgJsaFile.toPath(), newJsaFile.toPath(), REPLACE_EXISTING);
 
         // orgJsaFile is read only, and Files.copy passes on this attribute to newJsaFile.


### PR DESCRIPTION
SharedArchiveConsistency.java runs a child process with a JSA file. Then, it modifies the JSA file, and then reuses this same JSA file to run another child process.

However, on Windows, after first child process has exited, some sort of file lock is still held on the JSA file, so when we try to modify the JSA file for the second process, sometimes we get the "The requested operation cannot be performed on a file with a user-mapped section open" error.

The fix is to always create a new JSA file for every new test case, and never modify/reuse the JSA files. (We have been following this rule for other CDS tests).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263054](https://bugs.openjdk.java.net/browse/JDK-8263054): [testbug] SharedArchiveConsistency.java reuses jsa files


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 826c7c9ca79408b1da6a55e5fb5ed28879e1ff20
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 826c7c9ca79408b1da6a55e5fb5ed28879e1ff20


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2839/head:pull/2839`
`$ git checkout pull/2839`
