### PR TITLE
8263446: Avoid unary minus over unsigned type in ObjectSynchronizer::dec_in_use_list_ceiling

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1113,7 +1113,7 @@ size_t ObjectSynchronizer::in_use_list_ceiling() {
 }
 
 void ObjectSynchronizer::dec_in_use_list_ceiling() {
-  Atomic::add(&_in_use_list_ceiling, -AvgMonitorsPerThreadEstimate);
+  Atomic::sub(&_in_use_list_ceiling, AvgMonitorsPerThreadEstimate);
 }
 
 void ObjectSynchronizer::inc_in_use_list_ceiling() {


### PR DESCRIPTION
SonarCloud complains:
  Unary minus should not be applied to an unsigned expression

Here:

```
void ObjectSynchronizer::dec_in_use_list_ceiling() {
  Atomic::add(&_in_use_list_ceiling, -AvgMonitorsPerThreadEstimate);
}
```

We can instead use `Atomic::sub`.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot:tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263446](https://bugs.openjdk.java.net/browse/JDK-8263446): Avoid unary minus over unsigned type in ObjectSynchronizer::dec_in_use_list_ceiling


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2939/head:pull/2939`
`$ git checkout pull/2939`
