### PR TITLE
8263410: ListModel javadoc refers to non-existent interface

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/ListModel.java
@@ -31,7 +31,7 @@ import javax.swing.event.ListDataListener;
  * This interface defines the methods components like JList use
  * to get the value of each cell in a list and the length of the list.
  * Logically the model is a vector, indices vary from 0 to
- * ListDataModel.getSize() - 1.  Any change to the contents or
+ * ListModel.getSize() - 1.  Any change to the contents or
  * length of the data model must be reported to all of the
  * ListDataListeners.
  *

--- a/src/java.desktop/share/classes/javax/swing/ListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/ListModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
ListModel class javadoc refers to ListDataModel interface but there is no ListDataModel interface. Rectified the anomaly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263410](https://bugs.openjdk.java.net/browse/JDK-8263410): ListModel javadoc refers to non-existent interface


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2931/head:pull/2931`
`$ git checkout pull/2931`
