### PR TITLE
8263108: Class initialization deadlock in java.lang.constant

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
@@ -64,7 +64,7 @@ public abstract class DynamicConstantDesc<T>
     private final String constantName;
     private final ClassDesc constantType;
 
-    private static volatile Map<MethodHandleDesc, Function<DynamicConstantDesc<?>, ConstantDesc>> canonicalMap;
+    private static Map<MethodHandleDesc, Function<DynamicConstantDesc<?>, ConstantDesc>> canonicalMap;
 
     /**
      * Creates a nominal descriptor for a dynamic constant.
@@ -274,7 +274,7 @@ public abstract class DynamicConstantDesc<T>
     }
 
     private ConstantDesc tryCanonicalize() {
-        Map<MethodHandleDesc, Function<DynamicConstantDesc<?>, ConstantDesc>> canonDescs = canonicalMap;
+        var canonDescs = canonicalMap;
         if (canonDescs == null) {
             canonDescs = Map.ofEntries(
                     Map.entry(ConstantDescs.BSM_PRIMITIVE_CLASS, DynamicConstantDesc::canonicalizePrimitiveClass),
@@ -286,9 +286,10 @@ public abstract class DynamicConstantDesc<T>
             synchronized (DynamicConstantDesc.class) {
                 if (canonicalMap == null) {
                     canonicalMap = canonDescs;
+                } else {
+                    canonDescs = canonicalMap;
                 }
             }
-            canonDescs = canonicalMap;
         }
 
         Function<DynamicConstantDesc<?>, ConstantDesc> f = canonDescs.get(bootstrapMethod);

--- a/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicConstantDesc.java
@@ -128,6 +128,8 @@ public abstract class DynamicConstantDesc<T>
      * format
      * @jvms 4.2.2 Unqualified Names
      */
