### PR TITLE
8263460: DynamicArchiveRelocationTest.java fails in product VM

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -37,6 +37,9 @@
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicArchiveRelocationTest
  */
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 
@@ -87,18 +90,12 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
         String topArchiveName  = getNewArchiveName("top");
 
         String runtimeMsg = "Try to map archive(s) at an alternative address";
-        String runtimeRelocMsg = "runtime archive relocation start";
-        String unmapPrefix = ".*Unmapping region #3 at base 0x.*";
-        String unmapPattern = unmapPrefix + "(Bitmap)";
-        String archiveRelocPattern = ".*ArchiveRelocationMode == 1.*";
-        String unmapRgn1Pattern = ".*Unmapping region #1 at base 0x.*";
-        String unmapRgn0Pattern = ".*Unmapping region #0 at base 0x.*(ReadWrite)";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
 
         // (1) Dump base archive (static)
 
-        OutputAnalyzer out = TestCommon.dumpBaseArchive(baseArchiveName, unlockArg, logArg);
-        out.shouldContain("Relocating archive from");
+        TestCommon.dumpBaseArchive(baseArchiveName, unlockArg, logArg)
+          .shouldContain("Relocating archive from");
 
         // (2) Dump top archive (dynamic)
 
@@ -121,19 +118,41 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                     if (run_reloc) {
                         output.shouldContain(runtimeMsg);
-                        try {
-                            output.shouldContain(runtimeRelocMsg)
-                                  // Check that there are two of the following lines in
-                                  // the output. One for static archive and one for
-                                  // dynamic archive:
-                                  // Unmapping region #3 at base 0x<hex digits> (Bitmap)
-                                  .shouldMatchByLine(unmapPrefix, "Hello World", unmapPattern);
-                        } catch(java.lang.RuntimeException ex) {
-                            // On Windows, sometimes the OS picks the same archive
-                            // base address even with ArchiveRelcationMode=1. In
-                            // this case, runtime relocation won't happen. Checking
-                            // for "Unmapping region #0" messages instead.
-                            output.shouldMatchByLine(archiveRelocPattern, unmapRgn1Pattern, unmapRgn0Pattern);
+                        if (Platform.isDebugBuild()) {
+                            // In debug builds, we try to thoroughly test unmapping: if ArchiveRelocationMode
+                            // is 1, we always map all the regions at the requested address first, and then unmap
+                            // them, and then map them again at an alternative. Let's check that
+                            // this logic is indeed performed. We expect output like this:
+                            //
+                            // ArchiveRelocationMode == 1: always map archive(s) at an alternative address
+                            // Unmapping region #0 at base 0x0000000800000000 (ReadWrite)
+                            // Unmapping region #1 at base 0x0000000800492000 (ReadOnly)
+                            // Unmapping region #0 at base 0x0000000800c2b000 (ReadWrite)
+                            // Unmapping region #1 at base 0x0000000800c2c000 (ReadOnly)
+                            // Released shared space (archive + class) 0x0000000800000000
+                            // Try to map archive(s) at an alternative address
+                            // Reserved archive_space_rs [0x00007f63cb000000 - 0x00007f63cc000000] (16777216) bytes
+                            // Reserved class_space_rs   [0x00007f63cc000000 - 0x00007f640c000000] (1073741824) bytes
+                            // Mapped static  region #0 at base 0x00007f63cb000000 top 0x00007f63cb492000 (ReadWrite)
+                            // Mapped static  region #1 at base 0x00007f63cb492000 top 0x00007f63cbc2b000 (ReadOnly)
+                            // runtime archive relocation start
+
+                            String archiveRelocPattern = "ArchiveRelocationMode == 1.*";
+                            String unmapRgn1Pattern    = "Unmapping region #1 at base 0x.*";
+                            String unmapRgn0Pattern    = "Unmapping region #0 at base 0x.*";
+                            String runtimeRelocMsg     = "runtime archive relocation start";
+                            String regexp = archiveRelocPattern +
+                                            unmapRgn0Pattern + // unmap static #0
+                                            unmapRgn1Pattern + // unmap static #1
+                                            unmapRgn0Pattern + // unmap dynamic #0
+                                            unmapRgn1Pattern + // unmap dynamic #1
+                                            runtimeRelocMsg;
+                            Pattern pattern = Pattern.compile(regexp, Pattern.MULTILINE | Pattern.DOTALL);
+                            Matcher stdoutMatcher = pattern.matcher(output.getStdout());
+                            if (!stdoutMatcher.find()) {
+                                throw new RuntimeException("'" + regexp
+                                                           + "' missing from stdout\n");
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
Please review this test bug. 

The handling of -XX:ArchiveRelocationMode=1 is different between fastdebug and product builds:

- fastdebug: (to improve test coverage) -- we always map at the default location, then unmap, and then map again at a random location.
- product: (for faster performance) -- don't attempt to map at the default location. Just map at random location

Therefore, the "unmap" messages are not available in product mode.

I added comments to explain what output is expected, and rearranged the regexp for better matching.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263460](https://bugs.openjdk.java.net/browse/JDK-8263460): DynamicArchiveRelocationTest.java fails in product VM


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 27dfc7c593e4e28926a2330e44f5b2e22b89319d
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2947/head:pull/2947`
`$ git checkout pull/2947`
