### PR TITLE
JDK-8263362: Avoid division by 0 in java/awt/font/TextJustifier.java justify

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextJustifier.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextJustifier.java
@@ -155,7 +155,10 @@ class TextJustifier {
             boolean absorbing = hitLimit && absorbweight > 0;
 
             // predivide delta by weight
-            float weightedDelta = delta / weight; // not used if weight == 0
+            float weightedDelta = 0;
+            if (weight != 0) { // not used if weight == 0
+                weightedDelta = delta / weight;
+            }
 
             float weightedAbsorb = 0;
             if (hitLimit && absorbweight > 0) {

--- a/src/java.desktop/share/classes/java/awt/font/TextJustifier.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextJustifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ class TextJustifier {
             }
 
             float weightedAbsorb = 0;
-            if (hitLimit && absorbweight > 0) {
+            if (hitLimit && absorbweight != 0) {
                 weightedAbsorb = (delta - gslimit) / absorbweight;
             }
 


### PR DESCRIPTION
In java/awt/font/TextJustifier.java justify-method there is a potential code path where divison by zero might happen , see also the Sonar finding 
https://sonarcloud.io/project/issues?id=shipilev_jdk&open=AXcqMwpm8sPJZZzONu1k&resolved=false&severities=CRITICAL&types=BUG


            boolean hitLimit = (weight == 0) || (!lastPass && ((delta < 0) == (delta < gslimit)));
            boolean absorbing = hitLimit && absorbweight > 0;
            // predivide delta by weight
            float weightedDelta = delta / weight; // not used if weight == 0

In case of (weight == 0) the division should not be done because the value of weightedDelta is unused in this case anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263362](https://bugs.openjdk.java.net/browse/JDK-8263362): Avoid division by 0 in  java/awt/font/TextJustifier.java justify


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2912/head:pull/2912` \
`$ git checkout pull/2912`

Update a local copy of the PR: \
`$ git checkout pull/2912` \
`$ git pull https://git.openjdk.java.net/jdk pull/2912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2912`

View PR using the GUI difftool: \
`$ git pr show -t 2912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2912.diff">https://git.openjdk.java.net/jdk/pull/2912.diff</a>

</details>
