### PR TITLE
8263465: JDK-8236847 causes tier1 build failure on linux-aarch64

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -598,7 +598,7 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_COMPATIBLE_CDS_ALIGNMENT],
       CHECKING_MSG: [if compatible cds region alignment enabled],
       CHECK_AVAILABLE: [
         AC_MSG_CHECKING([if CDS archive is available])
-        if test "x$BUILD_CDS_ARCHIVE" = "xfalse"; then
+        if test "x$ENABLE_CDS" = "xfalse"; then
           AVAILABLE=false
           AC_MSG_RESULT([no (CDS is disabled)])
         else


### PR DESCRIPTION
Hi, Please review

  JDK-8236847 changes failed on build linux-aarch64 on xcross build. The reason is we check BUILD_CDS_ARCHIVE which is not correct in such case. We should check ENABLE_CDS instead.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263465](https://bugs.openjdk.java.net/browse/JDK-8263465): JDK-8236847 causes tier1 build failure on linux-aarch64


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2946/head:pull/2946`
`$ git checkout pull/2946`
