### PR TITLE
8262080: vmTestbase/nsk/jdi/Event/request/request001/TestDescription.java failed with "ERROR: new event is not ThreadStartEvent"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,7 +355,7 @@ public class request001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadStartEvent");
-            getEventSet();
+            waitThreadStart("thread2");
             eventSets[10] = eventSet;
 
             Event receivedEvent = eventIterator.nextEvent();
@@ -370,7 +370,7 @@ public class request001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadDeathEvent");
-            getEventSet();
+            waitThreadDeath("thread2");
             eventSets[9] = eventSet;
             receivedEvent = eventIterator.nextEvent();
             if ( !(receivedEvent instanceof ThreadDeathEvent) ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -355,7 +355,7 @@ public class request001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadStartEvent");
-            waitThreadStart("thread2");
+            getEventSetForThreadStartDeath("thread2");
             eventSets[10] = eventSet;
 
             Event receivedEvent = eventIterator.nextEvent();
@@ -370,7 +370,7 @@ public class request001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadDeathEvent");
-            waitThreadDeath("thread2");
+            getEventSetForThreadStartDeath("thread2");
             eventSets[9] = eventSet;
             receivedEvent = eventIterator.nextEvent();
             if ( !(receivedEvent instanceof ThreadDeathEvent) ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -161,15 +161,13 @@ public class JDIBase {
         while (!gotDesiredEvent) {
             getEventSet();
             Event event = eventIterator.nextEvent();
-            if (event instanceof ThreadStartEvent) {
-                ThreadStartEvent evt = (ThreadStartEvent)event;
+            if (event instanceof ThreadStartEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
                     gotDesiredEvent = true;
                 } else {
                     log2("Got ThreadStartEvent for wrong thread: " + event);
                 }
-            } else if (event instanceof ThreadDeathEvent) {
-                ThreadDeathEvent evt = (ThreadDeathEvent)event;
+            } else if (event instanceof ThreadDeathEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
                     gotDesiredEvent = true;
                 } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -153,9 +153,10 @@ public class JDIBase {
     }
 
     // Special version of getEventSet for ThreadStartEvent/ThreadDeathEvent.
-    // When ThreadStartRequest and/or ThreadDeathRequest are enabled, we can get the events from system threads
-    // unexpected for tests.
-    // The method skips ThreadStartEvent/ThreadDeathEvent events for all threads except the expected one.
+    // When ThreadStartRequest and/or ThreadDeathRequest are enabled,
+    // we can get the events from system threads unexpected for tests.
+    // The method skips ThreadStartEvent/ThreadDeathEvent events
+    // for all threads except the expected one.
     protected void getEventSetForThreadStartDeath(String threadName) throws JDITestRuntimeException {
         boolean gotDesiredEvent = false;
         while (!gotDesiredEvent) {


### PR DESCRIPTION
The fix updates the test to skip ThreadStartEvent/ThreadDeathEvent from other threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262080](https://bugs.openjdk.java.net/browse/JDK-8262080): vmTestbase/nsk/jdi/Event/request/request001/TestDescription.java failed with "ERROR: new event is not ThreadStartEvent"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2927/head:pull/2927`
`$ git checkout pull/2927`
