### PR TITLE
8263659: Reflow GTestResultParser for better readability

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestResultParser.java
+++ b/test/hotspot/jtreg/gtest/GTestResultParser.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -39,34 +40,32 @@ public class GTestResultParser {
     public GTestResultParser(Path file) {
         List<String> failedTests = new ArrayList<>();
         try (Reader r = Files.newBufferedReader(file)) {
-            try {
-                XMLStreamReader xmlReader = XMLInputFactory.newInstance()
-                                                           .createXMLStreamReader(r);
-                String testSuite = null;
-                String testCase = null;
-                while (xmlReader.hasNext()) {
-                    switch (xmlReader.next()) {
-                        case XMLStreamConstants.START_ELEMENT:
-                            switch (xmlReader.getLocalName()) {
-                                case "testsuite":
-                                    testSuite = xmlReader.getAttributeValue("", "name");
-                                    break;
-                                case "testcase":
-                                    testCase = xmlReader.getAttributeValue("", "name");
-                                    break;
-                                case "failure":
-                                    failedTests.add(testSuite + "::" + testCase);
-                                default:
-                                    // ignore
-                            }
+            XMLInputFactory factory = XMLInputFactory.newInstance();
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            XMLStreamReader xmlReader = factory.createXMLStreamReader(r);
+            String testSuite = null;
+            String testCase = null;
+            while (xmlReader.hasNext()) {
+                int code = xmlReader.next();
+                if (code == XMLStreamConstants.START_ELEMENT) {
+                    switch (xmlReader.getLocalName()) {
+                        case "testsuite":
+                            testSuite = xmlReader.getAttributeValue("", "name");
+                            break;
+                        case "testcase":
+                            testCase = xmlReader.getAttributeValue("", "name");
+                            break;
+                        case "failure":
+                            failedTests.add(testSuite + "::" + testCase);
                             break;
                         default:
                             // ignore
                     }
                 }
-            } catch (XMLStreamException e) {
-                throw new IllegalArgumentException("can't open parse xml " + file, e);
             }
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException("can't open parse xml " + file, e);
         } catch (IOException e) {
             throw new IllegalArgumentException("can't open result file " + file, e);
         }


### PR DESCRIPTION
As noted by https://sonarcloud.io/code?id=shipilev_jdk&selected=shipilev_jdk%3Atest%2Fhotspot%2Fjtreg%2Fgtest%2FGTestResultParser.java there are a few fixes that can be applied for the GTestResultParser:

* Avoiding nested 'try' statements
* Avoiding nested 'switch' statements
* Adding a break for each switch case to prevent accidental/unwanted fall-through
* Disabling ability to load from remote files when parsing XML files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263659](https://bugs.openjdk.java.net/browse/JDK-8263659): Reflow GTestResultParser for better readability


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2991/head:pull/2991`
`$ git checkout pull/2991`

To update a local copy of the PR:
`$ git checkout pull/2991`
`$ git pull https://git.openjdk.java.net/jdk pull/2991/head`
