### PR TITLE
8263091: Remove CharacterData.isOtherUppercase/-Lowercase

### DIFF
--- a/make/data/characterdata/CharacterData00.java.template
+++ b/make/data/characterdata/CharacterData00.java.template
@@ -84,16 +84,6 @@ class CharacterData00 extends CharacterData {
         return (props & $$maskType);
     }
 
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
-    }
-
     boolean isOtherAlphabetic(int ch) {
         int props = getPropertiesEx(ch);
         return (props & $$maskOtherAlphabetic) != 0;
@@ -765,13 +755,13 @@ class CharacterData00 extends CharacterData {
     }
 
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0;
     }
 
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherUppercase) != 0;
     }
 
     boolean isWhitespace(int ch) {

--- a/make/data/characterdata/CharacterData01.java.template
+++ b/make/data/characterdata/CharacterData01.java.template
@@ -83,16 +83,6 @@ class CharacterData01 extends CharacterData {
         return (props & $$maskType);
     }
 
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
-    }
- 
     boolean isOtherAlphabetic(int ch) {
         int props = getPropertiesEx(ch);
         return (props & $$maskOtherAlphabetic) != 0;
@@ -503,13 +493,13 @@ class CharacterData01 extends CharacterData {
     }
 
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0;
     }
 
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherUppercase) != 0;
     }
 
     boolean isWhitespace(int ch) {

--- a/make/data/characterdata/CharacterData02.java.template
+++ b/make/data/characterdata/CharacterData02.java.template
@@ -77,16 +77,6 @@ class CharacterData02 extends CharacterData {
         return props;
     }
 
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
-    }
-
     boolean isOtherAlphabetic(int ch) {
         int props = getPropertiesEx(ch);
         return (props & $$maskOtherAlphabetic) != 0;
@@ -222,14 +212,15 @@ class CharacterData02 extends CharacterData {
     }
 
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0;
     }
 
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherUppercase) != 0;
     }
+
 
     boolean isWhitespace(int ch) {
         return (getProperties(ch) & $$maskIdentifierInfo) == $$valueJavaWhitespace;

--- a/make/data/characterdata/CharacterData03.java.template
+++ b/make/data/characterdata/CharacterData03.java.template
@@ -77,16 +77,6 @@ class CharacterData03 extends CharacterData {
         return props;
     }
 
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
-    }
-
     boolean isOtherAlphabetic(int ch) {
         int props = getPropertiesEx(ch);
         return (props & $$maskOtherAlphabetic) != 0;
@@ -222,13 +212,13 @@ class CharacterData03 extends CharacterData {
     }
 
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0;
     }
 
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherUppercase) != 0;
     }
 
     boolean isWhitespace(int ch) {

--- a/make/data/characterdata/CharacterData0E.java.template
+++ b/make/data/characterdata/CharacterData0E.java.template
@@ -77,16 +77,6 @@ class CharacterData0E extends CharacterData {
         return props;
     }
 
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
-    }
-
     boolean isOtherAlphabetic(int ch) {
         int props = getPropertiesEx(ch);
         return (props & $$maskOtherAlphabetic) != 0;
@@ -222,13 +212,13 @@ class CharacterData0E extends CharacterData {
     }
 
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0;
     }
 
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherUppercase) != 0;
     }
 
     boolean isWhitespace(int ch) {

--- a/make/data/characterdata/CharacterDataLatin1.java.template
+++ b/make/data/characterdata/CharacterDataLatin1.java.template
@@ -87,24 +87,13 @@ class CharacterDataLatin1 extends CharacterData {
 
     @IntrinsicCandidate
     boolean isLowerCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.LOWERCASE_LETTER;
+        return (getProperties(ch) & $$maskType) == Character.LOWERCASE_LETTER
+            || (getPropertiesEx(ch) & $$maskOtherLowercase) != 0; // 0xaa, 0xba
     }
 
     @IntrinsicCandidate
     boolean isUpperCase(int ch) {
-        int props = getProperties(ch);
-        return (props & $$maskType) == Character.UPPERCASE_LETTER;
-    }
-
-    boolean isOtherLowercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherLowercase) != 0;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        int props = getPropertiesEx(ch);
-        return (props & $$maskOtherUppercase) != 0;
+        return (getProperties(ch) & $$maskType) == Character.UPPERCASE_LETTER;
     }
 
     boolean isOtherAlphabetic(int ch) {
@@ -290,6 +279,6 @@ class CharacterDataLatin1 extends CharacterData {
 
     static {
         $$Initializers
-    }        
+    }
 }
 

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -9495,8 +9495,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      * @since   1.5
      */
     public static boolean isLowerCase(int codePoint) {
-        return CharacterData.of(codePoint).isLowerCase(codePoint) ||
-               CharacterData.of(codePoint).isOtherLowercase(codePoint);
+        return CharacterData.of(codePoint).isLowerCase(codePoint);
     }
 
     /**
@@ -9561,8 +9560,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      * @since   1.5
      */
     public static boolean isUpperCase(int codePoint) {
-        return CharacterData.of(codePoint).isUpperCase(codePoint) ||
-               CharacterData.of(codePoint).isOtherUppercase(codePoint);
+        return CharacterData.of(codePoint).isUpperCase(codePoint);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -54,14 +54,6 @@ abstract class CharacterData {
         return null;
     }
 
-    boolean isOtherLowercase(int ch) {
-        return false;
-    }
-
-    boolean isOtherUppercase(int ch) {
-        return false;
-    }
-
     boolean isOtherAlphabetic(int ch) {
         return false;
     }


### PR DESCRIPTION
This patch removes the CharacterData.isOtherUppercase and isOtherLowercase methods. It also exploits the fact that isOtherUppercase is always false for all codepoints in the CharacterDataLatin1 range for a small speed-up.

I have no means to test if this is correct on PPC, which has intrinsics for isLowerCase/isUpperCase, but unless I'm reading the code wrong the intrinsic for isLowerCase on PPC already appears to effectively do the fused logic of isLowerCase(ch) || isOtherLowerCase(ch) since it handles the two values where isLowerCase and isOtherLowercase disagrees (0xaa, 0xba), which means this change should make the intrinsic and the java code be in better agreement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263091](https://bugs.openjdk.java.net/browse/JDK-8263091): Remove CharacterData.isOtherUppercase/-Lowercase


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2846/head:pull/2846`
`$ git checkout pull/2846`
