### PR TITLE
8261957: [PPC64] Support for Concurrent Thread-Stack Processing

### DIFF
--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -47,6 +47,7 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
     address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
 
     __ bind(_entry);
+    // Using pc relative address computation.
     {
       Label next_pc;
       __ bl(next_pc);
@@ -54,7 +55,7 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
     }
     int current_offset = __ offset();
     __ mflr(R12);
-    __ addi(R12, R12, safepoint_offset() - current_offset);
+    __ add_const_optimized(R12, R12, safepoint_offset() - current_offset);
     __ std(R12, in_bytes(JavaThread::saved_exception_pc_offset()), R16_thread);
 
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(stub));

--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,28 @@
 #define __ ce->masm()->
 
 void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
-  ShouldNotReachHere();
+  if (UseSIGTRAP) {
+    DEBUG_ONLY( __ should_not_reach_here("C1SafepointPollStub::emit_code"); )
+  } else {
+    assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
+           "polling page return stub not created yet");
+    address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
+
+    __ bind(_entry);
+    {
+      Label next_pc;
+      __ bl(next_pc);
+      __ bind(next_pc);
+    }
+    int current_offset = __ offset();
+    __ mflr(R12);
+    __ addi(R12, R12, safepoint_offset() - current_offset);
+    __ std(R12, in_bytes(JavaThread::saved_exception_pc_offset()), R16_thread);
+
+    __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(stub));
+    __ mtctr(R0);
+    __ bctr();
+  }
 }
 
 RangeCheckStub::RangeCheckStub(CodeEmitInfo* info, LIR_Opr index, LIR_Opr array)

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1327,8 +1327,8 @@ void LIR_Assembler::reg2mem(LIR_Opr from_reg, LIR_Opr dest, BasicType type,
 
 
 void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
-  const Register return_pc        = R31;  // Must survive C-call to enable_stack_reserved_zone().
-  const Register polling_page     = R12;
+  const Register return_pc = R31;  // Must survive C-call to enable_stack_reserved_zone().
+  const Register temp      = R12;
 
   // Pop the stack before the safepoint code.
   int frame_size = initial_frame_size_in_bytes();
@@ -1337,8 +1337,6 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   } else {
     __ pop_frame();
   }
-
-  __ ld(polling_page, in_bytes(Thread::polling_page_offset()), R16_thread);
 
   // Restore return pc relative to callers' sp.
   __ ld(return_pc, _abi0(lr), R1_SP);
@@ -1351,8 +1349,11 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
 
   // We need to mark the code position where the load from the safepoint
   // polling page was emitted as relocInfo::poll_return_type here.
-  __ relocate(relocInfo::poll_return_type);
-  __ load_from_polling_page(polling_page);
+  if (!UseSIGTRAP) {
+    code_stub->set_safepoint_offset(__ offset());
+    __ relocate(relocInfo::poll_return_type);
+  }
+  __ safepoint_poll(*code_stub->entry(), temp, true /* at_return */, true /* in_nmethod */);
 
   // Return.
   __ blr();

--- a/src/hotspot/cpu/ppc/c2_safepointPollStubTable_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_safepointPollStubTable_ppc.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "macroAssembler_ppc.inline.hpp"
+#include "opto/compile.hpp"
+#include "opto/node.hpp"
+#include "opto/output.hpp"
+#include "runtime/sharedRuntime.hpp"
+
+#define __ masm.
+void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointPollStub* entry) const {
+  assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
+         "polling page return stub not created yet");
+  address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
+
+  __ bind(entry->_stub_label);
+  {
+    Label next_pc;
+    __ bl(next_pc);
+    __ bind(next_pc);
+  }
+  int current_offset = __ offset();
+  __ mflr(R12);
+  __ addi(R12, R12, entry->_safepoint_offset - current_offset);
+  __ std(R12, in_bytes(JavaThread::saved_exception_pc_offset()), R16_thread);
+
+  __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(stub));
+  __ mtctr(R0);
+  __ bctr();
+}
+#undef __

--- a/src/hotspot/cpu/ppc/c2_safepointPollStubTable_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_safepointPollStubTable_ppc.cpp
@@ -37,14 +37,17 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
 
   __ bind(entry->_stub_label);
+  // Using pc relative address computation.
   {
     Label next_pc;
     __ bl(next_pc);
     __ bind(next_pc);
   }
   int current_offset = __ offset();
-  __ mflr(R12);
-  __ addi(R12, R12, entry->_safepoint_offset - current_offset);
+  // Code size should not depend on offset: see _stub_size computation in output.cpp
+  __ load_const32(R12, entry->_safepoint_offset - current_offset);
+  __ mflr(R0);
+  __ add(R12, R12, R0);
   __ std(R12, in_bytes(JavaThread::saved_exception_pc_offset()), R16_thread);
 
   __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(stub));

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2017 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/signature.hpp"
+#include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
 #ifdef COMPILER1
@@ -229,7 +230,7 @@ address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
   return sender_pc_addr();
 }
 
