### PR TITLE
8263326: Remove ReceiverTypeData check from serviceability/sa/TestPrintMdo.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@ public class TestPrintMdo {
             expStrMap.put("printmdo -a", List.of(
                 "VirtualCallData",
                 "CounterData",
-                "ReceiverTypeData",
                 "bci",
                 "MethodData",
                 "java/lang/Object"));


### PR DESCRIPTION
See CR for a description of why this change is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263326](https://bugs.openjdk.java.net/browse/JDK-8263326): Remove ReceiverTypeData check from serviceability/sa/TestPrintMdo.java


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2905/head:pull/2905`
`$ git checkout pull/2905`
