### PR TITLE
8263055: hsdb Command Line Debugger does not properly direct output for some commands

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1735,13 +1735,13 @@ public class CommandProcessor {
                     if (metadata instanceof InstanceKlass) {
                         ik = (InstanceKlass) metadata;
                     } else {
-                        System.out.println("Specified address is not an InstanceKlass");
+                        out.println("Specified address is not an InstanceKlass");
                         return;
                     }
                 } else {
                     ik = SystemDictionaryHelper.findInstanceKlass(classname);
                     if (ik == null) {
-                        System.out.println("class not found: " + classname);
+                        out.println("class not found: " + classname);
                         return;
                     }
                 }
@@ -1853,9 +1853,9 @@ public class CommandProcessor {
                 String classname = t.nextToken();
                 InstanceKlass ik = SystemDictionaryHelper.findInstanceKlass(classname);
                 if (ik == null) {
-                    System.out.println("class not found: " + classname);
+                    out.println("class not found: " + classname);
                 } else {
-                    System.out.println(ik.getName().asString() + " @" + ik.getAddress());
+                    out.println(ik.getName().asString() + " @" + ik.getAddress());
                 }
             }
         },
@@ -1868,7 +1868,7 @@ public class CommandProcessor {
                 ClassLoaderDataGraph cldg = VM.getVM().getClassLoaderDataGraph();
                 cldg.classesDo(new ClassLoaderDataGraph.ClassVisitor() {
                         public void visit(Klass k) {
-                            System.out.println(k.getName().asString() + " @" + k.getAddress());
+                            out.println(k.getName().asString() + " @" + k.getAddress());
                         }
                     }
                 );


### PR DESCRIPTION
I ran the hsdb Command Line Debugger (Windows -> Console menu item) and tried the class and classes commands, and neither appeared to produce any output. Other commands seemed to work as expected. I then went back to the terminal window I used to launch hsdb, and notice all the output from class and classes commands went there instead. The reason is because these commands are using System.out.println instead of out.println. "out" is a PrintStream field of the CommandProcessor instance, and should be used for all output other than error output, which can use "err".

We have no test for this, but I did run the hsdb GUI, brought up the Command Line Debugger, and confirmed that `class` and `classes` now properly show the output there. We do have clhsdb tests that also exercise this CommandProcessor code, but clhsdb directs all the output to System.out, so `out.println` and `System.out.println` end up being the same, thus the issue was not noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263055](https://bugs.openjdk.java.net/browse/JDK-8263055): hsdb Command Line Debugger does not properly direct output for some commands


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2887/head:pull/2887`
`$ git checkout pull/2887`
