### PR TITLE
8263425: AArch64: two potential bugs in C1 LIRGenerator::generate_address()

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -174,7 +174,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
     if (large_disp != 0) {
       LIR_Opr tmp = new_pointer_register();
       if (Assembler::operand_valid_for_add_sub_immediate(large_disp)) {
-        __ add(tmp, tmp, LIR_OprFact::intptrConst(large_disp));
+        __ add(index, LIR_OprFact::intptrConst(large_disp), tmp);
         index = tmp;
       } else {
         __ move(tmp, LIR_OprFact::intptrConst(large_disp));
@@ -191,7 +191,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   }
 
   // at this point we either have base + index or base + displacement
-  if (large_disp == 0) {
+  if (large_disp == 0 && index->is_register()) {
     return new LIR_Address(base, index, type);
   } else {
     assert(Address::offset_ok_for_immed(large_disp, 0), "must be");


### PR DESCRIPTION
Around line 177 we have:

```
  LIR_Opr tmp = new_pointer_register();
  if (Assembler::operand_valid_for_add_sub_immediate(large_disp)) {
    __ add(tmp, tmp, LIR_OprFact::intptrConst(large_disp));    <----
    index = tmp;
   } else {
```

This is supposed to be calculating "tmp = index + large_disp" where tmp
is a freshly allocated register but it actually does "large_disp = tmp +
tmp".

On line 155 we check if index is a constant and if so accumulate its
value into large_disp. Then on line 194:

```
  // at this point we either have base + index or base + displacement
  if (large_disp == 0) {
    return new LIR_Address(base, index, type);      <----
  } else {
```

LIR_Address::verify() asserts that index is either a register or an
illegal value, but if the displacement and constant index sum to zero we
pass a constant in here.

C1 in mainline JDK doesn't hit these code paths, but I don't see any
reason why it couldn't in the future, and indeed it does on the lworld
branch. Tested tier1 on AArch64 with TieredStopAtLevel=1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263425](https://bugs.openjdk.java.net/browse/JDK-8263425): AArch64: two potential bugs in C1 LIRGenerator::generate_address()


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2961/head:pull/2961`
`$ git checkout pull/2961`
