### PR TITLE
8263136: C4530 was reported from VS 2019 at access bridge

### DIFF
--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ ifeq ($(call isTargetOs, windows), true)
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
         CFLAGS := $(filter-out -MD, $(CFLAGS_JDKLIB)) -MT \
-            -DACCESSBRIDGE_ARCH_$2, \
+            -DACCESSBRIDGE_ARCH_$2 -EHsc, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.base:include \
@@ -70,7 +70,7 @@ ifeq ($(call isTargetOs, windows), true)
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
         CFLAGS := $(CFLAGS_JDKLIB) \
-            -DACCESSBRIDGE_ARCH_$2, \
+            -DACCESSBRIDGE_ARCH_$2 -EHsc, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.base:include, \

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ ifeq ($(call isTargetOs, windows), true)
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
         CFLAGS := $(filter-out -MD, $(CFLAGS_JDKLIB)) -MT \
-            -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+            -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.base:include \
@@ -70,7 +70,7 @@ ifeq ($(call isTargetOs, windows), true)
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
         CFLAGS := $(CFLAGS_JDKLIB) \
-            -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+            -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.base:include, \

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <windows.h>
 #include <cstdlib>
-#include <chrono>
 #include <cstring>
 
 #ifdef __cplusplus
@@ -72,11 +71,13 @@ void finalizeFileLogger() {
     }
 }
 
-auto getTimeStamp() -> long long {
-    using namespace std::chrono;
-    auto timeNow = duration_cast<milliseconds>(steady_clock::now().time_since_epoch());
-
-    return timeNow.count();
+unsigned long long getTimeStamp() {
+    FILETIME ft;
+    ULARGE_INTEGER uli;
+    GetSystemTimeAsFileTime(&ft);
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart / 10000ULL) - 11644473600000ULL; // Rebase Epoch from 1601 to 1970
 }
 
 /**


### PR DESCRIPTION
I saw C4530 with VS 2019 (16.9.0) as following (on Japanese locale):

```
AccessBridgeDebug.cpp
メモ: インクルード ファイル: d:\github-forked\jdk\src\jdk.accessibility\windows\native\common\AccessBridgeDebug.h

    :

c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\ostream(611): error C2220: 次の警
告はエラーとして処理されます
c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\ostream(611): warning C4530: C++
例外処理を使っていますが、アンワインド セマンティクスは有効にはなりません。/EHsc を指定してください。
メモ: インクルード ファイル: c:\progra~2\micros~2\2019\commun~1\vc\tools\msvc\1428~1.299\include\string
```

`/EHsc` has been already passed in other makefiles, and also AccessBridgeDebug.cpp uses some STL classes (e.g. `chrono` namespace). So `/EHsc` is a solution for this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263136](https://bugs.openjdk.java.net/browse/JDK-8263136): C4530 was reported from VS 2019 at access bridge


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2859/head:pull/2859`
`$ git checkout pull/2859`
