### PR TITLE
8263530: sun.awt.X11.ListHelper.removeAll() should use clear()

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
@@ -147,7 +147,7 @@ final class ListHelper implements XScrollbarClient {
     }
 
     void removeAll() {
-        items.removeAll(items);
+        items.clear();
         updateScrollbars();
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
SonarCloud reports:
  Remove or correct this "removeAll" call.

```
    void removeAll() {
        items.removeAll(items); // <--- here
        updateScrollbars();
    }
```

Calling `removeAll()` with the same collection risks concurrent modification exceptions. `clear()` would be correct and more efficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263530](https://bugs.openjdk.java.net/browse/JDK-8263530): sun.awt.X11.ListHelper.removeAll() should use clear()


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 7dc5ab533ff81ee4479c8eeb4bf1f8bede765a4c
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 7dc5ab533ff81ee4479c8eeb4bf1f8bede765a4c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2974/head:pull/2974`
`$ git checkout pull/2974`
