### PR TITLE
8187450: JNI local refs exceeds capacity warning in NetworkInterface::getAll

### DIFF
--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -503,6 +503,7 @@ JNIEXPORT jobjectArray JNICALL Java_java_net_NetworkInterface_getAll
 
         // put the NetworkInterface into the array
         (*env)->SetObjectArrayElement(env, netIFArr, arr_index++, netifObj);
+        (*env)->DeleteLocalRef(env, netifObj);
 
         curr = curr->next;
     }
@@ -766,12 +767,14 @@ static jobject createNetworkInterface(JNIEnv *env, netif *ifs) {
                             ((struct sockaddr_in*)addrP->brdcast)->sin_addr.s_addr));
                         JNU_CHECK_EXCEPTION_RETURN(env, NULL);
                         (*env)->SetObjectField(env, ibObj, ni_ib4broadcastID, ia2Obj);
+                        (*env)->DeleteLocalRef(env, ia2Obj);
                     } else {
                         return NULL;
                     }
                 }
                 (*env)->SetShortField(env, ibObj, ni_ib4maskID, addrP->mask);
                 (*env)->SetObjectArrayElement(env, bindArr, bind_index++, ibObj);
+                (*env)->DeleteLocalRef(env, ibObj);
             } else {
                 return NULL;
             }
@@ -800,12 +803,14 @@ static jobject createNetworkInterface(JNIEnv *env, netif *ifs) {
                 (*env)->SetObjectField(env, ibObj, ni_ibaddressID, iaObj);
                 (*env)->SetShortField(env, ibObj, ni_ib4maskID, addrP->mask);
                 (*env)->SetObjectArrayElement(env, bindArr, bind_index++, ibObj);
+                (*env)->DeleteLocalRef(env, ibObj);
             } else {
                 return NULL;
             }
         }
 
         (*env)->SetObjectArrayElement(env, addrArr, addr_index++, iaObj);
+        (*env)->DeleteLocalRef(env, iaObj);
         addrP = addrP->next;
     }
 
@@ -837,6 +842,11 @@ static jobject createNetworkInterface(JNIEnv *env, netif *ifs) {
     (*env)->SetObjectField(env, netifObj, ni_addrsID, addrArr);
     (*env)->SetObjectField(env, netifObj, ni_bindsID, bindArr);
     (*env)->SetObjectField(env, netifObj, ni_childsID, childArr);
+
+    (*env)->DeleteLocalRef(env, name);
+    (*env)->DeleteLocalRef(env, addrArr);
+    (*env)->DeleteLocalRef(env, bindArr);
+    (*env)->DeleteLocalRef(env, childArr);
 
     // return the NetworkInterface
     return netifObj;

--- a/src/java.base/windows/native/libnet/NetworkInterface.c
+++ b/src/java.base/windows/native/libnet/NetworkInterface.c
@@ -641,8 +641,10 @@ jobject createNetworkInterface
                   return NULL;
               }
               (*env)->SetObjectField(env, ibObj, ni_ibbroadcastID, ia2Obj);
+              (*env)->DeleteLocalRef(env, ia2Obj);
               (*env)->SetShortField(env, ibObj, ni_ibmaskID, addrs->mask);
               (*env)->SetObjectArrayElement(env, bindsArr, bind_index++, ibObj);
+              (*env)->DeleteLocalRef(env, ibObj);
             }
         } else /* AF_INET6 */ {
             int scope;
@@ -667,14 +669,13 @@ jobject createNetworkInterface
                 (*env)->SetObjectField(env, ibObj, ni_ibaddressID, iaObj);
                 (*env)->SetShortField(env, ibObj, ni_ibmaskID, addrs->mask);
                 (*env)->SetObjectArrayElement(env, bindsArr, bind_index++, ibObj);
+                (*env)->DeleteLocalRef(env, ibObj);
             }
         }
         (*env)->SetObjectArrayElement(env, addrArr, addr_index, iaObj);
+        (*env)->DeleteLocalRef(env, iaObj);
         addrs = addrs->next;
         addr_index++;
-        (*env)->DeleteLocalRef(env, iaObj);
-        (*env)->DeleteLocalRef(env, ibObj);
-        (*env)->DeleteLocalRef(env, ia2Obj);
     }
     (*env)->SetObjectField(env, netifObj, ni_addrsID, addrArr);
     (*env)->SetObjectField(env, netifObj, ni_bindsID, bindsArr);

--- a/src/java.base/windows/native/libnet/NetworkInterface.c
+++ b/src/java.base/windows/native/libnet/NetworkInterface.c
@@ -672,11 +672,18 @@ jobject createNetworkInterface
         (*env)->SetObjectArrayElement(env, addrArr, addr_index, iaObj);
         addrs = addrs->next;
         addr_index++;
+        (*env)->DeleteLocalRef(env, iaObj);
+        (*env)->DeleteLocalRef(env, ibObj);
+        (*env)->DeleteLocalRef(env, ia2Obj);
     }
     (*env)->SetObjectField(env, netifObj, ni_addrsID, addrArr);
     (*env)->SetObjectField(env, netifObj, ni_bindsID, bindsArr);
 
     free_netaddr(netaddrP);
+    (*env)->DeleteLocalRef(env, name);
+    (*env)->DeleteLocalRef(env, displayName);
+    (*env)->DeleteLocalRef(env, addrArr);
+    (*env)->DeleteLocalRef(env, bindsArr);
 
     /*
      * Windows doesn't have virtual interfaces, so child array
@@ -687,6 +694,7 @@ jobject createNetworkInterface
       return NULL;
     }
     (*env)->SetObjectField(env, netifObj, ni_childsID, childArr);
+    (*env)->DeleteLocalRef(env, childArr);
 
     /* return the NetworkInterface */
     return netifObj;
