### PR TITLE
8263206: assert(*error_msg != '\0') failed: Must have error_message while parsing -XX:CompileCommand=unknown

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -416,7 +416,7 @@ static enum CompileCommand match_option_name(const char* line, int* bytes_read, 
   *bytes_read = 0;
   char option_buf[256];
   int matches = sscanf(line, "%255[a-zA-Z0-9]%n", option_buf, bytes_read);
-  if (matches > 0) {
+  if (matches > 0 && strcasecmp(option_buf, "unknown") != 0) {
     for (uint i = 0; i < ARRAY_SIZE(option_names); i++) {
       if (strcasecmp(option_buf, option_names[i]) == 0) {
         return static_cast<enum CompileCommand>(i);

--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestInvalidCompileCommand
+ * @bug 8263206
+ * @summary Regression tests of -XX:CompileCommand
+ * @library /test/lib
+ * @run driver compiler.oracle.TestInvalidCompileCommand
+ */
+
+package compiler.oracle;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestInvalidCompileCommand {
+
+    private static final String[][] ARGUMENTS = {
+        {
+            "-XX:CompileCommand=unknown",
+            "-version"
+        }
+    };
+
+    private static final String[][] OUTPUTS = {
+        {
+            "Unrecognized option 'unknown'"
+        }
+    };
+
+    private static void verifyInvalidOption(String[] arguments, String[] expected_outputs) throws Exception {
+        ProcessBuilder pb;
+        OutputAnalyzer out;
+
+        pb = ProcessTools.createJavaProcessBuilder(arguments);
+        out = new OutputAnalyzer(pb.start());
+
+        for (String expected_output : expected_outputs) {
+            out.shouldContain(expected_output);
+        }
+
+        out.shouldContain("CompileCommand: An error occurred during parsing");
+        out.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (ARGUMENTS.length != OUTPUTS.length) {
+            throw new RuntimeException("Test is set up incorrectly: length of arguments and expected outputs does not match.");
+        }
+
+        for (int i = 0; i < ARGUMENTS.length; i++) {
+            verifyInvalidOption(ARGUMENTS[i], OUTPUTS[i]);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

The following assert fired while parsing '-XX:CompileCommand=unknown' .

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/jvm/jdk/src/hotspot/share/compiler/compilerOracle.cpp:688), pid=76463, tid=76464
#  assert(*error_msg != '\0') failed: Must have error_message
#
# JRE version:  (17.0) (fastdebug build )
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 17-internal+0-adhoc.jvm.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x9b1f5c]  CompilerOracle::print_parse_error(char*, char*)+0xdc
#
```

It would be better to fix it.

Testing:
  - tier1~3 on Linux/x64

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263206](https://bugs.openjdk.java.net/browse/JDK-8263206): assert(*error_msg != '\0') failed: Must have error_message while parsing -XX:CompileCommand=unknown


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2883/head:pull/2883`
`$ git checkout pull/2883`
