### PR TITLE
8252173: Use handles instead of jobjects in modules.cpp

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -100,13 +100,12 @@ static PackageEntryTable* get_package_entry_table(Handle h_loader) {
   return loader_cld->packages();
 }
 
-static ModuleEntry* get_module_entry(jobject module, TRAPS) {
-  oop m = JNIHandles::resolve_non_null(module);
-  if (!java_lang_Module::is_instance(m)) {
+static ModuleEntry* get_module_entry(Handle module, TRAPS) {
+  if (!java_lang_Module::is_instance(module())) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
                    "module is not an instance of type java.lang.Module");
   }
-  return java_lang_Module::module_entry(m);
+  return java_lang_Module::module_entry(module());
 }
 
 
@@ -272,23 +271,22 @@ void throw_dup_pkg_exception(const char* module_name, PackageEntry* package, TRA
   }
 }
 
-void Modules::define_module(jobject module, jboolean is_open, jstring version,
+void Modules::define_module(Handle module, jboolean is_open, jstring version,
                             jstring location, jobjectArray packages, TRAPS) {
   check_cds_restrictions(CHECK);
   ResourceMark rm(THREAD);
 
-  if (module == NULL) {
+  if (module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Null module object");
   }
 
-  Handle module_handle(THREAD, JNIHandles::resolve_non_null(module));
-  if (!java_lang_Module::is_instance(module_handle())) {
+  if (!java_lang_Module::is_instance(module())) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "module is not an instance of type java.lang.Module");
   }
 
   int module_name_len;
-  char* module_name = get_module_name(module_handle(), module_name_len, CHECK);
+  char* module_name = get_module_name(module(), module_name_len, CHECK);
   if (module_name == NULL) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "Module name cannot be null");
@@ -301,11 +299,11 @@ void Modules::define_module(jobject module, jboolean is_open, jstring version,
   // Special handling of java.base definition
   if (strcmp(module_name, JAVA_BASE_NAME) == 0) {
     assert(is_open == JNI_FALSE, "java.base module cannot be open");
-    define_javabase_module(module_handle, version, location, packages_h, num_packages, CHECK);
+    define_javabase_module(module, version, location, packages_h, num_packages, CHECK);
     return;
   }
 
-  oop loader = java_lang_Module::loader(module_handle());
+  oop loader = java_lang_Module::loader(module());
   // Make sure loader is not the jdk.internal.reflect.DelegatingClassLoader.
   if (loader != java_lang_ClassLoader::non_reflection_class_loader(loader)) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
@@ -402,7 +400,7 @@ void Modules::define_module(jobject module, jboolean is_open, jstring version,
     if (!dupl_modules && existing_pkg == NULL) {
       if (module_table->lookup_only(module_symbol) == NULL) {
         // Create the entry for this module in the class loader's module entry table.
-        ModuleEntry* module_entry = module_table->locked_create_entry(module_handle,
+        ModuleEntry* module_entry = module_table->locked_create_entry(module,
                                     (is_open == JNI_TRUE), module_symbol,
                                     version_symbol, location_symbol, loader_data);
         assert(module_entry != NULL, "module_entry creation failed");
@@ -419,7 +417,7 @@ void Modules::define_module(jobject module, jboolean is_open, jstring version,
         }
 
         // Store pointer to ModuleEntry record in java.lang.Module object.
-        java_lang_Module::set_module_entry(module_handle(), module_entry);
+        java_lang_Module::set_module_entry(module(), module_entry);
       } else {
          dupl_modules = true;
       }
@@ -476,7 +474,7 @@ void Modules::define_module(jobject module, jboolean is_open, jstring version,
 }
 
 #if INCLUDE_CDS_JAVA_HEAP
-void Modules::define_archived_modules(jobject platform_loader, jobject system_loader, TRAPS) {
+void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_loader, TRAPS) {
   assert(UseSharedSpaces && MetaspaceShared::use_full_module_graph(), "must be");
 
   // We don't want the classes used by the archived full module graph to be redefined by JVMTI.
@@ -490,19 +488,17 @@ void Modules::define_archived_modules(jobject platform_loader, jobject system_lo
   // Patch any previously loaded class's module field with java.base's java.lang.Module.
   ModuleEntryTable::patch_javabase_entries(java_base_module);
 
-  if (platform_loader == NULL) {
+  if (h_platform_loader.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Null platform loader object");
   }
 
-  if (system_loader == NULL) {
+  if (h_system_loader.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Null system loader object");
   }
 
-  Handle h_platform_loader(THREAD, JNIHandles::resolve_non_null(platform_loader));
   ClassLoaderData* platform_loader_data = SystemDictionary::register_loader(h_platform_loader);
   ClassLoaderDataShared::restore_java_platform_loader_from_archive(platform_loader_data);
 
-  Handle h_system_loader(THREAD, JNIHandles::resolve_non_null(system_loader));
   ClassLoaderData* system_loader_data = SystemDictionary::register_loader(h_system_loader);
   ClassLoaderDataShared::restore_java_system_loader_from_archive(system_loader_data);
 }
@@ -515,27 +511,26 @@ void Modules::check_cds_restrictions(TRAPS) {
 }
 #endif // INCLUDE_CDS_JAVA_HEAP
 
-void Modules::set_bootloader_unnamed_module(jobject module, TRAPS) {
+void Modules::set_bootloader_unnamed_module(Handle module, TRAPS) {
   ResourceMark rm(THREAD);
 
-  if (module == NULL) {
+  if (module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Null module object");
   }
-  Handle module_handle(THREAD, JNIHandles::resolve(module));
-  if (!java_lang_Module::is_instance(module_handle())) {
+  if (!java_lang_Module::is_instance(module())) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "module is not an instance of type java.lang.Module");
   }
 
   // Ensure that this is an unnamed module
-  oop name = java_lang_Module::name(module_handle());
+  oop name = java_lang_Module::name(module());
   if (name != NULL) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "boot loader's unnamed module's java.lang.Module has a name");
   }
 
   // Validate java_base's loader is the boot loader.
-  oop loader = java_lang_Module::loader(module_handle());
+  oop loader = java_lang_Module::loader(module());
   if (loader != NULL) {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "Class loader must be the boot class loader");
@@ -547,19 +542,19 @@ void Modules::set_bootloader_unnamed_module(jobject module, TRAPS) {
   ClassLoaderData* boot_loader_data = ClassLoaderData::the_null_class_loader_data();
   ModuleEntry* unnamed_module = boot_loader_data->unnamed_module();
   assert(unnamed_module != NULL, "boot loader's unnamed ModuleEntry not defined");
-  unnamed_module->set_module(boot_loader_data->add_handle(module_handle));
+  unnamed_module->set_module(boot_loader_data->add_handle(module));
   // Store pointer to the ModuleEntry in the unnamed module's java.lang.Module object.
-  java_lang_Module::set_module_entry(module_handle(), unnamed_module);
+  java_lang_Module::set_module_entry(module(), unnamed_module);
 }
 
-void Modules::add_module_exports(jobject from_module, jstring package_name, jobject to_module, TRAPS) {
+void Modules::add_module_exports(Handle from_module, jstring package_name, Handle to_module, TRAPS) {
   check_cds_restrictions(CHECK);
 
   if (package_name == NULL) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(),
               "package is null");
   }
-  if (from_module == NULL) {
+  if (from_module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(),
               "from_module is null");
   }
@@ -573,7 +568,7 @@ void Modules::add_module_exports(jobject from_module, jstring package_name, jobj
   if (!from_module_entry->is_named() || from_module_entry->is_open()) return;
 
   ModuleEntry* to_module_entry;
-  if (to_module == NULL) {
+  if (to_module.is_null()) {
     to_module_entry = NULL;  // It's an unqualified export.
   } else {
     to_module_entry = get_module_entry(to_module, CHECK);
@@ -619,19 +614,19 @@ void Modules::add_module_exports(jobject from_module, jstring package_name, jobj
 }
 
 
-void Modules::add_module_exports_qualified(jobject from_module, jstring package,
-                                           jobject to_module, TRAPS) {
+void Modules::add_module_exports_qualified(Handle from_module, jstring package,
+                                           Handle to_module, TRAPS) {
   check_cds_restrictions(CHECK);
-  if (to_module == NULL) {
+  if (to_module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(),
               "to_module is null");
   }
   add_module_exports(from_module, package, to_module, CHECK);
 }
 
-void Modules::add_reads_module(jobject from_module, jobject to_module, TRAPS) {
+void Modules::add_reads_module(Handle from_module, Handle to_module, TRAPS) {
   check_cds_restrictions(CHECK);
-  if (from_module == NULL) {
+  if (from_module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(),
               "from_module is null");
   }
@@ -643,7 +638,7 @@ void Modules::add_reads_module(jobject from_module, jobject to_module, TRAPS) {
   }
 
   ModuleEntry* to_module_entry;
-  if (to_module != NULL) {
+  if (!to_module.is_null()) {
     to_module_entry = get_module_entry(to_module, CHECK);
     if (to_module_entry == NULL) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
@@ -735,9 +730,9 @@ jobject Modules::get_named_module(Handle h_loader, const char* package_name, TRA
 }
 
 // Export package in module to all unnamed modules.
-void Modules::add_module_exports_to_all_unnamed(jobject module, jstring package_name, TRAPS) {
+void Modules::add_module_exports_to_all_unnamed(Handle module, jstring package_name, TRAPS) {
   check_cds_restrictions(CHECK);
-  if (module == NULL) {
+  if (module.is_null()) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(),
               "module is null");
   }

--- a/src/hotspot/share/classfile/modules.hpp
+++ b/src/hotspot/share/classfile/modules.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -50,10 +50,10 @@ public:
   // * A package already exists in another module for this class loader
   // * Module is an unnamed module
   //  NullPointerExceptions are thrown if module is null.
-  static void define_module(jobject module, jboolean is_open, jstring version,
+  static void define_module(Handle module, jboolean is_open, jstring version,
                             jstring location, jobjectArray packages, TRAPS);
 
-  static void define_archived_modules(jobject platform_loader, jobject system_loader,
+  static void define_archived_modules(Handle h_platform_loader, Handle h_system_loader,
                                       TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
 
   // Provides the java.lang.Module for the unnamed module defined
@@ -64,7 +64,7 @@ public:
   //  * Module is not a subclass of java.lang.Module
   //  * Module's class loader is not the boot loader
   //  NullPointerExceptions are thrown if module is null.
-  static void set_bootloader_unnamed_module(jobject module, TRAPS);
+  static void set_bootloader_unnamed_module(Handle module, TRAPS);
 
   // This either does a qualified export of package in module from_module to module
   // to_module or, if to_module is null, does an unqualified export of package.
@@ -76,7 +76,7 @@ public:
   // * Package is not syntactically correct
   // * Package is not defined for from_module's class loader
   // * Package is not in module from_module.
-  static void add_module_exports(jobject from_module, jstring package, jobject to_module, TRAPS);
+  static void add_module_exports(Handle from_module, jstring package, Handle to_module, TRAPS);
 
   // This does a qualified export of package in module from_module to module
   // to_module.  Any "." in the package name will be converted to "/"
@@ -87,7 +87,7 @@ public:
   // * Package is not syntactically correct
   // * Package is not defined for from_module's class loader
   // * Package is not in module from_module.
-  static void add_module_exports_qualified(jobject from_module, jstring package, jobject to_module, TRAPS);
+  static void add_module_exports_qualified(Handle from_module, jstring package, Handle to_module, TRAPS);
 
   // add_reads_module adds module to_module to the list of modules that from_module
   // can read.  If from_module is the same as to_module then this is a no-op.
@@ -95,7 +95,7 @@ public:
   // from_module can read all current and future unnamed  modules).
   // An IllegalArgumentException is thrown if from_module is null or either (non-null)
   // module does not exist.
-  static void add_reads_module(jobject from_module, jobject to_module, TRAPS);
+  static void add_reads_module(Handle from_module, Handle to_module, TRAPS);
 
   // Return the java.lang.Module object for this class object.
   static jobject get_module(jclass clazz, TRAPS);
@@ -112,7 +112,7 @@ public:
   // If either module or package is null then NullPointerException is thrown.
   // If module or package is bad, or module is unnamed, or package is not in
   // module then IllegalArgumentException is thrown.
-  static void add_module_exports_to_all_unnamed(jobject module, jstring package, TRAPS);
+  static void add_module_exports_to_all_unnamed(Handle module, jstring package, TRAPS);
 
   // Return TRUE iff package is defined by loader
   static bool is_package_defined(Symbol* package_name, Handle h_loader, TRAPS);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1086,31 +1086,41 @@ JVM_END
 
 JVM_ENTRY(void, JVM_DefineModule(JNIEnv *env, jobject module, jboolean is_open, jstring version,
                                  jstring location, jobjectArray packages))
-  Modules::define_module(module, is_open, version, location, packages, CHECK);
+  Handle h_module (THREAD, JNIHandles::resolve(module));
+  Modules::define_module(h_module, is_open, version, location, packages, CHECK);
 JVM_END
 
 JVM_ENTRY(void, JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module))
-  Modules::set_bootloader_unnamed_module(module, CHECK);
+  Handle h_module (THREAD, JNIHandles::resolve(module));
+  Modules::set_bootloader_unnamed_module(h_module, CHECK);
 JVM_END
 
 JVM_ENTRY(void, JVM_AddModuleExports(JNIEnv *env, jobject from_module, jstring package, jobject to_module))
-  Modules::add_module_exports_qualified(from_module, package, to_module, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Handle h_to_module (THREAD, JNIHandles::resolve(to_module));
+  Modules::add_module_exports_qualified(h_from_module, package, h_to_module, CHECK);
 JVM_END
 
 JVM_ENTRY(void, JVM_AddModuleExportsToAllUnnamed(JNIEnv *env, jobject from_module, jstring package))
-  Modules::add_module_exports_to_all_unnamed(from_module, package, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Modules::add_module_exports_to_all_unnamed(h_from_module, package, CHECK);
 JVM_END
 
 JVM_ENTRY(void, JVM_AddModuleExportsToAll(JNIEnv *env, jobject from_module, jstring package))
-  Modules::add_module_exports(from_module, package, NULL, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Modules::add_module_exports(h_from_module, package, Handle(), CHECK);
 JVM_END
 
 JVM_ENTRY (void, JVM_AddReadsModule(JNIEnv *env, jobject from_module, jobject source_module))
-  Modules::add_reads_module(from_module, source_module, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Handle h_source_module (THREAD, JNIHandles::resolve(source_module));
+  Modules::add_reads_module(h_from_module, h_source_module, CHECK);
 JVM_END
 
 JVM_ENTRY(void, JVM_DefineArchivedModules(JNIEnv *env, jobject platform_loader, jobject system_loader))
-  Modules::define_archived_modules(platform_loader, system_loader, CHECK);
+  Handle h_platform_loader (THREAD, JNIHandles::resolve(platform_loader));
+  Handle h_system_loader (THREAD, JNIHandles::resolve(system_loader));
+  Modules::define_archived_modules(h_platform_loader, h_system_loader, CHECK);
 JVM_END
 
 // Reflection support //////////////////////////////////////////////////////////////////////////////

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1702,23 +1702,30 @@ WB_END
 
 WB_ENTRY(void, WB_DefineModule(JNIEnv* env, jobject o, jobject module, jboolean is_open,
                                 jstring version, jstring location, jobjectArray packages))
-  Modules::define_module(module, is_open, version, location, packages, CHECK);
+  Handle h_module (THREAD, JNIHandles::resolve(module));
+  Modules::define_module(h_module, is_open, version, location, packages, CHECK);
 WB_END
 
 WB_ENTRY(void, WB_AddModuleExports(JNIEnv* env, jobject o, jobject from_module, jstring package, jobject to_module))
-  Modules::add_module_exports_qualified(from_module, package, to_module, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Handle h_to_module (THREAD, JNIHandles::resolve(to_module));
+  Modules::add_module_exports_qualified(h_from_module, package, h_to_module, CHECK);
 WB_END
 
 WB_ENTRY(void, WB_AddModuleExportsToAllUnnamed(JNIEnv* env, jobject o, jclass module, jstring package))
-  Modules::add_module_exports_to_all_unnamed(module, package, CHECK);
+  Handle h_module (THREAD, JNIHandles::resolve(module));
+  Modules::add_module_exports_to_all_unnamed(h_module, package, CHECK);
 WB_END
 
 WB_ENTRY(void, WB_AddModuleExportsToAll(JNIEnv* env, jobject o, jclass module, jstring package))
-  Modules::add_module_exports(module, package, NULL, CHECK);
+  Handle h_module (THREAD, JNIHandles::resolve(module));
+  Modules::add_module_exports(h_module, package, Handle(), CHECK);
 WB_END
 
 WB_ENTRY(void, WB_AddReadsModule(JNIEnv* env, jobject o, jobject from_module, jobject source_module))
-  Modules::add_reads_module(from_module, source_module, CHECK);
+  Handle h_from_module (THREAD, JNIHandles::resolve(from_module));
+  Handle h_source_module (THREAD, JNIHandles::resolve(source_module));
+  Modules::add_reads_module(h_from_module, h_source_module, CHECK);
 WB_END
 
 WB_ENTRY(jlong, WB_IncMetaspaceCapacityUntilGC(JNIEnv* env, jobject wb, jlong inc))


### PR DESCRIPTION
Hi,
Please review this change for JDK-8252173 to use handles instead of jobjects in modules.cpp to make modules.cpp more debuggable.  The change was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, and tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252173](https://bugs.openjdk.java.net/browse/JDK-8252173): Use handles instead of jobjects in modules.cpp


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2878/head:pull/2878`
`$ git checkout pull/2878`
