### PR TITLE
8263066: Add -overwrite and -stream options to jcmd GC.heap_dump

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2699,10 +2699,12 @@ int os::open(const char *path, int oflag, int mode) {
 }
 
 // create binary file, rewriting existing file if required
-int os::create_binary_file(const char* path, bool rewrite_existing) {
-  int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
+int os::create_binary_file(const char* path, bool rewrite_existing, bool streaming) {
+  int oflags = O_WRONLY | O_NOCTTY;
+  if (rewrite_existing) {
+    oflags |= O_CREAT | O_TRUNC;
+  } else if (!streaming) {
+    oflags |= O_CREAT | O_EXCL;
   }
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2404,10 +2404,12 @@ int os::open(const char *path, int oflag, int mode) {
 
 
 // create binary file, rewriting existing file if required
-int os::create_binary_file(const char* path, bool rewrite_existing) {
-  int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
+int os::create_binary_file(const char* path, bool rewrite_existing, bool streaming) {
+  int oflags = O_WRONLY | O_NOCTTY;
+  if (rewrite_existing) {
+    oflags |= O_CREAT | O_TRUNC;
+  } else if (!streaming) {
+    oflags |= O_CREAT | O_EXCL;
   }
   return ::open(path, oflags, S_IREAD | S_IWRITE);
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4979,10 +4979,12 @@ int os::open(const char *path, int oflag, int mode) {
 
 
 // create binary file, rewriting existing file if required
-int os::create_binary_file(const char* path, bool rewrite_existing) {
-  int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
+int os::create_binary_file(const char* path, bool rewrite_existing, bool streaming) {
+  int oflags = O_WRONLY | O_NOCTTY;
+  if (rewrite_existing) {
+    oflags |= O_CREAT | O_TRUNC;
+  } else if (!streaming) {
+    oflags |= O_CREAT | O_EXCL;
   }
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4691,10 +4691,12 @@ bool os::dir_is_empty(const char* path) {
 }
 
 // create binary file, rewriting existing file if required
-int os::create_binary_file(const char* path, bool rewrite_existing) {
-  int oflags = _O_CREAT | _O_WRONLY | _O_BINARY;
-  if (!rewrite_existing) {
-    oflags |= _O_EXCL;
+int os::create_binary_file(const char* path, bool rewrite_existing, bool streaming) {
+  int oflags = _O_WRONLY | _O_BINARY;
+  if (rewrite_existing) {
+    oflags |= _O_CREAT | O_TRUNC;
+  } else if (!streaming) {
+    oflags |= _O_CREAT | _O_EXCL;
   }
   return ::open(path, oflags, _S_IREAD | _S_IWRITE);
 }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -742,7 +742,7 @@ class os: AllStatic {
   static bool dir_is_empty(const char* path);
 
   // IO operations on binary files
-  static int create_binary_file(const char* path, bool rewrite_existing);
+  static int create_binary_file(const char* path, bool rewrite_existing, bool streaming);
   static jlong current_file_offset(int fd);
   static jlong seek_to_file_offset(int fd, jlong offset);
 

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -331,6 +331,9 @@ protected:
   DCmdArgument<char*> _filename;
   DCmdArgument<bool>  _all;
   DCmdArgument<jlong> _gzip;
+  DCmdArgument<bool>  _overwrite;
+  DCmdArgument<bool>  _stream;
+
 public:
   HeapDumpDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1905,7 +1905,7 @@ void VM_HeapDumper::dump_stack_traces() {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path, outputStream* out, int compression) {
+int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite, bool stream) {
   assert(path != NULL && strlen(path) > 0, "path missing");
 
   // print message in interactive case
@@ -1928,12 +1928,12 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression) {
     }
   }
 
-  DumpWriter writer(new (std::nothrow) FileWriter(path), compressor);
+  DumpWriter writer(new (std::nothrow) FileWriter(path, overwrite, stream), compressor);
 
   if (writer.error() != NULL) {
     set_error(writer.error());
     if (out != NULL) {
-      out->print_cr("Unable to create %s: %s", path,
+      out->print_cr("Unable to %s %s: %s", stream ? "stream to " : "create", path,
         (error() != NULL) ? error() : "reason unknown");
     }
     return -1;

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -71,7 +71,8 @@ class HeapDumper : public StackObj {
   // dumps the heap to the specified file, returns 0 if success.
   // additional info is written to out if not NULL.
   // compression >= 0 creates a gzipped file with the given compression level.
-  int dump(const char* path, outputStream* out = NULL, int compression = -1);
+  int dump(const char* path, outputStream* out = NULL, int compression = -1,
+           bool overwrite = false, bool stream = false);
 
   // returns error message (resource allocated), or NULL if no error
   char* error_as_C_string() const;

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -34,7 +34,7 @@
 char const* FileWriter::open_writer() {
   assert(_fd < 0, "Must not already be open");
 
-  _fd = os::create_binary_file(_path, false);    // don't replace existing file
+  _fd = os::create_binary_file(_path, _overwrite, _stream);
 
   if (_fd < 0) {
     return os::strerror(errno);

--- a/src/hotspot/share/services/heapDumperCompression.hpp
+++ b/src/hotspot/share/services/heapDumperCompression.hpp
@@ -62,9 +62,16 @@ class FileWriter : public AbstractWriter {
 private:
   char const* _path;
   int _fd;
+  bool _overwrite;
+  bool _stream;
 
 public:
-  FileWriter(char const* path) : _path(path), _fd(-1) { }
+  FileWriter(char const* path, bool overwrite, bool stream) :
+    _path(path),
+    _fd(-1),
+    _overwrite(overwrite),
+    _stream(stream) {
+  }
 
   ~FileWriter();
 

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpOverwriteStreamTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpOverwriteStreamTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.io.IOException;
+import java.util.List;
+
+import jdk.test.lib.hprof.HprofParser;
+import jdk.test.lib.hprof.parser.Reader;
+import jdk.test.lib.hprof.model.Snapshot;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/*
+ * @test
+ * @summary Test of diagnostic command GC.heap_dump with -overwrite or -stream
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run main/othervm HeapDumpOverwriteStreamTest
+ */
+
+public class HeapDumpOverwriteStreamTest {
+    public static HeapDumpOverwriteStreamTest ref;
+
+    public static void main(String[] args) throws Exception {
+        PidJcmdExecutor executor = new PidJcmdExecutor();
+        ref = new HeapDumpOverwriteStreamTest();
+        File dump = new File("jcmd.gc.heap_dump." + System.currentTimeMillis() + ".hprof.gz");
+        String path = dump.getAbsolutePath();
+
+        if (dump.exists()) {
+            dump.delete();
+        }
+
+        // Check we can throw an error if -overwrite and -stream are
+        // both present
+        OutputAnalyzer output = executor.execute("GC.heap_dump -overwrite -stream " + path);
+        output.shouldContain("Cannot specify -overwrite and -stream simultaneously.");
+
+        // Check we can create a new dump file with -overwrite
+        output = executor.execute("GC.heap_dump -overwrite " + path);
+        output.shouldContain("Heap dump file created");
+        verifyHeapDump(dump);
+
+        // Check we can overwrite the file. Create a larger file first, so we
+        // see if it is completely replaced.
+        long len = dump.length();
+        Asserts.assertTrue(dump.delete());
+        RandomAccessFile file = new RandomAccessFile(dump, "rw");
+        file.seek(len * 2);
+        file.writeByte(0);
+        file.close();
+        output = executor.execute("GC.heap_dump -overwrite " + path);
+        output.shouldContain("Heap dump file created");
+        Asserts.assertLT(dump.length(), 2 * len + 1);
+        verifyHeapDump(dump);
+        dump.delete();
+
+        // Check that we don't create a new file when using -stream
+        output = executor.execute("GC.heap_dump -stream " + path);
+        output.shouldContain("Unable to stream to ");
+
+        // Check that we write to a file when using -stream.
+        file = new RandomAccessFile(dump, "rw");
+        file.close();
+        output = executor.execute("GC.heap_dump -stream " + path);
+        output.shouldContain("Heap dump file created");
+        verifyHeapDump(dump);
+    }
+
+    private static void verifyHeapDump(File dump) throws Exception {
+
+        Asserts.assertTrue(dump.exists() && dump.isFile(),
+                           "Could not create dump file " + dump.getAbsolutePath());
+
+        try {
+            File out = HprofParser.parse(dump);
+
+            Asserts.assertTrue(out != null && out.exists() && out.isFile(),
+                               "Could not find hprof parser output file");
+            List<String> lines = Files.readAllLines(out.toPath());
+            Asserts.assertTrue(lines.size() > 0, "hprof parser output file is empty");
+            for (String line : lines) {
+                Asserts.assertFalse(line.matches(".*WARNING(?!.*Failed to resolve " +
+                                                 "object.*constantPoolOop.*).*"));
+            }
+
+            out.delete();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Asserts.fail("Could not parse dump file " + dump.getAbsolutePath());
+        }
+    }
+}
+


### PR DESCRIPTION
This change adds to options to the GC.heap_dump diagnostic command:
- the -overwrite flag allows the user to specify an already existing file, which will then be overwritten; if the file doesn't already exists, it will be created
-  the -stream flag allows the user to specify an special file like a named pipe, a domain socket or tty to write the heap dump too; if the file name doesn't exists, it will not be created and instead an error is displayed

Note that while -stream should be used for writing to special files, it is not enforced that the specified file is really a special file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8263066](https://bugs.openjdk.java.net/browse/JDK-8263066)

### Issue
 * [JDK-8263066](https://bugs.openjdk.java.net/browse/JDK-8263066): Add option to jcmd to overwrite a heap dump or stream to special files ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2873/head:pull/2873` \
`$ git checkout pull/2873`

Update a local copy of the PR: \
`$ git checkout pull/2873` \
`$ git pull https://git.openjdk.java.net/jdk pull/2873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2873`

View PR using the GUI difftool: \
`$ git pr show -t 2873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2873.diff">https://git.openjdk.java.net/jdk/pull/2873.diff</a>

</details>
