### PR TITLE
8261247: some compiler/whitebox/ tests fail w/ DeoptimizeALot

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
@@ -25,9 +25,12 @@
  * @test
  * @bug 8150646 8153013
  * @summary Add support for blocking compiles through whitebox API
- * @requires vm.compiler1.enabled | !vm.graal.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
+ *
+ * @requires vm.compiler1.enabled | !vm.graal.enabled
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm

--- a/test/hotspot/jtreg/compiler/whitebox/ClearMethodStateTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/ClearMethodStateTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
@@ -29,6 +29,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/EnqueueMethodForCompilationTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/EnqueueMethodForCompilationTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/EnqueueMethodForCompilationTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/EnqueueMethodForCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/ForceNMethodSweepTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/ForceNMethodSweepTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/ForceNMethodSweepTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/ForceNMethodSweepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
@@ -25,11 +25,13 @@
  * @test IsMethodCompilableTest
  * @bug 8007270 8006683 8007288 8022832
  * @summary testing of WB::isMethodCompilable()
- * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
- * @requires !vm.emulatedClient
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires !vm.emulatedClient
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
@@ -28,6 +28,9 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/OSRFailureLevel4Test.java
+++ b/test/hotspot/jtreg/compiler/whitebox/OSRFailureLevel4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/whitebox/OSRFailureLevel4Test.java
+++ b/test/hotspot/jtreg/compiler/whitebox/OSRFailureLevel4Test.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
+ * @requires vm.opt.DeoptimizeALot != true
  * @comment the test can't be run w/ TieredStopAtLevel < 4
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  *


### PR DESCRIPTION
Hi all,

could you please review this small test-only patch that adds `@requries vm.opt.DeoptimizeALot != true` to `compiler/whitebox/` tests that check if a method gets compiled? such checks can fail intermittently when are `DeoptimizeALot` is used (as the method can get deoptimized before we checked if it was compiled).

testing: 
* [x] `compiler/whitebox/` on `macosx-x64-fastdebug` w/o any flags (17 tests)
* [x] `compiler/whitebox/` on `macosx-x64-fastdebug` w/ -XX:+DeoptimizeALot (6 tests)

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261247](https://bugs.openjdk.java.net/browse/JDK-8261247): some compiler/whitebox/ tests fail w/ DeoptimizeALot


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2849/head:pull/2849`
`$ git checkout pull/2849`
