### PR TITLE
JDK-8263467: Incorrect double-checked locking in sun.java2d.CRenderer

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/CRenderer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/CRenderer.java
@@ -49,23 +49,26 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawLine(sg2d, (float) x1, (float) y1, (float) x2, (float) y2);
     }
 
-    Line2D lineToShape;
+    volatile Line2D lineToShape;
 
     public void drawLine(SunGraphics2D sg2d, float x1, float y1, float x2, float y2) {
         OSXSurfaceData surfaceData = (OSXSurfaceData) sg2d.getSurfaceData();
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doLine(this, sg2d, x1, y1, x2, y2);
         } else {
-            if (lineToShape == null) {
+            Line2D lts = lineToShape;
+            if (lts == null) {
                 synchronized (this) {
-                    if (lineToShape == null) {
-                        lineToShape = new Line2D.Float();
+                    lts = lineToShape;
+                    if (lts == null) {
+                        lts = new Line2D.Float();
+                        lineToShape = lts;
                     }
                 }
             }
-            synchronized (lineToShape) {
-                lineToShape.setLine(x1, y1, x2, y2);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(lineToShape), true, true);
+            synchronized (lts) {
+                lts.setLine(x1, y1, x2, y2);
+                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(lts), true, true);
             }
         }
     }
@@ -76,7 +79,7 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawRect(sg2d, (float) x, (float) y, (float) width, (float) height);
     }
 
-    Rectangle2D rectToShape;
+    volatile Rectangle2D rectToShape;
 
     public void drawRect(SunGraphics2D sg2d, float x, float y, float width, float height) {
         if ((width < 0) || (height < 0)) return;
@@ -85,16 +88,19 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doRect(this, sg2d, x, y, width, height, false);
         } else {
-            if (rectToShape == null) {
+            Rectangle2D rts = rectToShape;
+            if (rts == null) {
                 synchronized (this) {
-                    if (rectToShape == null) {
-                        rectToShape = new Rectangle2D.Float();
+                    rts = rectToShape;
+                    if (rts == null) {
+                        rts = new Rectangle2D.Float();
+                        rectToShape = rts;
                     }
                 }
             }
-            synchronized (rectToShape) {
-                rectToShape.setRect(x, y, width, height);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rectToShape), true, true);
+            synchronized (rts) {
+                rts.setRect(x, y, width, height);
+                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rts), true, true);
             }
         }
     }
@@ -116,7 +122,7 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawRoundRect(sg2d, (float) x, (float) y, (float) width, (float) height, (float) arcWidth, (float) arcHeight);
     }
 
-    RoundRectangle2D roundrectToShape;
+    volatile RoundRectangle2D roundrectToShape;
 
     public void drawRoundRect(SunGraphics2D sg2d, float x, float y, float width, float height, float arcWidth, float arcHeight) {
         if ((width < 0) || (height < 0)) return;
@@ -125,16 +131,19 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doRoundRect(this, sg2d, x, y, width, height, arcWidth, arcHeight, false);
         } else {
-            if (roundrectToShape == null) {
+            RoundRectangle2D rts = roundrectToShape;
+            if (rts == null) {
                 synchronized (this) {
-                    if (roundrectToShape == null) {
-                        roundrectToShape = new RoundRectangle2D.Float();
+                    rts = roundrectToShape;
+                    if (rts == null) {
+                        rts = new RoundRectangle2D.Float();
+                        roundrectToShape = rts;
                     }
                 }
             }
-            synchronized (roundrectToShape) {
-                roundrectToShape.setRoundRect(x, y, width, height, arcWidth, arcHeight);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(roundrectToShape), true, true);
+            synchronized (rts) {
+                rts.setRoundRect(x, y, width, height, arcWidth, arcHeight);
+                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rts), true, true);
             }
         }
     }
@@ -155,7 +164,7 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawOval(sg2d, (float) x, (float) y, (float) width, (float) height);
     }
 
-    Ellipse2D ovalToShape;
+    volatile Ellipse2D ovalToShape;
 
     public void drawOval(SunGraphics2D sg2d, float x, float y, float width, float height) {
         if ((width < 0) || (height < 0)) return;
@@ -164,16 +173,19 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doOval(this, sg2d, x, y, width, height, false);
         } else {
-            if (ovalToShape == null) {
+            Ellipse2D ots = ovalToShape;
+            if (ots == null) {
                 synchronized (this) {
-                    if (ovalToShape == null) {
-                        ovalToShape = new Ellipse2D.Float();
+                    ots = ovalToShape;
+                    if (ots == null) {
+                        ots = new Ellipse2D.Float();
+                        ovalToShape = ots;
                     }
                 }
             }
-            synchronized (ovalToShape) {
-                ovalToShape.setFrame(x, y, width, height);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ovalToShape), true, true);
+            synchronized (ots) {
+                ots.setFrame(x, y, width, height);
+                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ots), true, true);
             }
         }
     }
