### PR TITLE
8263135: unique_ptr should not be used for types that are not pointers

### DIFF
--- a/src/jdk.jpackage/windows/native/common/MsiDb.h
+++ b/src/jdk.jpackage/windows/native/common/MsiDb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,27 +34,9 @@
 
 class Guid;
 
-/**
- * Helpers to interact with MSI through database interface.
- */
-
 namespace msi {
+
 void closeDatabaseView(MSIHANDLE h);
-
-struct MsiDbViewDeleter {
-    typedef MSIHANDLE pointer;
-
-    void operator()(MSIHANDLE h) {
-        closeDatabaseView(h);
-    }
-};
-} // namespace msi
-
-
-typedef std::unique_ptr<MSIHANDLE, msi::MsiDbViewDeleter> UniqueDbView;
-
-
-namespace msi {
 
 class CA;
 class DatabaseView;
@@ -95,6 +77,12 @@ public:
      */
     explicit Database(const CA& ca);
 
+    ~Database() {
+      if (dbHandle != 0) {
+        closeMSIHANDLE(dbHandle);
+      }
+    }
+
     /**
      * Returns value of property with the given name.
      * Throws NoMoreItemsError if property with the given name doesn't exist
@@ -116,7 +104,7 @@ private:
     Database& operator=(const Database&);
 private:
     const tstring msiPath;
-    UniqueMSIHANDLE dbHandle;
+    MSIHANDLE dbHandle;
 };
 
 typedef std::unique_ptr<Database> DatabasePtr;
@@ -128,7 +116,8 @@ public:
     }
 
     DatabaseRecord(const DatabaseRecord& other): handle(MSIHANDLE(0)) {
-        handle.swap(other.handle);
+        handle = other.handle;
+        other.handle = 0;
     }
 
     DatabaseRecord& operator=(const DatabaseRecord& other);
@@ -139,6 +128,12 @@ public:
 
     explicit DatabaseRecord(DatabaseView& view) {
         fetch(view);
+    }
+
+    ~DatabaseRecord() {
+      if (handle != 0) {
+        closeMSIHANDLE(handle);
+      }
     }
 
     DatabaseRecord& fetch(DatabaseView& view);
@@ -160,15 +155,15 @@ public:
     void saveStreamToFile(unsigned idx, const tstring& path) const;
 
     bool empty() const {
-        return 0 == handle.get();
+        return 0 == handle;
     }
 
     MSIHANDLE getHandle() const {
-        return handle.get();
+        return handle;
     }
 
 private:
-    mutable UniqueMSIHANDLE handle;
+    mutable MSIHANDLE handle;
 };
 
 
@@ -186,7 +181,7 @@ public:
 private:
     tstring sqlQuery;
     const Database& db;
-    UniqueDbView handle;
+    MSIHANDLE handle;
 };
 
 } // namespace msi

--- a/src/jdk.jpackage/windows/native/common/MsiUtils.cpp
+++ b/src/jdk.jpackage/windows/native/common/MsiUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ void closeMSIHANDLE(MSIHANDLE h) {
 // However it can't access handy msi::getProperty() from that location.
 tstring DatabaseRecord::getString(unsigned idx) const {
     return ::msi::getProperty(MsiRecordGetString, "MsiRecordGetString",
-                                                    handle.get(), UINT(idx));
+                                                    handle, UINT(idx));
 }
 
 

--- a/src/jdk.jpackage/windows/native/common/MsiUtils.h
+++ b/src/jdk.jpackage/windows/native/common/MsiUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 #include <stdexcept>
 #include <new>
 #include <map>
-#include <memory>
 
 #include "ErrorHandling.h"
 #include "Toolbox.h"
@@ -44,20 +43,6 @@
 namespace msi {
 
 void closeMSIHANDLE(MSIHANDLE h);
-
-struct MsiHandleDeleter {
-    typedef MSIHANDLE pointer;
-
-    void operator()(MSIHANDLE h) {
-        closeMSIHANDLE(h);
-    }
-};
-
-} // namespace msi
-
-typedef std::unique_ptr<MSIHANDLE, msi::MsiHandleDeleter> UniqueMSIHANDLE;
-
-namespace msi {
 
 tstring getProductInfo(const Guid& productCode, const tstring& prop);
 


### PR DESCRIPTION
I saw error during jpackage compilation with VS 2019 (16.9.0) as following (on Japanese locale):

```
c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\utility(604): error C2440: '=': '_Other' から '_Ty' に変換できません。
        with
        [
            _Other=nullptr
        ]
        and
        [
            _Ty=unsigned long
        ]
c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\utility(604): note: ネイティブの nullptr はブールに変換するか、または reinterpret_cast を使用して整数型に変換することのみが可能です
c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\memory(3423): note: コンパイル対象の関数 テンプレート インスタンス化 '_Ty std::exchange<_Ty2,nullptr>(_Ty &,_Other &&) noexcept(false)' のリファレンスを確認してください
        with
        [
            _Ty=unsigned long,
            _Ty2=unsigned long,
            _Other=nullptr
        ]
c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\memory(3422): note: クラス テンプ レート メンバー関数 'unsigned long std::unique_ptr<MSIHANDLE,msi::MsiHandleDeleter>::release(void) noexcept' のコンパイル中
d:\github-forked\jdk\src\jdk.jpackage\windows\native\common\MsiDb.cpp(237): note: コンパイル対象の関数 テンプレート インスタンス化 'unsigned long std::unique_ptr<MSIHANDLE,msi::MsiHandleDeleter>::release(void) noexcept' のリファレンスを確認してください
d:\github-forked\jdk\src\jdk.jpackage\windows\native\common\MsiDb.h(119): note: コンパイル対象の クラ ス テンプレート インスタンス化 'std::unique_ptr<MSIHANDLE,msi::MsiHandleDeleter>' のリファレンスを確認してください
```

`UniqueMSIHANDLE` is declared in MsiUtils.h as `unique_ptr` for `MSIHANDLE`. `MSIHANDLE` seems to be declared as synonym for `unsigned long`, not a pointer type.
I think `MSIHANDLE` does not need to handle as `unique_ptr` if it releases at d'tor of the class which holds it (`Database`, `DatabaseRecord`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263135](https://bugs.openjdk.java.net/browse/JDK-8263135): unique_ptr should not be used for types that are not pointers


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2858/head:pull/2858`
`$ git checkout pull/2858`
