### PR TITLE
8263546: Add "findsym" command to clhsdb.html help file

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -53,7 +53,8 @@ Available commands:
   echo [ true | false ] <font color="red">turn on/off command echo mode</font>
   examine [ address/count ] | [ address,address] <font color="red">show contents of memory from given address</font>
   field [ type [ name fieldtype isStatic offset address ] ] <font color="red">print info about a field of HotSpot type</font>
-  findpc address <font color="red">print info. about pointer location</font>
+  findpc address <font color="red">print info about pointer location</font>
+  findsym name <font color="red">print address of symbol in the executable or shared library</font>
   flags [ flag ] <font color="red">show all -XX flag name value pairs. or just show given flag</font>
   help [ command ] <font color="red">print help message for all commands or just given command</font>
   history <font color="red">show command history. usual !command-number syntax works.</font>


### PR DESCRIPTION
Added clhsdb help for findsym, which was missed when the findsym command was recently added. Also fixed a very minor typo in the findpc help.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263546](https://bugs.openjdk.java.net/browse/JDK-8263546): Add "findsym" command to clhsdb.html help file


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2983/head:pull/2983`
`$ git checkout pull/2983`

To update a local copy of the PR:
`$ git checkout pull/2983`
`$ git pull https://git.openjdk.java.net/jdk pull/2983/head`
