### PR TITLE
8263097: Update JMH devkit to 1.28

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1114,7 +1114,7 @@ var getJibProfilesDependencies = function (input, common) {
         jmh: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "1.21+1.0"
+            revision: "1.28+1.0"
         },
 
         jcov: {

--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.26
+JMH_VERSION=1.28
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=4.6
 


### PR DESCRIPTION
Currently at 1.26, so there are a few good improvements and a few bug fixes - notably resolving a build reproducibility issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263097](https://bugs.openjdk.java.net/browse/JDK-8263097): Update JMH devkit to 1.28


### Reviewers
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer) ⚠️ Review applies to bd98cf7f03c629a31f6d8bddfd16990712000653
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2848/head:pull/2848`
`$ git checkout pull/2848`
