### PR TITLE
JDK-8263528: Make static page ids safe from collision with language elements

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -90,6 +90,8 @@ public class HtmlIds {
     static final HtmlId PACKAGE_SUMMARY_TABLE = HtmlId.of("package-summary-table");
     static final HtmlId PROPERTY_DETAIL = HtmlId.of("property-detail");
     static final HtmlId PROPERTY_SUMMARY = HtmlId.of("property-summary");
+    static final HtmlId RESET_BUTTON = HtmlId.of("reset-button");
+    static final HtmlId SEARCH_INPUT = HtmlId.of("search-input");
     static final HtmlId SERVICES = HtmlId.of("services-summary");
     static final HtmlId SKIP_NAVBAR_TOP = HtmlId.of("skip-navbar-top");
     static final HtmlId UNNAMED_PACKAGE_ANCHOR = HtmlId.of("unnamed-package");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -892,8 +892,8 @@ public class Navigation {
     private void addSearch(Content tree) {
         String searchValueId = "search";
         String reset = "reset";
-        HtmlTree inputText = HtmlTree.INPUT("text", searchValueId, searchValueId);
-        HtmlTree inputReset = HtmlTree.INPUT(reset, reset, reset);
+        HtmlTree inputText = HtmlTree.INPUT("text", HtmlIds.SEARCH_INPUT, searchValueId);
+        HtmlTree inputReset = HtmlTree.INPUT(reset, HtmlIds.RESET_BUTTON, reset);
         HtmlTree searchDiv = HtmlTree.DIV(HtmlStyle.navListSearch, HtmlTree.LABEL(searchValueId, searchLabel));
         searchDiv.add(inputText);
         searchDiv.add(inputReset);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -528,10 +528,10 @@ public class HtmlTree extends Content {
      * @param value the initial value
      * @return the element
      */
-    public static HtmlTree INPUT(String type, String id, String value) {
+    public static HtmlTree INPUT(String type, HtmlId id, String value) {
         return new HtmlTree(TagName.INPUT)
                 .put(HtmlAttr.TYPE, type)
-                .put(HtmlAttr.ID, id)
+                .setId(id)
                 .put(HtmlAttr.VALUE, value)
                 .put(HtmlAttr.DISABLED, "disabled");
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -98,8 +98,8 @@ function createMatcher(pattern, flags) {
 }
 var watermark = 'Search';
 $(function() {
-    var search = $("#search");
-    var reset = $("#reset");
+    var search = $("#search-input");
+    var reset = $("#reset-button");
     search.val('');
     search.prop("disabled", false);
     reset.prop("disabled", false);
@@ -291,7 +291,7 @@ function doSearch(request, response) {
     response(result);
 }
 $(function() {
-    $("#search").catcomplete({
+    $("#search-input").catcomplete({
         minLength: 1,
         delay: 300,
         source: doSearch,
@@ -299,7 +299,7 @@ $(function() {
             if (!ui.content.length) {
                 ui.content.push(noResult);
             } else {
-                $("#search").empty();
+                $("#search-input").empty();
             }
         },
         autoFocus: true,
@@ -347,7 +347,7 @@ $(function() {
                 } else {
                     window.location.href = pathtoroot + url;
                 }
-                $("#search").focus();
+                $("#search-input").focus();
             }
         }
     });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -605,7 +605,7 @@ ul.ui-autocomplete  li {
 .result-highlight {
     font-weight:bold;
 }
-#search {
+#search-input {
     background-image:url('resources/glass.png');
     background-size:13px;
     background-repeat:no-repeat;
@@ -615,7 +615,7 @@ ul.ui-autocomplete  li {
     right:-18px;
     width:400px;
 }
-#reset {
+#reset-button {
     background-color: rgb(255,255,255);
     background-image:url('resources/x.png');
     background-position:center;
@@ -783,12 +783,12 @@ table.striped > tbody > tr > th {
  * Tweak font sizes and paddings for small screens.
  */
 @media screen and (max-width: 1050px) {
-    #search {
+    #search-input {
         width: 300px;
     }
 }
 @media screen and (max-width: 800px) {
-    #search {
+    #search-input {
         width: 200px;
     }
     .top-nav,
@@ -821,7 +821,7 @@ table.striped > tbody > tr > th {
     }
 }
 @media screen and (max-width: 500px) {
-    #search {
+    #search-input {
         width: 150px;
     }
     .top-nav,

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8141492 8071982 8141636 8147890 8166175 8168965 8176794 8175218 8147881
  *      8181622 8182263 8074407 8187521 8198522 8182765 8199278 8196201 8196202
- *      8184205 8214468 8222548 8223378 8234746 8241219 8254627 8247994
+ *      8184205 8214468 8222548 8223378 8234746 8241219 8254627 8247994 8263528
  * @summary Test the search feature of javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -420,8 +420,8 @@ public class TestSearch extends JavadocTester {
                 "<div class=\"nav-list-search\">",
                 """
                     <label for="search">SEARCH:</label>
-                    <input type="text" id="search" value="search" disabled="disabled">
-                    <input type="reset" id="reset" value="reset" disabled="disabled">
+                    <input type="text" id="search-input" value="search" disabled="disabled">
+                    <input type="reset" id="reset-button" value="reset" disabled="disabled">
                     """);
         checkOutput(fileName, true,
                 "<div class=\"flex-box\">");

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -25,7 +25,7 @@
  * @test
  * @bug      4494033 7028815 7052425 8007338 8023608 8008164 8016549 8072461 8154261 8162363 8160196 8151743 8177417
  *           8175218 8176452 8181215 8182263 8183511 8169819 8183037 8185369 8182765 8196201 8184205 8223378 8241544
- *           8253117
+ *           8253117 8263528
  * @summary  Run tests on doclet stylesheet.
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -179,7 +179,7 @@ public class TestStylesheet extends JavadocTester {
                         display:inline-block;
                     }""",
                 """
-                    #reset {
+                    #reset-button {
                         background-color: rgb(255,255,255);
                         background-image:url('resources/x.png');
                         background-position:center;


### PR DESCRIPTION
A simple change to make the HTML ids used for search input and reset button safe from collision with Java elements. The ids are also added th the `HtmlIds` class instead of using strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263528](https://bugs.openjdk.java.net/browse/JDK-8263528): Make static page ids safe from collision with language elements


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2973/head:pull/2973`
`$ git checkout pull/2973`

To update a local copy of the PR:
`$ git checkout pull/2973`
`$ git pull https://git.openjdk.java.net/jdk pull/2973/head`
