### PR TITLE
JDK-8263104: fix warnings for empty paragraphs

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CryptoAllPermission.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoAllPermission.java
@@ -32,7 +32,6 @@ import java.util.Vector;
 /**
  * The CryptoAllPermission is a permission that implies
  * any other crypto permissions.
- * <p>
  *
  * @see java.security.Permission
  * @see java.security.AllPermission

--- a/src/java.base/share/classes/javax/crypto/CryptoPermission.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermission.java
@@ -39,7 +39,7 @@ import javax.crypto.spec.*;
  * CryptoPermission object is used to represent
  * the ability of an application/applet to use certain
  * algorithms with certain key sizes and other
- * restrictions in certain environments. <p>
+ * restrictions in certain environments.
  *
  * @see java.security.Permission
  *

--- a/src/java.management/share/classes/javax/management/loading/package.html
+++ b/src/java.management/share/classes/javax/management/loading/package.html
@@ -66,8 +66,7 @@ questions.
 	subclass of <code>MLet</code> that implements
 	<code>PrivateClassLoader</code>.</p>
 
-    <p id="spec">
-    @see <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
+    @see <a id="spec" href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
       JMX Specification, version 1.4</a>
 
       @since 1.5

--- a/src/java.management/share/classes/javax/management/monitor/package.html
+++ b/src/java.management/share/classes/javax/management/monitor/package.html
@@ -183,8 +183,7 @@ questions.
 
 	</li>
       </ul>
-    <p id="spec">
-    @see <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
+    @see <a id="spec" href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
       JMX Specification, version 1.4</a>
       @since 1.5
 

--- a/src/java.management/share/classes/javax/management/package.html
+++ b/src/java.management/share/classes/javax/management/package.html
@@ -388,8 +388,7 @@ questions.
 
         </ul>
 
-        <p id="spec">
-        @see <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
+        @see <a id="spec" href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
         JMX Specification, version 1.4</a>
 
         @since 1.5


### PR DESCRIPTION
Please review some simple cleanup for empty `<p>` tags.

Two of the tags are completely redundant, and simply deleted.

The other three, in _package.html_ files are generally undesirable. Although the presumed intent of the `id` declaration is to label the `@see` info, proximity in the source code does not ensure proximity in the generated code. The actual result is an empty paragraph at the end of the enclosing generated `<div>`, and before the generated output for the `@since` tag.

The better solution is to move the `id` declaration into the `@see <a href...` and then delete the empty `<p>`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263104](https://bugs.openjdk.java.net/browse/JDK-8263104): fix warnings for empty paragraphs


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2850/head:pull/2850`
`$ git checkout pull/2850`
