### PR TITLE
8263470: Consolidate copies of getClassBytes in various tests

### DIFF
--- a/test/hotspot/jtreg/runtime/BadObjectClass/TestUnloadClassError.java
+++ b/test/hotspot/jtreg/runtime/BadObjectClass/TestUnloadClassError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,14 @@
  *          java.lang.Object class.
  *          Also, make sure the vm doesn't crash on notification for unloading an invalid
  *          java.lang.Object class.
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  * @run main TestUnloadClassError
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class TestUnloadClassError extends ClassLoader {
 

--- a/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
  *          java.compiler
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @compile p2/c2.java MyDiffClassLoader.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -36,7 +36,7 @@
  */
 
 import sun.hotspot.WhiteBox;
-
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class ConstantPoolDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();

--- a/test/hotspot/jtreg/runtime/ClassUnload/DictionaryDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/DictionaryDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
  *          java.compiler
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @compile p2/c2.java MyDiffClassLoader.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -36,6 +36,7 @@
  */
 import sun.hotspot.WhiteBox;
 import java.lang.reflect.Method;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class DictionaryDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClass.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary This test case uses a java.lang.Class instance to keep a class alive.
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -35,6 +35,7 @@
 
 import java.lang.ref.SoftReference;
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClassLoader.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary This test case uses a java.lang.ClassLoader instance to keep a class alive.
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -34,6 +34,7 @@
  */
 
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary This test case uses a class instance to keep the class alive.
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -34,6 +34,7 @@
  */
 
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary This test case uses a java.lang.ref.SoftReference referencing a class instance to keep a class alive.
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -35,6 +35,7 @@
 
 import java.lang.ref.SoftReference;
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.

--- a/test/hotspot/jtreg/runtime/ClassUnload/MyDiffClassLoader.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/MyDiffClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import java.io.*;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class MyDiffClassLoader extends ClassLoader {
 
@@ -48,24 +49,9 @@ public class MyDiffClassLoader extends ClassLoader {
             return c;
         }
 
-        byte[] data = switchClassData ? getNewClassData(name) : getClassData(name);
+        byte[] data = switchClassData ? getNewClassData(name) : ClassUnloadCommon.getClassData(name);
         System.out.println("name is " + name);
         return defineClass(name, data, 0, data.length);
-    }
-    byte[] getClassData(String name) {
-        try {
-           String TempName = name.replaceAll("\\.", "/");
-           String currentDir = System.getProperty("test.classes");
-           String filename = currentDir + File.separator + TempName + ".class";
-           FileInputStream fis = new FileInputStream(filename);
-           byte[] b = new byte[5000];
-           int cnt = fis.read(b, 0, 5000);
-           byte[] c = new byte[cnt];
-           for (int i=0; i<cnt; i++) c[i] = b[i];
-             return c;
-        } catch (IOException e) {
-           return null;
-        }
     }
 
     // Return p2.c2 with everything removed

--- a/test/hotspot/jtreg/runtime/ClassUnload/SuperDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/SuperDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,14 +28,16 @@
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
  *          java.compiler
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @compile p2/c2.java MyDiffClassLoader.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -XX:+WhiteBoxAPI SuperDependsTest
  */
+
 import sun.hotspot.WhiteBox;
 import p2.*;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class SuperDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadInterfaceTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test UnloadInterfaceTest
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @compile test/Interface.java
  * @compile test/ImplementorClass.java
  * @build sun.hotspot.WhiteBox
@@ -35,6 +35,7 @@
 import sun.hotspot.WhiteBox;
 import test.Interface;
 import java.lang.ClassLoader;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that class unloaded removes the implementor from its the interface that it implements

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,14 @@
  * @bug 8210559
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @library classes
  * @build sun.hotspot.WhiteBox test.Empty
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=debug UnloadTest
  */
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * Test that verifies that classes are unloaded when they are no longer reachable.

--- a/test/hotspot/jtreg/runtime/DefineClass/NullClassBytesTest.java
+++ b/test/hotspot/jtreg/runtime/DefineClass/NullClassBytesTest.java
@@ -31,7 +31,7 @@
  * @run main/native NullClassBytesTest
  */
 
-import java.io.*;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class NullClassBytesTest {
 
@@ -50,7 +50,7 @@ public class NullClassBytesTest {
 
                 // load the class data from the connection
                 if (name.equals("A")) {
-                    byte[] b = getClassData("A");
+                    byte[] b = ClassUnloadCommon.getClassData("A");
                     return defineClass(name, b, 0, b.length);
                 } else if (name.equals("B")) {
                     byte[] b = new byte[0];
@@ -68,14 +68,6 @@ public class NullClassBytesTest {
                     return super.loadClass(name);
                 }
             }
-        }
-
-        byte[] getClassData(String name) {
-           try {
-             return SimpleLoader.class.getClassLoader().getResourceAsStream(name + ".class").readAllBytes();
-           } catch (IOException e) {
-              return null;
-           }
         }
     }
 

--- a/test/hotspot/jtreg/runtime/MemberName/MemberNameLeak.java
+++ b/test/hotspot/jtreg/runtime/MemberName/MemberNameLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8174749 8213307
  * @summary MemberNameTable should reuse entries
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler
  * @build sun.hotspot.WhiteBox
@@ -45,6 +45,7 @@ import jdk.test.lib.Utils;
 import sun.hotspot.WhiteBox;
 import sun.hotspot.code.Compiler;
 import sun.hotspot.gc.GC;
+import jdk.test.lib.classloader.ClassWithManyMethodsClassLoader;
 
 public class MemberNameLeak {
     private static String className  = "MemberNameLeakTestClass";

--- a/test/hotspot/jtreg/runtime/Nestmates/membership/TestNestHostErrorWithClassUnload.java
+++ b/test/hotspot/jtreg/runtime/Nestmates/membership/TestNestHostErrorWithClassUnload.java
@@ -28,7 +28,7 @@
  *          successfully but fail validation. This tests a specific, otherwise
  *          untested, code path in ResolutionErrorTable::free_entry.
  *
- * @library /runtime/testlibrary
+ * @library /test/lib
  * @compile TestNestHostErrorWithClassUnload.java
  *          Helper.java
  *          PackagedNestHost.java
@@ -61,6 +61,8 @@
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class TestNestHostErrorWithClassUnload {
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,13 @@
  * @summary Hello World test for AppCDS custom loader support
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /runtime/testlibrary
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/HelloUnload.java test-classes/CustomLoadee.java
- * @build sun.hotspot.WhiteBox ClassUnloadCommon
- * @run driver ClassFileInstaller -jar hello.jar HelloUnload ClassUnloadCommon ClassUnloadCommon$1 ClassUnloadCommon$TestFailure
+ * @build sun.hotspot.WhiteBox jdk.test.lib.classloader.ClassUnloadCommon
+ * @run driver ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
  * @run driver ClassFileInstaller -jar hello_custom.jar CustomLoadee
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run driver HelloCustom

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom_JFR.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom_JFR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,13 @@
  * @requires vm.hasJFR
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /runtime/testlibrary
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/HelloUnload.java test-classes/CustomLoadee.java
- * @build sun.hotspot.WhiteBox ClassUnloadCommon
- * @run driver ClassFileInstaller -jar hello.jar HelloUnload ClassUnloadCommon ClassUnloadCommon$1 ClassUnloadCommon$TestFailure
+ * @build sun.hotspot.WhiteBox jdk.test.lib.classloader.ClassUnloadCommon
+ * @run driver ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
  * @run driver ClassFileInstaller -jar hello_custom.jar CustomLoadee
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run driver HelloCustom_JFR

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnloadUnregisteredLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnloadUnregisteredLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,13 @@
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
  * @requires vm.opt.final.ClassUnloading
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/testlibrary
- * @build sun.hotspot.WhiteBox ClassUnloadCommon
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build sun.hotspot.WhiteBox jdk.test.lib.classloader.ClassUnloadCommon
  * @compile test-classes/UnloadUnregisteredLoader.java test-classes/CustomLoadee.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                                ClassUnloadCommon
- *                                ClassUnloadCommon$1
- *                                ClassUnloadCommon$TestFailure
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
  * @run driver UnloadUnregisteredLoaderTest
  */
 
@@ -46,7 +46,9 @@ public class UnloadUnregisteredLoaderTest {
     public static void main(String[] args) throws Exception {
         String appJar1 = JarBuilder.build("UnloadUnregisteredLoader_app1", "UnloadUnregisteredLoader");
         String appJar2 = JarBuilder.build(true, "UnloadUnregisteredLoader_app2",
-                                          "ClassUnloadCommon", "ClassUnloadCommon$1", "ClassUnloadCommon$TestFailure");
+                                          "jdk/test/lib/classloader/ClassUnloadCommon",
+                                          "jdk/test/lib/classloader/ClassUnloadCommon$1",
+                                          "jdk/test/lib/classloader/ClassUnloadCommon$TestFailure");
         String customJarPath = JarBuilder.build("UnloadUnregisteredLoader_custom", "CustomLoadee");
         String wbJar = JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
         String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
@@ -54,9 +56,9 @@ public class UnloadUnregisteredLoaderTest {
         String classpath = TestCommon.concatPaths(appJar1, appJar2);
         String classlist[] = new String[] {
             "UnloadUnregisteredLoader",
-            "ClassUnloadCommon",
-            "ClassUnloadCommon$1",
-            "ClassUnloadCommon$TestFailure",
+            "jdk/test/lib/classloader/ClassUnloadCommon",
+            "jdk/test/lib/classloader/ClassUnloadCommon$1",
+            "jdk/test/lib/classloader/ClassUnloadCommon$TestFailure",
             "java/lang/Object id: 1",
             "CustomLoadee id: 2 super: 1 source: " + customJarPath,
         };

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class HelloUnload {
     private static String className = "CustomLoadee";

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/UnloadUnregisteredLoader.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/UnloadUnregisteredLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class UnloadUnregisteredLoader {
     public static void main(String args[]) throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
@@ -26,10 +26,13 @@
  * @test
  * @summary Hello World test for dynamic archive with custom loader
  * @requires vm.cds
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes /runtime/testlibrary
- * @build HelloUnload CustomLoadee ClassUnloadCommon
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes
+ * @build HelloUnload CustomLoadee jdk.test.lib.classloader.ClassUnloadCommon
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller -jar hello.jar HelloUnload ClassUnloadCommon ClassUnloadCommon$1 ClassUnloadCommon$TestFailure
+ * @run driver ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
  * @run driver ClassFileInstaller -jar hello_custom.jar CustomLoadee
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar HelloDynamicCustom

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustomUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustomUnload.java
@@ -29,10 +29,13 @@
  *          dump time and run time. The custom loader will be unloaded
  *          during dump time.
  * @requires vm.cds
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes /runtime/testlibrary
- * @build HelloUnload CustomLoadee ClassUnloadCommon
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes
+ * @build HelloUnload CustomLoadee jdk.test.lib.classloader.ClassUnloadCommon
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller -jar hello.jar HelloUnload ClassUnloadCommon ClassUnloadCommon$1 ClassUnloadCommon$TestFailure
+ * @run driver ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
  * @run driver ClassFileInstaller -jar hello_custom.jar CustomLoadee
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar HelloDynamicCustomUnload

--- a/test/hotspot/jtreg/runtime/defineAnonClass/TestAnonSymbolLeak.java
+++ b/test/hotspot/jtreg/runtime/defineAnonClass/TestAnonSymbolLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.org.objectweb.asm
  *          java.management
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @build p1.AnonSymbolLeak
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
@@ -39,6 +39,7 @@
 import java.lang.reflect.Method;
 import sun.hotspot.WhiteBox;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class TestAnonSymbolLeak {
     static String className = "p1.AnonSymbolLeak";

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8142506
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary
+ * @library /test/lib
  * @library classes
  * @build test.Empty
  * @run driver ClassLoadUnloadTest
@@ -40,6 +40,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class ClassLoadUnloadTest {
     private static OutputAnalyzer out;

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test LoaderConstraintsTest
  * @bug 8149996
  * @modules java.base/jdk.internal.misc
- * @library /test/lib /runtime/testlibrary classes
+ * @library /test/lib classes
  * @run driver LoaderConstraintsTest
  */
 
@@ -37,6 +37,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class LoaderConstraintsTest {
     private static OutputAnalyzer out;

--- a/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
+++ b/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
@@ -25,23 +25,18 @@
  * @test
  * @bug 8187305
  * @summary Tests logging of shared library loads and unloads.
- * @library /runtime/testlibrary /test/lib
+ * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main LoadLibraryTest
  */
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class LoadLibraryTest {
 
@@ -86,18 +81,6 @@ public class LoadLibraryTest {
 
         public static class MyClassLoader extends ClassLoader {
 
-            static ByteBuffer readClassFile(String name) {
-                File f = new File(testClasses, name);
-                try (FileInputStream fin = new FileInputStream(f);
-                     FileChannel fc = fin.getChannel())
-                {
-                    return fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-                } catch (IOException e) {
-                    throw new RuntimeException("Can't open file: " + name +
-                                               ", exception: " + e.toString());
-                }
-            }
-
             protected Class<?> loadClass(String name, boolean resolve)
                 throws ClassNotFoundException {
                 Class<?> c;
@@ -117,7 +100,8 @@ public class LoadLibraryTest {
                 if (!CLASS_NAME.equals(name)) {
                     throw new ClassNotFoundException("Unexpected class: " + name);
                 }
-                return defineClass(name, readClassFile(name + ".class"), null);
+                byte[] class_bytes = ClassUnloadCommon.getClassData(name);
+                return defineClass(name, class_bytes, 0, class_bytes.length);
             }
         } // MyClassLoader
     }

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodDiffCL_Umod.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodDiffCL_Umod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  *          defined in an unnamed module. Access allowed since unnamed module
  *          can read unnamed module even when class p1.c1 is loaded by
  *          a different loader than p2.c2.
+ * @library /test/lib
  * @compile myloaders/MyDiffClassLoader.java
  * @compile p2/c2.java
  * @compile p1/c1.java

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodDiffCL_UmodUpkg.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodDiffCL_UmodUpkg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary class p3.c3 defined in a named package in an unnamed module tries to access c4
  *          defined in an unnamed package in an unnamed module.  Access allowed since
  *          any class in an unnamed module can read an unnamed module.
+ * @library /test/lib
  * @compile myloaders/MyDiffClassLoader.java
  * @compile c4.java
  * @compile p3/c3.jcod

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodUpkgDiffCL_Umod.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodUpkgDiffCL_Umod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @summary Test public type c5 defined in an unnamed package and unnamed module can
  *          access public type p6.c6 defined in an unnamed module.
+ * @library /test/lib
  * @compile myloaders/MyDiffClassLoader.java
  * @compile p6/c6.java
  * @compile c5.java

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodUpkg_Umod.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/UmodUpkg_Umod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @summary Test public type c5 defined in an unnamed package and unnamed module can
  *          access public type p6.c6 defined in an unnamed module.
+ * @library /test/lib
  * @compile myloaders/MySameClassLoader.java
  * @compile p6/c6.java
  * @compile c5.java

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/Umod_UmodUpkg.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/Umod_UmodUpkg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary class p3.c3 defined in an unnamed module tries to access c4 defined in an unnamed package
  *          and an unnamed module.
  *          Access allowed since any class in an unnamed module can read an unnamed module.
+ * @library /test/lib
  * @compile myloaders/MySameClassLoader.java
  * @compile c4.java
  * @compile p3/c3.jcod

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/myloaders/MyDiffClassLoader.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/myloaders/MyDiffClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ package myloaders;
 
 import java.io.*;
 import java.lang.module.ModuleReference;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 // Declare a MyDiffClassLoader class to be used to map modules to.
 // This class loader will also be used to load classes within modules.
@@ -49,23 +50,8 @@ public class MyDiffClassLoader extends ClassLoader
             return MyDiffClassLoader.loader2.loadClass(name);
         }
 
-        byte[] data = getClassData(name);
+        byte[] data = ClassUnloadCommon.getClassData(name);
         return defineClass(name, data, 0, data.length);
-    }
-    byte[] getClassData(String name) {
-        try {
-           String TempName = name.replaceAll("\\.", "/");
-           String currentDir = System.getProperty("test.classes");
-           String filename = currentDir + File.separator + TempName + ".class";
-           FileInputStream fis = new FileInputStream(filename);
-           byte[] b = new byte[5000];
-           int cnt = fis.read(b, 0, 5000);
-           byte[] c = new byte[cnt];
-           for (int i=0; i<cnt; i++) c[i] = b[i];
-              return c;
-        } catch (IOException e) {
-           return null;
-        }
     }
 
     public void register(ModuleReference mref) { }

--- a/test/hotspot/jtreg/runtime/modules/AccessCheck/myloaders/MySameClassLoader.java
+++ b/test/hotspot/jtreg/runtime/modules/AccessCheck/myloaders/MySameClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ package myloaders;
 
 import java.io.*;
 import java.lang.module.ModuleReference;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 // Declare a MySameClassLoader class to be used to map modules to the same
 // class loader.  This class loader will also be used to load classes
@@ -45,23 +46,8 @@ public class MySameClassLoader extends ClassLoader
             !name.equals("p6.c6")) {
             return super.loadClass(name);
         }
-        byte[] data = getClassData(name);
+        byte[] data = ClassUnloadCommon.getClassData(name);
         return defineClass(name, data, 0, data.length);
-    }
-    byte[] getClassData(String name) {
-        try {
-           String TempName = name.replaceAll("\\.", "/");
-           String currentDir = System.getProperty("test.classes");
-           String filename = currentDir + File.separator + TempName + ".class";
-           FileInputStream fis = new FileInputStream(filename);
-           byte[] b = new byte[5000];
-           int cnt = fis.read(b, 0, 5000);
-           byte[] c = new byte[cnt];
-           for (int i=0; i<cnt; i++) c[i] = b[i];
-              return c;
-        } catch (IOException e) {
-           return null;
-        }
     }
 
     public void register(ModuleReference mref) { }

--- a/test/hotspot/jtreg/runtime/modules/CCE_module_msg.java
+++ b/test/hotspot/jtreg/runtime/modules/CCE_module_msg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @modules java.base/jdk.internal.misc
- * @library /test/lib ..
+ * @library /test/lib
  * @compile p2/c2.java
  * @compile p4/c4.java
  * @build sun.hotspot.WhiteBox
@@ -39,6 +39,8 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import static jdk.test.lib.Asserts.*;
+
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 // Test that the message in a runtime ClassCastException contains module info.
 public class CCE_module_msg {
@@ -208,23 +210,7 @@ class MyURLClassLoader extends URLClassLoader {
         if (!name.equals("p4.c4")) {
             return super.loadClass(name);
         }
-        byte[] data = getClassData(name);
+        byte[] data = ClassUnloadCommon.getClassData(name);
         return defineClass(name, data, 0, data.length);
-    }
-
-    byte[] getClassData(String name) {
-        try {
-           String TempName = name.replaceAll("\\.", "/");
-           String currentDir = System.getProperty("test.classes");
-           String filename = currentDir + File.separator + TempName + ".class";
-           FileInputStream fis = new FileInputStream(filename);
-           byte[] b = new byte[5000];
-           int cnt = fis.read(b, 0, 5000);
-           byte[] c = new byte[cnt];
-           for (int i=0; i<cnt; i++) c[i] = b[i];
-              return c;
-        } catch (IOException e) {
-           return null;
-        }
     }
 }

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * for an example.
  */
 
+
+package jdk.test.lib.classloader;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -111,18 +113,10 @@ public class ClassUnloadCommon {
     // Get data for pre-compiled class file to load.
     public static byte[] getClassData(String name) {
         try {
-           String TempName = name.replaceAll("\\.", "/");
-           String currentDir = System.getProperty("test.classes");
-           String filename = currentDir + File.separator + TempName + ".class";
-           System.out.println("filename is " + filename);
-           FileInputStream fis = new FileInputStream(filename);
-           byte[] b = new byte[5000];
-           int cnt = fis.read(b, 0, 5000);
-           byte[] c = new byte[cnt];
-           for (int i=0; i<cnt; i++) c[i] = b[i];
-              return c;
-        } catch (IOException e) {
-           return null;
+            String tempName = name.replaceAll("\\.", "/");
+            return ClassUnloadCommon.class.getClassLoader().getResourceAsStream(tempName + ".class").readAllBytes();
+        } catch (Exception e) {
+              return null;
         }
     }
 }

--- a/test/lib/jdk/test/lib/classloader/ClassWithManyMethodsClassLoader.java
+++ b/test/lib/jdk/test/lib/classloader/ClassWithManyMethodsClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package jdk.test.lib.classloader;
 
 import java.io.DataInputStream;
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
See issue for details. This also moves ClassUnloadCommon and ClassWithManyMethodsClassLoader to jdk/lib/test/classloader and puts it in a package with other class loader test utility functions. I left getClassBytes in ClassunloadCommon, because most tests that use it also need to import ClassUnloadCommon.

Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263470](https://bugs.openjdk.java.net/browse/JDK-8263470): Consolidate copies of getClassBytes in various tests


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2954/head:pull/2954`
`$ git checkout pull/2954`
