### PR TITLE
8263248: IGV: accept graphs without node categories

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/nbproject/project.xml
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/nbproject/project.xml
@@ -22,6 +22,14 @@
                         <specification-version>1.0</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.14.1</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <public-packages/>
         </data>


### PR DESCRIPTION
Currently, IGV fails if the input graphs do not contain node category information (added in JDK 17). This change replaces the failing assertion with a warning message in the log file, to support using the latest IGV on graphs generated before JDK 17.

Tested manually on graphs generated [from JDK 11](https://bugs.openjdk.java.net/secure/attachment/93600/from-jdk-11.zip) and [from JDK 17](https://bugs.openjdk.java.net/secure/attachment/93601/from-jdk-17.zip).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263248](https://bugs.openjdk.java.net/browse/JDK-8263248): IGV: accept graphs without node categories


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2909/head:pull/2909`
`$ git checkout pull/2909`
