### PR TITLE
8263164: assert(_base >= VectorA && _base <= VectorZ) failed: Not a Vector while calling StoreVectorNode::memory_size()

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -672,7 +672,6 @@ PackNode* PackNode::binary_tree_pack(int lo, int hi) {
   int ct = hi - lo;
   assert(is_power_of_2(ct), "power of 2");
   if (ct == 2) {
-    assert(vect_type() != NULL, "sanity");
     PackNode* pk = PackNode::make(in(lo), 2, vect_type()->element_basic_type());
     pk->add_opd(in(lo+1));
     return pk;
@@ -681,7 +680,6 @@ PackNode* PackNode::binary_tree_pack(int lo, int hi) {
     PackNode* n1 = binary_tree_pack(lo,  mid);
     PackNode* n2 = binary_tree_pack(mid, hi );
 
-    assert(n1->vect_type() != NULL && n2->vect_type() != NULL, "sanity");
     BasicType bt = n1->vect_type()->element_basic_type();
     assert(bt == n2->vect_type()->element_basic_type(), "should be the same");
     switch (bt) {
@@ -1030,7 +1028,6 @@ int VectorCastNode::opcode(BasicType bt) {
 Node* VectorCastNode::Identity(PhaseGVN* phase) {
   if (!in(1)->is_top()) {
     BasicType  in_bt = in(1)->bottom_type()->is_vect()->element_basic_type();
-    assert(vect_type() != NULL, "sanity");
     BasicType out_bt = vect_type()->element_basic_type();
     if (in_bt == out_bt) {
       return in(1); // redundant cast
@@ -1174,7 +1171,6 @@ Node* VectorNode::degenerate_vector_rotate(Node* src, Node* cnt, bool is_rotate_
 
 Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
-  assert(vect_type() != NULL, "sanity");
   BasicType bt = vect_type()->element_basic_type();
   if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateLeftV, vlen, bt)) {
@@ -1185,7 +1181,6 @@ Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
 Node* RotateRightVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
-  assert(vect_type() != NULL, "sanity");
   BasicType bt = vect_type()->element_basic_type();
   if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateRightV, vlen, bt)) {

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -672,6 +672,7 @@ PackNode* PackNode::binary_tree_pack(int lo, int hi) {
   int ct = hi - lo;
   assert(is_power_of_2(ct), "power of 2");
   if (ct == 2) {
+    assert(vect_type() != NULL, "sanity");
     PackNode* pk = PackNode::make(in(lo), 2, vect_type()->element_basic_type());
     pk->add_opd(in(lo+1));
     return pk;
@@ -680,6 +681,7 @@ PackNode* PackNode::binary_tree_pack(int lo, int hi) {
     PackNode* n1 = binary_tree_pack(lo,  mid);
     PackNode* n2 = binary_tree_pack(mid, hi );
 
+    assert(n1->vect_type() != NULL && n2->vect_type() != NULL, "sanity");
     BasicType bt = n1->vect_type()->element_basic_type();
     assert(bt == n2->vect_type()->element_basic_type(), "should be the same");
     switch (bt) {
@@ -1028,6 +1030,7 @@ int VectorCastNode::opcode(BasicType bt) {
 Node* VectorCastNode::Identity(PhaseGVN* phase) {
   if (!in(1)->is_top()) {
     BasicType  in_bt = in(1)->bottom_type()->is_vect()->element_basic_type();
+    assert(vect_type() != NULL, "sanity");
     BasicType out_bt = vect_type()->element_basic_type();
     if (in_bt == out_bt) {
       return in(1); // redundant cast
@@ -1171,6 +1174,7 @@ Node* VectorNode::degenerate_vector_rotate(Node* src, Node* cnt, bool is_rotate_
 
 Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
+  assert(vect_type() != NULL, "sanity");
   BasicType bt = vect_type()->element_basic_type();
   if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateLeftV, vlen, bt)) {
@@ -1181,6 +1185,7 @@ Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
 Node* RotateRightVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
+  assert(vect_type() != NULL, "sanity");
   BasicType bt = vect_type()->element_basic_type();
   if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateRightV, vlen, bt)) {

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -709,7 +709,15 @@ class LoadVectorNode : public LoadNode {
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
+  virtual int memory_size() const {
+    if (type()->isa_vect() != NULL) {
+      return vect_type()->length_in_bytes();
+    } else {
+      // It's possible to be non-vector type during C2's optimization (e.g., Type::TOP).
+      // Return 0 for this case.
+      return 0;
+    }
+  }
 
   virtual int store_Opcode() const { return Op_StoreVector; }
 
@@ -753,7 +761,15 @@ class StoreVectorNode : public StoreNode {
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
+  virtual int memory_size() const {
+    if (in(MemNode::ValueIn)->bottom_type()->isa_vect() != NULL) {
+      return vect_type()->length_in_bytes();
+    } else {
+      // It's possible to be non-vector type during C2's optimization (e.g., Type::TOP).
+      // Return 0 for this case.
+      return 0;
+    }
+  }
 
   static StoreVectorNode* make(int opc, Node* ctl, Node* mem,
                                Node* adr, const TypePtr* atyp, Node* val,

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -709,15 +709,7 @@ class LoadVectorNode : public LoadNode {
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const {
-    if (type()->isa_vect() != NULL) {
-      return vect_type()->length_in_bytes();
-    } else {
-      // It's possible to be non-vector type during C2's optimization (e.g., Type::TOP).
-      // Return 0 for this case.
-      return 0;
-    }
-  }
+  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
 
   virtual int store_Opcode() const { return Op_StoreVector; }
 
@@ -761,15 +753,7 @@ class StoreVectorNode : public StoreNode {
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const {
-    if (in(MemNode::ValueIn)->bottom_type()->isa_vect() != NULL) {
-      return vect_type()->length_in_bytes();
-    } else {
-      // It's possible to be non-vector type during C2's optimization (e.g., Type::TOP).
-      // Return 0 for this case.
-      return 0;
-    }
-  }
+  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
 
   static StoreVectorNode* make(int opc, Node* ctl, Node* mem,
                                Node* adr, const TypePtr* atyp, Node* val,

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -60,13 +60,27 @@ class VectorNode : public TypeNode {
     init_req(4, n3);
   }
 
-  const TypeVect* vect_type() const { return type()->is_vect(); }
-  uint length() const { return vect_type()->length(); } // Vector length
-  uint length_in_bytes() const { return vect_type()->length_in_bytes(); }
+  const TypeVect* vect_type() const { return type()->isa_vect(); }
+
+  uint length() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length();
+    } else {
+      return 0;
+    }
+  } // Vector length
+
+  uint length_in_bytes() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length_in_bytes();
+    } else {
+      return 0;
+    }
+  }
 
   virtual int Opcode() const;
 
-  virtual uint ideal_reg() const { return Matcher::vector_ideal_reg(vect_type()->length_in_bytes()); }
+  virtual uint ideal_reg() const { return Matcher::vector_ideal_reg(length_in_bytes()); }
 
   static VectorNode* scalar2vector(Node* s, uint vlen, const Type* opd_t);
   static VectorNode* shift_count(int opc, Node* cnt, uint vlen, BasicType bt);
@@ -702,14 +716,28 @@ class LoadVectorNode : public LoadNode {
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const { return type()->is_vect(); }
-  uint length() const { return vect_type()->length(); } // Vector length
+  const TypeVect* vect_type() const { return type()->isa_vect(); }
+
+  uint length() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length();
+    } else {
+      return 0;
+    }
+  } // Vector length
 
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
+
+  virtual int memory_size() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length_in_bytes();
+    } else {
+      return 0;
+    }
+  }
 
   virtual int store_Opcode() const { return Op_StoreVector; }
 
@@ -717,7 +745,14 @@ class LoadVectorNode : public LoadNode {
                               Node* adr, const TypePtr* atyp,
                               uint vlen, BasicType bt,
                               ControlDependency control_dependency = LoadNode::DependsOnlyOnTest);
-  uint element_size(void) { return type2aelembytes(vect_type()->element_basic_type()); }
+
+  uint element_size(void) {
+    if (vect_type() != NULL) {
+      return type2aelembytes(vect_type()->element_basic_type());
+    } else {
+      return 0;
+    }
+  }
 };
 
 //------------------------------LoadVectorGatherNode------------------------------
@@ -746,14 +781,7 @@ class StoreVectorNode : public StoreNode {
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const {
-    const Type* type = in(MemNode::ValueIn)->bottom_type();
-    if (type != Type::TOP) {
-      return type->is_vect();
-    } else {
-      return NULL;
-    }
-  }
+  const TypeVect* vect_type() const { return in(MemNode::ValueIn)->bottom_type()->isa_vect(); }
 
   uint length() const {
     if (vect_type() != NULL) {
@@ -1219,7 +1247,13 @@ class VectorLoadShuffleNode : public VectorNode {
     assert(in->bottom_type()->is_vect()->element_basic_type() == T_BYTE, "must be BYTE");
   }
 
-  int GetOutShuffleSize() const { return type2aelembytes(vect_type()->element_basic_type()); }
+  int GetOutShuffleSize() const {
+    if (vect_type() != NULL) {
+      return type2aelembytes(vect_type()->element_basic_type());
+    } else {
+      return 0;
+    }
+  }
   virtual int Opcode() const;
 };
 

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -746,20 +746,47 @@ class StoreVectorNode : public StoreNode {
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const { return in(MemNode::ValueIn)->bottom_type()->is_vect(); }
-  uint length() const { return vect_type()->length(); } // Vector length
+  const TypeVect* vect_type() const {
+    const Type* type = in(MemNode::ValueIn)->bottom_type();
+    if (type != Type::TOP) {
+      return type->is_vect();
+    } else {
+      return NULL;
+    }
+  }
+
+  uint length() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length();
+    } else {
+      return 0;
+    }
+  } // Vector length
 
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
+
+  virtual int memory_size() const {
+    if (vect_type() != NULL) {
+      return vect_type()->length_in_bytes();
+    } else {
+      return 0;
+    }
+  }
 
   static StoreVectorNode* make(int opc, Node* ctl, Node* mem,
                                Node* adr, const TypePtr* atyp, Node* val,
                                uint vlen);
 
-  uint element_size(void) { return type2aelembytes(vect_type()->element_basic_type()); }
+  uint element_size(void) {
+    if (vect_type() != NULL) {
+      return type2aelembytes(vect_type()->element_basic_type());
+    } else {
+      return 0;
+    }
+  }
 };
 
 //------------------------------StoreVectorScatterNode------------------------------

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -161,8 +161,11 @@ public:
 //------------------------------ReductionNode------------------------------------
 // Perform reduction of a vector
 class ReductionNode : public Node {
+ private:
+  const Type* _bottom_type;
  public:
-  ReductionNode(Node *ctrl, Node* in1, Node* in2) : Node(ctrl, in1, in2) {}
+  ReductionNode(Node *ctrl, Node* in1, Node* in2) : Node(ctrl, in1, in2),
+               _bottom_type(Type::get_const_basic_type(in1->bottom_type()->basic_type())) {}
 
   static ReductionNode* make(int opc, Node *ctrl, Node* in1, Node* in2, BasicType bt);
   static int  opcode(int opc, BasicType bt);
@@ -170,13 +173,15 @@ class ReductionNode : public Node {
   static Node* make_reduction_input(PhaseGVN& gvn, int opc, BasicType bt);
 
   virtual const Type* bottom_type() const {
-    BasicType vbt = in(1)->bottom_type()->basic_type();
-    return Type::get_const_basic_type(vbt);
+    return _bottom_type;
   }
 
   virtual uint ideal_reg() const {
     return bottom_type()->ideal_reg();
   }
+
+  // Needed for proper cloning.
+  virtual uint size_of() const { return sizeof(*this); }
 };
 
 //------------------------------AddReductionVINode--------------------------------------

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -60,27 +60,13 @@ class VectorNode : public TypeNode {
     init_req(4, n3);
   }
 
-  const TypeVect* vect_type() const { return type()->isa_vect(); }
-
-  uint length() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length();
-    } else {
-      return 0;
-    }
-  } // Vector length
-
-  uint length_in_bytes() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length_in_bytes();
-    } else {
-      return 0;
-    }
-  }
+  const TypeVect* vect_type() const { return type()->is_vect(); }
+  uint length() const { return vect_type()->length(); } // Vector length
+  uint length_in_bytes() const { return vect_type()->length_in_bytes(); }
 
   virtual int Opcode() const;
 
-  virtual uint ideal_reg() const { return Matcher::vector_ideal_reg(length_in_bytes()); }
+  virtual uint ideal_reg() const { return Matcher::vector_ideal_reg(vect_type()->length_in_bytes()); }
 
   static VectorNode* scalar2vector(Node* s, uint vlen, const Type* opd_t);
   static VectorNode* shift_count(int opc, Node* cnt, uint vlen, BasicType bt);
@@ -716,28 +702,14 @@ class LoadVectorNode : public LoadNode {
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const { return type()->isa_vect(); }
-
-  uint length() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length();
-    } else {
-      return 0;
-    }
-  } // Vector length
+  const TypeVect* vect_type() const { return type()->is_vect(); }
+  uint length() const { return vect_type()->length(); } // Vector length
 
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-
-  virtual int memory_size() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length_in_bytes();
-    } else {
-      return 0;
-    }
-  }
+  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
 
   virtual int store_Opcode() const { return Op_StoreVector; }
 
@@ -745,14 +717,7 @@ class LoadVectorNode : public LoadNode {
                               Node* adr, const TypePtr* atyp,
                               uint vlen, BasicType bt,
                               ControlDependency control_dependency = LoadNode::DependsOnlyOnTest);
-
-  uint element_size(void) {
-    if (vect_type() != NULL) {
-      return type2aelembytes(vect_type()->element_basic_type());
-    } else {
-      return 0;
-    }
-  }
+  uint element_size(void) { return type2aelembytes(vect_type()->element_basic_type()); }
 };
 
 //------------------------------LoadVectorGatherNode------------------------------
@@ -781,40 +746,20 @@ class StoreVectorNode : public StoreNode {
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const { return in(MemNode::ValueIn)->bottom_type()->isa_vect(); }
-
-  uint length() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length();
-    } else {
-      return 0;
-    }
-  } // Vector length
+  const TypeVect* vect_type() const { return in(MemNode::ValueIn)->bottom_type()->is_vect(); }
+  uint length() const { return vect_type()->length(); } // Vector length
 
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
   virtual BasicType memory_type() const { return T_VOID; }
-
-  virtual int memory_size() const {
-    if (vect_type() != NULL) {
-      return vect_type()->length_in_bytes();
-    } else {
-      return 0;
-    }
-  }
+  virtual int memory_size() const { return vect_type()->length_in_bytes(); }
 
   static StoreVectorNode* make(int opc, Node* ctl, Node* mem,
                                Node* adr, const TypePtr* atyp, Node* val,
                                uint vlen);
 
-  uint element_size(void) {
-    if (vect_type() != NULL) {
-      return type2aelembytes(vect_type()->element_basic_type());
-    } else {
-      return 0;
-    }
-  }
+  uint element_size(void) { return type2aelembytes(vect_type()->element_basic_type()); }
 };
 
 //------------------------------StoreVectorScatterNode------------------------------
@@ -1247,13 +1192,7 @@ class VectorLoadShuffleNode : public VectorNode {
     assert(in->bottom_type()->is_vect()->element_basic_type() == T_BYTE, "must be BYTE");
   }
 
-  int GetOutShuffleSize() const {
-    if (vect_type() != NULL) {
-      return type2aelembytes(vect_type()->element_basic_type());
-    } else {
-      return 0;
-    }
-  }
+  int GetOutShuffleSize() const { return type2aelembytes(vect_type()->element_basic_type()); }
   virtual int Opcode() const;
 };
 

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -739,14 +739,16 @@ class LoadVectorGatherNode : public LoadVectorNode {
 //------------------------------StoreVectorNode--------------------------------
 // Store Vector to memory
 class StoreVectorNode : public StoreNode {
+ private:
+  const TypeVect* _vect_type;
  public:
   StoreVectorNode(Node* c, Node* mem, Node* adr, const TypePtr* at, Node* val)
-    : StoreNode(c, mem, adr, at, val, MemNode::unordered) {
+    : StoreNode(c, mem, adr, at, val, MemNode::unordered), _vect_type(val->bottom_type()->is_vect()) {
     init_class_id(Class_StoreVector);
     set_mismatched_access();
   }
 
-  const TypeVect* vect_type() const { return in(MemNode::ValueIn)->bottom_type()->is_vect(); }
+  const TypeVect* vect_type() const { return _vect_type; }
   uint length() const { return vect_type()->length(); } // Vector length
 
   virtual int Opcode() const;
@@ -760,6 +762,9 @@ class StoreVectorNode : public StoreNode {
                                uint vlen);
 
   uint element_size(void) { return type2aelembytes(vect_type()->element_basic_type()); }
+
+  // Needed for proper cloning.
+  virtual uint size_of() const { return sizeof(*this); }
 };
 
 //------------------------------StoreVectorScatterNode------------------------------


### PR DESCRIPTION
Hi all,

Several Vector API tests failed intermittently due to this assert.

```
#
#  Internal Error (/home/jvm/jdk/src/hotspot/share/opto/type.hpp:1686), pid=10561, tid=10577
#  assert(_base >= VectorA && _base <= VectorZ) failed: Not a Vector
#
# JRE version: OpenJDK Runtime Environment (17.0) (fastdebug build 17-internal+0-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc..jdk, compiled mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x918f44]  StoreVectorNode::memory_size() const+0xb4
```

The reason is that StoreVectorNode::memory_size() will fail if StoreVectorNode->in(MemNode::ValueIn)->bottom_type() == Type::TOP.
However, this case seems possible during C2's optimization.
And the same bug exists for LoadVectorNode::memory_size() as well.

The fix returns 0 if StoreVectorNode->in(MemNode::ValueIn)->bottom_type() is not a vector type.

Testing:
  - jdk/incubator/vector
  - tier1~tier3

Any comments?

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263164](https://bugs.openjdk.java.net/browse/JDK-8263164): assert(_base >= VectorA && _base <= VectorZ) failed: Not a Vector while calling StoreVectorNode::memory_size()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2867/head:pull/2867`
`$ git checkout pull/2867`
