### PR TITLE
8263436: Silly array comparison in GaloisCounterMode.overlapDetection

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -972,7 +972,7 @@ final class GaloisCounterMode extends FeedbackCipher {
         } else if (!src.isDirect() && !dst.isDirect()) {
             if (!src.isReadOnly()) {
                 // If using the heap, check underlying byte[] address.
-                if (!src.array().equals(dst.array()) ) {
+                if (src.array() != dst.array()) {
                     return dst;
                 }
 


### PR DESCRIPTION
SonarCloud reports:
  Use "Arrays.equals(array1, array2)" or the "==" operator instead of using the "Object.equals(Object obj)" method.

```
        } else if (!src.isDirect() && !dst.isDirect()) {
            if (!src.isReadOnly()) {
                // If using the heap, check underlying byte[] address.
                if (!src.array().equals(dst.array()) ) { // <--- here
```

Additional testing:
  - [x] Linux x86_64 fastdebug `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263436](https://bugs.openjdk.java.net/browse/JDK-8263436): Silly array comparison in GaloisCounterMode.overlapDetection


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2938/head:pull/2938`
`$ git checkout pull/2938`
