### PR TITLE
8263504: Some OutputMachOpcodes fields are uninitialized

### DIFF
--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -2136,7 +2136,9 @@ class OutputMachOpcodes : public OutputMap {
 public:
   OutputMachOpcodes(FILE *hpp, FILE *cpp, FormDict &globals, ArchDesc &AD)
     : OutputMap(hpp, cpp, globals, AD, "MachOpcodes"),
-      begin_inst_chain_rule(-1), end_inst_chain_rule(-1), end_instructions(-1)
+      begin_inst_chain_rule(-1), end_inst_chain_rule(-1),
+      begin_rematerialize(-1), end_rematerialize(-1),
+      end_instructions(-1)
   {};
 
   void declaration() { }


### PR DESCRIPTION
SonarCloud reports:
  2 uninitialized fields at the end of the constructor calls

```
class OutputMachOpcodes : public OutputMap {
  int begin_inst_chain_rule;
  int end_inst_chain_rule;
  int begin_rematerialize; // <--- this
  int end_rematerialize;   // <--- and this
  int end_instructions;
public:
  OutputMachOpcodes(FILE *hpp, FILE *cpp, FormDict &globals, ArchDesc &AD)
    : OutputMap(hpp, cpp, globals, AD, "MachOpcodes"),
      begin_inst_chain_rule(-1), end_inst_chain_rule(-1), end_instructions(-1)
```

They are written on all paths that I can see, but they should be initialized anyway, at least for proper checks in `closing()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263504](https://bugs.openjdk.java.net/browse/JDK-8263504): Some OutputMachOpcodes fields are uninitialized


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2967/head:pull/2967`
`$ git checkout pull/2967`
