### PR TITLE
8263403: [JVMCI] output written to tty via HotSpotJVMCIRuntime can be garbled

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -920,7 +920,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
             Unsafe unsafe = UnsafeAccess.UNSAFE;
             long buffer = unsafe.allocateMemory(length);
             try {
-                unsafe.copyMemory(bytes, vm.ARRAY_BYTE_BASE_OFFSET, null, buffer, length);
+                unsafe.copyMemory(bytes, Unsafe.ARRAY_BYTE_BASE_OFFSET, null, buffer, length);
                 vm.writeDebugOutput(buffer, length, flush);
             } finally {
                 unsafe.freeMemory(buffer);


### PR DESCRIPTION
The HotSpotJVMCIRuntime.writeDebugOutput0 method introduced in JDK-8262011 uses the HotSpot value of Unsafe.ARRAY_BYTE_BASE_OFFSET which is incorrect in the context of libgraal where the SVM value should be used instead. This results in garbled output being written to tty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263403](https://bugs.openjdk.java.net/browse/JDK-8263403): [JVMCI] output written to tty via HotSpotJVMCIRuntime can be garbled


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2928/head:pull/2928`
`$ git checkout pull/2928`
