### PR TITLE
8263404: RsaPrivateKeySpec is always recognized as RSAPrivateCrtKeySpec in RSAKeyFactory.engineGetKeySpec

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -405,24 +405,19 @@ public class RSAKeyFactory extends KeyFactorySpi {
         } else if (key instanceof RSAPrivateKey) {
             if (keySpec.isAssignableFrom(PKCS8_KEYSPEC_CLS)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
-                if (key instanceof RSAPrivateCrtKey) {
-                    RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
-                    return keySpec.cast(new RSAPrivateCrtKeySpec(
-                        crtKey.getModulus(),
-                        crtKey.getPublicExponent(),
-                        crtKey.getPrivateExponent(),
-                        crtKey.getPrimeP(),
-                        crtKey.getPrimeQ(),
-                        crtKey.getPrimeExponentP(),
-                        crtKey.getPrimeExponentQ(),
-                        crtKey.getCrtCoefficient(),
-                        crtKey.getParams()
-                    ));
-                } else {
-                    throw new InvalidKeySpecException
-                    ("RSAPrivateCrtKeySpec can only be used with CRT keys");
-                }
+            } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS) && key instanceof RSAPrivateCrtKey) {
+                RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
+                return keySpec.cast(new RSAPrivateCrtKeySpec(
+                    crtKey.getModulus(),
+                    crtKey.getPublicExponent(),
+                    crtKey.getPrivateExponent(),
+                    crtKey.getPrimeP(),
+                    crtKey.getPrimeQ(),
+                    crtKey.getPrimeExponentP(),
+                    crtKey.getPrimeExponentQ(),
+                    crtKey.getCrtCoefficient(),
+                    crtKey.getParams()
+                ));
             } else if (keySpec.isAssignableFrom(RSA_PRIV_KEYSPEC_CLS)) {
                 RSAPrivateKey rsaKey = (RSAPrivateKey)key;
                 return keySpec.cast(new RSAPrivateKeySpec(
@@ -430,6 +425,9 @@ public class RSAKeyFactory extends KeyFactorySpi {
                     rsaKey.getPrivateExponent(),
                     rsaKey.getParams()
                 ));
+	    } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
+                throw new InvalidKeySpecException
+                        ("RSAPrivateCrtKeySpec can only be used with CRT keys");
             } else {
                 throw new InvalidKeySpecException
                         ("KeySpec must be RSAPrivate(Crt)KeySpec or "

--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -425,7 +425,7 @@ public class RSAKeyFactory extends KeyFactorySpi {
                     rsaKey.getPrivateExponent(),
                     rsaKey.getParams()
                 ));
-	    } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
+            } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
                 throw new InvalidKeySpecException
                         ("RSAPrivateCrtKeySpec can only be used with CRT keys");
             } else {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -282,12 +282,12 @@ final class P11RSAKeyFactory extends P11KeyFactory {
         }
         // If the key is both extractable and not sensitive, then when it was converted into a P11Key
         // it was also converted into subclass of RSAPrivateKey which encapsulates all of the logic
-        // necessary to retrive the attributes we need. This sub-class will also cache these attributes
+        // necessary to retrieve the attributes we need. This sub-class will also cache these attributes
         // so that we do not need to query them more than once.
         // Rather than rewrite this logic and make possibly slow calls to the token, we'll just use
         // that existing logic.
         if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
-            // All supported keyspecs (other than PKCS8_KEYSPEC_CLS) descend from RSA_PRIVCRT_KEYSPEC_CLS
+            // All supported keyspecs (other than PKCS8EncodedKeySpec) descend from RSAPrivateCrtKeySpec
             if (key instanceof RSAPrivateCrtKey) {
                 RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
                 return keySpec.cast(new RSAPrivateCrtKeySpec(

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -277,59 +277,51 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        // must be either RSAPrivateKeySpec or RSAPrivateCrtKeySpec
+        if (key.sensitive || !key.extractable) {
+            throw new InvalidKeySpecException("Key is sensitive or not extractable");
+        }
+        // If the key is both extractable and not sensitive, then when it was converted into a P11Key
+        // it was also converted into subclass of RSAPrivateKey which encapsulates all of the logic
+        // necessary to retrive the attributes we need. This sub-class will also cache these attributes
+        // so that we do not need to query them more than once.
+        // Rather than rewrite this logic and make possibly slow calls to the token, we'll just use
+        // that existing logic.
         if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
-            session[0] = token.getObjSession();
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-                new CK_ATTRIBUTE(CKA_PRIME_1),
-                new CK_ATTRIBUTE(CKA_PRIME_2),
-                new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                new CK_ATTRIBUTE(CKA_COEFFICIENT),
-            };
-            long keyID = key.getKeyID();
-            try {
-                token.p11.C_GetAttributeValue(session[0].id(), keyID, attributes);
-                KeySpec spec = new RSAPrivateCrtKeySpec(
-                    attributes[0].getBigInteger(),
-                    attributes[1].getBigInteger(),
-                    attributes[2].getBigInteger(),
-                    attributes[3].getBigInteger(),
-                    attributes[4].getBigInteger(),
-                    attributes[5].getBigInteger(),
-                    attributes[6].getBigInteger(),
-                    attributes[7].getBigInteger()
-                );
-                return keySpec.cast(spec);
-            } catch (final PKCS11Exception ex) {
-                // bubble this up if RSAPrivateCrtKeySpec is specified
-                // otherwise fall through to RSAPrivateKeySpec
+            // All supported keyspecs (other than PKCS8_KEYSPEC_CLS) descend from RSA_PRIVCRT_KEYSPEC_CLS
+            if (key instanceof RSAPrivateCrtKey) {
+                RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
+                return keySpec.cast(new RSAPrivateCrtKeySpec(
+                    crtKey.getModulus(),
+                    crtKey.getPublicExponent(),
+                    crtKey.getPrivateExponent(),
+                    crtKey.getPrimeP(),
+                    crtKey.getPrimeQ(),
+                    crtKey.getPrimeExponentP(),
+                    crtKey.getPrimeExponentQ(),
+                    crtKey.getCrtCoefficient(),
+                    crtKey.getParams()
+                ));
+            } else { // RSAPrivateKey (non-CRT)
                 if (!keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
-                    throw ex;
+                    throw new InvalidKeySpecException
+                        ("RSAPrivateCrtKeySpec can only be used with CRT keys");
                 }
-            }  finally {
-                key.releaseKeyID();
-            }
 
-            attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-            };
-            keyID = key.getKeyID();
-            try {
-                token.p11.C_GetAttributeValue(session[0].id(), keyID, attributes);
-            } finally {
-                key.releaseKeyID();
-            }
+                if (!(key instanceof RSAPrivateKey)) {
+                    // We should never reach here as P11Key.privateKey() should always produce an instance
+                    // of RSAPrivateKey when the RSA key is both extractable and non-sensitive.
+                    throw new InvalidKeySpecException
+                    ("Key must be an instance of RSAPrivateKeySpec. Was " + key.getClass());
+                }
 
-            KeySpec spec = new RSAPrivateKeySpec(
-                attributes[0].getBigInteger(),
-                attributes[1].getBigInteger()
-            );
-            return keySpec.cast(spec);
+                // fall through to RSAPrivateKey (non-CRT)
+                RSAPrivateKey rsaKey = (RSAPrivateKey) key;
+                return keySpec.cast(new RSAPrivateKeySpec(
+                    rsaKey.getModulus(),
+                    rsaKey.getPrivateExponent(),
+                    rsaKey.getParams()
+                ));
+            }
         } else { // PKCS#8 handled in superclass
             throw new InvalidKeySpecException("Only RSAPrivate(Crt)KeySpec "
                 + "and PKCS8EncodedKeySpec supported for RSA private keys");

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -277,28 +277,22 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        // If a PKCS11Exception is thrown, then that implies that we cannot retrieve some attributes
-        // First, if we can retrieve the CRT parameters, we do so for better efficiency
-        try {
-            if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
-                session[0] = token.getObjSession();
-                CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                    new CK_ATTRIBUTE(CKA_MODULUS),
-                    new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                    new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-                    new CK_ATTRIBUTE(CKA_PRIME_1),
-                    new CK_ATTRIBUTE(CKA_PRIME_2),
-                    new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                    new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                    new CK_ATTRIBUTE(CKA_COEFFICIENT),
-                };
-                long keyID = key.getKeyID();
-                try {
-                    token.p11.C_GetAttributeValue(session[0].id(), keyID, attributes);
-                } finally {
-                    key.releaseKeyID();
-                }
-
+        // must be either RSAPrivateKeySpec or RSAPrivateCrtKeySpec
+        if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
+            session[0] = token.getObjSession();
+            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+                new CK_ATTRIBUTE(CKA_MODULUS),
+                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
+                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
+                new CK_ATTRIBUTE(CKA_PRIME_1),
+                new CK_ATTRIBUTE(CKA_PRIME_2),
+                new CK_ATTRIBUTE(CKA_EXPONENT_1),
+                new CK_ATTRIBUTE(CKA_EXPONENT_2),
+                new CK_ATTRIBUTE(CKA_COEFFICIENT),
+            };
+            long keyID = key.getKeyID();
+            try {
+                token.p11.C_GetAttributeValue(session[0].id(), keyID, attributes);
                 KeySpec spec = new RSAPrivateCrtKeySpec(
                     attributes[0].getBigInteger(),
                     attributes[1].getBigInteger(),
@@ -310,22 +304,21 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                     attributes[7].getBigInteger()
                 );
                 return keySpec.cast(spec);
+            } catch (final PKCS11Exception ex) {
+                // bubble this up if RSAPrivateCrtKeySpec is specified
+                // otherwise fall through to RSAPrivateKeySpec
+                if (!keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
+                    throw ex;
+                }
+            }  finally {
+                key.releaseKeyID();
             }
-        } catch (final PKCS11Exception ex) {
-            // Fall through to RSAPrivateKeySpec if possible, else, bubble this exception up
-            if (!keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
-                throw ex;
-            }
-        }
 