-frame frame::sender(RegisterMap* map) const {
+frame frame::sender_raw(RegisterMap* map) const {
   // Default is we do have to follow them. The sender_for_xxx will
   // update it accordingly.
   map->set_include_argument_oops(false);
@@ -244,6 +245,16 @@ frame frame::sender(RegisterMap* map) const {
   // Must be native-compiled frame, i.e. the marshaling code for native
   // methods that exists in the core system.
   return frame(sender_sp(), sender_pc());
+}
+
+frame frame::sender(RegisterMap* map) const {
+  frame result = sender_raw(map);
+
+  if (map->process_frames()) {
+    StackWatermarkSet::on_iteration(map->thread(), result);
+  }
+
+  return result;
 }
 
 void frame::patch_pc(Thread* thread, address pc) {

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -417,5 +417,8 @@
   };
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
+
+  // returns the sending frame, without applying any barriers
+  frame sender_raw(RegisterMap* map) const;
 
 #endif // CPU_PPC_FRAME_PPC_HPP

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -853,7 +853,9 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
   b(fast_path);
   bind(slow_path);
   push(state);
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind));
+  set_last_Java_frame(R1_SP, noreg);
+  call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), R16_thread);
+  reset_last_Java_frame();
   pop(state);
   align(32);
   bind(fast_path);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -666,7 +666,7 @@ class MacroAssembler: public Assembler {
                                    bool try_bias = UseBiasedLocking, bool use_rtm = false);
 
   // Check if safepoint requested and if so branch
