### PR TITLE
8259218: (fs) Add links in from overloaded methods in java.nio.file.Files

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -2849,9 +2849,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <blockquote><pre>
+     * <blockquote>{@link
+     * walkFileTree(Path, Set<FileVisitOption>, int, FileVisitor<? super Path>)
      * walkFileTree(start, EnumSet.noneOf(FileVisitOption.class), Integer.MAX_VALUE, visitor)
-     * </pre></blockquote>
+     * }</blockquote>
      * In other words, it does not follow symbolic links, and visits all levels
      * of the file tree.
      *
@@ -2925,9 +2926,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <pre>{@code
-     * Files.newBufferedReader(path, StandardCharsets.UTF_8)
-     * }</pre>
+     * <blockquote>{@link
+     * newBufferedReader(Path, Charset)
+     * newBufferedReader(path, StandardCharsets.UTF_8)
+     * }</blockquote>
      *
      * @param   path
      *          the path to the file
@@ -3006,9 +3008,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <pre>{@code
-     * Files.newBufferedWriter(path, StandardCharsets.UTF_8, options)
-     * }</pre>
+     * <blockquote>{@link
+     * newBufferedWriter(Path, Charset, OpenOption...)
+     * newBufferedWriter(path, StandardCharsets.UTF_8, options)
+     * }</blockquote>
      *
      * @param   path
      *          the path to the file
@@ -3286,8 +3289,8 @@ public final class Files {
      * The method ensures that the file is closed when all content have been read
      * or an I/O error, or other runtime exception, is thrown.
      *
-     * <p> This method is equivalent to:
-     * {@code readString(path, StandardCharsets.UTF_8) }
+     * <p> This method is equivalent to: {@link readString(Path, Charset)
+     * readString(path, StandardCharsets.UTF_8)}.
      *
      * @param   path the path to the file
      *
@@ -3411,9 +3414,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <pre>{@code
-     * Files.readAllLines(path, StandardCharsets.UTF_8)
-     * }</pre>
+     * <blockquote>{@link
+     * readAllLines(Path, Charset)
+     * readAllLines(path, StandardCharsets.UTF_8)
+     * }</blockquote>
      *
      * @param   path
      *          the path to the file
@@ -3569,9 +3573,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <pre>{@code
-     * Files.write(path, lines, StandardCharsets.UTF_8, options);
-     * }</pre>
+     * <blockquote>{@link
+     * write(Path, Iterable<? extends CharSequence>, Charset, OpenOption...)
+     * write(path, lines, StandardCharsets.UTF_8, options)
+     * }</blockquote>
      *
      * @param   path
      *          the path to the file
@@ -3612,8 +3617,9 @@ public final class Files {
      * Characters are encoded into bytes using the
      * {@link StandardCharsets#UTF_8 UTF-8} {@link Charset charset}.
      *
-     * <p> This method is equivalent to:
-     * {@code writeString(path, test, StandardCharsets.UTF_8, options) }
+     * <p> This method is equivalent to: {@link
+     * writeString(Path, CharSequence, Charset, OpenOption...)
+     * writeString(path, csq, StandardCharsets.UTF_8, options)}.
      *
      * @param   path
      *          the path to the file
@@ -3910,9 +3916,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <blockquote><pre>
+     * <blockquote>{@link
+     * walk(Path, int, FileVisitOption...)
      * walk(start, Integer.MAX_VALUE, options)
-     * </pre></blockquote>
+     * }</blockquote>
      * In other words, it visits all levels of the file tree.
      *
      * <p> The returned stream contains references to one or more open directories.
@@ -4171,9 +4178,10 @@ public final class Files {
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
-     * <pre>{@code
-     * Files.lines(path, StandardCharsets.UTF_8)
-     * }</pre>
+     * <blockquote>{@link
+     * lines(Path, Charset)
+     * lines(path, StandardCharsets.UTF_8)
+     * }</blockquote>
      *
      * @apiNote
      * This method must be used within a try-with-resources statement or similar


### PR DESCRIPTION
Please review this proposed change to make it simpler to navigate to a principal method from a convenience method.

This change does not appear to rise to the level of requiring a CSR as it involves changes such as `<pre>invocation</pre>` and `{@code invocation}` to `{@link target invocation}`.