### PR TITLE
8263501: compiler/oracle/TestInvalidCompileCommand.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -42,23 +42,19 @@ public class TestInvalidCompileCommand {
             "-version"
         },
         {
-            "-XX:CompileCommand=option,Test::test,TestOptionDouble,3.14",
+            "-XX:CompileCommand=option,Test::test,CompileThresholdScaling,3.14",
             "-version"
         },
         {
-            "-XX:CompileCommand=option,Test::test,TestOptionInt,3",
+            "-XX:CompileCommand=option,Test::test,RepeatCompilation,3",
             "-version"
         },
         {
-            "-XX:CompileCommand=option,Test::test,TestOptionUint,3",
+            "-XX:CompileCommand=option,Test::test,VectorizeDebug,3",
             "-version"
         },
         {
-            "-XX:CompileCommand=option,Test::test,TestOptionStr,hello",
-            "-version"
-        },
-        {
-            "-XX:CompileCommand=option,Test::test,TestOptionList,hello,world",
+            "-XX:CompileCommand=option,Test::test,ControlIntrinsic,-_maxD,-_minD",
             "-version"
         }
     };
@@ -68,19 +64,16 @@ public class TestInvalidCompileCommand {
             "Unrecognized option 'unknown'"
         },
         {
-            "Missing type 'double' before option 'TestOptionDouble'"
+            "Missing type 'double' before option 'CompileThresholdScaling'"
         },
         {
-            "Missing type 'intx' before option 'TestOptionInt'"
+            "Missing type 'intx' before option 'RepeatCompilation'"
         },
         {
-            "Missing type 'uintx' before option 'TestOptionUint'"
+            "Missing type 'uintx' before option 'VectorizeDebug'"
         },
         {
-            "Missing type 'ccstr' before option 'TestOptionStr'"
-        },
-        {
-            "Missing type 'ccstrlist' before option 'TestOptionList'"
+            "Missing type 'ccstrlist' before option 'ControlIntrinsic'"
         }
     };
 


### PR DESCRIPTION
Hi all,

compiler/oracle/TestInvalidCompileCommand.java fails with release VMs since it uses debug-only options in the test.

The fix replaces these debug-only with release-available options.
And the test for ccstr type has been removed since there is no ccstr type options in release mode.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263501](https://bugs.openjdk.java.net/browse/JDK-8263501): compiler/oracle/TestInvalidCompileCommand.java fails with release VMs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2965/head:pull/2965`
`$ git checkout pull/2965`
