### PR TITLE
8263514: Minor issue in JavacFileManager.SortFiles.REVERSE

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -123,7 +123,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
         REVERSE {
             @Override
             public int compare(Path f1, Path f2) {
-                return -f1.getFileName().compareTo(f2.getFileName());
+                return f2.getFileName().compareTo(f1.getFileName());
             }
         }
     }


### PR DESCRIPTION
SonarCloud reports the problem in  JavacFileManager.SortFiles.REVERSE definition:
 Neither "Math.abs" nor negation should be used on numbers that could be "MIN_VALUE"

```
        REVERSE {
            @Override
            public int compare(Path f1, Path f2) {
                return -f1.getFileName().compareTo(f2.getFileName());
            }
        }
```

Since `compareTo` can technically return `MIN_VALUE`, we cannot simply negate it. Luckily, we can just swap the `f1` and `f2` comparison order to achieve the same effect without exposing us to this corner case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263514](https://bugs.openjdk.java.net/browse/JDK-8263514): Minor issue in JavacFileManager.SortFiles.REVERSE


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2970/head:pull/2970`
`$ git checkout pull/2970`
