### PR TITLE
8261937: LambdaForClassInBaseArchive: SimpleApp$$Lambda$1 missing

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaForClassInBaseArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaForClassInBaseArchive.java
@@ -75,7 +75,7 @@ public class LambdaForClassInBaseArchive extends DynamicArchiveTestBase {
               appClass, "lambda")
             .assertNormalExit(out -> {
                     out.shouldHaveExitValue(0)
-                       .shouldMatch("Archiving hidden SimpleApp[$][$]Lambda[$].*");
+                       .shouldMatch("Archiving hidden SimpleApp[$][$]Lambda[$][\\d+]*");
                 });
 
         // Run with both base and dynamic archives. The SimpleApp class

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaForClassInBaseArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaForClassInBaseArchive.java
@@ -75,7 +75,7 @@ public class LambdaForClassInBaseArchive extends DynamicArchiveTestBase {
               appClass, "lambda")
             .assertNormalExit(out -> {
                     out.shouldHaveExitValue(0)
-                       .shouldContain("Archiving hidden SimpleApp$$Lambda$1");
+                       .shouldMatch("Archiving hidden SimpleApp[$][$]Lambda[$].*");
                 });
 
         // Run with both base and dynamic archives. The SimpleApp class


### PR DESCRIPTION
Please review this simple test fix to handle the situation if other lambda proxy classes loaded prior to the one from the test.

The fix passed mach5 tier1 and 2 testing.

Thanks!
Calvin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261937](https://bugs.openjdk.java.net/browse/JDK-8261937): LambdaForClassInBaseArchive: SimpleApp$$Lambda$1 missing 


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 7682a9a09bf911cb7f80ab97d33406b98aa96781
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 7682a9a09bf911cb7f80ab97d33406b98aa96781


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2897/head:pull/2897`
`$ git checkout pull/2897`
