### PR TITLE
8262323: do not special case JVMCI in tiered compilation policy

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -444,6 +444,16 @@ void CompilerConfig::set_jvmci_specific_flags() {
       if (FLAG_IS_DEFAULT(NewSizeThreadIncrease)) {
         FLAG_SET_DEFAULT(NewSizeThreadIncrease, MAX2(4*K, NewSizeThreadIncrease));
       }
+      if (FLAG_IS_DEFAULT(Tier3DelayOn)) {
+        // This effectively prevents the compile broker scheduling tier 2
+        // (i.e., limited C1 profiling) compilations instead of tier 3
+        // (i.e., full C1 profiling) compilations when the tier 4 queue
+        // backs up (which is quite likely when using a non-AOT compiled JVMCI
+        // compiler). The observation based on jargraal is that the downside
+        // of skipping full profiling is much worse for performance than the
+        // queue backing up.
+        FLAG_SET_DEFAULT(Tier3DelayOn, 100000);
+      }
     } // !UseJVMCINativeLibrary
   } // UseJVMCICompiler
 }


### PR DESCRIPTION
This PR moves some Graal specific code from shared compilation policy code into JVMCI specific files and tunes it better for libgraal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262323](https://bugs.openjdk.java.net/browse/JDK-8262323): do not special case JVMCI in tiered compilation policy


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2847/head:pull/2847`
`$ git checkout pull/2847`
