### PR TITLE
8263140: Japanese chars garble in console window in HSDB

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,7 +306,7 @@ public class AnnotatedMemoryPanel extends JPanel {
       });
 
     if (font == null) {
-      font = GraphicsUtilities.lookupFont("Courier");
+      font = GraphicsUtilities.getMonospacedFont();
     }
     if (font == null) {
       throw new RuntimeException("Error looking up monospace font Courier");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/CommandProcessorPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/CommandProcessorPanel.java
@@ -60,7 +60,7 @@ public class CommandProcessorPanel extends JPanel {
 
         editor = new JTextArea();
         editor.setDocument(new EditableAtEndDocument());
-        editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, GraphicsUtilities.FONT_SIZE));
+        editor.setFont(GraphicsUtilities.getMonospacedFont());
         JScrollPane scroller = new JScrollPane();
         scroller.getViewport().add(editor);
         add(scroller, BorderLayout.CENTER);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/CommandProcessorPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/CommandProcessorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class CommandProcessorPanel extends JPanel {
 
         editor = new JTextArea();
         editor.setDocument(new EditableAtEndDocument());
-        editor.setFont(GraphicsUtilities.lookupFont("Courier"));
+        editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, GraphicsUtilities.FONT_SIZE));
         JScrollPane scroller = new JScrollPane();
         scroller.getViewport().add(editor);
         add(scroller, BorderLayout.CENTER);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/DebuggerConsolePanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/DebuggerConsolePanel.java
@@ -58,7 +58,7 @@ public class DebuggerConsolePanel extends JPanel {
 
     editor = new JTextArea();
     editor.setDocument(new EditableAtEndDocument());
-    editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, GraphicsUtilities.FONT_SIZE));
+    editor.setFont(GraphicsUtilities.getMonospacedFont());
     JScrollPane scroller = new JScrollPane();
     scroller.getViewport().add(editor);
     add(scroller, BorderLayout.CENTER);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/DebuggerConsolePanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/DebuggerConsolePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class DebuggerConsolePanel extends JPanel {
 
     editor = new JTextArea();
     editor.setDocument(new EditableAtEndDocument());
-    editor.setFont(GraphicsUtilities.lookupFont("Courier"));
+    editor.setFont(new Font(Font.MONOSPACED, Font.PLAIN, GraphicsUtilities.FONT_SIZE));
     JScrollPane scroller = new JScrollPane();
     scroller.getViewport().add(editor);
     add(scroller, BorderLayout.CENTER);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@ import javax.swing.border.*;
 /** Useful utilities for drawing graphics */
 
 public class GraphicsUtilities {
+  public static final int FONT_SIZE = 12;
+
   /** Returns a plain-styled 12-point version of the given font, or
       null if the font could not be found */
   public static Font lookupFont(String fontName) {
@@ -48,7 +50,7 @@ public class GraphicsUtilities {
     if (font == null) {
       return null;
     }
-    return font.deriveFont(Font.PLAIN, 12);
+    return font.deriveFont(Font.PLAIN, FONT_SIZE);
   }
 
   /** Compute the width and height of given string given the current

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
@@ -34,7 +34,7 @@ import javax.swing.border.*;
 /** Useful utilities for drawing graphics */
 
 public class GraphicsUtilities {
-  public static final int FONT_SIZE = 12;
+  private static final int FONT_SIZE = 12;
 
   /** Returns a plain-styled 12-point version of the given font, or
       null if the font could not be found */
@@ -51,6 +51,10 @@ public class GraphicsUtilities {
       return null;
     }
     return font.deriveFont(Font.PLAIN, FONT_SIZE);
+  }
+
+  public static Font getMonospacedFont() {
+    return new Font(Font.MONOSPACED, Font.PLAIN, FONT_SIZE);
   }
 
   /** Compute the width and height of given string given the current

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/GraphicsUtilities.java
@@ -36,23 +36,6 @@ import javax.swing.border.*;
 public class GraphicsUtilities {
   private static final int FONT_SIZE = 12;
 
-  /** Returns a plain-styled 12-point version of the given font, or
-      null if the font could not be found */
-  public static Font lookupFont(String fontName) {
-    Font[] allFonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
-    Font font = null;
-    for (int i = 0; i < allFonts.length; i++) {
-      if (allFonts[i].getFontName().indexOf(fontName) != -1) {
-        font = allFonts[i];
-        break;
-      }
-    }
-    if (font == null) {
-      return null;
-    }
-    return font.deriveFont(Font.PLAIN, FONT_SIZE);
-  }
-
   public static Font getMonospacedFont() {
     return new Font(Font.MONOSPACED, Font.PLAIN, FONT_SIZE);
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,7 @@ public class MemoryPanel extends JPanel {
     table.setCellSelectionEnabled(true);
     table.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
     table.setDragEnabled(true);
-    Font font = GraphicsUtilities.lookupFont("Courier");
+    Font font = GraphicsUtilities.getMonospacedFont();
     if (font == null) {
       throw new RuntimeException("Error looking up monospace font Courier");
     }


### PR DESCRIPTION
We can command line debugger via "Windows" -> "Console" menu on HSDB. If the command shows error message in localized string (e.g. Japanese), it might garble as following:

![garbled](https://user-images.githubusercontent.com/7421132/110232635-39e89b00-7f62-11eb-95c9-1a5238072814.png)

Command line debugger and Debugger Console (WinDbg on Windows) will use Courier font on their console, but it does not show Japanese chars. I guess it would happen on CJK chars because monospaced font for Chinese, Japanese, Korean are different from Courier.

After this change on Windows which set to Japanese locale, it uses MS Gothic and we can see localized message as following:

![fixed](https://user-images.githubusercontent.com/7421132/110232699-a4014000-7f62-11eb-9185-6eff39394541.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263140](https://bugs.openjdk.java.net/browse/JDK-8263140): Japanese chars garble in console window in HSDB


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2862/head:pull/2862`
`$ git checkout pull/2862`