-        // Fall back to RSAPrivateKeySpec if this was requested and all the available attributes
-        if (keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
-            session[0] = token.getObjSession();
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
                 new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
             };
-            long keyID = key.getKeyID();
+            keyID = key.getKeyID();
             try {
                 token.p11.C_GetAttributeValue(session[0].id(), keyID, attributes);
             } finally {

--- a/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -23,17 +23,51 @@
 
 /**
  * @test
- * @bug 8254717
+ * @bug 8254717 8263404
  * @summary isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards.
  * @author Greg Rubin, Ziyi Luo
  */
 
+import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.*;
 
 public class KeyFactoryGetKeySpecForInvalidSpec {
+
+    // Test for 8263404: This method generates RSAPrivateKey (without Crt info) from a RSAPrivateCrtKey
+    public static RSAPrivateKey privateCrtToPrivate(RSAPrivateCrtKey crtKey) {
+        return new RSAPrivateKey() {
+            @Override
+            public BigInteger getPrivateExponent() {
+                return crtKey.getPrivateExponent();
+            }
+
+            @Override
+            public String getAlgorithm() {
+                return crtKey.getAlgorithm();
+            }
+
+            @Override
+            public String getFormat() {
+                return crtKey.getFormat();
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return crtKey.getEncoded();
+            }
+
+            @Override
+            public BigInteger getModulus() {
+                return crtKey.getModulus();
+            }
+        };
+    }
+
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA");
         kg.initialize(2048);
@@ -41,11 +75,38 @@ public class KeyFactoryGetKeySpecForInvalidSpec {
 
         KeyFactory factory = KeyFactory.getInstance("RSA");
 
+        // === Case 1: private key is RSAPrivateCrtKey, expected spec is RSAPrivateKeySpec
+        // === Expected: return RSAPrivateCrtKeySpec
         // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
         // (because the private key has CRT parts).
         KeySpec spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateKeySpec.class);
         if (!(spec instanceof RSAPrivateCrtKeySpec)) {
             throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+
+        // === Case 2: private key is RSAPrivateCrtKey, expected spec is RSAPrivateCrtKeySpec
+        // === Expected: return RSAPrivateCrtKeySpec
+        spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateCrtKeySpec.class);
+        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+
+        // === Case 3: private key is RSAPrivateKey, expected spec is RSAPrivateKeySpec
+        // === Expected: return RSAPrivateKeySpec not RSAPrivateCrtKeySpec
+        RSAPrivateKey notCrtKey = privateCrtToPrivate((RSAPrivateCrtKey)pair.getPrivate());
+        // InvalidKeySpecException should not be thrown
+        KeySpec notCrtSpec = factory.getKeySpec(notCrtKey, RSAPrivateKeySpec.class);
+        if (notCrtSpec instanceof RSAPrivateCrtKeySpec) {
+            throw new Exception("Spec should be an instance of RSAPrivateKeySpec not RSAPrivateCrtKeySpec");
+        }
+
+        // === Case 4: private key is RSAPrivateKey, expected spec is RSAPrivateCrtKeySpec
+        // === Expected: throw InvalidKeySpecException
+        try {
+            factory.getKeySpec(notCrtKey, RSAPrivateCrtKeySpec.class);
+            throw new Exception("InvalidKeySpecException is expected but not thrown");
+        } catch (InvalidKeySpecException e) {
+            // continue;
         }
 
         // This next line should give an InvalidKeySpec exception

--- a/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -69,13 +69,13 @@ public class KeyFactoryGetKeySpecForInvalidSpec {
     }
 
     public static void main(String[] args) throws Exception {
-        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA");
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
         kg.initialize(2048);
         KeyPair pair = kg.generateKeyPair();
 
         KeyFactory factory = KeyFactory.getInstance("RSA");
 
-        // === Case 1: private key is RSAPrivateCrtKey, expected spec is RSAPrivateKeySpec
+        // === Case 1: private key is RSAPrivateCrtKey, keySpec is RSAPrivateKeySpec
         // === Expected: return RSAPrivateCrtKeySpec
         // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
         // (because the private key has CRT parts).
@@ -84,14 +84,14 @@ public class KeyFactoryGetKeySpecForInvalidSpec {
             throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
         }
 
-        // === Case 2: private key is RSAPrivateCrtKey, expected spec is RSAPrivateCrtKeySpec
+        // === Case 2: private key is RSAPrivateCrtKey, keySpec is RSAPrivateCrtKeySpec
         // === Expected: return RSAPrivateCrtKeySpec
         spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateCrtKeySpec.class);
         if (!(spec instanceof RSAPrivateCrtKeySpec)) {
             throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
         }
 
-        // === Case 3: private key is RSAPrivateKey, expected spec is RSAPrivateKeySpec
+        // === Case 3: private key is RSAPrivateKey, keySpec is RSAPrivateKeySpec
         // === Expected: return RSAPrivateKeySpec not RSAPrivateCrtKeySpec
         RSAPrivateKey notCrtKey = privateCrtToPrivate((RSAPrivateCrtKey)pair.getPrivate());
         // InvalidKeySpecException should not be thrown
@@ -99,8 +99,11 @@ public class KeyFactoryGetKeySpecForInvalidSpec {
         if (notCrtSpec instanceof RSAPrivateCrtKeySpec) {
             throw new Exception("Spec should be an instance of RSAPrivateKeySpec not RSAPrivateCrtKeySpec");
         }
+        if (!(notCrtSpec instanceof RSAPrivateKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateKeySpec");
+        }
 
-        // === Case 4: private key is RSAPrivateKey, expected spec is RSAPrivateCrtKeySpec
+        // === Case 4: private key is RSAPrivateKey, keySpec is RSAPrivateCrtKeySpec
         // === Expected: throw InvalidKeySpecException
         try {
             factory.getKeySpec(notCrtKey, RSAPrivateCrtKeySpec.class);

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -190,7 +190,7 @@ public abstract class PKCS11Test {
                     test.enableSM = true;
                 } else {
                     throw new RuntimeException("Unknown Command, use 'sm' as "
-                            + "first arguemtn to enable security manager");
+                            + "first argument to enable security manager");
                 }
             }
             if (test.enableSM) {

--- a/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
+++ b/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
@@ -1,0 +1,56 @@
+
+# Configuration to run unit tests with NSS
+# Marks private and secret keys as sensitive
+
+name = NSS
+
+slot = 1
+
+#showInfo = true
+
+library = ${pkcs11test.nss.lib}
+
+nssArgs = "configdir='${pkcs11test.nss.db}' certPrefix='' keyPrefix='' secmod='secmod.db' flags=readOnly"
+
+disabledMechanisms = {
+  CKM_DSA_SHA224
+  CKM_DSA_SHA256
+  CKM_DSA_SHA384
+  CKM_DSA_SHA512
+  CKM_DSA_SHA3_224
+  CKM_DSA_SHA3_256
+  CKM_DSA_SHA3_384
+  CKM_DSA_SHA3_512
+  CKM_ECDSA_SHA224
+  CKM_ECDSA_SHA256
+  CKM_ECDSA_SHA384
+  CKM_ECDSA_SHA512
+  CKM_ECDSA_SHA3_224
+  CKM_ECDSA_SHA3_256
+  CKM_ECDSA_SHA3_384
+  CKM_ECDSA_SHA3_512
+}
+
+attributes = compatibility
+
+# NSS needs CKA_NETSCAPE_DB for DSA and DH private keys
+# just put an arbitrary value in there to make it happy
+
+attributes(*,CKO_PRIVATE_KEY,CKK_DSA) = {
+  CKA_NETSCAPE_DB = 0h00
+}
+
+attributes(*,CKO_PRIVATE_KEY,CKK_DH) = {
+  CKA_NETSCAPE_DB = 0h00
+}
+
+# Make all private keys sensitive
+attributes(*,CKO_PRIVATE_KEY,*) = {
+  CKA_SENSITIVE = true
+}
+
+
+# Make all secret keys sensitive
+attributes(*,CKO_SECRET_KEY,*) = {
+  CKA_SENSITIVE = true
+}

--- a/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
+++ b/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
@@ -44,6 +44,8 @@ attributes(*,CKO_PRIVATE_KEY,CKK_DH) = {
   CKA_NETSCAPE_DB = 0h00
 }
 
+# Everything above this line (with the exception of the comment at the top) is copy/pasted from p11-nss.txt
+
 # Make all private keys sensitive
 attributes(*,CKO_PRIVATE_KEY,*) = {
   CKA_SENSITIVE = true

--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -26,7 +26,7 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
-import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.*;
 
@@ -34,15 +34,19 @@ import java.security.spec.*;
  * @test
  * @bug 8263404
  * @summary RsaPrivateKeySpec is always recognized as RSAPrivateCrtKeySpec in RSAKeyFactory.engineGetKeySpec
+ * @summary Also checks to ensure that sensitive RSA keys are correctly not exposed
  * @author Greg Rubin, Ziyi Luo
  * @library /test/lib ..
  * @run main/othervm TestP11KeyFactoryGetRSAKeySpec
  * @run main/othervm TestP11KeyFactoryGetRSAKeySpec sm rsakeys.ks.policy
+ * @run main/othervm -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt -DNO_DEIMOS=true -DNO_DEFAULT=true TestP11KeyFactoryGetRSAKeySpec
  * @modules jdk.crypto.cryptoki
  */
 
 public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
+    private static boolean testingSensitiveKeys = false;
     public static void main(String[] args) throws Exception {
+        testingSensitiveKeys = "p11-nss-sensitive.txt".equals(System.getProperty("CUSTOM_P11_CONFIG_NAME"));
         main(new TestP11KeyFactoryGetRSAKeySpec(), args);
     }
 
@@ -51,6 +55,7 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
         KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA", p);
         kg.initialize(2048);
         KeyPair pair = kg.generateKeyPair();
+        PrivateKey privKey = pair.getPrivate();
 
         KeyFactory factory = KeyFactory.getInstance("RSA", p);
 
@@ -58,16 +63,35 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
         // === Expected: return RSAPrivateCrtKeySpec
         // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
         // (because the private key has CRT parts).
-        KeySpec spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateKeySpec.class);
-        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
-            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
-        }
+        testKeySpec(factory, privKey, RSAPrivateKeySpec.class);
 
         // === Case 2: private key is RSAPrivateCrtKey, keySpec is RSAPrivateCrtKeySpec
         // === Expected: return RSAPrivateCrtKeySpec
-        spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateCrtKeySpec.class);
-        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
-            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        testKeySpec(factory, privKey, RSAPrivateCrtKeySpec.class);
+
+        // If this is a sensitive key, then it shouldn't implement the RSAPrivateKey interface as that exposes sensitive fields
+        boolean keyExposesSensitiveFields = privKey instanceof RSAPrivateKey;
+        if (keyExposesSensitiveFields == testingSensitiveKeys) {
+            throw new Exception("Key of type " + privKey.getClass() + " returned when testing sensitive keys is " + testingSensitiveKeys);
+        }
+    }
+
+    private static void testKeySpec(KeyFactory factory, PrivateKey key, Class<? extends KeySpec> specClass) throws Exception {
+        try {
+            KeySpec spec = factory.getKeySpec(key, RSAPrivateKeySpec.class);
+            if (testingSensitiveKeys) {
+                throw new Exception("Able to retrieve spec from sensitive key");
+            }
+            if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+                throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+            }            
+        } catch (final InvalidKeySpecException ex) {
+            if (testingSensitiveKeys) {
+                // Expected exception so swallow it
+                ex.printStackTrace();
+            } else {
+                throw ex;
+            }
         }
     }
 }

