### PR TITLE
JDK-8263411: Convert jshell tool to use Stream.toList()

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ArgTokenizer.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ArgTokenizer.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static java.util.stream.Collectors.toList;
 
 /**
  * Parse command arguments, derived from StreamTokenizer by
@@ -102,7 +101,7 @@ class ArgTokenizer {
                 options.entrySet()
                        .stream()
                        .filter(e -> e.getKey().startsWith(opt))
-                       .collect(toList());
+                       .toList();
         if (matches.size() == 1) {
             matches.get(0).setValue(true);
         } else {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -247,8 +247,8 @@ class ConsoleIOContext extends IOContext {
     public Iterable<String> history(boolean currentSession) {
         return StreamSupport.stream(getHistory().spliterator(), false)
                             .filter(entry -> !currentSession || !historyLoad.equals(entry.time()))
-                            .map(entry -> entry.line())
-                            .collect(Collectors.toList());
+                            .map(History.Entry::line)
+                            .toList();
     }
 
     @Override
@@ -263,7 +263,7 @@ class ConsoleIOContext extends IOContext {
             StreamSupport.stream(in.getHistory().spliterator(), false)
                          .map(History.Entry::line)
                          .flatMap(this::toSplitEntries)
-                         .collect(Collectors.toList());
+                         .toList();
         if (!savedHistory.isEmpty()) {
             int len = (int) Math.ceil(Math.log10(savedHistory.size()+1));
             String format = HISTORY_LINE_PREFIX + "%0" + len + "d";
@@ -354,7 +354,7 @@ class ConsoleIOContext extends IOContext {
                     doc = repl.analysis.documentation(prefix + text, cursor + prefix.length(), false)
                                        .stream()
                                        .map(Documentation::signature)
-                                       .collect(Collectors.toList());
+                                       .toList();
                 }
                 long smartCount = suggestions.stream().filter(Suggestion::matchesType).count();
                 boolean hasSmart = smartCount > 0 && smartCount <= /*in.getAutoprintThreshold()*/AUTOPRINT_THRESHOLD;
