### PR TITLE
8251942: PrintStream specification is not clear which flush method is automatically invoked

### DIFF
--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -39,10 +39,10 @@ import java.nio.charset.UnsupportedCharsetException;
  * {@code IOException}; instead, exceptional situations merely set an
  * internal flag that can be tested via the {@code checkError} method.
  * Optionally, a {@code PrintStream} can be created so as to flush
- * automatically; this means that the {@code flush} method is
- * automatically invoked after a byte array is written, one of the
- * {@code println} methods is invoked, or a newline character or byte
- * ({@code '\n'}) is written.
+ * automatically; this means that the {@code flush} method of the underlying
+ * output stream is automatically invoked after a byte array is written, one
+ * of the {@code append}, {@code print}, or {@code println} methods is invoked,
+ * or a newline character or byte ({@code '\n'}) is written.
  *
  * <p> All characters printed by a {@code PrintStream} are converted into
  * bytes using the given encoding or charset, or the platform's default
@@ -50,8 +50,8 @@ import java.nio.charset.UnsupportedCharsetException;
  * The {@link PrintWriter} class should be used in situations that require
  * writing characters rather than bytes.
  *
- * <p> This class always replaces malformed and unmappable character sequences with
- * the charset's default replacement string.
+ * <p> This class always replaces malformed and unmappable character sequences
+ * with the charset's default replacement string.
  * The {@linkplain java.nio.charset.CharsetEncoder} class should be used when more
  * control over the encoding process is required.
  *
@@ -516,7 +516,7 @@ public class PrintStream extends FilterOutputStream
     /**
      * Writes the specified byte to this stream.  If the byte is a newline and
      * automatic flushing is enabled then the {@code flush} method will be
-     * invoked.
+     * invoked on the underlying output stream.
      *
      * <p> Note that the byte is written as given; to write a character that
      * will be translated according to the platform's default character
@@ -548,7 +548,8 @@ public class PrintStream extends FilterOutputStream
     /**
      * Writes {@code len} bytes from the specified byte array starting at
      * offset {@code off} to this stream.  If automatic flushing is
-     * enabled then the {@code flush} method will be invoked.
+     * enabled then the {@code flush} method will be invoked on the underlying
+     * output stream.
      *
      * <p> Note that the bytes will be written as given; to write characters
      * that will be translated according to the platform's default character
@@ -580,7 +581,7 @@ public class PrintStream extends FilterOutputStream
     /**
      * Writes all bytes from the specified byte array to this stream. If
      * automatic flushing is enabled then the {@code flush} method will be
-     * invoked.
+     * invoked on the underlying output stream.
      *
      * <p> Note that the bytes will be written as given; to write characters
      * that will be translated according to the platform's default character

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -41,8 +41,8 @@ import java.nio.charset.UnsupportedCharsetException;
  * Optionally, a {@code PrintStream} can be created so as to flush
  * automatically; this means that the {@code flush} method of the underlying
  * output stream is automatically invoked after a byte array is written, one
- * of the {@code append}, {@code print}, or {@code println} methods is invoked,
- * or a newline character or byte ({@code '\n'}) is written.
+ * of the {@code println} methods is invoked, or a newline character or byte
+ * ({@code '\n'}) is written.
  *
  * <p> All characters printed by a {@code PrintStream} are converted into
  * bytes using the given encoding or charset, or the platform's default


### PR DESCRIPTION
Please review this minor change to the specification of `java.io.PrintStream`. The longstanding behavior for flushing is to invoke the `flush()` method of the underlying `OutputStream` rather than its override but this was not made explicit in the specification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251942](https://bugs.openjdk.java.net/browse/JDK-8251942): PrintStream specification is not clear which flush method is automatically invoked


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2926/head:pull/2926`
`$ git checkout pull/2926`

To update a local copy of the PR:
`$ git checkout pull/2926`
`$ git pull https://git.openjdk.java.net/jdk pull/2926/head`