--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.*;
+
+/**
+ * @test
+ * @bug 8263404
+ * @summary RsaPrivateKeySpec is always recognized as RSAPrivateCrtKeySpec in RSAKeyFactory.engineGetKeySpec
+ * @author Greg Rubin, Ziyi Luo
+ * @library /test/lib ..
+ * @run main/othervm TestP11KeyFactoryGetRSAKeySpec
+ * @run main/othervm TestP11KeyFactoryGetRSAKeySpec sm rsakeys.ks.policy
+ * @modules jdk.crypto.cryptoki
+ */
+
+public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
+    public static void main(String[] args) throws Exception {
+        main(new TestP11KeyFactoryGetRSAKeySpec(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA", p);
+        kg.initialize(2048);
+        KeyPair pair = kg.generateKeyPair();
+
+        KeyFactory factory = KeyFactory.getInstance("RSA", p);
+
+        // === Case 1: private key is RSAPrivateCrtKey, keySpec is RSAPrivateKeySpec
+        // === Expected: return RSAPrivateCrtKeySpec
+        // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
+        // (because the private key has CRT parts).
+        KeySpec spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateKeySpec.class);
+        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+
+        // === Case 2: private key is RSAPrivateCrtKey, keySpec is RSAPrivateCrtKeySpec
+        // === Expected: return RSAPrivateCrtKeySpec
+        spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateCrtKeySpec.class);
+        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+    }
+}

