### PR TITLE
8263395: Incorrect use of Objects.nonNull

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -436,7 +436,7 @@ public final class Recording implements Closeable {
          * @since 14
          */
         /*package private*/ void setFlushInterval(Duration interval) {
-            Objects.nonNull(interval);
+            Objects.requireNonNull(interval);
             if (interval.isNegative()) {
                 throw new IllegalArgumentException("Stream interval can't be negative");
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/EventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/EventStream.java
@@ -159,7 +159,7 @@ public interface EventStream extends AutoCloseable {
      *         files in the directory.
      */
     public static EventStream openRepository(Path directory) throws IOException {
-        Objects.nonNull(directory);
+        Objects.requireNonNull(directory);
         AccessControlContext acc = AccessController.getContext();
         return new EventDirectoryStream(acc, directory, FileAccess.UNPRIVILEGED, null, Collections.emptyList());
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -104,7 +104,7 @@ public abstract class AbstractEventStream implements EventStream {
 
     @Override
     public final void setStartTime(Instant startTime) {
-        Objects.nonNull(startTime);
+        Objects.requireNonNull(startTime);
         synchronized (streamConfiguration) {
             if (streamConfiguration.started) {
                 throw new IllegalStateException("Stream is already started");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263395](https://bugs.openjdk.java.net/browse/JDK-8263395): Incorrect use of Objects.nonNull


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2923/head:pull/2923` \
`$ git checkout pull/2923`

Update a local copy of the PR: \
`$ git checkout pull/2923` \
`$ git pull https://git.openjdk.java.net/jdk pull/2923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2923`

View PR using the GUI difftool: \
`$ git pr show -t 2923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2923.diff">https://git.openjdk.java.net/jdk/pull/2923.diff</a>

</details>
