### PR TITLE
8252833: Correct "no comment" warnings from javadoc in java.smartcardio module

### DIFF
--- a/make/modules/java.smartcardio/Java.gmk
+++ b/make/modules/java.smartcardio/Java.gmk
@@ -23,5 +23,5 @@
 # questions.
 #
 
-DOCLINT += -Xdoclint:all/protected,-accessibility \
+DOCLINT += -Xdoclint:all/protected,-accessibility,-missing \
     '-Xdoclint/package:java.*,javax.*'

--- a/make/modules/java.smartcardio/Java.gmk
+++ b/make/modules/java.smartcardio/Java.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Disable the "missing" target for java.smartcardio from doclint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252833](https://bugs.openjdk.java.net/browse/JDK-8252833): Correct "no comment" warnings from javadoc in java.smartcardio module


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2930/head:pull/2930`
`$ git checkout pull/2930`
