### PR TITLE
8241619: (fs) Files.newByteChannel(path, Set.of(CREATE_NEW, READ)) does not throw a FileAlreadyExistsException when the file exists

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -209,8 +209,8 @@ public abstract class AsynchronousFileChannel
      * FileAttribute file-attributes} to set atomically when creating the file.
      *
      * <p> The new channel is created by invoking the {@link
-     * FileSystemProvider#newFileChannel newFileChannel} method on the
-     * provider that created the {@code Path}.
+     * FileSystemProvider#newAsynchronousFileChannel newAsynchronousFileChannel}
+     * method on the provider that created the {@code Path}.
      *
      * @param   file
      *          The path of the file to open or create

--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -232,6 +232,12 @@ public abstract class AsynchronousFileChannel
      *          support creating asynchronous file channels, or an unsupported
      *          open option is specified, or the array contains an attribute that
      *          cannot be set atomically when creating the file
+     * @throws  FileAlreadyExistsException
+     *          If a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(<a href="../file/package-summary.html#optspecex">optional
+     *          specific exception</a>)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException
@@ -287,6 +293,12 @@ public abstract class AsynchronousFileChannel
      *          If the {@code file} is associated with a provider that does not
      *          support creating file channels, or an unsupported open option is
      *          specified
+     * @throws  FileAlreadyExistsException
+     *          If a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(<a href="../file/package-summary.html#optspecex">optional
+     *          specific exception</a>)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -274,7 +274,8 @@ public abstract class FileChannel
      *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
-     *          <i>(optional specific exception)</i>
+     *          <i>(<a href="../file/package-summary.html#optspecex">optional
+     *          specific exception</a>)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException
@@ -328,7 +329,8 @@ public abstract class FileChannel
      *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
-     *          <i>(optional specific exception)</i>
+     *          <i>(<a href="../file/package-summary.html#optspecex">optional
+     *          specific exception</a>)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -270,6 +270,11 @@ public abstract class FileChannel
      *          support creating file channels, or an unsupported open option is
      *          specified, or the array contains an attribute that cannot be set
      *          atomically when creating the file
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException
@@ -319,6 +324,11 @@ public abstract class FileChannel
      *          If the {@code path} is associated with a provider that does not
      *          support creating file channels, or an unsupported open option is
      *          specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -271,7 +271,7 @@ public abstract class FileChannel
      *          specified, or the array contains an attribute that cannot be set
      *          atomically when creating the file
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>
@@ -325,7 +325,7 @@ public abstract class FileChannel
      *          support creating file channels, or an unsupported open option is
      *          specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>

--- a/src/java.base/share/classes/java/nio/channels/package-info.java
+++ b/src/java.base/share/classes/java/nio/channels/package-info.java
@@ -352,7 +352,10 @@
  *
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor
  * or method in any class or interface in this package will cause a {@link
- * java.lang.NullPointerException NullPointerException} to be thrown.
+ * java.lang.NullPointerException NullPointerException} to be thrown.  In some
+ * cases methods which are specified to throw an {@code IOException} may throw
+ * a more precise <a href="../file/package-summary.html#optspecex">optional
+ * specific exception</a>.
  *
  * @since 1.4
  * @author Mark Reinhold

