### PR TITLE
8263480: ProblemList two jpackage tests on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -839,6 +839,8 @@ jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-
 # jdk_jpackage
 
 tools/jpackage/share/jdk/jpackage/tests/ModulePathTest3.java#id0    8248418 generic-all
+tools/jpackage/windows/WinShortcutPromptTest.java                   8263474 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java                      8263474 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList two new tests on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263480](https://bugs.openjdk.java.net/browse/JDK-8263480): ProblemList two jpackage tests on Windows


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2952/head:pull/2952`
`$ git checkout pull/2952`
