### PR TITLE
6251901: BasicTextUI: installDefaults method are contrary to the documentation

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -303,10 +303,8 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
     /**
      * Initializes component properties, such as font, foreground,
      * background, caret color, selection color, selected text color,
-     * disabled text color, and border color.  The font, foreground, and
-     * background properties are only set if their current value is either null
-     * or a UIResource, other properties are set if the current
-     * value is null.
+     * disabled text color, and border color.  All properties are set
+     * if their current value is either null or a UIResource.
      *
      * @see #uninstallDefaults
      * @see #installUI


### PR DESCRIPTION
BasicTextUI: installDefaults javadoc specifies only font, foreground and background properties are set  if their current value is either null or a UIResource
and other properties are set if the current value is null
but in reality all properties such as font, foreground, background, caret color, selection color, selected text color, disabled text color, and border color are set if their current value is either null or a UIResource.
Fixed the javadoc to specify the same.





