### PR TITLE
New Spliterator to evenly split the collection with configurable threshold

### DIFF
--- a/src/java.base/share/classes/java/util/FixedSizeSpliterator.java
+++ b/src/java.base/share/classes/java/util/FixedSizeSpliterator.java
@@ -1,0 +1,46 @@
+package java.base.share.classes.java.util;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+public class FixedSizeSpliterator<T> implements Spliterator<T> {
+    private final T[] values;
+    private int start;
+    private int end;
+    private final int THRESHOLD;
+    public FixedSizeSpliterator(T[] values, int threshold) {
+        this(values, 0, values.length, threshold);
+    }
+    public FixedSizeSpliterator(T[] values, int start, int end, int threshold) {
+        this.values = values;
+        this.start = start;
+        this.end = end;
+        this.THRESHOLD = threshold;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer action) {
+        if(start< end){
+            action.accept(values[start++]);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Spliterator trySplit() {
+        if(end - start < THRESHOLD){
+            return null;
+        }
+        int mid = start + (end - start)/2;
+        return new FixedSizeSpliterator(values, start, start= mid+1, THRESHOLD);
+    }
+
+    @Override
+    public long estimateSize() {
+        return end - start;
+    }
+
+    @Override
+    public int characteristics() {
+        return ORDERED | SIZED | SUBSIZED | NONNULL;
+    }
+}


### PR DESCRIPTION
## Backkground

The existing default Spliterator implementation would unevenly split the collection by a multiplier of 1024.

https://github.com/openjdk/jdk/blob/d234388042e00f6933b4d723614ef42ec41e0c25/src/java.base/share/classes/java/util/Spliterators.java#L1777

This will cause an issue if the collection size for example is less than 1024, then would result in single thread to process the whole collection.

## Changes

This PR would provide a new Spliterator implementation, which would always evenly distribute among the threads. 
At the same time, the batch size can be configured (by setting up the THRESHOLD). This will add a great convenience when it's needed to batch the parallel processing by size.

For example, for protobuf serialization and deserialization, there is a hard limit of 2GB for file size. If each record in the collection we know is around 10KB, then we can configure the THRESHOLD in FixedSizeSpliterator to be 200_000 to batch process the records into different files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2907/head:pull/2907`
`$ git checkout pull/2907`
