### PR TITLE
8262351: Extra '0' in java.util.Formatter for '%012a' conversion with a sign character

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -3548,7 +3548,12 @@ public final class Formatter implements Closeable, Flushable {
                 sb.append(upper ? "0X" : "0x");
 
                 if (f.contains(Flags.ZERO_PAD)) {
-                    trailingZeros(sb, width - s.length() - 2);
+                    int leadingCharacters = 2;
+                    if(f.contains(Flags.LEADING_SPACE) ||
+                            f.contains(Flags.PLUS) || neg) {
+                        leadingCharacters = 3;
+                    }
+                    trailingZeros(sb, width - s.length() - leadingCharacters);
                 }
 
                 int idx = s.indexOf('p');

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Formatter/HexFloatZeroPadding.java
+++ b/test/jdk/java/util/Formatter/HexFloatZeroPadding.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8262351
+ * @summary Incorrect zero padding occurs in the presence of some leading sign
+ * flags for hexadecimal floating point conversions.
+ * @run testng HexFloatZeroPadding
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+@Test
+public class HexFloatZeroPadding {
+
+    public void testCorrectWidthHexFloatZeroPadding()
+    {
+        final int EXPECTEDLENGTH = 12;
+        assertEquals(String.format("|%010a|", 0.0).length(), EXPECTEDLENGTH);
+        assertEquals(String.format("|% 010a|", 0.0).length(), EXPECTEDLENGTH);
+        assertEquals(String.format("|%+010a|", 0.0).length(), EXPECTEDLENGTH);
+        assertEquals(String.format("|%010a|", -0.0).length(), EXPECTEDLENGTH);
+        assertEquals(String.format("|% 010a|", -0.0).length(), EXPECTEDLENGTH);
+        assertEquals(String.format("|%+010a|", -0.0).length(), EXPECTEDLENGTH);
+    }
+
+}


### PR DESCRIPTION
This fixes a zero-adding issue observed in the hex float conversion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262351](https://bugs.openjdk.java.net/browse/JDK-8262351): Extra '0' in java.util.Formatter for '%012a' conversion with a sign character


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2881/head:pull/2881`
`$ git checkout pull/2881`
