### PR TITLE
8263353: assert(CompilerOracle::option_matches_type(option, value)) failed: Value must match option type

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -781,7 +781,13 @@ void CompilerOracle::parse_from_line(char* line) {
           print_parse_error(error_buf, original.get());
           return;
         }
-        register_command(typed_matcher, option, true);
+        if (option2type(option) == OptionType::Bool) {
+          register_command(typed_matcher, option, true);
+        } else {
+          jio_snprintf(error_buf, sizeof(error_buf), "  Option '%s' is not a boolean type", option2name(option));
+          print_parse_error(error_buf, original.get());
+          return;
+        }
       }
       assert(typed_matcher != NULL, "sanity");
       assert(*error_buf == '\0', "No error here");

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -784,7 +784,8 @@ void CompilerOracle::parse_from_line(char* line) {
         if (option2type(option) == OptionType::Bool) {
           register_command(typed_matcher, option, true);
         } else {
-          jio_snprintf(error_buf, sizeof(error_buf), "  Option '%s' is not a boolean type", option2name(option));
+          jio_snprintf(error_buf, sizeof(error_buf), "  Missing type '%s' before option '%s'",
+                       optiontype2name(option2type(option)), option2name(option));
           print_parse_error(error_buf, original.get());
           return;
         }

--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -23,7 +23,7 @@
 
 /*
  * @test TestInvalidCompileCommand
- * @bug 8263206
+ * @bug 8263206 8263353
  * @summary Regression tests of -XX:CompileCommand
  * @library /test/lib
  * @run driver compiler.oracle.TestInvalidCompileCommand
@@ -52,7 +52,7 @@ public class TestInvalidCompileCommand {
             "Unrecognized option 'unknown'"
         },
         {
-            "Option 'TestOptionDouble' is not a boolean type"
+            "Missing type 'double' before option 'TestOptionDouble'"
         }
     };
 

--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -44,6 +44,22 @@ public class TestInvalidCompileCommand {
         {
             "-XX:CompileCommand=option,Test::test,TestOptionDouble,3.14",
             "-version"
+        },
+        {
+            "-XX:CompileCommand=option,Test::test,TestOptionInt,3",
+            "-version"
+        },
+        {
+            "-XX:CompileCommand=option,Test::test,TestOptionUint,3",
+            "-version"
+        },
+        {
+            "-XX:CompileCommand=option,Test::test,TestOptionStr,hello",
+            "-version"
+        },
+        {
+            "-XX:CompileCommand=option,Test::test,TestOptionList,hello,world",
+            "-version"
         }
     };
 
@@ -53,6 +69,18 @@ public class TestInvalidCompileCommand {
         },
         {
             "Missing type 'double' before option 'TestOptionDouble'"
+        },
+        {
+            "Missing type 'intx' before option 'TestOptionInt'"
+        },
+        {
+            "Missing type 'uintx' before option 'TestOptionUint'"
+        },
+        {
+            "Missing type 'ccstr' before option 'TestOptionStr'"
+        },
+        {
+            "Missing type 'ccstrlist' before option 'TestOptionList'"
         }
     };
 

--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -40,12 +40,19 @@ public class TestInvalidCompileCommand {
         {
             "-XX:CompileCommand=unknown",
             "-version"
+        },
+        {
+            "-XX:CompileCommand=option,Test::test,TestOptionDouble,3.14",
+            "-version"
         }
     };
 
     private static final String[][] OUTPUTS = {
         {
             "Unrecognized option 'unknown'"
+        },
+        {
+            "Option 'TestOptionDouble' is not a boolean type"
         }
     };
 


### PR DESCRIPTION
Hi all,

The following assert fired while parsing -XX:CompileCommand=option,Test::test,TestOptionDouble,3.14.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/jvm/jdk/src/hotspot/share/compiler/compilerOracle.cpp:288), pid=9522, tid=9523
#  assert(CompilerOracle::option_matches_type(option, value)) failed: Value must match option type
#
```

It would be better to fix it.

Testing:
  - tier1~tier3 on Linux/x64, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263353](https://bugs.openjdk.java.net/browse/JDK-8263353): assert(CompilerOracle::option_matches_type(option, value)) failed: Value must match option type


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to f1ed4da316c1d1b2dc5d307d638e429f5e58aebd
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2910/head:pull/2910`
`$ git checkout pull/2910`
