### PR TITLE
8263497: Clean up sun.security.krb5.PrincipalName::toByteArray

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -534,7 +534,6 @@ public class PrincipalName implements Cloneable {
     public byte[][] toByteArray() {
         byte[][] result = new byte[nameStrings.length][];
         for (int i = 0; i < nameStrings.length; i++) {
-            result[i] = new byte[nameStrings[i].length()];
             result[i] = nameStrings[i].getBytes();
         }
         return result;


### PR DESCRIPTION
SonarCloud actually found this:
  Verify this is the index that was intended; it was already set before.

``` 
    public byte[][] toByteArray() {
        byte[][] result = new byte[nameStrings.length][];
        for (int i = 0; i < nameStrings.length; i++) {
            result[i] = new byte[nameStrings[i].length()]; // <-- here
            result[i] = nameStrings[i].getBytes();
        }
        return result;
    }
```

`getBytes()` returns the `byte[]` array, there is no need to allocate the array before it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263497](https://bugs.openjdk.java.net/browse/JDK-8263497): Clean up sun.security.krb5.PrincipalName::toByteArray 


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 6223ee6fcd3e278a98b664b30b469afd5f717ec3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2962/head:pull/2962`
`$ git checkout pull/2962`
