### PR TITLE
8263420: Incorrect function name in NSAccessibilityStaticText native peer implementation

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -34,7 +34,7 @@
 @interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
 
 };
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range;
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
 - (nullable NSString *)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -27,7 +27,7 @@
 
 @implementation StaticTextAccessibility
 
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range
 {
     return [self accessibilityStringForRangeAttribute:range];
 }


### PR DESCRIPTION
The implementation of NSAccessibilityStaticText protocol (https://developer.apple.com/documentation/appkit/nsaccessibilitystatictext) has an incorrect function name which results in the function not being called by Voice Over. The Voice Over output is not getting affected by this bug as the accessibilityValue function returns the correct label value and Voice Over output is correct in all the Label test cases which were tested while implementing the NSAccessibilityStaticText, like few cases in this in following demo. This is the reason that this issue was not caught in testing. (https://docs.oracle.com/javase/tutorial/uiswing/examples/components/LabelDemoProject/src/components/LabelDemo.java).

Though it does not seem to cause any issue as of now and I still could not find a testcase where it is causing any difference in Voice Over output, this may create problem in future. The functions is getting called by Voice Over after this fix, so this should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263420](https://bugs.openjdk.java.net/browse/JDK-8263420): Incorrect function name in NSAccessibilityStaticText native peer implementation


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2933/head:pull/2933`
`$ git checkout pull/2933`
