### PR TITLE
8263131: reduce unnecessary downwards search when using linear search to find method

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1910,9 +1910,10 @@ int InstanceKlass::find_method_index(const Array<Method*>* methods,
       return hit;
     }
 
-    // search downwards through overloaded methods
     int i;
-    for (i = hit - 1; i >= 0; --i) {
+    if (!_disable_method_binary_search) {
+      // search downwards through overloaded methods
+      for (i = hit - 1; i >= 0; --i) {
         const Method* const m = methods->at(i);
         assert(m->is_method(), "must be method");
         if (m->name() != name) {
@@ -1921,6 +1922,7 @@ int InstanceKlass::find_method_index(const Array<Method*>* methods,
         if (method_matches(m, signature, skipping_overpass, skipping_static, skipping_private)) {
           return i;
         }
+      }
     }
     // search upwards
     for (i = hit + 1; i < methods->length(); ++i) {
@@ -1954,7 +1956,9 @@ int InstanceKlass::find_method_by_name(const Array<Method*>* methods,
   int start = quick_search(methods, name);
   int end = start + 1;
   if (start != -1) {
-    while (start - 1 >= 0 && (methods->at(start - 1))->name() == name) --start;
+    if (!_disable_method_binary_search) {
+      while (start - 1 >= 0 && (methods->at(start - 1))->name() == name) --start;
+    }
     while (end < methods->length() && (methods->at(end))->name() == name) ++end;
     *end_ptr = end;
     return start;


### PR DESCRIPTION
Hi,

The `InstanceKlass::find_method_by_name` and `InstanceKlass::find_method_index` use `InstanceKlass::quick_search` to find a method by name. If the method found doesn't match the expected method signature, It has to search downwards and upwards. But if `_disable_method_binary_search` was set to `true`, the `InstanceKlass::quick_search` will use linear search instead of binary search to find the method. So there no needs to search downwards because there no other method with the same name before it since the method found is the first matched method.

Best regards,
Lehua

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263131](https://bugs.openjdk.java.net/browse/JDK-8263131): reduce unnecessary downwards search when using linear search to find method


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2857/head:pull/2857`
`$ git checkout pull/2857`
