### PR TITLE
8210100: ParallelGC should use parallel WeakProcessor

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -52,7 +52,7 @@
 #include "gc/shared/scavengableNMethods.hpp"
 #include "gc/shared/spaceDecorator.inline.hpp"
 #include "gc/shared/taskTerminator.hpp"
-#include "gc/shared/weakProcessor.hpp"
+#include "gc/shared/weakProcessor.inline.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "gc/shared/workgroup.hpp"
 #include "memory/iterator.hpp"
@@ -520,11 +520,10 @@ bool PSScavenge::invoke_no_policy() {
 
     assert(promotion_manager->stacks_empty(),"stacks should be empty at this point");
 
-    PSScavengeRootsClosure root_closure(promotion_manager);
-
     {
       GCTraceTime(Debug, gc, phases) tm("Weak Processing", &_gc_timer);
-      WeakProcessor::weak_oops_do(&_is_alive_closure, &root_closure);
+      PSAdjustWeakRootsClosure root_closure;
+      WeakProcessor::weak_oops_do(&ParallelScavengeHeap::heap()->workers(), &_is_alive_closure, &root_closure, 1);
     }
 
     // Verify that usage of root_closure didn't copy any objects.


### PR DESCRIPTION
Benchmarking using specjvm2008 shows "Weak Processing" takes <1ms. There are >800 occurrences where "Weak Processing" takes >0.4ms, while only 5 occurrences after the patch, as shown in gc logs.

PS: I changed the log level from Debug to Info for "Weak Processing" for benchmarking in order not limit the logs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210100](https://bugs.openjdk.java.net/browse/JDK-8210100): ParallelGC should use parallel WeakProcessor


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2851/head:pull/2851`
`$ git checkout pull/2851`
