### PR TITLE
8263548: runtime/cds/appcds/SharedRegionAlignmentTest.java fails to compile after JDK-8263412

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedRegionAlignmentTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedRegionAlignmentTest.java
@@ -37,6 +37,7 @@
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
 
 public class SharedRegionAlignmentTest {
     static String appJar = ClassFileInstaller.getJarPath("hello.jar");


### PR DESCRIPTION
Hi all,

could you please review this tiny patch that adds import statement to `runtime/cds/appcds/SharedRegionAlignmentTest.java`?

testing:
- [x] `runtime/cds/appcds/SharedRegionAlignmentTest.java` on `macosx-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263548](https://bugs.openjdk.java.net/browse/JDK-8263548): runtime/cds/appcds/SharedRegionAlignmentTest.java fails to compile after JDK-8263412


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2984/head:pull/2984`
`$ git checkout pull/2984`
