### PR TITLE
8261931: IGV: quick search fails on multi-line node labels

### DIFF
--- a/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/com/sun/hotspot/igv/graph/Figure.java
@@ -279,7 +279,7 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
             // class NodeQuickSearch in the View module.
             for (InputNode n : getSource().getSourceNodes()) {
                 String label = resolveString(diagram.getNodeText(), n.getProperties());
-                n.getProperties().setProperty("label", label);
+                n.getProperties().setProperty("label", label.replaceAll("\\R", " "));
             }
         }
         return lines;


### PR DESCRIPTION
This change makes it possible to match any field of a multi-line node label, by removing line breaks from the `label` node property that is searched on by default.

Tested manually using different node label configurations (configurable in `Tools` -> `Options` -> `General`), with and without line breaks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261931](https://bugs.openjdk.java.net/browse/JDK-8261931): IGV: quick search fails on multi-line node labels


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2889/head:pull/2889`
`$ git checkout pull/2889`