@@ -959,6 +967,7 @@ JNIEXPORT jobjectArray JNICALL Java_java_net_NetworkInterface_getAll
 
         /* put the NetworkInterface into the array */
         (*env)->SetObjectArrayElement(env, netIFArr, arr_index++, netifObj);
+        (*env)->DeleteLocalRef(env, netifObj);
 
         curr = curr->next;
     }

--- a/test/jdk/java/net/NetworkInterface/Test.java
+++ b/test/jdk/java/net/NetworkInterface/Test.java
@@ -24,8 +24,8 @@
 /* @test
  * @bug 4405354 6594296 8058216
  * @library /test/lib
- * @run main Test -Xcheck:jni
- * @run main/othervm -Djava.net.preferIPv4Stack=true Test -Xcheck:jni
+ * @run main/othervm -Xcheck:jni Test
+ * @run main/othervm -Xcheck:jni -Djava.net.preferIPv4Stack=true Test
  * @summary Basic tests for NetworkInterface
  */
 import java.net.NetworkInterface;

--- a/test/jdk/java/net/NetworkInterface/Test.java
+++ b/test/jdk/java/net/NetworkInterface/Test.java
@@ -24,8 +24,8 @@
 /* @test
  * @bug 4405354 6594296 8058216
  * @library /test/lib
- * @run main Test
- * @run main/othervm -Djava.net.preferIPv4Stack=true Test
+ * @run main Test -Xcheck:jni
+ * @run main/othervm -Djava.net.preferIPv4Stack=true Test -Xcheck:jni
  * @summary Basic tests for NetworkInterface
  */
 import java.net.NetworkInterface;


### PR DESCRIPTION
This is an adaptation of a patch originally written by Shafi Ahmad in
a comment on the JBS page but never submitted or merged.

With -Xcheck:jni, the method java.net.NetworkInterface.getAll very
quickly breaches the default JNI local refs threshold (32). Exactly when
this happens depends upon the number of network interfaces (in state "UP")
visible to Java. On Linux, with current Trunk, 2 network interfaces is
sufficient to breach:

    $ ./addif.sh 0
    1 interfaces
    $ sudo ip netns exec jbase $JAVA_HOME/bin/java -Xcheck:jni NITest
     (nothing)
    $ ./addif.sh 1
    2 interfaces
    $ sudo ip netns exec jbase $JAVA_HOME/bin/java -Xcheck:jni NITest
    WARNING: JNI local refs: 33, exceeds capacity: 32
            at java.net.NetworkInterface.getAll(java.base/Native Method)
            at java.net.NetworkInterface.getNetworkInterfaces(java.base/NetworkInterface.java:351)
            at NITest.main(NITest.java:3)

This patch improves the situation:

    $ ./addif.sh 3
    4 interfaces
    $ sudo ip netns exec jbase $JAVA_HOME/bin/java -Xcheck:jni NITest
     (nothing)
    $ ./addif.sh 4
    5 interfaces
    $ sudo ip netns exec jbase $JAVA_HOME/bin/java -Xcheck:jni NITest
    WARNING: JNI local refs: 33, exceeds capacity: 32
            at java.net.NetworkInterface.getAll(java.base/Native Method)
            at java.net.NetworkInterface.getNetworkInterfaces(java.base/NetworkInterface.java:351)
            at NITest.main(NITest.java:3)


Once the JNI local refs threshold is breached, the threshold is raised.
With the patch, it takes 10 network interfaces to breach the new
threshold 

    $ ./addif.sh 9
    10 interfaces
    $ sudo ip netns exec jbase $JAVA_HOME/bin/java -Xcheck:jni NITest
    WARNING: JNI local refs: 33, exceeds capacity: 32
            at java.net.NetworkInterface.getAll(java.base/Native Method)
            at java.net.NetworkInterface.getNetworkInterfaces(java.base/NetworkInterface.java:351)
            at NITest.main(NITest.java:3)
    WARNING: JNI local refs: 66, exceeds capacity: 65
            at java.net.NetworkInterface.getAll(java.base/Native Method)
            at java.net.NetworkInterface.getNetworkInterfaces(java.base/NetworkInterface.java:351)
            at NITest.main(NITest.java:3)

Without the patch it takes 5.

Helper scripts for testing on Linux. `setupnet.sh`:

    #!/bin/bash
    set -euo pipefail

    namespace=${namespace:-jbase}
    sudo ip netns add ${namespace}

And `addif.sh`:

    #!/bin/bash
    set -euo pipefail

    namespace=${namespace:-jbase}
    num="$1"

    sudo ip link add name vethhost${num} type veth peer name veth${namespace}${num}
    sudo ip link set veth${namespace}${num} netns ${namespace}
    sudo ip addr add 192.168.2.${num}/24 dev vethhost${num}
    sudo ip netns exec ${namespace} ip addr add 192.168.2.${num}/24 dev veth${namespace}${num}
    sudo ip link set vethhost${num} up
    sudo ip netns exec ${namespace} ip link set veth${namespace}${num} up

    count="$(sudo ip netns exec ${namespace} ip link show |grep UP | wc -l)"
    echo "${count} interfaces"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8187450](https://bugs.openjdk.java.net/browse/JDK-8187450): JNI local refs exceeds capacity warning in NetworkInterface::getAll


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2963/head:pull/2963`
`$ git checkout pull/2963`

To update a local copy of the PR:
`$ git checkout pull/2963`
`$ git pull https://git.openjdk.java.net/jdk pull/2963/head`