@@ -597,13 +597,15 @@ class ConsoleIOContext extends IOContext {
                                .filter(Suggestion::matchesType)
                                .map(Suggestion::continuation)
                                .distinct()
-                               .collect(Collectors.toList());
+                               .map(s -> (CharSequence) s)
+                               .toList();
             } else {
                 toShow =
                     suggestions.stream()
                                .map(Suggestion::continuation)
                                .distinct()
-                               .collect(Collectors.toList());
+                               .map(s -> (CharSequence) s)
+                               .toList();
             }
 
             if (toShow.isEmpty()) {
@@ -658,7 +660,7 @@ class ConsoleIOContext extends IOContext {
                     suggestions.stream()
                                .map(Suggestion::continuation)
                                .distinct()
-                               .collect(Collectors.toList());
+                               .toList();
 
             Optional<String> prefix =
                     candidates.stream()
@@ -792,7 +794,7 @@ class ConsoleIOContext extends IOContext {
             List<String> doc = repl.analysis.documentation(prefix + text, cursor + prefix.length(), true)
                                             .stream()
                                             .map(convertor)
-                                            .collect(Collectors.toList());
+                                            .toList();
             return doPrintFullDocumentation(todo, doc, false);
         }
 

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -589,7 +589,7 @@ class ConsoleIOContext extends IOContext {
 
         @Override
         public Result perform(String text, int cursor) throws IOException {
-            List<CharSequence> toShow;
+            List<? extends CharSequence> toShow;
 
             if (showSmart) {
                 toShow =
@@ -597,14 +597,12 @@ class ConsoleIOContext extends IOContext {
                                .filter(Suggestion::matchesType)
                                .map(Suggestion::continuation)
                                .distinct()
-                               .map(s -> (CharSequence) s)
                                .toList();
             } else {
                 toShow =
                     suggestions.stream()
                                .map(Suggestion::continuation)
                                .distinct()
-                               .map(s -> (CharSequence) s)
                                .toList();
             }
 

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ContinuousCompletionProvider.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ContinuousCompletionProvider.java
@@ -30,7 +30,6 @@ import static java.util.Comparator.comparing;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
-import static java.util.stream.Collectors.toList;
 import java.util.stream.Stream;
 import jdk.internal.jshell.tool.JShellTool.CompletionProvider;
 import jdk.jshell.SourceCodeAnalysis;
@@ -79,7 +78,7 @@ class ContinuousCompletionProvider implements CompletionProvider {
             List<CompletionProvider> candidates = wordCompletionProvider.entrySet().stream()
                     .filter(e -> matcher.test(e.getKey(), word))
                     .map(Map.Entry::getValue)
-                    .collect(toList());
+                    .toList();
             if (candidates.size() == 1) {
                 result = candidates.get(0).completionSuggestions(rest, cursor - space - 1, anchor).stream();
             } else {
@@ -89,7 +88,7 @@ class ContinuousCompletionProvider implements CompletionProvider {
         }
 
         return result.sorted(comparing(Suggestion::continuation))
-                     .collect(toList());
+                     .toList();
     }
 
 }

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -121,7 +121,6 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static jdk.jshell.Snippet.SubKind.TEMP_VAR_EXPRESSION_SUBKIND;
 import static jdk.jshell.Snippet.SubKind.VAR_VALUE_SUBKIND;
 import static java.util.stream.Collectors.toMap;
@@ -407,7 +406,7 @@ public class JShellTool implements MessageHandler {
             if (failed) {
                 return Collections.emptyList();
             } else {
-                return result.collect(toList());
+                return result.toList();
             }
         }
 
@@ -458,7 +457,7 @@ public class JShellTool implements MessageHandler {
             addOptions(OptionKind.ADD_MODULES, options.valuesOf(argAddModules));
             addOptions(OptionKind.ADD_EXPORTS, options.valuesOf(argAddExports).stream()
                     .map(mp -> mp.contains("=") ? mp : mp + "=ALL-UNNAMED")
-                    .collect(toList())
+                    .toList()
             );
             if (options.has(argEnablePreview)) {
                 opts.addAll(OptionKind.ENABLE_PREVIEW, List.of(
@@ -486,7 +485,7 @@ public class JShellTool implements MessageHandler {
                 if (kind.passFlag) {
                     vals = vals.stream()
                             .flatMap(mp -> Stream.of(kind.optionFlag, mp))
-                            .collect(toList());
+                            .toList();
                 }
                 opts.addAll(kind, vals);
             }
@@ -1590,8 +1589,8 @@ public class JShellTool implements MessageHandler {
                                 ? Stream.of(String.valueOf(k.id()) + " ", ((DeclarationSnippet) k).name() + " ")
                                 : Stream.of(String.valueOf(k.id()) + " "))
                         .filter(k -> k.startsWith(argPrefix))
-                        .map(ArgSuggestion::new)
-                        .collect(Collectors.toList());
+                        .map(p -> (Suggestion) new ArgSuggestion(p))
+                        .toList();
         };
     }
 
@@ -1659,8 +1658,8 @@ public class JShellTool implements MessageHandler {
                 String flag = ovm.group("flag");
                 List<CompletionProvider> ps = ARG_OPTIONS.entrySet().stream()
                         .filter(es -> es.getKey().startsWith(flag))
-                        .map(es -> es.getValue())
-                        .collect(toList());
+                        .map(Map.Entry::getValue)
+                        .toList();
                 if (ps.size() == 1) {
                     int pastSpace = ovm.start("val");
                     List<Suggestion> result = ps.get(0).completionSuggestions(
@@ -1687,7 +1686,8 @@ public class JShellTool implements MessageHandler {
                                     return false;
                                 }
                             })
-                            .collect(toList());
+                            .map(e -> (Suggestion) e)
+                            .toList();
                     --pastSpace;
                 }
                 anchor[0] += pastSpace;
@@ -1927,8 +1927,8 @@ public class JShellTool implements MessageHandler {
             toShow =
                 Arrays.stream(SET_SUBCOMMANDS)
                        .filter(s -> s.startsWith(setSubcommand))
-                        .map(s -> new SimpleEntry<>("/set " + s, "help.set." + s))
-                        .collect(toList());
+                        .map(s -> (Entry<String,String>) new SimpleEntry<>("/set " + s, "help.set." + s))
+                        .toList();
         } else if (RERUN_ID.matcher(stripped).matches()) {
             toShow =
                 singletonList(new SimpleEntry<>("/<id>", "help.rerun"));
@@ -1944,8 +1944,8 @@ public class JShellTool implements MessageHandler {
                         .filter(c -> c.kind.showInHelp
                                   || (inHelp && c.kind == CommandKind.HELP_SUBJECT))
                         .sorted((c1, c2) -> c1.command.compareTo(c2.command))
-                        .map(c -> new SimpleEntry<>(c.command, c.helpKey))
-                        .collect(toList());
+                        .map(c -> (Entry<String,String>) new SimpleEntry<>(c.command, c.helpKey))
+                        .toList();
         }
 
         if (toShow.size() == 1 && !inHelp) {
@@ -2367,7 +2367,7 @@ public class JShellTool implements MessageHandler {
                     Snippet sn = e.snippet();
 
                     // Show any diagnostics
-                    List<Diag> diagnostics = state.diagnostics(sn).collect(toList());
+                    List<Diag> diagnostics = state.diagnostics(sn).toList();
                     String source = sn.source();
                     displayDiagnostics(source, diagnostics);
 
@@ -2769,7 +2769,7 @@ public class JShellTool implements MessageHandler {
             if (allIds == null) {
                 allSnippets = snippetSupplier.get()
                         .sorted((a, b) -> order(a) - order(b))
-                        .collect(toList());
+                        .toList();
                 allIds = allSnippets.stream()
                         .map(sn -> sn.id())
                         .toArray(n -> new String[n]);
@@ -3394,7 +3394,7 @@ public class JShellTool implements MessageHandler {
     }
 
     private boolean cmdUseHistoryEntry(int index) {
-        List<Snippet> keys = state.snippets().collect(toList());
+        List<Snippet> keys = state.snippets().toList();
         if (index < 0)
             index += keys.size();
         else
@@ -3455,7 +3455,7 @@ public class JShellTool implements MessageHandler {
     List<Diag> errorsOnly(List<Diag> diagnostics) {
         return diagnostics.stream()
                 .filter(Diag::isError)
-                .collect(toList());
+                .toList();
     }
 
     /**
@@ -3633,7 +3633,7 @@ public class JShellTool implements MessageHandler {
             debug("Event with null key: %s", ste);
             return false;
         }
-        List<Diag> diagnostics = state.diagnostics(sn).collect(toList());
+        List<Diag> diagnostics = state.diagnostics(sn).toList();
         String source = sn.source();
         if (ste.causeSnippet() == null) {
             // main event
@@ -3742,7 +3742,7 @@ public class JShellTool implements MessageHandler {
     }
 
     void printSnippetStatus(DeclarationSnippet sn, boolean resolve) {
-        List<Diag> otherErrors = errorsOnly(state.diagnostics(sn).collect(toList()));
+        List<Diag> otherErrors = errorsOnly(state.diagnostics(sn).toList());
         new DisplayEvent(sn, state.status(sn), resolve, otherErrors)
                 .displayDeclarationAndValue();
     }
@@ -3811,7 +3811,7 @@ public class JShellTool implements MessageHandler {
         }
 
         private String unresolved(DeclarationSnippet key) {
-            List<String> unr = state.unresolvedDependencies(key).collect(toList());
+            List<String> unr = state.unresolvedDependencies(key).toList();
             StringBuilder sb = new StringBuilder();
             int fromLast = unr.size();
             if (fromLast > 0) {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1589,7 +1589,7 @@ public class JShellTool implements MessageHandler {
                                 ? Stream.of(String.valueOf(k.id()) + " ", ((DeclarationSnippet) k).name() + " ")
                                 : Stream.of(String.valueOf(k.id()) + " "))
                         .filter(k -> k.startsWith(argPrefix))
-                        .map(p -> (Suggestion) new ArgSuggestion(p))
+                        .<Suggestion>map(ArgSuggestion::new)
                         .toList();
         };
     }
@@ -1920,14 +1920,14 @@ public class JShellTool implements MessageHandler {
         String prefix = space != (-1) ? stripped.substring(0, space) : stripped;
         List<String> result = new ArrayList<>();
 
-        List<Entry<String, String>> toShow;
+        List<? extends Entry<String, String>> toShow;
 
         if (SET_SUB.matcher(stripped).matches()) {
             String setSubcommand = stripped.replaceFirst("/?set ([^ ]*)($| .*)", "$1");
             toShow =
                 Arrays.stream(SET_SUBCOMMANDS)
                        .filter(s -> s.startsWith(setSubcommand))
-                        .map(s -> (Entry<String,String>) new SimpleEntry<>("/set " + s, "help.set." + s))
+                        .map(s -> new SimpleEntry<>("/set " + s, "help.set." + s))
                         .toList();
         } else if (RERUN_ID.matcher(stripped).matches()) {
             toShow =
@@ -1944,7 +1944,7 @@ public class JShellTool implements MessageHandler {
                         .filter(c -> c.kind.showInHelp
                                   || (inHelp && c.kind == CommandKind.HELP_SUBJECT))
                         .sorted((c1, c2) -> c1.command.compareTo(c2.command))
-                        .map(c -> (Entry<String,String>) new SimpleEntry<>(c.command, c.helpKey))
+                        .map(c -> new SimpleEntry<>(c.command, c.helpKey))
                         .toList();
         }
 

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1675,7 +1675,7 @@ public class JShellTool implements MessageHandler {
                         om.group("flag"), cursor - pastSpace, anchor);
                 if (!om.group("dd").isEmpty()) {
                     result = result.stream()
-                            .map(sug -> new Suggestion() {
+                            .<Suggestion>map(sug -> new Suggestion() {
                                 @Override
                                 public String continuation() {
                                     return "-" + sug.continuation();
@@ -1686,7 +1686,6 @@ public class JShellTool implements MessageHandler {
                                     return false;
                                 }
                             })
-                            .map(e -> (Suggestion) e)
                             .toList();
                     --pastSpace;
                 }

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Selector.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Selector.java
@@ -31,7 +31,6 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 /**
  * Selector is the representation of the selector in a "/set format" command.  This class, among other things, provides

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Startup.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Startup.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static jdk.internal.jshell.tool.JShellTool.RECORD_SEPARATOR;
 import static jdk.internal.jshell.tool.JShellTool.getResource;
 import static jdk.internal.jshell.tool.JShellTool.readResource;
@@ -276,7 +275,7 @@ class Startup {
     static Startup fromFileList(List<String> fns, String context, MessageHandler mh) {
         List<StartupEntry> entries = fns.stream()
                 .map(fn -> readFile(fn, context, mh))
-                .collect(toList());
+                .toList();
         if (entries.stream().anyMatch(sue -> sue == null)) {
             return null;
         }

--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -71,7 +71,6 @@ import jdk.jshell.spi.ExecutionControl.NotImplementedException;
 import jdk.jshell.spi.ExecutionControl.ResolutionException;
 import jdk.jshell.spi.ExecutionControl.RunException;
 import jdk.jshell.spi.ExecutionControl.UserException;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static java.util.Collections.singletonList;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
@@ -1005,11 +1004,11 @@ class Eval {
                 .filter(u -> u != c)
                 .map(u -> u.event(null, null))
                 .filter(this::interestingEvent)
-                .collect(Collectors.toList()));
+                .toList());
         events.addAll(outs.stream()
                 .flatMap(u -> u.secondaryEvents().stream())
                 .filter(this::interestingEvent)
-                .collect(Collectors.toList()));
+                .toList());
         //System.err.printf("Events: %s\n", events);
         return events;
     }
@@ -1052,7 +1051,7 @@ class Eval {
             while (true) {
                 List<Unit> legit = ins.stream()
                         .filter(Unit::isDefined)
-                        .collect(toList());
+                        .toList();
                 state.debug(DBG_GEN, "compileAndLoad ins = %s -- legit = %s\n",
                         ins, legit);
                 if (legit.isEmpty()) {
@@ -1084,7 +1083,7 @@ class Eval {
                         // attempt to redefine the remaining classes
                         List<Unit> toReplace = legit.stream()
                                 .filter(u -> !u.doRedefines())
-                                .collect(toList());
+                                .toList();
 
                         // prevent alternating redefine/replace cyclic dependency
                         // loop by replacing all that have been replaced
@@ -1111,7 +1110,7 @@ class Eval {
             // add any new dependencies to the working set
             List<Unit> newDependencies = ins.stream()
                     .flatMap(Unit::effectedDependents)
-                    .collect(toList());
+                    .toList();
             state.debug(DBG_GEN, "compileAndLoad %s -- deps: %s  success: %s\n",
                     ins, newDependencies, success);
             if (!ins.addAll(newDependencies) && success) {

--- a/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
@@ -173,13 +173,11 @@ final class SnippetMaps {
         Stream<String> pkgs = importSnippets()
                                .filter(isi -> isi.isStar)
                                .map(isi -> isi.fullname.substring(0, isi.fullname.lastIndexOf(".")));
-        pkgs = Stream.concat(Stream.of("java.lang"), pkgs);
-        for (String ipkg : pkgs.toList()) {
-            if (!ipkg.isEmpty() && ipkg.equals(pkg)) {
-                return full.substring(pkg.length() + 1);
-            }
-        }
-        return full;
+        return Stream.concat(Stream.of("java.lang"), pkgs)
+                     .filter(ipkg -> !ipkg.isEmpty() && ipkg.equals(pkg))
+                     .map(ipkg -> full.substring(pkg.length() + 1))
+                     .findFirst()
+                     .orElse(full);
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
@@ -164,18 +164,17 @@ final class SnippetMaps {
         List<String> klasses = importSnippets()
                                .filter(isi -> !isi.isStar)
                                .map(isi -> isi.fullname)
-                               .collect(toList());
+                               .toList();
         for (String k : klasses) {
             if (k.equals(full)) {
                 return full.substring(full.lastIndexOf(".")+1, full.length());
             }
         }
-        List<String> pkgs = importSnippets()
+        Stream<String> pkgs = importSnippets()
                                .filter(isi -> isi.isStar)
-                               .map(isi -> isi.fullname.substring(0, isi.fullname.lastIndexOf(".")))
-                               .collect(toList());
-        pkgs.add(0, "java.lang");
-        for (String ipkg : pkgs) {
+                               .map(isi -> isi.fullname.substring(0, isi.fullname.lastIndexOf(".")));
+        pkgs = Stream.concat(Stream.of("java.lang"), pkgs);
+        for (String ipkg : pkgs.toList()) {
             if (!ipkg.isEmpty() && ipkg.equals(pkg)) {
                 return full.substring(pkg.length() + 1);
             }

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -103,9 +103,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.stream.Stream;
@@ -294,7 +292,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
         return computeSuggestions(codeWrap, cursor, anchor).stream()
                 .filter(s -> s.continuation().startsWith(requiredPrefix) && !s.continuation().equals(REPL_DOESNOTMATTER_CLASS_NAME))
                 .sorted(Comparator.comparing(Suggestion::continuation))
-                .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+                .toList();
     }
 
     private List<Suggestion> computeSuggestions(OuterWrap code, int cursor, int[] anchor) {
@@ -589,7 +587,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     public List<SnippetWrapper> wrappers(String input) {
         return proc.eval.sourceToSnippetsWithWrappers(input).stream()
                 .map(this::wrapper)
-                .collect(toList());
+                .toList();
     }
 
     @Override
@@ -838,7 +836,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     private List<? extends Element> membersOf(AnalyzeTask at, List<? extends Element> elements) {
         return elements.stream()
                 .flatMap(e -> membersOf(at, e.asType(), true).stream())
-                .collect(toList());
+                .toList();
     }
 
     private List<? extends Element> getEnclosedElements(PackageElement packageEl) {
@@ -852,7 +850,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                                 .stream()
                                 .filter(el -> el.asType() != null)
                                 .filter(el -> el.asType().getKind() != TypeKind.ERROR)
-                                .collect(toList());
+                                .toList();
             } catch (CompletionFailure cf) {
                 //ignore...
             }
@@ -867,7 +865,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                 TypeKind.LONG, TypeKind.SHORT, TypeKind.VOID)
                 .map(tk -> (Type)(tk == TypeKind.VOID ? types.getNoType(tk) : types.getPrimitiveType(tk)))
                 .map(Type::asElement)
-                .collect(toList());
+                .toList();
     }
 
     void classpathChanged() {
@@ -1273,7 +1271,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                             this.filterExecutableTypesByArguments(at, candidates, fullActuals)
                                 .stream()
                                 .filter(method -> parameterType(method.fst, method.snd, fullActuals.size(), true).findAny().isPresent())
-                                .collect(Collectors.toList());
+                                .toList();
                 }
 
                 elements = Util.stream(candidates).map(method -> method.fst);
@@ -1304,7 +1302,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             try (JavadocHelper helper = JavadocHelper.create(at.task, findSources())) {
                 result = elements.map(el -> constructDocumentation(at, helper, el, computeJavadoc))
                                  .filter(Objects::nonNull)
-                                 .collect(Collectors.toList());
+                                 .toList();
             } catch (IOException ex) {
                 proc.debug(ex, "JavadocHelper.close()");
             }
@@ -1607,7 +1605,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                                        .distinct()
                                        .filter(fqn -> isAccessible(at, scope, fqn))
                                        .sorted()
-                                       .collect(Collectors.toList());
+                                       .toList();
             }
 
             return new QualifiedNames(result, simpleName.length(), upToDate, !erroneous);

--- a/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TaskFactory.java
@@ -52,8 +52,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import static java.util.stream.Collectors.toList;
 import java.util.stream.Stream;
 import javax.lang.model.util.Elements;
 import javax.tools.FileObject;
@@ -201,7 +199,7 @@ class TaskFactory {
             allOptions.addAll(state.extraCompilerOptions);
             Iterable<? extends JavaFileObject> compilationUnits = inputs
                             .map(in -> sh.sourceToFileObject(fileManager, in))
-                            .collect(Collectors.toList());
+                            .toList();
             DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
             state.debug(DBG_FMGR, "Task (%s %s) Options: %s\n", this, compilationUnits, allOptions);
             return javacTaskPool.getTask(null, fileManager, diagnostics, allOptions, null,
@@ -351,7 +349,7 @@ class TaskFactory {
                         List<? extends ImportTree> imps = cut.getImports();
                         return (!imps.isEmpty() ? imps : cut.getTypeDecls()).stream();
                     })
-                    .collect(toList());
+                    .toList();
         }
 
         private Iterable<? extends CompilationUnitTree> parse() {

--- a/src/jdk.jshell/share/classes/jdk/jshell/Unit.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Unit.java
@@ -42,7 +42,6 @@ import jdk.jshell.spi.ExecutionControl.ClassBytecodes;
 import jdk.jshell.spi.ExecutionControl.ClassInstallException;
 import jdk.jshell.spi.ExecutionControl.EngineTerminationException;
 import jdk.jshell.spi.ExecutionControl.NotImplementedException;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static jdk.internal.jshell.debug.InternalDebugControl.DBG_EVNT;
 import static jdk.internal.jshell.debug.InternalDebugControl.DBG_GEN;
@@ -158,7 +157,7 @@ final class Unit {
                 units = plusUnfiltered.stream()
                         .filter(u -> u.snippet().kind() == Kind.METHOD &&
                                  ((MethodSnippet) u.snippet()).name().equals(name))
-                        .collect(toList());
+                        .toList();
             } else {
                 units = Collections.singletonList(this);
             }
@@ -170,15 +169,15 @@ final class Unit {
             Collection<Snippet> plus = plusUnfiltered.stream()
                     .filter(u -> !units.contains(u))
                     .map(Unit::snippet)
-                    .collect(toList());
+                    .toList();
             // Snippets to wrap in an outer
             List<Snippet> snippets = units.stream()
                     .map(Unit::snippet)
-                    .collect(toList());
+                    .toList();
             // Snippet wraps to wrap in an outer
             List<Wrap> wraps = units.stream()
                     .map(u -> u.activeGuts)
-                    .collect(toList());
+                    .toList();
             // Set the outer wrap for this snippet
             si.setOuterWrap(state.outerMap.wrapInClass(except, plus, snippets, wraps));
             state.debug(DBG_WRAP, "++setWrap() %s\n%s\n",
@@ -420,7 +419,7 @@ final class Unit {
                         && sn.status().isActive()
                         && sn.name().equals(msi.name())
                         && qpt.equals(sn.qualifiedParameterTypes()))
-                .collect(toList());
+                .toList();
 
         // Look through all methods for a method of the same name, with the
         // same computed qualified parameter types


### PR DESCRIPTION
This converts jshell from using `Stream.collect(Collectiors.toList())` to `Stream.toList()` - an immutable list with better performance characteristics. Local inspection only turned up one place that was mutating a resulting list and that has been refactored. 

This work is a subtask to: https://bugs.openjdk.java.net/browse/JDK-8260559

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263411](https://bugs.openjdk.java.net/browse/JDK-8263411): Convert jshell tool to use Stream.toList()


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to bf0f3cfb6940674b3aa2cd88d5ddd533cfb90dd1


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2979/head:pull/2979`
`$ git checkout pull/2979`

To update a local copy of the PR:
`$ git checkout pull/2979`
`$ git pull https://git.openjdk.java.net/jdk pull/2979/head`
