### PR TITLE
8263170: ComboBoxModel documentation refers to a nonexistent type

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ComboBoxModel.java
+++ b/src/java.desktop/share/classes/javax/swing/ComboBoxModel.java
@@ -25,7 +25,7 @@
 package javax.swing;
 
 /**
- * A data model for a combo box. This interface extends <code>ListDataModel</code>
+ * A data model for a combo box. This interface extends <code>ListModel</code>
  * and adds the concept of a <i>selected item</i>. The selected item is generally
  * the item which is visible in the combo box display area.
  * <p>

--- a/src/java.desktop/share/classes/javax/swing/ComboBoxModel.java
+++ b/src/java.desktop/share/classes/javax/swing/ComboBoxModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
javadoc of ComboBoxModel incorrectly specifies "extends ListDataModel" but actually it extends ListModel and there is no such interface as ListDataModel. Rectified the anomaly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263170](https://bugs.openjdk.java.net/browse/JDK-8263170): ComboBoxModel documentation refers to a nonexistent type


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to 68b4fbe66af0c3754b21a5d204bb4aef1e4303c2
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer) ⚠️ Review applies to 68b4fbe66af0c3754b21a5d204bb4aef1e4303c2
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to 68b4fbe66af0c3754b21a5d204bb4aef1e4303c2
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to 68b4fbe66af0c3754b21a5d204bb4aef1e4303c2
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 68b4fbe66af0c3754b21a5d204bb4aef1e4303c2


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2886/head:pull/2886`
`$ git checkout pull/2886`
