### PR TITLE
8261916: gtest/GTestWrapper.java vmErrorTest.unimplemented1_vm_asset failed

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -972,12 +972,15 @@ static const char* get_java_version_info(InstanceKlass* ik,
 // General purpose hook into Java code, run once when the VM is initialized.
 // The Java library method itself may be changed independently from the VM.
 static void call_postVMInitHook(TRAPS) {
-  Klass* klass = SystemDictionary::resolve_or_null(vmSymbols::jdk_internal_vm_PostVMInitHook(), THREAD);
-  if (klass != NULL) {
-    JavaValue result(T_VOID);
-    JavaCalls::call_static(&result, klass, vmSymbols::run_method_name(),
-                           vmSymbols::void_method_signature(),
-                           CHECK);
+  // Java code can interfere with running gtests.
+  if (!ExecutingUnitTests) {
+    Klass* klass = SystemDictionary::resolve_or_null(vmSymbols::jdk_internal_vm_PostVMInitHook(), THREAD);
+    if (klass != NULL) {
+      JavaValue result(T_VOID);
+      JavaCalls::call_static(&result, klass, vmSymbols::run_method_name(),
+                             vmSymbols::void_method_signature(),
+                             CHECK);
+    }
   }
 }
 


### PR DESCRIPTION
Some post-vm hooks were interfering with the gtests that expect exceptions to be thrown.  When running gtests, disable postVMInitHooks.
Tested with failing tests and configurations, and tier1 on linux-x64, linux-aarch64, macos-x64, windows-x64, and their -debug equivalents.