### PR TITLE
8263472: Specification of JComponent::updateUI should document that the default implementation does nothing

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -657,7 +657,7 @@ public abstract class JComponent extends Container implements Serializable,
 
     /**
      * Resets the UI property to a value from the current look and feel.
-     * Since the default implementation of this method doesn't do anything,
+     * @implnote Since the default implementation of this method doesn't do anything,
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -656,8 +656,7 @@ public abstract class JComponent extends Container implements Serializable,
 
 
     /**
-     * Resets the UI property to a value from the current look and feel.
-     * @implNote The default implementation of this method doesn't do anything.
+     * Resets the UI property to a value from the current look and feel.     *
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>
@@ -665,6 +664,8 @@ public abstract class JComponent extends Container implements Serializable,
      *      setUI((SliderUI)UIManager.getUI(this);
      *   }
      *  </pre>
+     *
+     * @implNote The default implementation of this method doesn't do anything.
      *
      * @see #setUI
      * @see UIManager#getLookAndFeel

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -657,6 +657,7 @@ public abstract class JComponent extends Container implements Serializable,
 
     /**
      * Resets the UI property to a value from the current look and feel.
+     * Since default implementation of this method don't do anything,
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -657,7 +657,7 @@ public abstract class JComponent extends Container implements Serializable,
 
     /**
      * Resets the UI property to a value from the current look and feel.
-     * @implNote Since the default implementation of this method doesn't do anything,
+     * @implNote The default implementation of this method doesn't do anything.
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -657,7 +657,7 @@ public abstract class JComponent extends Container implements Serializable,
 
     /**
      * Resets the UI property to a value from the current look and feel.
-     * @implnote Since the default implementation of this method doesn't do anything,
+     * @implNote Since the default implementation of this method doesn't do anything,
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -656,7 +656,7 @@ public abstract class JComponent extends Container implements Serializable,
 
 
     /**
-     * Resets the UI property to a value from the current look and feel.     *
+     * Resets the UI property to a value from the current look and feel.
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -657,7 +657,7 @@ public abstract class JComponent extends Container implements Serializable,
 
     /**
      * Resets the UI property to a value from the current look and feel.
-     * Since default implementation of this method don't do anything,
+     * Since the default implementation of this method doesn't do anything,
      * <code>JComponent</code> subclasses must override this method
      * like this:
      * <pre>

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -666,7 +666,7 @@ public abstract class JComponent extends Container implements Serializable,
      *   }
      *  </pre>
      *
-     * @implSpec The default implementation of this method doesn't do anything.
+     * @implSpec The default implementation of this method does nothing.
      *
      * @see #setUI
      * @see UIManager#getLookAndFeel

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -658,13 +658,15 @@ public abstract class JComponent extends Container implements Serializable,
     /**
      * This method is called to update the UI property to a value from the
      * current look and feel.
-     * This base method is empty and therefore {@code JComponent} subclasses
-     * must override this method like this:
+     * {@code JComponent} subclasses must override this method
+     * like this:
      * <pre>
      *   public void updateUI() {
      *      setUI((SliderUI)UIManager.getUI(this);
      *   }
      *  </pre>
+     *
+     * @implSpec The default implementation of this method doesn't do anything.
      *
      * @see #setUI
      * @see UIManager#getLookAndFeel

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -656,16 +656,15 @@ public abstract class JComponent extends Container implements Serializable,
 
 
     /**
-     * Resets the UI property to a value from the current look and feel.
-     * <code>JComponent</code> subclasses must override this method
-     * like this:
+     * This method is called to update the UI property to a value from the
+     * current look and feel.
+     * This base method is empty and therefore {@code JComponent} subclasses
+     * must override this method like this:
      * <pre>
      *   public void updateUI() {
      *      setUI((SliderUI)UIManager.getUI(this);
      *   }
      *  </pre>
-     *
-     * @implNote The default implementation of this method doesn't do anything.
      *
      * @see #setUI
      * @see UIManager#getLookAndFeel


### PR DESCRIPTION
It's unclear from the spec that the original implementation of the method JComponent.updateUI() does nothing which needs to be explicitly stated in the javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263472](https://bugs.openjdk.java.net/browse/JDK-8263472): Specification of JComponent::updateUI should document that the default implementation does nothing


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to ec7755a42235e9b8d4eb4cbd89fd6afddb512803
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to ec7755a42235e9b8d4eb4cbd89fd6afddb512803


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2955/head:pull/2955`
`$ git checkout pull/2955`

To update a local copy of the PR:
`$ git checkout pull/2955`
`$ git pull https://git.openjdk.java.net/jdk pull/2955/head`
