### PR TITLE
8263185: Mallinfo deprecated in glibc 2.33

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2235,7 +2235,7 @@ void os::Linux::print_process_memory_info(outputStream* st) {
 #if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
   mallinfo_ptr = dlsym(RTLD_DEFAULT, "mallinfo2");
   if (mallinfo_ptr != NULL) {
-    struct mallinfo2 mi = reinterpret_cast<struct mallinfo2 (*)(void)>(mallinfo_ptr)();
+    struct mallinfo2 mi = CAST_TO_FN_PTR(struct mallinfo2 (*)(void), mallinfo_ptr)();
     total_allocated = mi.uordblks;
   }
 #endif // __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
@@ -2245,7 +2245,7 @@ void os::Linux::print_process_memory_info(outputStream* st) {
       // mallinfo is an old API. Member names mean next to nothing and, beyond that, are int.
       // So values may have wrapped around. Still useful enough to see how much glibc thinks
       // we allocated.
-      struct mallinfo mi = reinterpret_cast<struct mallinfo (*)(void)>(mallinfo_ptr)();
+      struct mallinfo mi = CAST_TO_FN_PTR(struct mallinfo (*)(void), mallinfo_ptr)();
       total_allocated = (size_t)(unsigned)mi.uordblks;
       // Since mallinfo members are int, glibc values may have wrapped. Warn about this.
       might_have_wrapped = (vmrss * K) > UINT_MAX && (vmrss * K) > (total_allocated + UINT_MAX);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -253,6 +253,9 @@ class Linux {
   };
   static NumaAllocationPolicy _current_numa_policy;
 
+  static void* _mallinfo_fun_ptr;
+  static void* _mallinfo2_fun_ptr;
+
  public:
   static int sched_getcpu()  { return _sched_getcpu != NULL ? _sched_getcpu() : -1; }
   static int numa_node_to_cpus(int node, unsigned long *buffer, int bufferlen);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -253,8 +253,39 @@ class Linux {
   };
   static NumaAllocationPolicy _current_numa_policy;
 
-  static void* _mallinfo_fun_ptr;
-  static void* _mallinfo2_fun_ptr;
+#ifdef __GLIBC__
+  struct glibc_mallinfo {
+    int arena;
+    int ordblks;
+    int smblks;
+    int hblks;
+    int hblkhd;
+    int usmblks;
+    int fsmblks;
+    int uordblks;
+    int fordblks;
+    int keepcost;
+  };
+
+  struct glibc_mallinfo2 {
+    size_t arena;
+    size_t ordblks;
+    size_t smblks;
+    size_t hblks;
+    size_t hblkhd;
+    size_t usmblks;
+    size_t fsmblks;
+    size_t uordblks;
+    size_t fordblks;
+    size_t keepcost;
+  };
+
+  typedef struct glibc_mallinfo (*mallinfo_func_t)(void);
+  typedef struct glibc_mallinfo2 (*mallinfo2_func_t)(void);
+
+  static mallinfo_func_t _mallinfo;
+  static mallinfo2_func_t _mallinfo2;
+#endif
 
  public:
   static int sched_getcpu()  { return _sched_getcpu != NULL ? _sched_getcpu() : -1; }


### PR DESCRIPTION
Starting with glibc 2.33, mallinfo is deprecated in favor of the new mallinfo2 API. Both APIs work the same way, the only difference is, that mallinfo2 uses size_t instead of int for the fields of the struct, containing the information about malloc. Please see the [glibc release notes](https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html).

Testing with tier1 on a system with glibc 2.33 and on a system with glibc 2.31.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263185](https://bugs.openjdk.java.net/browse/JDK-8263185): Mallinfo deprecated in glibc 2.33


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2964/head:pull/2964`
`$ git checkout pull/2964`

To update a local copy of the PR:
`$ git checkout pull/2964`
`$ git pull https://git.openjdk.java.net/jdk pull/2964/head`