@@ -194,7 +206,7 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawArc(sg2d, x, y, width, height, startAngle, arcAngle, Arc2D.OPEN);
     }
 
-    Arc2D arcToShape;
+    volatile Arc2D arcToShape;
 
     public void drawArc(SunGraphics2D sg2d, float x, float y, float width, float height, float startAngle, float arcAngle, int type) {
         if ((width < 0) || (height < 0)) return;
@@ -203,16 +215,19 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doArc(this, sg2d, x, y, width, height, startAngle, arcAngle, type, false);
         } else {
-            if (arcToShape == null) {
+            Arc2D ats = arcToShape;
+            if (ats == null) {
                 synchronized (this) {
-                    if (arcToShape == null) {
-                        arcToShape = new Arc2D.Float();
+                    ats = arcToShape;
+                    if (ats == null) {
+                        ats = new Arc2D.Float();
+                        arcToShape = ats;
                     }
                 }
             }
-            synchronized (arcToShape) {
-                arcToShape.setArc(x, y, width, height, startAngle, arcAngle, type);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(arcToShape), true, true);
+            synchronized (ats) {
+                ats.setArc(x, y, width, height, startAngle, arcAngle, type);
+                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ats), true, true);
             }
         }
     }

--- a/src/java.desktop/macosx/classes/sun/java2d/CRenderer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/CRenderer.java
@@ -49,27 +49,13 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawLine(sg2d, (float) x1, (float) y1, (float) x2, (float) y2);
     }
 
-    volatile Line2D lineToShape;
-
     public void drawLine(SunGraphics2D sg2d, float x1, float y1, float x2, float y2) {
         OSXSurfaceData surfaceData = (OSXSurfaceData) sg2d.getSurfaceData();
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doLine(this, sg2d, x1, y1, x2, y2);
         } else {
-            Line2D lts = lineToShape;
-            if (lts == null) {
-                synchronized (this) {
-                    lts = lineToShape;
-                    if (lts == null) {
-                        lts = new Line2D.Float();
-                        lineToShape = lts;
-                    }
-                }
-            }
-            synchronized (lts) {
-                lts.setLine(x1, y1, x2, y2);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(lts), true, true);
-            }
+            Line2D lineToShape = new Line2D.Float(x1, y1, x2, y2);
+            drawfillShape(sg2d, sg2d.stroke.createStrokedShape(lineToShape), true, true);
         }
     }
 
@@ -79,8 +65,6 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawRect(sg2d, (float) x, (float) y, (float) width, (float) height);
     }
 
-    volatile Rectangle2D rectToShape;
-
     public void drawRect(SunGraphics2D sg2d, float x, float y, float width, float height) {
         if ((width < 0) || (height < 0)) return;
 
@@ -88,20 +72,8 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doRect(this, sg2d, x, y, width, height, false);
         } else {
-            Rectangle2D rts = rectToShape;
-            if (rts == null) {
-                synchronized (this) {
-                    rts = rectToShape;
-                    if (rts == null) {
-                        rts = new Rectangle2D.Float();
-                        rectToShape = rts;
-                    }
-                }
-            }
-            synchronized (rts) {
-                rts.setRect(x, y, width, height);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rts), true, true);
-            }
+            Rectangle2D rectToShape = new Rectangle2D.Float(x, y, width, height);
+            drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rectToShape), true, true);
         }
     }
 
@@ -122,8 +94,6 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawRoundRect(sg2d, (float) x, (float) y, (float) width, (float) height, (float) arcWidth, (float) arcHeight);
     }
 
