### PR TITLE
JDK-8263137: Typos in sun.security.ssl.RenegoInfoExtension

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/RenegoInfoExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/RenegoInfoExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,7 +280,7 @@ final class RenegoInfoExtension {
                             CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV.id) {
                         if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                             SSLLogger.finest(
-                                "Safe renegotiation, using the SCSV signgling");
+                                "Safe renegotiation, using the SCSV signaling");
                         }
                         shc.conContext.secureRenegotiation = true;
                         return;
@@ -341,7 +341,7 @@ final class RenegoInfoExtension {
             RenegotiationInfoSpec requestedSpec = (RenegotiationInfoSpec)
                     shc.handshakeExtensions.get(CH_RENEGOTIATION_INFO);
             if (requestedSpec == null && !shc.conContext.secureRenegotiation) {
-                // Ignore, no renegotiation_info extension or SCSV signgling
+                // Ignore, no renegotiation_info extension or SCSV signaling
                 // requested.
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.finest(


### PR DESCRIPTION
Two typos on SCSV "signgling", which should be "signaling".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263137](https://bugs.openjdk.java.net/browse/JDK-8263137): Typos in sun.security.ssl.RenegoInfoExtension


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2860/head:pull/2860`
`$ git checkout pull/2860`
