### PR TITLE
8263555: use driver-mode to run ClassFileInstaller

### DIFF
--- a/test/hotspot/jtreg/gc/TestReferenceClearDuringMarking.java
+++ b/test/hotspot/jtreg/gc/TestReferenceClearDuringMarking.java
@@ -28,7 +28,7 @@ package gc;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/TestReferenceClearDuringReferenceProcessing.java
+++ b/test/hotspot/jtreg/gc/TestReferenceClearDuringReferenceProcessing.java
@@ -30,7 +30,7 @@ package gc;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersTo.java
@@ -28,7 +28,7 @@ package gc;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
+++ b/test/hotspot/jtreg/gc/TestReferenceRefersToDuringConcMark.java
@@ -28,7 +28,7 @@ package gc;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
@@ -28,7 +28,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -41,7 +41,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI


### PR DESCRIPTION
Hi all,

could you please review this small and trivial clean-up patch that replaces `@run main j.t.l.h.ClassFileInstaller` w/ `@run driver j.t.l.h.ClassFileInstaller`?

from JBS:
> there is no point in running ClassFileInstaller class w/ external flags, so it should be run w/ `@run driver`.  

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263555](https://bugs.openjdk.java.net/browse/JDK-8263555): use driver-mode to run ClassFileInstaller


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2989/head:pull/2989`
`$ git checkout pull/2989`
