### PR TITLE
8263380: Unintended use of Objects.nonNull in VarHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -360,9 +360,9 @@ final class VarHandles {
     }
 
     public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
-        Objects.nonNull(target);
-        Objects.nonNull(filterToTarget);
-        Objects.nonNull(filterFromTarget);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(filterToTarget);
+        Objects.requireNonNull(filterFromTarget);
         //check that from/to filters do not throw checked exceptions
         noCheckedExceptions(filterToTarget);
         noCheckedExceptions(filterFromTarget);
@@ -459,8 +459,8 @@ final class VarHandles {
     }
 
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
-        Objects.nonNull(target);
-        Objects.nonNull(filters);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(filters);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -488,8 +488,8 @@ final class VarHandles {
     }
 
     public static VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
-        Objects.nonNull(target);
-        Objects.nonNull(values);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(values);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -517,9 +517,9 @@ final class VarHandles {
     }
 
     public static VarHandle permuteCoordinates(VarHandle target, List<Class<?>> newCoordinates, int... reorder) {
-        Objects.nonNull(target);
-        Objects.nonNull(newCoordinates);
-        Objects.nonNull(reorder);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(newCoordinates);
+        Objects.requireNonNull(reorder);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         MethodHandles.permuteArgumentChecks(reorder,
@@ -565,8 +565,8 @@ final class VarHandles {
     }
 
     public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
-        Objects.nonNull(target);
-        Objects.nonNull(filter);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(filter);
         noCheckedExceptions(filter);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
@@ -587,8 +587,8 @@ final class VarHandles {
     }
 
     public static VarHandle dropCoordinates(VarHandle target, int pos, Class<?>... valueTypes) {
-        Objects.nonNull(target);
-        Objects.nonNull(valueTypes);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(valueTypes);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos > targetCoordinates.size()) {


### PR DESCRIPTION
Use requireNonNull instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263380](https://bugs.openjdk.java.net/browse/JDK-8263380): Unintended use of Objects.nonNull in VarHandles


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2914/head:pull/2914`
`$ git checkout pull/2914`