-  void safepoint_poll(Label& slow_path, Register temp_reg);
+  void safepoint_poll(Label& slow_path, Register temp, bool at_return, bool in_nmethod);
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2,
                        MacroAssembler::PreservationLevel preservation_level);

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,6 @@ class NativeInstruction {
 #endif
 
   bool is_safepoint_poll() {
-    // Is the current instruction a POTENTIAL read access to the polling page?
     // The current arguments of the instruction are not checked!
     if (USE_POLL_BIT_ONLY) {
       int encoding = SafepointMechanism::poll_bit();
@@ -91,6 +90,12 @@ class NativeInstruction {
                                     -1, encoding);
     }
     return MacroAssembler::is_load_from_polling_page(long_at(0), NULL);
+  }
+
+  bool is_safepoint_poll_return() {
+    // Safepoint poll at nmethod return with watermark check.
+    return MacroAssembler::is_td(long_at(0), Assembler::traptoGreaterThanUnsigned,
+                                 /* R1_SP */ 1, /* any reg */ -1);
   }
 
   address get_stack_bang_address(void *ucontext) {

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+// Copyright (c) 2012, 2021 SAP SE. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1562,7 +1562,7 @@ void MachEpilogNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   st->print("pop frame\n\t");
 
   if (do_polling() && C->is_method_compilation()) {
-    st->print("touch polling page\n\t");
+    st->print("safepoint poll\n\t");
   }
 }
 #endif
@@ -1577,18 +1577,11 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   const bool method_needs_polling = do_polling() && C->is_method_compilation();
   const bool method_is_frameless  = false /* TODO: PPC port C->is_frameless_method()*/;
   const Register return_pc        = R31;  // Must survive C-call to enable_stack_reserved_zone().
-  const Register polling_page     = R12;
+  const Register temp             = R12;
 
   if (!method_is_frameless) {
     // Restore return pc relative to callers' sp.
     __ ld(return_pc, ((int)framesize) + _abi0(lr), R1_SP);
-  }
-
-  if (method_needs_polling) {
-    __ ld(polling_page, in_bytes(JavaThread::polling_page_offset()), R16_thread);
-  }
-
-  if (!method_is_frameless) {
     // Move return pc to LR.
     __ mtlr(return_pc);
     // Pop frame (fixed frame-size).
@@ -1600,10 +1593,13 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   }
 
   if (method_needs_polling) {
-    // We need to mark the code position where the load from the safepoint
-    // polling page was emitted as relocInfo::poll_return_type here.
-    __ relocate(relocInfo::poll_return_type);
-    __ load_from_polling_page(polling_page);
+    Label dummy_label;
+    Label* code_stub = &dummy_label;
+    if (!UseSIGTRAP && !C->output()->in_scratch_emit_size()) {
+      code_stub = &C->output()->safepoint_poll_table()->add_safepoint(__ offset());
+      __ relocate(relocInfo::poll_return_type);
+    }
+    __ safepoint_poll(*code_stub, temp, true /* at_return */, true /* in_nmethod */);
   }
 }
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2273,6 +2273,9 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   if (is_critical_native) {
     Label needs_safepoint;
     Register sync_state      = r_temp_5;
+    // Note: We should not reach here with active stack watermark. There's no safepoint between
+    //       start of the native wrapper and this check where it could have been added.
+    //       We don't check the watermark in the fast path.
     __ safepoint_poll(needs_safepoint, sync_state, false /* at_return */, false /* in_nmethod */);
 
     Register suspend_flags   = r_temp_6;

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2273,7 +2273,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   if (is_critical_native) {
     Label needs_safepoint;
     Register sync_state      = r_temp_5;
-    __ safepoint_poll(needs_safepoint, sync_state);
+    __ safepoint_poll(needs_safepoint, sync_state, false /* at_return */, false /* in_nmethod */);
 
     Register suspend_flags   = r_temp_6;
     __ lwz(suspend_flags, thread_(suspend_flags));
@@ -2320,7 +2320,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
     // No synchronization in progress nor yet synchronized
     // (cmp-br-isync on one path, release (same as acquire on PPC64) on the other path).
-    __ safepoint_poll(sync, sync_state);
+    __ safepoint_poll(sync, sync_state, true /* at_return */, false /* in_nmethod */);
 
     // Not suspended.
     // TODO: PPC port assert(4 == Thread::sz_suspend_flags(), "unexpected field size");
@@ -3019,7 +3019,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
   if (cause_return) {
     // Nothing to do here. The frame has already been popped in MachEpilogNode.
     // Register LR already contains the return pc.
-    return_pc_location = RegisterSaver::return_pc_is_lr;
+    return_pc_location = RegisterSaver::return_pc_is_pre_saved;
   } else {
     // Use thread()->saved_exception_pc() as return pc.
     return_pc_location = RegisterSaver::return_pc_is_thread_saved_exception_pc;

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1449,7 +1449,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   Label do_safepoint, sync_check_done;
   // No synchronization in progress nor yet synchronized.
-  __ safepoint_poll(do_safepoint, sync_state);
+  __ safepoint_poll(do_safepoint, sync_state, true /* at_return */, false /* in_nmethod */);
 
   // Not suspended.
   // TODO PPC port assert(4 == Thread::sz_suspend_flags(), "unexpected field size");
@@ -1749,7 +1749,7 @@ address TemplateInterpreterGenerator::generate_CRC32_update_entry() {
 
     // Safepoint check
     const Register sync_state = R11_scratch1;
-    __ safepoint_poll(slow_path, sync_state);
+    __ safepoint_poll(slow_path, sync_state, false /* at_return */, false /* in_nmethod */);
 
     // We don't generate local frame and don't align stack because
     // we not even call stub code (we generate the code inline)
@@ -1803,7 +1803,7 @@ address TemplateInterpreterGenerator::generate_CRC32_updateBytes_entry(AbstractI
 
     // Safepoint check
     const Register sync_state = R11_scratch1;
-    __ safepoint_poll(slow_path, sync_state);
+    __ safepoint_poll(slow_path, sync_state, false /* at_return */, false /* in_nmethod */);
 
     // We don't generate local frame and don't align stack because
     // we not even call stub code (we generate the code inline)

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,7 @@ public:
 
   // PPC64 supports fast class initialization checks for static methods.
   static bool supports_fast_class_init_checks() { return true; }
+  constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   // CPU instruction support

--- a/src/hotspot/os/aix/safepointMechanism_aix.cpp
+++ b/src/hotspot/os/aix/safepointMechanism_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,6 +110,6 @@ void SafepointMechanism::pd_initialize() {
   }
   uintptr_t bad_page_val  = reinterpret_cast<uintptr_t>(map_address),
             good_page_val = bad_page_val + os::vm_page_size();
-  _poll_page_armed_value    = bad_page_val  + poll_bit();
+  _poll_page_armed_value    = bad_page_val;
   _poll_page_disarmed_value = good_page_val;
 }

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -268,6 +268,17 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                         USE_POLL_BIT_ONLY ? "SIGTRAP" : "SIGSEGV");
         }
         stub = SharedRuntime::get_poll_stub(pc);
+      }
+
+      else if (UseSIGTRAP && sig == SIGTRAP &&
+               ((NativeInstruction*)pc)->is_safepoint_poll_return() &&
+               CodeCache::contains((void*) pc) &&
+               ((cb = CodeCache::find_blob(pc)) != NULL) &&
+               cb->is_compiled()) {
+        if (TraceTraps) {
+          tty->print_cr("trap: safepoint_poll at return at " INTPTR_FORMAT " (nmethod)", p2i(pc));
+        }
+        stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
       }
 
       // SIGTRAP-based ic miss check in compiled code.


### PR DESCRIPTION
I'd like to support Concurrent Thread-Stack Processing on PPC64. This will be needed by ShenandoahGC and zGC when implemented. Maybe for other purposes in the future, too.
I'm using conditional trap instructions by default, so we don't need the extra stubs unless -XX:-UseSIGTRAP is used.

Original change: https://github.com/openjdk/jdk/commit/b9873e18

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261957](https://bugs.openjdk.java.net/browse/JDK-8261957): [PPC64] Support for Concurrent Thread-Stack Processing


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to 68326ddc1dd6d138b71e8763dda43e709de572e9
 * [Niklas Radomski](https://openjdk.java.net/census#nradomski) (@Quaffel - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2841/head:pull/2841` \
`$ git checkout pull/2841`

Update a local copy of the PR: \
`$ git checkout pull/2841` \
`$ git pull https://git.openjdk.java.net/jdk pull/2841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2841`

View PR using the GUI difftool: \
`$ git pr show -t 2841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2841.diff">https://git.openjdk.java.net/jdk/pull/2841.diff</a>

</details>
