### PR TITLE
8263509: LdapSchemaParser.readNextTag checks array length incorrectly

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
@@ -376,7 +376,7 @@ final class LdapSchemaParser {
         values = readTag(tagName, string, pos);
 
         // make sure at least one value was returned
-        if(values.length < 0) {
+        if (values.length == 0) {
             throw new InvalidAttributeValueException("no values for " +
                                                      "attribute \"" +
                                                      tagName + "\"");


### PR DESCRIPTION
SonarCloud rightfully says:
  The length of "values" is always ">=0", so update this test to either "==0" or ">0".

```
        // make sure at least one value was returned
        if(values.length < 0) { // <--- here
            throw new InvalidAttributeValueException("no values for " +
                                                     "attribute \"" +
                                                     tagName + "\"");
        }
```

There is a subsequent access to values[0], which means the failure would throw `AIOOB`, not `InvalidAttributeValueException`.

Additional testing:
 - [x] Linux x86_64 fastdebug, `com/sun/jndi`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263509](https://bugs.openjdk.java.net/browse/JDK-8263509): LdapSchemaParser.readNextTag checks array length incorrectly


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2968/head:pull/2968`
`$ git checkout pull/2968`