+    // Do not call this method from the static initialization of java.lang.constant.ConstantDescs
+    // since that can lead to potential deadlock during multi-threaded concurrent execution
     public static<T> ConstantDesc ofCanonical(DirectMethodHandleDesc bootstrapMethod,
                                               String constantName,
                                               ClassDesc constantType,

--- a/test/jdk/java/lang/constant/DynamicConstantDescTest.java
+++ b/test/jdk/java/lang/constant/DynamicConstantDescTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * @test
+ * @bug 8263108
+ * @summary Verify that concurrent classloading of java.lang.constant.DynamicConstantDesc and
+ * java.lang.constant.ConstantDescs doesn't lead to a deadlock
+ * @run main/othervm DynamicConstantDescTest
+ * @run main/othervm DynamicConstantDescTest
+ * @run main/othervm DynamicConstantDescTest
+ * @run main/othervm DynamicConstantDescTest
+ * @run main/othervm DynamicConstantDescTest
+ */
+// Implementation note: This test cannot use testng, since by the time this test gets a chance
+// to trigger a concurrent classloading of the classes it's interested in, the testng infrastructure
+// would already have loaded those classes in a single main thread.
+public class DynamicConstantDescTest {
+
+    /**
+     * Loads {@code java.lang.constant.DynamicConstantDesc} and {@code java.lang.constant.ConstantDescs}
+     * and invokes {@code java.lang.constant.DynamicConstantDesc#ofCanonical()} concurrently in a thread
+     * of their own and expects the classloading of both those classes
+     * to succeed.
+     */
+    public static void main(final String[] args) throws Exception {
+        final CountDownLatch taskTriggerLatch = new CountDownLatch(4);
+        final List<Callable<?>> tasks = new ArrayList<>();
+        // a bunch of tasks - some doing just Class.forName and some
+        // invoking DynamicConstantDesc.ofCanonical
+        tasks.add(new Task("java.lang.constant.DynamicConstantDesc", taskTriggerLatch));
+        tasks.add(new InvokeOfCanonical(taskTriggerLatch));
+        tasks.add(new Task("java.lang.constant.ConstantDescs", taskTriggerLatch));
+        tasks.add(new InvokeOfCanonical(taskTriggerLatch));
+        final ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        try {
+            final Future<?>[] results = new Future[tasks.size()];
+            // submit
+            int i = 0;
+            for (final Callable<?> task : tasks) {
+                results[i++] = executor.submit(task);
+            }
+            // wait for completion
+            for (i = 0; i < tasks.size(); i++) {
+                results[i].get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static class Task implements Callable<Class<?>> {
+        private final String className;
+        private final CountDownLatch latch;
+
+        private Task(final String className, final CountDownLatch latch) {
+            this.className = className;
+            this.latch = latch;
+        }
+
+        @Override
+        public Class<?> call() {
+            System.out.println(Thread.currentThread().getName() + " loading " + this.className);
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                return Class.forName(this.className);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    enum MyEnum {A, B}
+
+    private static class InvokeOfCanonical implements Callable<Object> {
+        private final CountDownLatch latch;
+
+        private InvokeOfCanonical(final CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public Object call() {
+            System.out.println(Thread.currentThread().getName()
+                    + " calling  DynamicConstantDesc.ofCanonical()");
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                ConstantDesc desc = DynamicConstantDesc.ofCanonical(ConstantDescs.BSM_ENUM_CONSTANT,
+                        "A", ClassDesc.of("DynamicConstantDescTest").nested("MyEnum"),
+                        new ConstantDesc[0]);
+                if (desc == null) {
+                    throw new Exception("DynamicConstantDesc.ofCanonical unexpectedly returned null");
+                }
+                if (!MyEnum.A.equals(desc.resolveConstantDesc(MethodHandles.lookup()))) {
+                    throw new Exception("DynamicConstantDesc.ofCanonical returned unexpected result " + desc);
+                }
+                return desc;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/test/jdk/java/lang/constant/DynamicConstantDescTest.java
+++ b/test/jdk/java/lang/constant/DynamicConstantDescTest.java
@@ -23,8 +23,10 @@
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
-import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -124,7 +126,7 @@ public class DynamicConstantDescTest {
                 latch.countDown();
                 // wait for the other task to let us know they are ready to trigger their work too
                 latch.await();
-                ConstantDesc desc = DynamicConstantDesc.ofCanonical(ConstantDescs.BSM_ENUM_CONSTANT,
+                ConstantDesc desc = DynamicConstantDesc.ofCanonical(boostrapMethodForEnumConstant(),
                         "A", ClassDesc.of("DynamicConstantDescTest").nested("MyEnum"),
                         new ConstantDesc[0]);
                 if (desc == null) {
@@ -138,6 +140,17 @@ public class DynamicConstantDescTest {
                 throw new RuntimeException(e);
             }
         }
+
+        private static DirectMethodHandleDesc boostrapMethodForEnumConstant() {
+            ClassDesc[] args = {ClassDesc.of("java.lang.invoke.MethodHandles").nested("Lookup"),
+                    ClassDesc.of("java.lang.String"),
+                    ClassDesc.of("java.lang.Class")};
+            return MethodHandleDesc.ofMethod(java.lang.constant.DirectMethodHandleDesc.Kind.STATIC,
+                    ClassDesc.of("java.lang.invoke.ConstantBootstraps"),
+                    "enumConstant", MethodTypeDesc.of(ClassDesc.of("java.lang.Enum"), new ClassDesc[0])
+                            .insertParameterTypes(0, args));
+        }
+
     }
 
 }


### PR DESCRIPTION
Can I please get a review for this proposed patch for the issue reported in https://bugs.openjdk.java.net/browse/JDK-8263108?

As noted in that issue, the `java.lang.constant.DynamicConstantDesc` and `java.lang.constant.ConstantDescs` can end up in a classloading deadlock due to the nature of the code involved in their static blocks. A thread dump of one such deadlock (reproduced using the code attached to that issue) is as follows:

```
"Thread A" #14 prio=5 os_prio=31 cpu=101.45ms elapsed=8.30s tid=0x00007ff88e01ca00 nid=0x6003 in Object.wait()  [0x000070000a4c6000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.constant.DynamicConstantDesc.<clinit>(java.base@16-ea/DynamicConstantDesc.java:67)
	- waiting on the Class initialization monitor for java.lang.constant.ConstantDescs
	at Deadlock.threadA(Deadlock.java:14)
	at Deadlock$$Lambda$1/0x0000000800c00a08.run(Unknown Source)
	at java.lang.Thread.run(java.base@16-ea/Thread.java:831)

"Thread B" #15 prio=5 os_prio=31 cpu=103.15ms elapsed=8.30s tid=0x00007ff88b936a00 nid=0x9b03 in Object.wait()  [0x000070000a5c9000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.constant.ClassDesc.ofDescriptor(java.base@16-ea/ClassDesc.java:145)
	- waiting on the Class initialization monitor for java.lang.constant.DynamicConstantDesc
	at java.lang.constant.ConstantDescs.<clinit>(java.base@16-ea/ConstantDescs.java:239)
	at Deadlock.threadB(Deadlock.java:24)
	at Deadlock$$Lambda$2/0x0000000800c00c28.run(Unknown Source)
	at java.lang.Thread.run(java.base@16-ea/Thread.java:831)
```

The commit in this PR resolves that deadlock by moving the `canonicalMap` initialization in `DynamicConstantDesc`, from the static block, to a lazily initialized map, into the `tryCanonicalize` (private) method of the same class. That's the only method which uses this map.

The implementation in `tryCanonicalize` carefully ensures that the deadlock isn't shifted from the static block to this method, by making sure that the `synchronization` on `DynamicConstantDesc` in this method happens only when it's time to write the state to the shared `canonicalMap`. This has an implication that the method local variable `canonDescs` can get initialized by multiple threads unnecessarily but from what I can see, that's the only way we can avoid this deadlock. This penalty of multiple threads initializing and then throwing away that map isn't too huge because that will happen only once when the `canonicalMap` is being initialized for the first time.

An alternate approach that I thought of was to completely get rid of this shared cache `canonicalMap` and instead just use method level map (that gets initialized each time) in the `tryCanonicalize` method (thus requiring no locks/synchronization). I ran a JMH benchmark with the current change proposed in this PR and with the alternate approach of using the method level map. The performance number from that run showed that the approach of using the method level map has relatively big impact on performance (even when there's a cache hit in that method). So I decided to not pursue that approach. I'll include the benchmark code and the numbers in a comment in this PR, for reference.

The commit in this PR also includes a jtreg testcase which (consistently) reproduces the deadlock without the fix and passes when this fix is applied. Extra manual testing has been done to verify that the classes of interest (noted in that testcase) are indeed getting loaded in those concurrent threads and not in the main thread. For future maintainers, there's a implementation note added on that testcase explaining why it cannot be moved into testng test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263108](https://bugs.openjdk.java.net/browse/JDK-8263108): Class initialization deadlock in java.lang.constant


### Reviewers
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to 3b8e4a5df6a262e152321d701e77cc5e66435443
 * [Peter Levart](https://openjdk.java.net/census#plevart) (@plevart - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2893/head:pull/2893`
`$ git checkout pull/2893`

To update a local copy of the PR:
`$ git checkout pull/2893`
`$ git pull https://git.openjdk.java.net/jdk pull/2893/head`
