### PR TITLE
JDK-8263300: add HtmlId for the block containing a class's description.

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -176,7 +176,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
 
     @Override
     public Content getClassInfo(Content classInfoTree) {
-        return getMemberTree(HtmlStyle.description, classInfoTree);
+        return getMemberTree(HtmlIds.CLASS_DESCRIPTION, HtmlStyle.classDescription, classInfoTree);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -70,6 +70,7 @@ public class HtmlIds {
     static final HtmlId ANNOTATION_TYPE_ELEMENT_DETAIL = HtmlId.of("annotation-interface-element-detail");
     static final HtmlId ANNOTATION_TYPE_OPTIONAL_ELEMENT_SUMMARY = HtmlId.of("annotation-interface-optional-element-summary");
     static final HtmlId ANNOTATION_TYPE_REQUIRED_ELEMENT_SUMMARY = HtmlId.of("annotation-interface-required-element-summary");
+    static final HtmlId CLASS_DESCRIPTION = HtmlId.of("class-description");
     static final HtmlId CONSTRUCTOR_DETAIL = HtmlId.of("constructor-detail");
     static final HtmlId CONSTRUCTOR_SUMMARY = HtmlId.of("constructor-summary");
     static final HtmlId ENUM_CONSTANT_DETAIL = HtmlId.of("enum-constant-detail");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
@@ -327,11 +327,12 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
     /**
      * Get the member tree
      *
+     * @param id the id to be used for the content tree
      * @param style the style class to be added to the content tree
      * @param contentTree the tree used to generate the complete member tree
      * @return the member tree
      */
-    public Content getMemberTree(HtmlStyle style, Content contentTree) {
-        return HtmlTree.SECTION(style, contentTree);
+    public Content getMemberTree(HtmlId id, HtmlStyle style, Content contentTree) {
+        return HtmlTree.SECTION(style, contentTree).setId(id);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -473,11 +473,10 @@ public enum HtmlStyle {
     // generated from documentation comments.
 
     /**
-     * The class of the element used to present the documentation comment for a type or member
-     * element.
+     * The class of the element used to present the documentation comment for a type element.
      * The content of the block tags will be in a nested element with class {@link #notes}.
      */
-    description,
+    classDescription,
 
     /**
      * The class of the element used to present the documentation comment for a module element,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -655,7 +655,7 @@ ul.ui-autocomplete  li {
 .inherited-list {
     margin: 10px 0 10px 0;
 }
-section.description {
+section.class-description {
     line-height: 1.4;
 }
 .summary section[class$="-summary"], .details section[class$="-details"],

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -119,7 +119,7 @@ public class TestMemberInheritance extends JavadocTester {
 
         checkOutput("pkg2/DocumentedNonGenericChild.html", true,
                 """
-                    <section class="description">
+                    <section class="class-description" id="class-description">
                     <hr>
                     <div class="type-signature"><span class="modifiers">public abstract class </span\
                     ><span class="element-name type-name-label">DocumentedNonGenericChild</span>

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1339,7 +1339,7 @@ public class TestModules extends JavadocTester {
                     """);
         checkOutput("moduleA/testpkgmdlA/TestClassInModuleA.html", true,
                 """
-                    <section class="description">
+                    <section class="class-description" id="class-description">
                     <hr>
                     <div class="type-signature"><span class="modifiers">public class </span><span cl\
                     ass="element-name"><a href="../../src-html/moduleA/testpkgmdlA/TestClassInModule\


### PR DESCRIPTION
This is a relatively simple change to add an `id="class-description"` to the description section of type pages. It also changes the CSS class for this section from `description` to `class-description` for consistency with package and module pages. 

My initial plan was to move the beginning of the section to after the type signature, as this is how it is done for package and module pages. However, I'm not sure there's any benefit to this that would be worth the change, so I decided to keep it simple.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263300](https://bugs.openjdk.java.net/browse/JDK-8263300): add HtmlId for the block containing a class's description.


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2971/head:pull/2971`
`$ git checkout pull/2971`

To update a local copy of the PR:
`$ git checkout pull/2971`
`$ git pull https://git.openjdk.java.net/jdk pull/2971/head`