-    volatile RoundRectangle2D roundrectToShape;
-
     public void drawRoundRect(SunGraphics2D sg2d, float x, float y, float width, float height, float arcWidth, float arcHeight) {
         if ((width < 0) || (height < 0)) return;
 
@@ -131,20 +101,8 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doRoundRect(this, sg2d, x, y, width, height, arcWidth, arcHeight, false);
         } else {
-            RoundRectangle2D rts = roundrectToShape;
-            if (rts == null) {
-                synchronized (this) {
-                    rts = roundrectToShape;
-                    if (rts == null) {
-                        rts = new RoundRectangle2D.Float();
-                        roundrectToShape = rts;
-                    }
-                }
-            }
-            synchronized (rts) {
-                rts.setRoundRect(x, y, width, height, arcWidth, arcHeight);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(rts), true, true);
-            }
+            RoundRectangle2D roundrectToShape = new RoundRectangle2D.Float(x, y, width, height, arcWidth, arcHeight);
+            drawfillShape(sg2d, sg2d.stroke.createStrokedShape(roundrectToShape), true, true);
         }
     }
 
@@ -164,8 +122,6 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawOval(sg2d, (float) x, (float) y, (float) width, (float) height);
     }
 
-    volatile Ellipse2D ovalToShape;
-
     public void drawOval(SunGraphics2D sg2d, float x, float y, float width, float height) {
         if ((width < 0) || (height < 0)) return;
 
@@ -173,20 +129,8 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doOval(this, sg2d, x, y, width, height, false);
         } else {
-            Ellipse2D ots = ovalToShape;
-            if (ots == null) {
-                synchronized (this) {
-                    ots = ovalToShape;
-                    if (ots == null) {
-                        ots = new Ellipse2D.Float();
-                        ovalToShape = ots;
-                    }
-                }
-            }
-            synchronized (ots) {
-                ots.setFrame(x, y, width, height);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ots), true, true);
-            }
+            Ellipse2D ovalToShape = new Ellipse2D.Float(x, y, width, height);
+            drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ovalToShape), true, true);
         }
     }
 
@@ -206,8 +150,6 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         drawArc(sg2d, x, y, width, height, startAngle, arcAngle, Arc2D.OPEN);
     }
 
-    volatile Arc2D arcToShape;
-
     public void drawArc(SunGraphics2D sg2d, float x, float y, float width, float height, float startAngle, float arcAngle, int type) {
         if ((width < 0) || (height < 0)) return;
 
@@ -215,20 +157,8 @@ public class CRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe, D
         if ((sg2d.strokeState != SunGraphics2D.STROKE_CUSTOM) && (OSXSurfaceData.IsSimpleColor(sg2d.paint))) {
             surfaceData.doArc(this, sg2d, x, y, width, height, startAngle, arcAngle, type, false);
         } else {
-            Arc2D ats = arcToShape;
-            if (ats == null) {
-                synchronized (this) {
-                    ats = arcToShape;
-                    if (ats == null) {
-                        ats = new Arc2D.Float();
-                        arcToShape = ats;
-                    }
-                }
-            }
-            synchronized (ats) {
-                ats.setArc(x, y, width, height, startAngle, arcAngle, type);
-                drawfillShape(sg2d, sg2d.stroke.createStrokedShape(ats), true, true);
-            }
+            Arc2D arcToShape = new Arc2D.Float(x, y, width, height, startAngle, arcAngle, type);
+            drawfillShape(sg2d, sg2d.stroke.createStrokedShape(arcToShape), true, true);
         }
     }
 


### PR DESCRIPTION
SonarCloud reports multiple incorrect double-checked locking cases in `sun.java2d.CRenderer`. For example:

```
  Arc2D arcToShape;

  ...
            if (arcToShape == null) {
                synchronized (this) {
                    if (arcToShape == null) {
                        arcToShape = new Arc2D.Float();
                    }
                }
            }
```

`Arc2D` contains fields that are not `final`. `arcToShape` is not `volatile`. This makes it an incorrect DCL.
This code is used by Mac OS, do it would probably blow up some time later on M1.

This is the candidate fix that preserves the semantics. I am doing this fix blindly so far, without testing on real Mac OS. But maybe there is no need to do any of this, because the setter methods overwrite the contents of all these objects under their own sync. So, maybe we can just allocate those objects without DCL-backed caching and pass them in?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263467](https://bugs.openjdk.java.net/browse/JDK-8263467): Incorrect double-checked locking in sun.java2d.CRenderer


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/2948/head:pull/2948` \
`$ git checkout pull/2948`

Update a local copy of the PR: \
`$ git checkout pull/2948` \
`$ git pull https://git.openjdk.java.net/jdk pull/2948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2948`

View PR using the GUI difftool: \
`$ git pr show -t 2948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/2948.diff">https://git.openjdk.java.net/jdk/pull/2948.diff</a>

</details>
