### PR TITLE
8198317: Enhance JavacTool.getTask for flexibility

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
@@ -170,9 +170,9 @@ public final class JavacTool implements JavaCompiler {
             if (out == null && context.get(Log.errKey) == null)
                 // Situation: out is null and the value is not set in the context.
                 context.put(Log.errKey, new PrintWriter(System.err, true));
-            else if (out instanceof PrintWriter)
+            else if (out instanceof PrintWriter pw)
                 // Situation: out is not null and out is a PrintWriter.
-                context.put(Log.errKey, (PrintWriter) out);
+                context.put(Log.errKey, pw);
             else if (out != null)
                 // Situation: out is not null and out is not a PrintWriter.
                 context.put(Log.errKey, new PrintWriter(out, true));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
@@ -166,9 +166,15 @@ public final class JavacTool implements JavaCompiler {
             if (diagnosticListener != null)
                 context.put(DiagnosticListener.class, ccw.wrap(diagnosticListener));
 
-            if (out == null)
+            // If out is null and the value is set in the context, we need to do nothing.
+            if (out == null && context.get(Log.errKey) == null)
+                // Situation: out is null and the value is not set in the context.
                 context.put(Log.errKey, new PrintWriter(System.err, true));
-            else
+            else if (out instanceof PrintWriter)
+                // Situation: out is not null and out is a PrintWriter.
+                context.put(Log.errKey, (PrintWriter) out);
+            else if (out != null)
+                // Situation: out is not null and out is not a PrintWriter.
                 context.put(Log.errKey, new PrintWriter(out, true));
 
             if (fileManager == null) {

--- a/test/langtools/tools/javac/api/8198317/T8198317.java
+++ b/test/langtools/tools/javac/api/8198317/T8198317.java
@@ -79,15 +79,18 @@ public class T8198317 extends TestRunner{
         List<? extends JavaFileObject> files = Arrays.asList(new MemFile("Test.java", code));
 
         // Situation: out is null and the value is not set in the context.
-        ByteArrayOutputStream bais = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(bais);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos);
         PrintStream prev = System.err;
-        System.setErr(printStream);
-        ToolProvider.getSystemJavaCompiler()
-                .getTask(null, null, null, Arrays.asList("-XDrawDiagnostics", "-Xlint:serial"), null, files)
-                .call();
-        tb.checkEqual(expected, Arrays.asList(bais.toString().split(lineSeparator)));
-        System.setErr(prev);
+        try {
+            System.setErr(printStream);
+            ToolProvider.getSystemJavaCompiler()
+                    .getTask(null, null, null, Arrays.asList("-XDrawDiagnostics", "-Xlint:serial"), null, files)
+                    .call();
+            tb.checkEqual(expected, Arrays.asList(baos.toString().split(lineSeparator)));
+        } finally {
+            System.setErr(prev);
+        }
 
         // Situation: out is not null and out is a PrintWriter.
         StringWriter stringWriter2 = new StringWriter();

--- a/test/langtools/tools/javac/api/8198317/T8198317.java
+++ b/test/langtools/tools/javac/api/8198317/T8198317.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8198317
+ * @summary Enhance JavacTool.getTask for flexibility
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox
+ * @run main T8198317
+ */
+
+import java.io.*;
+import java.lang.reflect.*;
+import javax.tools.ToolProvider;
+
+import com.sun.tools.javac.api.JavacTaskImpl;
+import com.sun.tools.javac.util.Log;
+
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+
+public class T8198317 extends TestRunner{
+    ToolBox tb;
+
+    public T8198317() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        T8198317 t = new T8198317();
+        t.runTests();
+    }
+
+    @Test
+    public void testLogSettingInJavacTool() throws Exception {
+        // TODO Situation: out is null and the value is not set in the context.
+        // TODO Situation: out is not null and out is not a PrintWriter.
+
+        // Situation: out is not null and out is a PrintWriter.
+        PrintWriter expectedPW = new PrintWriter(System.out);
+        JavacTaskImpl task2 = (JavacTaskImpl) ToolProvider
+                .getSystemJavaCompiler()
+                .getTask(expectedPW, null, null, null, null, null);
+        PrintWriter writer2 = task2.getContext().get(Log.errKey);
+        if (!expectedPW.equals(writer2)) {
+            throw new Error("The PrintWriter is set uncorrectly.");
+        }
+    }
+}

--- a/test/langtools/tools/javac/api/TestContextLoggingOutput.java
+++ b/test/langtools/tools/javac/api/TestContextLoggingOutput.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @build toolbox.ToolBox
- * @run main T8198317
+ * @run main TestContextLoggingOutput
  */
 
 import java.io.StringWriter;
@@ -44,23 +44,20 @@ import javax.tools.ToolProvider;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.JavaFileObject;
 
-import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.util.Log;
-
 import toolbox.ToolBox;
 import toolbox.TestRunner;
 import static toolbox.ToolBox.lineSeparator;
 
-public class T8198317 extends TestRunner{
+public class TestContextLoggingOutput extends TestRunner {
     ToolBox tb;
 
-    public T8198317() {
+    public TestContextLoggingOutput() {
         super(System.err);
         tb = new ToolBox();
     }
 
     public static void main(String[] args) throws Exception {
-        T8198317 t = new T8198317();
+        TestContextLoggingOutput t = new TestContextLoggingOutput();
         t.runTests();
     }
 

--- a/test/langtools/tools/javac/api/TestContextLoggingOutput.java
+++ b/test/langtools/tools/javac/api/TestContextLoggingOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This is a clone of https://github.com/openjdk/jdk/pull/1896, which got closed by Skara.

@lgxbslgx, please let me know if you would prefer to resubmit the PR yourself.

/contributor add lgxbslgx

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198317](https://bugs.openjdk.java.net/browse/JDK-8198317): Enhance JavacTool.getTask for flexibility


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**) ⚠️ Review applies to ec3c8927179f86d1da76e4648512820d04aca9bb


### Contributors
 * Guoxiong Li `<lgxbslgx@gmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2871/head:pull/2871` \
`$ git checkout pull/2871`

Update a local copy of the PR: \
`$ git checkout pull/2871` \
`$ git pull https://git.openjdk.java.net/jdk pull/2871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2871`

View PR using the GUI difftool: \
`$ git pr show -t 2871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2871.diff">https://git.openjdk.java.net/jdk/pull/2871.diff</a>

</details>
