### PR TITLE
8261918: two runtime/cds/appcds/VerifierTest failed with "Unable to use shared archive"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,10 +177,27 @@ public class TestCommon extends CDSTestUtils {
     // name of the base archive to be used for dynamic dump
     private static String tempBaseArchive = null;
 
+    private static void captureVerifyOpts(ArrayList<String> opts, ArrayList<String> verifyOpts) {
+        boolean addedDiagnosticOpt = false;
+        for (String s : opts) {
+            if (s.startsWith("-XX:-BytecodeVerification")) {
+                if (!addedDiagnosticOpt) {
+                    verifyOpts.add("-XX:+UnlockDiagnosticVMOptions");
+                    addedDiagnosticOpt = true;
+                }
+                verifyOpts.add(s);
+            }
+            if (s.startsWith("-Xverify")) {
+                verifyOpts.add(s);
+            }
+        }
+    }
+
     // Create AppCDS archive using appcds options
     public static OutputAnalyzer createArchive(AppCDSOptions opts)
         throws Exception {
         ArrayList<String> cmd = new ArrayList<String>();
+        ArrayList<String> verifyOpts = new ArrayList<String>();
         startNewArchiveName();
 
         for (String p : opts.prefix) cmd.add(p);
@@ -200,11 +217,18 @@ public class TestCommon extends CDSTestUtils {
             opts.archiveName = getCurrentArchiveName();
         }
 
+        captureVerifyOpts(opts.suffix, verifyOpts);
+
         if (DYNAMIC_DUMP) {
             File baseArchive = null;
-            if (tempBaseArchive == null || !(new File(tempBaseArchive)).isFile()) {
+            int size = verifyOpts.size();
+            if (tempBaseArchive == null || !(new File(tempBaseArchive)).isFile() || size > 0) {
                 tempBaseArchive = getNewArchiveName("tempBaseArchive");
-                dumpBaseArchive(tempBaseArchive);
+                if (size == 0) {
+                    dumpBaseArchive(tempBaseArchive);
+                } else {
+                    dumpBaseArchive(tempBaseArchive, verifyOpts.toArray(new String[size]));
+                }
             }
             cmd.add("-Xshare:on");
             cmd.add("-XX:SharedArchiveFile=" + tempBaseArchive);

--- a/test/hotspot/jtreg/runtime/cds/appcds/VerifierTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/VerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,8 @@ public class VerifierTest implements Opcodes {
         "ERROR: class VerifierTestC was loaded unexpectedly";
     static final String MAP_FAIL =
         "shared archive file was created with less restrictive verification setting";
+    static final String MAP_FAIL_VFY_LOCAL =
+        "shared archive file's BytecodeVerificationLocal setting";
     static final String VFY_ERR = "java.lang.VerifyError";
     static final String PASS_RESULT = "Hi, how are you?";
     static final String VFY_INFO_MESSAGE =
@@ -132,7 +134,7 @@ public class VerifierTest implements Opcodes {
 
             // Dump app/ext with -Xverify:remote
             {"app",   VFY_REMOTE, VFY_REMOTE, VFY_ERR},
-            {"app",   VFY_REMOTE, VFY_ALL,    MAP_FAIL},
+            {"app",   VFY_REMOTE, VFY_ALL,    MAP_FAIL_VFY_LOCAL},
             {"app",   VFY_REMOTE, VFY_NONE,   ERR },
             // Dump app/ext with -Xverify:all
             {"app",   VFY_ALL,    VFY_REMOTE, VFY_ERR },
@@ -140,11 +142,11 @@ public class VerifierTest implements Opcodes {
             {"app",   VFY_ALL,    VFY_NONE,   ERR },
             // Dump app/ext with verifier turned off
             {"app",   VFY_NONE,   VFY_REMOTE, VFY_ERR},
-            {"app",   VFY_NONE,   VFY_ALL,    MAP_FAIL},
+            {"app",   VFY_NONE,   VFY_ALL,    MAP_FAIL_VFY_LOCAL},
             {"app",   VFY_NONE,   VFY_NONE,   ERR },
             // Dump sys only with -Xverify:remote
             {"noApp", VFY_REMOTE, VFY_REMOTE, VFY_ERR},
-            {"noApp", VFY_REMOTE, VFY_ALL,    VFY_ERR},
+            {"noApp", VFY_REMOTE, VFY_ALL,    MAP_FAIL_VFY_LOCAL},
             {"noApp", VFY_REMOTE, VFY_NONE,   ERR},
             // Dump sys only with -Xverify:all
             {"noApp", VFY_ALL, VFY_REMOTE,    VFY_ERR},
@@ -152,7 +154,7 @@ public class VerifierTest implements Opcodes {
             {"noApp", VFY_ALL, VFY_NONE,      ERR},
             // Dump sys only with verifier turned off
             {"noApp", VFY_NONE, VFY_REMOTE,   VFY_ERR},
-            {"noApp", VFY_NONE, VFY_ALL,      VFY_ERR},
+            {"noApp", VFY_NONE, VFY_ALL,      MAP_FAIL_VFY_LOCAL},
             {"noApp", VFY_NONE, VFY_NONE,     ERR},
         };
 
@@ -245,7 +247,7 @@ public class VerifierTest implements Opcodes {
 
             // Dump app/ext with -Xverify:remote
             {"app",   VFY_REMOTE, VFY_REMOTE, PASS_RESULT},
-            {"app",   VFY_REMOTE, VFY_ALL,    MAP_FAIL},
+            {"app",   VFY_REMOTE, VFY_ALL,    MAP_FAIL_VFY_LOCAL},
             {"app",   VFY_REMOTE, VFY_NONE,   PASS_RESULT },
             // Dump app/ext with -Xverify:all
             {"app",   VFY_ALL,    VFY_REMOTE, PASS_RESULT },
@@ -253,7 +255,7 @@ public class VerifierTest implements Opcodes {
             {"app",   VFY_ALL,    VFY_NONE,   PASS_RESULT },
             // Dump app/ext with verifier turned off
             {"app",   VFY_NONE,   VFY_REMOTE, PASS_RESULT},
-            {"app",   VFY_NONE,   VFY_ALL,    MAP_FAIL},
+            {"app",   VFY_NONE,   VFY_ALL,    MAP_FAIL_VFY_LOCAL},
             {"app",   VFY_NONE,   VFY_NONE,   PASS_RESULT },
         };
         String prev_dump_setting = "";


### PR DESCRIPTION
In the VerifierTest_*.java, we only dump the static archive once. When the -Xverify setting has changed for the dynamic archive, the static archive cannot be used due to different -Xverify settings in the following check in filemap.cpp:

```
  if (_has_platform_or_app_classes && 
      ((!_verify_local && BytecodeVerificationLocal) || 
       (!_verify_remote && BytecodeVerificationRemote))) { 
    FileMapInfo::fail_continue("The shared archive file was created with less restrictive " 
                  "verification setting than the current setting."); 
    return false; 
  } 
```
The changes in TestCommon.java is to look for the -Xverify options in the input opts.suffix. If there exists -Xverify options and "DYNAMIC_DUMP", it will dump the static archive again using the new -Xverify option(s). 

This change also separates the above condition into 2; the `_has_platform_or_app_classes` should only be tied to `BytecodeVerificationRemote`.

Thanks,
Calvin