### PR TITLE
8263477: serviceability/sa/ClhsdbDumpheap.java timed out

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
@@ -41,7 +41,7 @@ import jtreg.SkippedException;
  * @summary Test clhsdb dumpheap command
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm ClhsdbDumpheap
+ * @run main/othervm/timeout=240 ClhsdbDumpheap
  */
 
 public class ClhsdbDumpheap {


### PR DESCRIPTION
[JDK-8257234](https://bugs.openjdk.java.net/browse/JDK-8257234) added a lot more subtests to this test, so now it sometimes times out. I've double the amount of time given to 240. I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263477](https://bugs.openjdk.java.net/browse/JDK-8263477): serviceability/sa/ClhsdbDumpheap.java timed out


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2981/head:pull/2981`
`$ git checkout pull/2981`
