### PR TITLE
8255790: GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -453,7 +453,7 @@ else
    # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
    # when building libharfbuzz
    ifeq ($(call isTargetOs, aix), true)
-     LIBHARFBUZZ_CFLAGS += -qdebug=necan
+     HARFBUZZ_CFLAGS += -qdebug=necan
    endif
 
    ifeq ($(call isTargetOs, macosx), false)

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -450,19 +450,25 @@ else
      HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
    endif
 
+   # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
+   # when building libharfbuzz
+   ifeq ($(call isTargetOs, aix), true)
+     LIBHARFBUZZ_CFLAGS += -qdebug=necan
+   endif
+
    ifeq ($(call isTargetOs, macosx), false)
      LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
    endif
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-    HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
-    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
+   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
         maybe-uninitialized class-memaccess
-    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
+   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
         undef missing-field-initializers range-loop-analysis
-    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
+   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
 
    LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -431,92 +431,43 @@ endif
 
 ###########################################################################
 
+
 ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-  LIBHARFBUZZ_LIBS := $(HARFBUZZ_LIBS)
+   LIBFONTMANAGER_EXTRA_SRC =
+   BUILD_LIBFONTMANAGER_FONTLIB += $(LIBHARFBUZZ_LIBS)
 else
+   LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
 
-  # This is better than adding EXPORT_ALL_SYMBOLS
-  ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__attribute__\(\(visibility\(\"default\"\)\)\)
-  else ifeq ($(TOOLCHAIN_TYPE), microsoft)
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__declspec\(dllexport\)
-  endif
+   ifeq ($(call isTargetOs, windows), false)
+     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
+                        -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
+                        -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
+   endif
+   ifeq ($(call isTargetOs, linux macosx), true)
+     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
+   endif
+   ifeq ($(call isTargetOs, macosx), true)
+     HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
+   endif
 
-  ifeq ($(call isTargetOs, windows), false)
-    HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
-                      -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
-                      -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
-  endif
-  ifeq ($(call isTargetOs, linux macosx), true)
-    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
-  endif
-  ifeq ($(call isTargetOs, macosx), true)
-    HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
-  endif
-  ifeq ($(call isTargetOs, macosx), false)
-    LIBHARFBUZZ_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
-  endif
-  # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-  LIBHARFBUZZ_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
+   ifeq ($(call isTargetOs, macosx), false)
+     LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
+   endif
+   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
+   LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-  LIBHARFBUZZ_CFLAGS += $(HARFBUZZ_CFLAGS)
-
-  # For use by libfontmanager:
-  ifeq ($(call isTargetOs, windows), true)
-    LIBHARFBUZZ_LIBS := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libharfbuzz/harfbuzz.lib
-  else
-    LIBHARFBUZZ_LIBS := -lharfbuzz
-  endif
-
-  LIBHARFBUZZ_EXTRA_HEADER_DIRS := \
-    libharfbuzz/hb-ucdn \
-    #
-
-  LIBHARFBUZZ_OPTIMIZATION := HIGH
-  # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
-  # when building libharfbuzz
-  ifeq ($(call isTargetOs, aix), true)
-    LIBHARFBUZZ_CFLAGS += -qdebug=necan
-  endif
-
-  LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \
-      NAME := harfbuzz, \
-      EXCLUDE_FILES := $(LIBHARFBUZZ_EXCLUDE_FILES), \
-      TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      OPTIMIZATION := $(LIBHARFBUZZ_OPTIMIZATION), \
-      CFLAGS_windows = -DCC_NOEX, \
-      EXTRA_HEADER_DIRS := $(LIBHARFBUZZ_EXTRA_HEADER_DIRS), \
-      WARNINGS_AS_ERRORS_xlc := false, \
-      DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing, \
-      DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-        maybe-uninitialized class-memaccess, \
-      DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
+    HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
+        maybe-uninitialized class-memaccess
+    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
-        undef missing-field-initializers range-loop-analysis, \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-        $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
-      LDFLAGS_aix := -Wl$(COMMA)-berok, \
-      LIBS := $(BUILD_LIBHARFBUZZ), \
-      LIBS_unix := $(LIBM) $(LIBCXX), \
-      LIBS_macosx := -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
-      LIBS_windows := user32.lib, \
-  ))
+        undef missing-field-initializers range-loop-analysis
+    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
 
-  ifeq ($(FREETYPE_TO_USE), bundled)
-    $(BUILD_LIBHARFBUZZ): $(BUILD_LIBFREETYPE)
-  endif
-
-  TARGETS += $(BUILD_LIBHARFBUZZ)
+   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 
 endif
 
-###########################################################################
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libharfbuzz \
@@ -527,10 +478,10 @@ LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libawt/java2d/loops \
     #
 
-LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS) $(HARFBUZZ_FLAGS)
-BUILD_LIBFONTMANAGER_FONTLIB += $(LIBHARFBUZZ_LIBS) $(LIBFREETYPE_LIBS)
+LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS)
+BUILD_LIBFONTMANAGER_FONTLIB +=  $(LIBFREETYPE_LIBS)
 
