### PR TITLE
JDK-8251210: Link JDK api docs to other versions

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -261,6 +261,7 @@ endef
 #   SHORT_NAME - The short name of this documentation collection
 #   LONG_NAME - The long name of this documentation collection
 #   TARGET_DIR - Where to store the output
+#   OTHER_VERSIONS - URL for other page listing versions
 #
 SetupApiDocsGeneration = $(NamedParamsMacroTemplate)
 define SetupApiDocsGenerationBody
@@ -297,10 +298,16 @@ define SetupApiDocsGenerationBody
   # Ignore the doclint warnings in the W3C DOM package
   $1_OPTIONS += -Xdoclint/package:-org.w3c.*
 
+  ifneq ($$($1_OTHER_VERSIONS), )
+    $1_LINKED_SHORT_NAME = <a href="$$($1_OTHER_VERSIONS)">$$($1_SHORT_NAME)</a>
+  else
+    $1_LINKED_SHORT_NAME = $$($1_SHORT_NAME)
+  endif
+
   $1_DOC_TITLE := $$($1_LONG_NAME)<br>Version $$(VERSION_SPECIFICATION) API \
       Specification
   $1_WINDOW_TITLE := $$(subst &amp;,&,$$($1_SHORT_NAME))$$(DRAFT_MARKER_TITLE)
-  $1_HEADER_TITLE := <div $$(HEADER_STYLE)><strong>$$($1_SHORT_NAME)</strong> \
+  $1_HEADER_TITLE := <div $$(HEADER_STYLE)><strong>$$($1_LINKED_SHORT_NAME)</strong> \
       $$(DRAFT_MARKER_STR)</div>
 
   $1_OPTIONS += -doctitle '$$($1_DOC_TITLE)'
@@ -438,6 +445,7 @@ $(eval $(call SetupApiDocsGeneration, JDK_API, \
     SHORT_NAME := $(JDK_SHORT_NAME), \
     LONG_NAME := $(JDK_LONG_NAME), \
     TARGET_DIR := $(DOCS_OUTPUTDIR)/api, \
+    OTHER_VERSIONS := $(OTHER_JDK_VERSIONS_URL), \
 ))
 
 # Targets generated are returned in JDK_API_JAVADOC_TARGETS and

--- a/make/conf/javadoc.conf
+++ b/make/conf/javadoc.conf
@@ -28,3 +28,4 @@ BUG_SUBMIT_URL=https://bugreport.java.com/bugreport/
 COPYRIGHT_URL=legal/copyright.html
 LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_NUMBER)speclicense.html
 REDISTRIBUTION_URL=https://www.oracle.com/technetwork/java/redist-137594.html
+OTHER_JDK_VERSIONS_URL=https://docs.oracle.com/en/java/javase/index.html


### PR DESCRIPTION
Please review a small change to Docs.gmk, such that the short version string in the upper right corner of the main API docs bundle is linked to a page that links to other versions of the documentation.  While it is not so useful in this release, to be able to access _older_ versions, going forward, this will simplify the ability to get to _newer_ versions when search engines take you to the docs for an older release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251210](https://bugs.openjdk.java.net/browse/JDK-8251210): Link JDK api docs to other versions


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2854/head:pull/2854`
`$ git checkout pull/2854`