--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -84,7 +84,7 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
             }
             if (!(spec instanceof RSAPrivateCrtKeySpec)) {
                 throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
-            }            
+            }
         } catch (final InvalidKeySpecException ex) {
             if (testingSensitiveKeys) {
                 // Expected exception so swallow it


### PR DESCRIPTION
This is a P2 regression introduced by JDK-8254717.

In `RSAKeyFactory.engineGetKeySpec`, when the key is a RSA key and the KeySpec is RSAPrivateKeySpec or RSAPrivateCrtKeySpec. The method behavior is described as follow:

X-axis: type of `keySpec`
Y-axis: type of `key`

Before JDK-8254717:

|  | RSAPrivateKeySpec.class | RSAPrivateCrtKeySpec.class |
|--|--|--|
| RSAPrivateKey | Return RSAPrivateKeySpec  | Throw `InvalidKeySpecException` |
| RSAPrivateCrtKey | Return RSAPrivateKeySpec | Return RSAPrivateKeyCrtSpec |

After JDK-8254717 (Green check is what we want to fix, red cross is the regression):

|  | RSAPrivateKeySpec.class | RSAPrivateCrtKeySpec.class |
|--|--|--|
| RSAPrivateKey | Throw `InvalidKeySpecException` :x:  | Throw `InvalidKeySpecException` |
| RSAPrivateCrtKey | Return RSAPrivateKeyCrtSpec :white_check_mark: | Return RSAPrivateKeyCrtSpec |

This commit fixes the regression.


### Tests

* Jtreg: All tests under `java/security`, `sun/security`, `javax/crypto` passed
* JCK: All JCK-16 (I do not have jCK-17)tests under `api/java_security` passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263404](https://bugs.openjdk.java.net/browse/JDK-8263404): RsaPrivateKeySpec is always recognized as RSAPrivateCrtKeySpec in RSAKeyFactory.engineGetKeySpec


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Contributors
 * Greg Rubin `<rubin@amazon.com>`

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2949/head:pull/2949`
`$ git checkout pull/2949`

To update a local copy of the PR:
`$ git checkout pull/2949`
`$ git pull https://git.openjdk.java.net/jdk pull/2949/head`