-LIBFONTMANAGER_OPTIMIZATION := HIGH
+LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
 ifeq ($(call isTargetOs, windows), true)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c \
@@ -568,7 +519,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     OPTIMIZATION := $(LIBFONTMANAGER_OPTIMIZATION), \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
+    EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
     WARNINGS_AS_ERRORS_xlc := false, \
+    DISABLED_WARNINGS_gcc := $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
+    DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
+    DISABLED_WARNINGS_clang := $(HARFBUZZ_DISABLED_WARNINGS_clang), \
+    DISABLED_WARNINGS_microsoft := $(HARFBUZZ_DISABLED_WARNINGS_microsoft), \
     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \
         $(subst -Wl$(COMMA)-z$(COMMA)defs,,$(LDFLAGS_JDKLIB))) $(LDFLAGS_CXX_JDK) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -576,16 +532,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
     LIBS_unix := -lawt -ljava -ljvm $(LIBM) $(LIBCXX), \
-    LIBS_macosx := -lawt_lwawt, \
+    LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
     LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
         $(WIN_AWT_LIB), \
 ))
 
 $(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT)
-
-ifeq ($(USE_EXTERNAL_HARFBUZZ), false)
-  $(BUILD_LIBFONTMANAGER): $(BUILD_LIBHARFBUZZ)
-endif
 
 ifeq ($(call isTargetOs, macosx), true)
   $(BUILD_LIBFONTMANAGER): $(call FindLib, $(MODULE), awt_lwawt)

--- a/src/java.desktop/share/classes/sun/font/FontManagerNativeLibrary.java
+++ b/src/java.desktop/share/classes/sun/font/FontManagerNativeLibrary.java
@@ -53,8 +53,6 @@ public class FontManagerNativeLibrary {
                       NB: consider moving freetype wrapper part to separate
                           shared library in order to avoid dependency. */
                    System.loadLibrary("freetype");
-                   /* Same for harfbuzz */
-                   System.loadLibrary("harfbuzz");
                }
                System.loadLibrary("fontmanager");
 


### PR DESCRIPTION
From a build perspective this partially reverts https://bugs.openjdk.java.net/browse/JDK-8249821 except that it keeps 
the harfbuzz sources separate and still supports building and running against a system harfbuzz which is only of interest or relevance on Linux.

I ended up having to go this way because its is the least unsatisfactory solution.
I did not want us to build a devkit to link against a system linux only to find we couldn't use it at runtime
because too many systems have to old a version of harfbuzz.

This solves the Manjaro Linux problem and I've manually verified building against a system hardbuxz on Ubuntu 20.10

There are couple of incidental fixes in here too
- "libharfbuzz" should not have been in the EXTRA_HEADERS var when building against a system version
- harfbuzz/hb-ucdn is gone and should not be listed as a header directory needed to build the bundled copy
- I expect it also resolves https://bugs.openjdk.java.net/browse/JDK-8262502

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255790](https://bugs.openjdk.java.net/browse/JDK-8255790): GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 29d3e4b2b89100c466a2bc1a5e69efd05c065d29
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2982/head:pull/2982`
`$ git checkout pull/2982`
