### PR TITLE
8263490: [macos] Crash occurs on JPasswordField with activated InputMethod

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1164,8 +1164,12 @@ static jclass jc_CInputMethod = NULL;
 #ifdef IM_DEBUG
     fprintf(stderr, "AWTView InputMethod Selector Called : [attributedSubstringFromRange] location=%lu, length=%lu\n", (unsigned long)theRange.location, (unsigned long)theRange.length);
 #endif // IM_DEBUG
+    if (!fInputMethodLOCKABLE) {
+        return nil;
+    }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CIM_CLASS_RETURN(nil);
     DECLARE_METHOD_RETURN(jm_substringFromRange, jc_CInputMethod, "attributedSubstringFromRange", "(II)Ljava/lang/String;", nil);
     jobject theString = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_substringFromRange, theRange.location, theRange.length);
     CHECK_EXCEPTION_NULL_RETURN(theString, nil);


### PR DESCRIPTION
Hi,
Please review the fix for the issue of JPasswordField and activated InputMethod on macOS.
I don't think this condition is usual, but I'd like to avoid crash.

It needs two additional checks in "AWTView attributedSubstringForProposedRange:actualRange".

Tested test/jdk/java/awt on macOS Catalina and BigSur (both headful), and no regression was occurred.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263490](https://bugs.openjdk.java.net/browse/JDK-8263490): [macos] Crash occurs on JPasswordField with activated InputMethod


### Reviewers
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2959/head:pull/2959`
`$ git checkout pull/2959`
