### PR TITLE
8263102: Expand documention of Method.isBridge

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -511,6 +511,7 @@ public final class Constructor<T> extends Executable {
     /**
      * {@inheritDoc}
      * @jls 13.1 The Form of a Binary
+     * @jvms 4.6 Methods
      * @since 1.5
      */
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -518,6 +518,7 @@ public abstract class Executable extends AccessibleObject
      * construct as defined by
      * <cite>The Java Language Specification</cite>.
      * @jls 13.1 The Form of a Binary
+     * @jvms 4.6 Methods
      */
     public boolean isSynthetic() {
         return Modifier.isSynthetic(getModifiers());

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -567,12 +567,34 @@ public final class Method extends Executable {
     }
 
     /**
-     * Returns {@code true} if this method is a bridge
-     * method; returns {@code false} otherwise.
+     * {@return {@code true} if this method is a bridge
+     * method; returns {@code false} otherwise}
      *
-     * @return true if and only if this method is a bridge
-     * method as defined by the Java Language Specification.
+     * <p>A bridge method is a method synthesized by a Java compiler
+     * alongside a method originating from the source code. One
+     * example of a bridge method is a way for a Java compiler to
+     * support <i>covariant overrides</i>, where a subclass overrides
+     * a method and gives the new method a more specific return type
+     * than the method in the superclass. A common case where
+     * covariant overrides are used is for a {@link
+     * java.lang.Cloneable Cloneable} class where the {@code clone}
+     * method is declared to return the type of the class rather than
+     * {@code Object}, for example {@link java.util.EnumSet#clone()
+     * EnumSet.clone()} returns {@code EnumSet<E>} rather than {@link
+     * java.lang.Object#clone() Object}. The class file for {@code
+     * EnumSet} would have two {@code clone} methods, one returning
+     * {@code EnumSet<E>} and a bridge method returning {@code
+     * Object}; the body of the {@code clone} bridge method calls its
+     * non-bridge sibling and returns its result. (While the Java
+     * language specification forbids a class declaring two methods
+     * with the same parameter types but a different return type, the
+     * virtual machine does not.)
+     *
      * @since 1.5
+     *
+     * @jls 8.4.8.3 Requirements in Overriding and Hiding 
+     * @jls 15.12.4.5 Create Frame, Synchronize, Transfer Control
+     * @jvms 4.6 Methods
      */
     public boolean isBridge() {
         return (getModifiers() & Modifier.BRIDGE) != 0;

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -571,7 +571,7 @@ public final class Method extends Executable {
      * method; returns {@code false} otherwise}
      *
      * @apiNote
-     * A bridge method is a synthetic method created by a Java
+     * A bridge method is a {@linkplain isSynthetic synthetic} method created by a Java
      * compiler alongside a method originating from the source
      * code. One example use of a bridge method is as technique for a
      * Java compiler to support <i>covariant overrides</i>, where a
@@ -618,6 +618,7 @@ public final class Method extends Executable {
     /**
      * {@inheritDoc}
      * @jls 13.1 The Form of a Binary
+     * @jvms 4.6 Methods
      * @since 1.5
      */
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -578,17 +578,17 @@ public final class Method extends Executable {
      * than the method in the superclass. A common case where
      * covariant overrides are used is for a {@link
      * java.lang.Cloneable Cloneable} class where the {@code clone}
-     * method is declared to return the type of the class rather than
-     * {@code Object}, for example {@link java.util.EnumSet#clone()
-     * EnumSet.clone()} returns {@code EnumSet<E>} rather than {@link
-     * java.lang.Object#clone() Object}. The class file for {@code
-     * EnumSet} would have two {@code clone} methods, one returning
-     * {@code EnumSet<E>} and a bridge method returning {@code
-     * Object}; the body of the {@code clone} bridge method calls its
-     * non-bridge sibling and returns its result. (While the Java
-     * language specification forbids a class declaring two methods
-     * with the same parameter types but a different return type, the
-     * virtual machine does not.)
+     * method inherited from {@code java.lang.Object} is overridden
+     * and declared to return the type of the class; for example
+     * {@link java.util.EnumSet#clone() EnumSet.clone()} returns
+     * {@code EnumSet<E>} rather than {@link java.lang.Object#clone()
+     * Object}. The class file for {@code EnumSet} would have two
+     * {@code clone} methods, one returning {@code EnumSet<E>} and a
+     * bridge method returning {@code Object}; the body of the {@code
+     * clone} bridge method calls its non-bridge sibling and returns
+     * its result. (While the Java language specification forbids a
+     * class declaring two methods with the same parameter types but a
+     * different return type, the virtual machine does not.)
      *
      * @since 1.5
      *

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -575,7 +575,7 @@ public final class Method extends Executable {
      * compiler alongside a method originating from the source
      * code.
      * Bridge methods are used by Java compilers in various
-     * circumstances to span across differences in Java programming
+     * circumstances to span differences in Java programming
      * language semantics and JVM semantics.
      *
      * One example use of bridge methods is as technique for a
@@ -587,15 +587,18 @@ public final class Method extends Executable {
      * different return type, the virtual machine does not.
      * A
      * common case where covariant overrides are used is for a {@link
-     * java.lang.Cloneable Cloneable} class where the {@code clone}
-     * method inherited from {@code java.lang.Object} and returning {@code Object} is overridden
-     * and declared to return the type of the class; for example
-     * {@link java.util.EnumSet#clone() EnumSet.clone()} returns
-     * {@code EnumSet<E>} rather than {@link java.lang.Object#clone()
-     * Object}. If this technique was being used, the resulting class
+     * java.lang.Cloneable Cloneable} class where the {@link Object#clone() clone}
+     * method inherited from {@code java.lang.Object} is overridden
+     * and declared to return the type of the class. For example, {@code Object}
+     * declares<br>
+     * {@code protected Object clone() throws CloneNotSupportedException {...}}<br>
+     * and {@code EnumSet<E>} declares its language-level {@linkplain java.util.EnumSet#clone() covariant override}<br>
+     * {@code public EnumSet<E> clone() {...}}<br>
+     * If this technique was being used, the resulting class
      * file for {@code EnumSet} would have two {@code clone} methods,
      * one returning {@code EnumSet<E>} and the second a bridge method
-     * returning {@code Object}; the body of the {@code clone} bridge
+     * returning {@code Object}. The bridge method is a JVM-level override of {@code Object.clone()}.
+     * The body of the {@code clone} bridge
      * method calls its non-bridge counterpart and returns its
      * result.
      * @since 1.5

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -598,7 +598,7 @@ public final class Method extends Executable {
      *
      * @since 1.5
      *
-     * @jls 8.4.8.3 Requirements in Overriding and Hiding 
+     * @jls 8.4.8.3 Requirements in Overriding and Hiding
      * @jls 15.12.4.5 Create Frame, Synchronize, Transfer Control
      * @jvms 4.6 Methods
      */

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -571,36 +571,35 @@ public final class Method extends Executable {
      * method; returns {@code false} otherwise}
      *
      * @apiNote
-     * A bridge method is a {@linkplain isSynthetic synthetic} method created by a Java
-     * compiler alongside a method originating from the source
-     * code.
-     * Bridge methods are used by Java compilers in various
-     * circumstances to span differences in Java programming
+     * A bridge method is a {@linkplain isSynthetic synthetic} method
+     * created by a Java compiler alongside a method originating from
+     * the source code. Bridge methods are used by Java compilers in
+     * various circumstances to span differences in Java programming
      * language semantics and JVM semantics.
      *
-     * One example use of bridge methods is as a technique for a
+     * <p>One example use of bridge methods is as a technique for a
      * Java compiler to support <i>covariant overrides</i>, where a
      * subclass overrides a method and gives the new method a more
-     * specific return type than the method in the superclass.
-     * While the Java language specification forbids a class
-     * declaring two methods with the same parameter types but a
-     * different return type, the virtual machine does not.
-     * A
-     * common case where covariant overrides are used is for a {@link
-     * java.lang.Cloneable Cloneable} class where the {@link Object#clone() clone}
-     * method inherited from {@code java.lang.Object} is overridden
-     * and declared to return the type of the class. For example, {@code Object}
-     * declares<br>
-     * {@code protected Object clone() throws CloneNotSupportedException {...}}<br>
-     * and {@code EnumSet<E>} declares its language-level {@linkplain java.util.EnumSet#clone() covariant override}<br>
-     * {@code public EnumSet<E> clone() {...}}<br>
-     * If this technique was being used, the resulting class
-     * file for {@code EnumSet} would have two {@code clone} methods,
-     * one returning {@code EnumSet<E>} and the second a bridge method
-     * returning {@code Object}. The bridge method is a JVM-level override of {@code Object.clone()}.
-     * The body of the {@code clone} bridge
-     * method calls its non-bridge counterpart and returns its
-     * result.
+     * specific return type than the method in the superclass.  While
+     * the Java language specification forbids a class declaring two
+     * methods with the same parameter types but a different return
+     * type, the virtual machine does not. A common case where
+     * covariant overrides are used is for a {@link
+     * java.lang.Cloneable Cloneable} class where the {@link
+     * Object#clone() clone} method inherited from {@code
+     * java.lang.Object} is overridden and declared to return the type
+     * of the class. For example, {@code Object} declares
+     * <pre>{@code protected Object clone() throws CloneNotSupportedException {...}}</pre>
+     * and {@code EnumSet<E>} declares its language-level {@linkplain
+     * java.util.EnumSet#clone() covariant override}
+     * <pre>{@code public EnumSet<E> clone() {...}}</pre>
+     * If this technique was being used, the resulting class file for
+     * {@code EnumSet} would have two {@code clone} methods, one
+     * returning {@code EnumSet<E>} and the second a bridge method
+     * returning {@code Object}. The bridge method is a JVM-level
+     * override of {@code Object.clone()}.  The body of the {@code
+     * clone} bridge method calls its non-bridge counterpart and
+     * returns its result.
      * @since 1.5
      *
      * @jls 8.4.8.3 Requirements in Overriding and Hiding

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -578,7 +578,7 @@ public final class Method extends Executable {
      * circumstances to span differences in Java programming
      * language semantics and JVM semantics.
      *
-     * One example use of bridge methods is as technique for a
+     * One example use of bridge methods is as a technique for a
      * Java compiler to support <i>covariant overrides</i>, where a
      * subclass overrides a method and gives the new method a more
      * specific return type than the method in the superclass.

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -573,13 +573,22 @@ public final class Method extends Executable {
      * @apiNote
      * A bridge method is a {@linkplain isSynthetic synthetic} method created by a Java
      * compiler alongside a method originating from the source
-     * code. One example use of a bridge method is as technique for a
+     * code.
+     * Bridge methods are used by Java compilers in various
+     * circumstances to span across differences in Java programming
+     * language semantics and JVM semantics.
+     *
+     * One example use of bridge methods is as technique for a
      * Java compiler to support <i>covariant overrides</i>, where a
      * subclass overrides a method and gives the new method a more
-     * specific return type than the method in the superclass. A
+     * specific return type than the method in the superclass.
+     * While the Java language specification forbids a class
+     * declaring two methods with the same parameter types but a
+     * different return type, the virtual machine does not.
+     * A
      * common case where covariant overrides are used is for a {@link
      * java.lang.Cloneable Cloneable} class where the {@code clone}
-     * method inherited from {@code java.lang.Object} is overridden
+     * method inherited from {@code java.lang.Object} and returning {@code Object} is overridden
      * and declared to return the type of the class; for example
      * {@link java.util.EnumSet#clone() EnumSet.clone()} returns
      * {@code EnumSet<E>} rather than {@link java.lang.Object#clone()
@@ -588,14 +597,7 @@ public final class Method extends Executable {
      * one returning {@code EnumSet<E>} and the second a bridge method
      * returning {@code Object}; the body of the {@code clone} bridge
      * method calls its non-bridge counterpart and returns its
-     * result. (While the Java language specification forbids a class
-     * declaring two methods with the same parameter types but a
-     * different return type, the virtual machine does not.)
-     *
-     * <p>Bridge methods may also be used by Java compiler in other
-     * circumstances to span across difference in Java Language
-     * semantics and JVM semantics.
-     *
+     * result.
      * @since 1.5
      *
      * @jls 8.4.8.3 Requirements in Overriding and Hiding

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -570,25 +570,31 @@ public final class Method extends Executable {
      * {@return {@code true} if this method is a bridge
      * method; returns {@code false} otherwise}
      *
-     * <p>A bridge method is a method synthesized by a Java compiler
-     * alongside a method originating from the source code. One
-     * example of a bridge method is a way for a Java compiler to
-     * support <i>covariant overrides</i>, where a subclass overrides
-     * a method and gives the new method a more specific return type
-     * than the method in the superclass. A common case where
-     * covariant overrides are used is for a {@link
+     * @apiNote
+     * A bridge method is a synthetic method created by a Java
+     * compiler alongside a method originating from the source
+     * code. One example use of a bridge method is as technique for a
+     * Java compiler to support <i>covariant overrides</i>, where a
+     * subclass overrides a method and gives the new method a more
+     * specific return type than the method in the superclass. A
+     * common case where covariant overrides are used is for a {@link
      * java.lang.Cloneable Cloneable} class where the {@code clone}
      * method inherited from {@code java.lang.Object} is overridden
      * and declared to return the type of the class; for example
      * {@link java.util.EnumSet#clone() EnumSet.clone()} returns
      * {@code EnumSet<E>} rather than {@link java.lang.Object#clone()
-     * Object}. The class file for {@code EnumSet} would have two
-     * {@code clone} methods, one returning {@code EnumSet<E>} and a
-     * bridge method returning {@code Object}; the body of the {@code
-     * clone} bridge method calls its non-bridge sibling and returns
-     * its result. (While the Java language specification forbids a
-     * class declaring two methods with the same parameter types but a
+     * Object}. If this technique was being used, the resulting class
+     * file for {@code EnumSet} would have two {@code clone} methods,
+     * one returning {@code EnumSet<E>} and the second a bridge method
+     * returning {@code Object}; the body of the {@code clone} bridge
+     * method calls its non-bridge counterpart and returns its
+     * result. (While the Java language specification forbids a class
+     * declaring two methods with the same parameter types but a
      * different return type, the virtual machine does not.)
+     *
+     * <p>Bridge methods may also be used by Java compiler in other
+     * circumstances to span across difference in Java Language
+     * semantics and JVM semantics.
      *
      * @since 1.5
      *


### PR DESCRIPTION
The existing documentation of Method.isBridge isn't terribly helpful to the reader. This RFE proposes to given a common example of how bridge methods are used. The JLS does *not* have a section discussing bridge methods in detail; bridge methods are a compilation technique for lowering the Java language to the JVM, they are not a language feature per se. The example given is not exhaustive; there can be and are other uses of bridge methods.

Once the text is agreed to; I'll update the copyright year as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263102](https://bugs.openjdk.java.net/browse/JDK-8263102): Expand documention of Method.isBridge


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 0425a2f3db78fd126c6bcd124d7ceba704586cbd


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2852/head:pull/2852`
`$ git checkout pull/2852`
