### PR TITLE
8213177: GlobalCounter::CSContext could be an enum class

### DIFF
--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -65,12 +65,11 @@ class GlobalCounter : public AllStatic {
 
  public:
 
-
   // The type of the critical section context passed from
   // critical_section_begin() to critical_section_end().
-  enum class CSContext : uintx {}; // [COUNTER_ACTIVE, COUNTER_INCREMENT)
+  enum class CSContext : uintx {}; // (COUNTER_ACTIVE, COUNTER_INCREMENT)
 
-  // Give these access to the private COUNTER_* constants.
+  // Give this access to the private COUNTER_* constants.
   friend struct EnumeratorRange<CSContext>;
 
   // Must be called before accessing the data.  The result must be passed

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -27,7 +27,6 @@
 
 #include "memory/allocation.hpp"
 #include "memory/padded.hpp"
-#include "utilities/enumIterator.hpp"
 
 class Thread;
 

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "memory/padded.hpp"
+#include "utilities/enumIterator.hpp"
 
 class Thread;
 
@@ -63,9 +64,14 @@ class GlobalCounter : public AllStatic {
   class CounterThreadCheck;
 
  public:
+
+
   // The type of the critical section context passed from
   // critical_section_begin() to critical_section_end().
-  typedef uintx CSContext;
+  enum class CSContext : uintx {}; // [COUNTER_ACTIVE, COUNTER_INCREMENT)
+
+  // Give these access to the private COUNTER_* constants.
+  friend struct EnumeratorRange<CSContext>;
 
   // Must be called before accessing the data.  The result must be passed
   // to the associated call to critical_section_end().  Acts as a full
@@ -85,5 +91,9 @@ class GlobalCounter : public AllStatic {
   // A scoped object for a read-side critical-section.
   class CriticalSection;
 };
+
+ENUMERATOR_VALUE_RANGE(GlobalCounter::CSContext,
+                       GlobalCounter::COUNTER_ACTIVE,
+                       GlobalCounter::COUNTER_INCREMENT);
 
 #endif // SHARE_UTILITIES_GLOBALCOUNTER_HPP

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -67,10 +67,7 @@ class GlobalCounter : public AllStatic {
 
   // The type of the critical section context passed from
   // critical_section_begin() to critical_section_end().
-  enum class CSContext : uintx {}; // (COUNTER_ACTIVE, COUNTER_INCREMENT)
-
-  // Give this access to the private COUNTER_* constants.
-  friend struct EnumeratorRange<CSContext>;
+  enum class CSContext : uintx {};
 
   // Must be called before accessing the data.  The result must be passed
   // to the associated call to critical_section_end().  Acts as a full
@@ -90,9 +87,5 @@ class GlobalCounter : public AllStatic {
   // A scoped object for a read-side critical-section.
   class CriticalSection;
 };
-
-ENUMERATOR_VALUE_RANGE(GlobalCounter::CSContext,
-                       GlobalCounter::COUNTER_ACTIVE,
-                       GlobalCounter::COUNTER_INCREMENT);
 
 #endif // SHARE_UTILITIES_GLOBALCOUNTER_HPP


### PR DESCRIPTION
Please review this small change for JDK-8213177.  The change was regression tested with Mach5 tiers 1 and 2 on Linux, Windows, and Mac OS, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213177](https://bugs.openjdk.java.net/browse/JDK-8213177): GlobalCounter::CSContext could be an enum class


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2895/head:pull/2895`
`$ git checkout pull/2895`
