### PR TITLE
8263200: Add -XX:StressCCP to CTW

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -289,6 +289,7 @@ public class CtwRunner {
                     "-XX:+StressLCM",
                     "-XX:+StressGCM",
                     "-XX:+StressIGVN",
+                    "-XX:+StressCCP",
                     // StressSeed is uint
                     "-XX:StressSeed=" + Math.abs(rng.nextLong()),
                     // CTW entry point


### PR DESCRIPTION
Hi all,

could you please review the tiny patch which adds `-XX:+StressCCP` flag to CTW testlibrary?

from JBS:
> similar to StressLCM, StressGCM, and StressIGVN flags, recently introduced (by [JDK-8256535](https://bugs.openjdk.java.net/browse/JDK-8256535)) StressCCP can increase the probability to find compiler bugs, hence it makes sense to add this flag to CTW testlibrary.

testing:
 - [x] `test/hotspot/jtreg/applications/ctw/` 20 times on `{linux,windows,macosx}-x64` 
 - [x] `testlibrary_tests/ctw/` on `macosx-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263200](https://bugs.openjdk.java.net/browse/JDK-8263200): Add -XX:StressCCP to CTW


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2877/head:pull/2877`
`$ git checkout pull/2877`