--- a/src/java.base/share/classes/java/nio/channels/package-info.java
+++ b/src/java.base/share/classes/java/nio/channels/package-info.java
@@ -352,10 +352,7 @@
  *
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor
  * or method in any class or interface in this package will cause a {@link
- * java.lang.NullPointerException NullPointerException} to be thrown.  In some
- * cases methods which are specified to throw an {@code IOException} may throw
- * a more precise <a href="../file/package-summary.html#optspecex">optional
- * specific exception</a>.
+ * java.lang.NullPointerException NullPointerException} to be thrown.
  *
  * @since 1.4
  * @author Mark Reinhold

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -209,7 +209,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  IOException
@@ -353,7 +353,7 @@ public final class Files {
      *          if an unsupported open option is specified or the array contains
      *          attributes that cannot be set atomically when creating the file
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing <i>(optional specific
      *          exception)</i>
@@ -400,7 +400,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported open option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing <i>(optional specific
      *          exception)</i>
@@ -643,7 +643,7 @@ public final class Files {
      *          if the array contains an attribute that cannot be set atomically
      *          when creating the file
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists
+     *          If a file of that name already exists
      *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          if an I/O error occurs or the parent directory does not exist
@@ -2986,7 +2986,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  SecurityException
@@ -3035,7 +3035,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  SecurityException
@@ -3489,7 +3489,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  SecurityException
@@ -3557,7 +3557,7 @@ public final class Files {
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  SecurityException

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -208,6 +208,10 @@ public final class Files {
      *          if {@code options} contains an invalid combination of options
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          if an I/O error occurs
      * @throws  SecurityException
@@ -351,7 +355,8 @@ public final class Files {
      * @throws  FileAlreadyExistsException
      *          if a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
-     *          <i>(optional specific exception)</i>
+     *          and the file is being opened for writing <i>(optional specific
+     *          exception)</i>
      * @throws  IOException
      *          if an I/O error occurs
      * @throws  SecurityException
@@ -397,7 +402,8 @@ public final class Files {
      * @throws  FileAlreadyExistsException
      *          if a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
-     *          <i>(optional specific exception)</i>
+     *          and the file is being opened for writing <i>(optional specific
+     *          exception)</i>
      * @throws  IOException
      *          if an I/O error occurs
      * @throws  SecurityException
@@ -2979,6 +2985,10 @@ public final class Files {
      *          if an I/O error occurs opening or creating the file
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkWrite(String) checkWrite}
@@ -3024,6 +3034,10 @@ public final class Files {
      *          if an I/O error occurs opening or creating the file
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkWrite(String) checkWrite}
@@ -3474,6 +3488,10 @@ public final class Files {
      *          if an I/O error occurs writing to or creating the file
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkWrite(String) checkWrite}
@@ -3538,6 +3556,10 @@ public final class Files {
      *          text cannot be encoded using the specified charset
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkWrite(String) checkWrite}

--- a/src/java.base/share/classes/java/nio/file/package-info.java
+++ b/src/java.base/share/classes/java/nio/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@
  * provider} with a parameter that is an object created by another provider,
  * will throw {@link java.nio.file.ProviderMismatchException}. </p>
  *
- * <h2>Optional Specific Exceptions</h2>
+ * <h2><a id="optspecex">Optional Specific Exceptions</a></h2>
  * Most of the methods defined by classes in this package that access the
  * file system specify that {@link java.io.IOException} be thrown when an I/O
  * error occurs. In some cases, these methods define specific I/O exceptions

--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -452,7 +452,7 @@ public abstract class FileSystemProvider {
      * @throws  IOException
      *          if an I/O error occurs
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          <i>(optional specific exception)</i>
      * @throws  SecurityException
@@ -512,7 +512,7 @@ public abstract class FileSystemProvider {
      *          If this provider that does not support creating file channels,
      *          or an unsupported open option or file attribute is specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>
@@ -565,7 +565,7 @@ public abstract class FileSystemProvider {
      *          channels, or an unsupported open option or file attribute is
      *          specified
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>
@@ -608,7 +608,7 @@ public abstract class FileSystemProvider {
      *          if an unsupported open option is specified or the array contains
      *          attributes that cannot be set atomically when creating the file
      * @throws  FileAlreadyExistsException
-     *          if a file of that name already exists and the {@link
+     *          If a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
      *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>

--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -451,6 +451,10 @@ public abstract class FileSystemProvider {
      *          if an unsupported option is specified
      * @throws  IOException
      *          if an I/O error occurs
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          <i>(optional specific exception)</i>
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkWrite(String) checkWrite}
@@ -507,6 +511,11 @@ public abstract class FileSystemProvider {
      * @throws  UnsupportedOperationException
      *          If this provider that does not support creating file channels,
      *          or an unsupported open option or file attribute is specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException
@@ -555,6 +564,11 @@ public abstract class FileSystemProvider {
      *          If this provider that does not support creating asynchronous file
      *          channels, or an unsupported open option or file attribute is
      *          specified
+     * @throws  FileAlreadyExistsException
+     *          if a file of that name already exists and the {@link
+     *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
+     *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          If an I/O error occurs
      * @throws  SecurityException
@@ -596,6 +610,7 @@ public abstract class FileSystemProvider {
      * @throws  FileAlreadyExistsException
      *          if a file of that name already exists and the {@link
      *          StandardOpenOption#CREATE_NEW CREATE_NEW} option is specified
+     *          and the file is being opened for writing
      *          <i>(optional specific exception)</i>
      * @throws  IOException
      *          if an I/O error occurs

--- a/src/java.base/share/classes/java/nio/file/spi/package-info.java
+++ b/src/java.base/share/classes/java/nio/file/spi/package-info.java
@@ -33,8 +33,8 @@
  * or method in any class or interface in this package will cause a {@link
  * java.lang.NullPointerException NullPointerException} to be thrown.  In some
  * cases methods which are specified to throw an {@code IOException} may throw
- * a more precise <a href="../file/package-summary.html#optspecex">optional
- * specific exception</a>.
+ * a more specific <i><a href="../package-summary.html#optspecex">optional
+ * specific exception</a></i>.
  *
  * @since 1.7
  */

--- a/src/java.base/share/classes/java/nio/file/spi/package-info.java
+++ b/src/java.base/share/classes/java/nio/file/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,10 @@
  *
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor
  * or method in any class or interface in this package will cause a {@link
- * java.lang.NullPointerException NullPointerException} to be thrown.
+ * java.lang.NullPointerException NullPointerException} to be thrown.  In some
+ * cases methods which are specified to throw an {@code IOException} may throw
+ * a more precise <a href="../file/package-summary.html#optspecex">optional
+ * specific exception</a>.
  *
  * @since 1.7
  */


### PR DESCRIPTION
Please consider this proposal to add `@throws FileAlreadyExistsException` or modify an existing such throws clause's description in a number of methods in `java.nio.file.Files`, `java.nio.file.spi.FileSystemProvider`, and `java.nio.channels.FileChannel`. The methods affected are `open()` in `FileChannel` and various `new*()` methods in `Files` and `FileSystemProvider`. The `Files.newByteChannel()` methods already documented this exception so this would bring the other methods in line.

A `FileAlreadyExistsException` is an optional specific exception, i.e., a subclass of `IOException` intended to provide a more precise description of the error. The package specification of `java.nio.file` describes optional specific exceptions but those of the other two packages do not. If these exceptions are to be added to the `FileChannel` and `FileSystemProvider` classes, then perhaps a similar paragraph (or a link) should be added to their respective package specifications as well.

The change to `java.nio.channels.AsynchronousFileChannel` is an incidental correction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241619](https://bugs.openjdk.java.net/browse/JDK-8241619): (fs) Files.newByteChannel(path, Set.of(CREATE_NEW, READ)) does not throw a FileAlreadyExistsException when the file exists


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2980/head:pull/2980`
`$ git checkout pull/2980`

To update a local copy of the PR:
`$ git checkout pull/2980`
`$ git pull https://git.openjdk.java.net/jdk pull/2980/head`
