### PR TITLE
8263142: Delete unused entry points in libawt/libawt_xawt/libawt_headless

### DIFF
--- a/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
+++ b/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,13 +41,6 @@
 
 #ifdef DEBUG
 #define VERBOSE_AWT_DEBUG
-#endif
-
-#ifdef STATIC_BUILD
-extern void Java_sun_xawt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
-jobject frame, jstring jcommand);
-
-extern void Java_sun_xawt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray);
 #endif
 
 static void *awtHandle = NULL;
@@ -193,75 +186,3 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 {
     return AWT_OnLoad(vm, reserved);
 }
-
-/*
- * This entry point must remain in libawt.so as part of a contract
- * with the CDE variant of Java Media Framework. (sdtjmplay)
- * Reflect this call over to the correct libawt_<toolkit>.so.
- */
-JNIEXPORT void JNICALL
-Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
-                                     jobject frame, jstring jcommand)
-{
-    /* type of the old backdoor function */
-    typedef void JNICALL
-        XsessionWMcommand_type(JNIEnv *env, jobject this,
-                               jobject frame, jstring jcommand);
-
-    static XsessionWMcommand_type *XsessionWMcommand = NULL;
-#ifndef STATIC_BUILD
-    if (XsessionWMcommand == NULL && awtHandle == NULL) {
-        return;
-    }
-
-    XsessionWMcommand = (XsessionWMcommand_type *)
-        dlsym(awtHandle, "Java_sun_awt_motif_XsessionWMcommand");
-#else
-    XsessionWMcommand = (XsessionWMcommand_type *)Java_sun_xawt_motif_XsessionWMcommand;
-#endif
-    if (XsessionWMcommand == NULL)
-        return;
-
-    (*XsessionWMcommand)(env, this, frame, jcommand);
-}
-
-
-/*
- * This entry point must remain in libawt.so as part of a contract
- * with the CDE variant of Java Media Framework. (sdtjmplay)
- * Reflect this call over to the correct libawt_<toolkit>.so.
- */
-JNIEXPORT void JNICALL
-Java_sun_awt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jargv)
-{
-    typedef void JNICALL
-        XsessionWMcommand_New_type(JNIEnv *env, jobjectArray jargv);
-
-    static XsessionWMcommand_New_type *XsessionWMcommand = NULL;
-#ifndef STATIC_BUILD
-    if (XsessionWMcommand == NULL && awtHandle == NULL) {
-        return;
-    }
-
-    XsessionWMcommand = (XsessionWMcommand_New_type *)
-        dlsym(awtHandle, "Java_sun_awt_motif_XsessionWMcommand_New");
-#else
-    XsessionWMcommand = (XsessionWMcommand_New_type *)Java_sun_xawt_motif_XsessionWMcommand_New;
-#endif
-
-    if (XsessionWMcommand == NULL)
-        return;
-
-    (*XsessionWMcommand)(env, jargv);
-}
-
-#ifdef STATIC_BUILD
-__attribute__((weak)) void Java_sun_xawt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray)
-{
-}
-
-__attribute__((weak)) void Java_sun_xawt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
-        jobject frame, jstring jcommand)
-{
-}
-#endif

--- a/src/java.desktop/unix/native/libawt_headless/awt/HeadlessToolkit.c
+++ b/src/java.desktop/unix/native/libawt_headless/awt/HeadlessToolkit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,12 +36,5 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     jvm = vm;
     return JNI_VERSION_1_2;
 }
-
-#ifndef STATIC_BUILD
-// The same function exists in libawt.a::awt_LoadLibrary.c
-JNIEXPORT jboolean JNICALL AWTIsHeadless() {
-    return JNI_TRUE;
-}
-#endif
 
 #endif


### PR DESCRIPTION
During the review of:
   8254024: Enhance native libs for AWT and Swing to work with GraalVM Native Image

I have found that some of the entry points in our libraries are never used, and can be removed, we do not need to update the code to make it work in static_build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263142](https://bugs.openjdk.java.net/browse/JDK-8263142): Delete unused entry points in libawt/libawt_xawt/libawt_headless


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2865/head:pull/2865`
`$ git checkout pull/2865`
