### PR TITLE
8263658: Use the blessed modifier order in java.base

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -226,12 +226,12 @@ public interface ObjectInputFilter {
         /**
          * Lock object for system-wide filter.
          */
-        private final static Object serialFilterLock = new Object();
+        private static final Object serialFilterLock = new Object();
 
         /**
          * Debug: Logger
          */
-        private final static System.Logger configLog;
+        private static final System.Logger configLog;
 
         /**
          * Logger for debugging.
@@ -246,14 +246,14 @@ public interface ObjectInputFilter {
          * The name for the system-wide deserialization filter.
          * Used as a system property and a java.security.Security property.
          */
-        private final static String SERIAL_FILTER_PROPNAME = "jdk.serialFilter";
+        private static final String SERIAL_FILTER_PROPNAME = "jdk.serialFilter";
 
         /**
          * The system-wide filter; may be null.
          * Lookup the filter in java.security.Security or
          * the system property.
          */
-        private final static ObjectInputFilter configuredFilter;
+        private static final ObjectInputFilter configuredFilter;
 
         static {
             configuredFilter = AccessController
@@ -405,7 +405,7 @@ public interface ObjectInputFilter {
          * used for all ObjectInputStreams that do not set their own filters.
          *
          */
-        final static class Global implements ObjectInputFilter {
+        static final class Global implements ObjectInputFilter {
             /**
              * The pattern used to create the filter.
              */

--- a/src/java.base/share/classes/java/lang/StackFrameInfo.java
+++ b/src/java.base/share/classes/java/lang/StackFrameInfo.java
@@ -31,7 +31,7 @@ import java.lang.StackWalker.StackFrame;
 import java.lang.invoke.MethodType;
 
 class StackFrameInfo implements StackFrame {
-    private final static JavaLangInvokeAccess JLIA =
+    private static final JavaLangInvokeAccess JLIA =
         SharedSecrets.getJavaLangInvokeAccess();
 
     private final boolean retainClassRef;

--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -63,7 +63,7 @@ final class StackStreamFactory {
 
     // Stack walk implementation classes to be excluded during stack walking
     // lazily add subclasses when they are loaded.
-    private final static Set<Class<?>> stackWalkImplClasses = init();
+    private static final Set<Class<?>> stackWalkImplClasses = init();
 
     private static final int SMALL_BATCH       = 8;
     private static final int BATCH_SIZE        = 32;
@@ -81,7 +81,7 @@ final class StackStreamFactory {
      * Performance work and extensive testing is needed to replace the
      * VM built-in backtrace filled in Throwable with the StackWalker.
      */
-    final static boolean isDebug =
+    static final boolean isDebug =
             "true".equals(GetPropertyAction.privilegedGetProperty("stackwalk.debug"));
 
     static <T> StackFrameTraverser<T>

--- a/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/src/java.base/share/classes/java/lang/StackWalker.java
@@ -290,7 +290,7 @@ public final class StackWalker {
 
     static final EnumSet<Option> DEFAULT_EMPTY_OPTION = EnumSet.noneOf(Option.class);
 
-    private final static StackWalker DEFAULT_WALKER =
+    private static final StackWalker DEFAULT_WALKER =
         new StackWalker(DEFAULT_EMPTY_OPTION);
 
     private final Set<Option> options;

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -643,7 +643,7 @@ final class StringLatin1 {
         return (right != value.length) ? newString(value, 0, right) : null;
     }
 
-    private final static class LinesSpliterator implements Spliterator<String> {
+    private static final class LinesSpliterator implements Spliterator<String> {
         private byte[] value;
         private int index;        // current index, modified on advance/split
         private final int fence;  // one past last index

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1065,7 +1065,7 @@ final class StringUTF16 {
         return (right != length) ? newString(value, 0, right) : null;
     }
 
-    private final static class LinesSpliterator implements Spliterator<String> {
+    private static final class LinesSpliterator implements Spliterator<String> {
         private byte[] value;
         private int index;        // current index, modified on advance/split
         private final int fence;  // one past last index

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -664,7 +664,7 @@ abstract class MethodHandleImpl {
                                    DONT_INLINE_THRESHOLD);
     }
 
-    private final static class Makers {
+    private static final class Makers {
         /** Constructs reinvoker lambda form which block inlining during JIT-compilation for a particular method handle */
         static final Function<MethodHandle, LambdaForm> PRODUCE_BLOCK_INLINING_FORM = new Function<MethodHandle, LambdaForm>() {
             @Override

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -33,7 +33,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_L_L(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_L_L(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -50,7 +50,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LL_V(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LL_V(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -68,7 +68,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LLL_Z(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LLL_Z(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -84,7 +84,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_LLL_L(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_LLL_L(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -101,7 +101,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_LL_L(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_LL_L(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -118,7 +118,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_L_I(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_L_I(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -134,7 +134,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LI_V(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LI_V(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -152,7 +152,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LII_Z(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LII_Z(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -168,7 +168,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LII_I(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LII_I(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -184,7 +184,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LI_I(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LI_I(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -200,7 +200,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_L_J(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_L_J(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -216,7 +216,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LJ_V(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LJ_V(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -234,7 +234,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -250,7 +250,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -266,7 +266,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LJ_J(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LJ_J(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -282,7 +282,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_L_F(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_L_F(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -298,7 +298,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LF_V(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LF_V(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -316,7 +316,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LFF_Z(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LFF_Z(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -332,7 +332,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_LFF_F(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_LFF_F(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -348,7 +348,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_LF_F(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_LF_F(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -364,7 +364,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_L_D(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_L_D(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -380,7 +380,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LD_V(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LD_V(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -398,7 +398,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LDD_Z(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LDD_Z(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -414,7 +414,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_LDD_D(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_LDD_D(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -430,7 +430,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_LD_D(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_LD_D(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -446,7 +446,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard__L(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard__L(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -463,7 +463,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_L_V(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_L_V(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -481,7 +481,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LL_Z(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LL_Z(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -497,7 +497,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard__I(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard__I(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -513,7 +513,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_I_V(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_I_V(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -531,7 +531,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_II_Z(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_II_Z(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -547,7 +547,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_II_I(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_II_I(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -563,7 +563,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_I_I(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_I_I(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -579,7 +579,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard__J(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard__J(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -595,7 +595,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_J_V(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_J_V(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -613,7 +613,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_JJ_Z(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_JJ_Z(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -629,7 +629,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_JJ_J(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_JJ_J(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -645,7 +645,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_J_J(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_J_J(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -661,7 +661,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard__F(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard__F(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -677,7 +677,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_F_V(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_F_V(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -695,7 +695,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_FF_Z(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_FF_Z(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -711,7 +711,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_FF_F(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_FF_F(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -727,7 +727,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_F_F(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_F_F(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -743,7 +743,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard__D(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard__D(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -759,7 +759,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_D_V(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_D_V(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -777,7 +777,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_DD_Z(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_DD_Z(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -793,7 +793,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_DD_D(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_DD_D(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -809,7 +809,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_D_D(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_D_D(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -825,7 +825,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_LI_L(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_LI_L(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -842,7 +842,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LIL_V(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LIL_V(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -860,7 +860,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LILL_Z(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LILL_Z(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -876,7 +876,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_LILL_L(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_LILL_L(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -893,7 +893,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static Object guard_LIL_L(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final Object guard_LIL_L(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -910,7 +910,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LII_V(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LII_V(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -928,7 +928,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LIII_Z(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LIII_Z(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -944,7 +944,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LIII_I(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LIII_I(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -960,7 +960,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LI_J(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LI_J(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -976,7 +976,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LIJ_V(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LIJ_V(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -994,7 +994,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LIJJ_Z(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LIJJ_Z(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1010,7 +1010,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LIJJ_J(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LIJJ_J(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1026,7 +1026,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LIJ_J(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LIJ_J(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1042,7 +1042,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_LI_F(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_LI_F(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1058,7 +1058,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LIF_V(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LIF_V(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1076,7 +1076,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LIFF_Z(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LIFF_Z(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1092,7 +1092,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_LIFF_F(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_LIFF_F(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1108,7 +1108,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static float guard_LIF_F(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final float guard_LIF_F(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1124,7 +1124,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_LI_D(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_LI_D(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1140,7 +1140,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LID_V(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LID_V(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1158,7 +1158,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LIDD_Z(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LIDD_Z(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1174,7 +1174,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_LIDD_D(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_LIDD_D(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1190,7 +1190,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static double guard_LID_D(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final double guard_LID_D(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1206,7 +1206,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LJ_I(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LJ_I(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1222,7 +1222,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LJI_V(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LJI_V(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1240,7 +1240,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LJII_Z(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LJII_Z(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1256,7 +1256,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LJII_I(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LJII_I(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1272,7 +1272,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static int guard_LJI_I(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final int guard_LJI_I(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1288,7 +1288,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static void guard_LJJ_V(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final void guard_LJJ_V(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1306,7 +1306,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static boolean guard_LJJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final boolean guard_LJJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);
@@ -1322,7 +1322,7 @@ final class VarHandleGuards {
     @ForceInline
     @LambdaForm.Compiled
     @Hidden
-    final static long guard_LJJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
+    static final long guard_LJJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
                     + ad.symbolicMethodTypeExact);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -686,7 +686,7 @@ final class VarHandles {
 //                @ForceInline
 //                @LambdaForm.Compiled
 //                @Hidden
-//                final static <METHOD> throws Throwable {
+//                static final <METHOD> throws Throwable {
 //                    if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
 //                        throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
 //                                + ad.symbolicMethodTypeExact);
@@ -704,7 +704,7 @@ final class VarHandles {
 //                @ForceInline
 //                @LambdaForm.Compiled
 //                @Hidden
-//                final static <METHOD> throws Throwable {
+//                static final <METHOD> throws Throwable {
 //                    if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
 //                        throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
 //                                + ad.symbolicMethodTypeExact);

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -135,7 +135,7 @@ public class ModuleDescriptor
      * @since 9
      */
 
-    public final static class Requires
+    public static final class Requires
         implements Comparable<Requires>
     {
 
@@ -362,7 +362,7 @@ public class ModuleDescriptor
      * @since 9
      */
 
-    public final static class Exports
+    public static final class Exports
         implements Comparable<Exports>
     {
 
@@ -568,7 +568,7 @@ public class ModuleDescriptor
      * @since 9
      */
 
-    public final static class Opens
+    public static final class Opens
         implements Comparable<Opens>
     {
         /**
@@ -767,7 +767,7 @@ public class ModuleDescriptor
      * @since 9
      */
 
-    public final static class Provides
+    public static final class Provides
         implements Comparable<Provides>
     {
         private final String service;
@@ -940,7 +940,7 @@ public class ModuleDescriptor
      * @since 9
      */
 
-    public final static class Version
+    public static final class Version
         implements Comparable<Version>
     {
 

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -98,9 +98,9 @@ final class ProxyGenerator extends ClassWriter {
                             "jdk.proxy.ProxyGenerator.saveGeneratedFiles"));
 
     /* Preloaded ProxyMethod objects for methods in java.lang.Object */
-    private final static ProxyMethod hashCodeMethod;
-    private final static ProxyMethod equalsMethod;
-    private final static ProxyMethod toStringMethod;
+    private static final ProxyMethod hashCodeMethod;
+    private static final ProxyMethod equalsMethod;
+    private static final ProxyMethod toStringMethod;
 
     static {
         try {

--- a/src/java.base/share/classes/java/nio/BufferMismatch.java
+++ b/src/java.base/share/classes/java/nio/BufferMismatch.java
@@ -32,7 +32,7 @@ import jdk.internal.util.ArraysSupport;
  */
 final class BufferMismatch {
 
-    final static ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
+    static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
     static int mismatch(ByteBuffer a, int aOff, ByteBuffer b, int bOff, int length) {
         int i = 0;

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -1211,14 +1211,14 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     // Patterns for plurals syntax validation
-    private final static String EXPR = "([niftvwe])\\s*(([/%])\\s*(\\d+))*";
-    private final static String RELATION = "(!?=)";
-    private final static String VALUE_RANGE = "((\\d+)\\.\\.(\\d+)|\\d+)";
-    private final static String CONDITION = EXPR + "\\s*" +
+    private static final String EXPR = "([niftvwe])\\s*(([/%])\\s*(\\d+))*";
+    private static final String RELATION = "(!?=)";
+    private static final String VALUE_RANGE = "((\\d+)\\.\\.(\\d+)|\\d+)";
+    private static final String CONDITION = EXPR + "\\s*" +
                                              RELATION + "\\s*" +
                                              VALUE_RANGE + "\\s*" +
                                              "(,\\s*" + VALUE_RANGE + ")*";
-    private final static Pattern PLURALRULES_PATTERN =
+    private static final Pattern PLURALRULES_PATTERN =
             Pattern.compile("(zero|one|two|few|many):\\s*" +
                             CONDITION +
                             "(\\s*(and|or)\\s*" + CONDITION + ")*");
@@ -2421,12 +2421,12 @@ public final class CompactNumberFormat extends NumberFormat {
                 .allMatch(r -> relationCheck(r, input)));
     }
 
-    private final static String NAMED_EXPR = "(?<op>[niftvwe])\\s*((?<div>[/%])\\s*(?<val>\\d+))*";
-    private final static String NAMED_RELATION = "(?<rel>!?=)";
-    private final static String NAMED_VALUE_RANGE = "(?<start>\\d+)\\.\\.(?<end>\\d+)|(?<value>\\d+)";
-    private final static Pattern EXPR_PATTERN = Pattern.compile(NAMED_EXPR);
-    private final static Pattern RELATION_PATTERN = Pattern.compile(NAMED_RELATION);
-    private final static Pattern VALUE_RANGE_PATTERN = Pattern.compile(NAMED_VALUE_RANGE);
+    private static final String NAMED_EXPR = "(?<op>[niftvwe])\\s*((?<div>[/%])\\s*(?<val>\\d+))*";
+    private static final String NAMED_RELATION = "(?<rel>!?=)";
+    private static final String NAMED_VALUE_RANGE = "(?<start>\\d+)\\.\\.(?<end>\\d+)|(?<value>\\d+)";
+    private static final Pattern EXPR_PATTERN = Pattern.compile(NAMED_EXPR);
+    private static final Pattern RELATION_PATTERN = Pattern.compile(NAMED_RELATION);
+    private static final Pattern VALUE_RANGE_PATTERN = Pattern.compile(NAMED_VALUE_RANGE);
 
     /**
      * Checks if the 'input' equals the value, or within the range.

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -619,7 +619,7 @@ public abstract class NumberFormat extends Format  {
     /**
      * Returns a scientific format for the current default locale.
      */
-    /*public*/ final static NumberFormat getScientificInstance() {
+    /*public*/ static final NumberFormat getScientificInstance() {
         return getInstance(Locale.getDefault(Locale.Category.FORMAT), null, SCIENTIFICSTYLE);
     }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -5041,7 +5041,7 @@ public final class DateTimeFormatterBuilder {
      */
     static final class DayPeriodPrinterParser implements DateTimePrinterParser {
         private final TextStyle textStyle;
-        private final static ConcurrentMap<Locale, LocaleStore> DAYPERIOD_LOCALESTORE = new ConcurrentHashMap<>();
+        private static final ConcurrentMap<Locale, LocaleStore> DAYPERIOD_LOCALESTORE = new ConcurrentHashMap<>();
 
         /**
          * Constructor.
@@ -5148,15 +5148,15 @@ public final class DateTimeFormatterBuilder {
         /**
          *  DayPeriod cache
          */
-        private final static Map<Locale, Map<DayPeriod, Long>> DAYPERIOD_CACHE = new ConcurrentHashMap<>();
+        private static final Map<Locale, Map<DayPeriod, Long>> DAYPERIOD_CACHE = new ConcurrentHashMap<>();
         /**
          * comparator based on the duration of the day period.
          */
-        private final static Comparator<DayPeriod> DPCOMPARATOR = (dp1, dp2) -> (int)(dp1.duration() - dp2.duration());
+        private static final Comparator<DayPeriod> DPCOMPARATOR = (dp1, dp2) -> (int)(dp1.duration() - dp2.duration());
         /**
          * Pattern to parse day period rules
          */
-        private final static Pattern RULE = Pattern.compile("(?<type>[a-z12]+):(?<from>\\d{2}):00(-(?<to>\\d{2}))*");
+        private static final Pattern RULE = Pattern.compile("(?<type>[a-z12]+):(?<from>\\d{2}):00(-(?<to>\\d{2}))*");
         /**
          * minute-of-day of "at" or "from" attribute
          */

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -204,7 +204,7 @@ public final class ImageReader implements AutoCloseable {
         return reader.getResourceStream(loc);
     }
 
-    private final static class SharedImageReader extends BasicImageReader {
+    private static final class SharedImageReader extends BasicImageReader {
         static final int SIZE_OF_OFFSET = Integer.BYTES;
 
         static final Map<Path, SharedImageReader> OPEN_FILES = new HashMap<>();

--- a/src/java.base/share/classes/jdk/internal/jrtfs/SystemImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/SystemImage.java
@@ -80,9 +80,9 @@ abstract class SystemImage {
 
     static final String RUNTIME_HOME;
     // "modules" jimage file Path
-    final static Path moduleImageFile;
+    static final Path moduleImageFile;
     // "modules" jimage exists or not?
-    final static boolean modulesImageExists;
+    static final boolean modulesImageExists;
     // <JAVA_HOME>/modules directory Path
     static final Path explodedModulesDir;
 

--- a/src/java.base/share/classes/jdk/internal/logger/DefaultLoggerFinder.java
+++ b/src/java.base/share/classes/jdk/internal/logger/DefaultLoggerFinder.java
@@ -134,8 +134,8 @@ public class DefaultLoggerFinder extends LoggerFinder {
             return w;
         }
 
-        final static SharedLoggers system = new SharedLoggers();
-        final static SharedLoggers application = new SharedLoggers();
+        static final SharedLoggers system = new SharedLoggers();
+        static final SharedLoggers application = new SharedLoggers();
     }
 
     public static boolean isSystem(Module m) {

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/SerialVersionUIDAdder.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/SerialVersionUIDAdder.java
@@ -349,7 +349,7 @@ public class SerialVersionUIDAdder extends ClassVisitor {
     }
 
     /**
-      * Adds a final static serialVersionUID field to the class, with the given value.
+      * Adds a static final serialVersionUID field to the class, with the given value.
       *
       * @param svuid the serialVersionUID field value.
       */

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ThreadFactory;
 public final class CleanerFactory {
 
     /* The common Cleaner. */
-    private final static Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
+    private static final Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
             return InnocuousThread.newSystemThread("Common-Cleaner",

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -204,7 +204,7 @@ public final class CleanerImpl implements Runnable {
      * The factory is a singleton.
      */
     static final class InnocuousThreadFactory implements ThreadFactory {
-        final static ThreadFactory factory = new InnocuousThreadFactory();
+        static final ThreadFactory factory = new InnocuousThreadFactory();
 
         static ThreadFactory factory() {
             return factory;

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -307,7 +307,7 @@ public class IPAddressUtil {
      * Mapping from unscoped local Inet(6)Address to the same address
      * including the correct scope-id, determined from NetworkInterface.
      */
-    private final static ConcurrentHashMap<InetAddress,InetAddress>
+    private static final ConcurrentHashMap<InetAddress,InetAddress>
         cache = new ConcurrentHashMap<>();
 
     /**

--- a/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
@@ -518,7 +518,7 @@ public abstract class AbstractDrbg {
      * assumed to support prediction resistance and always contains
      * full-entropy.
      */
-    private final static EntropySource defaultES =
+    private static final EntropySource defaultES =
             (minE, minLen, maxLen, pr) -> {
         byte[] result = new byte[minLen];
         SeedGenerator.generateSeed(result);

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -411,7 +411,7 @@ enum SSLCipher {
     private static final HashMap<String, Long> cipherLimits = new HashMap<>();
 
     // Keywords found on the jdk.tls.keyLimits security property.
-    final static String[] tag = {"KEYUPDATE"};
+    static final String[] tag = {"KEYUPDATE"};
 
     static  {
         final long max = 4611686018427387904L; // 2^62

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -58,9 +58,9 @@ import sun.security.util.Cache;
  */
 
 final class SSLSessionContextImpl implements SSLSessionContext {
-    private final static int DEFAULT_MAX_CACHE_SIZE = 20480;
+    private static final int DEFAULT_MAX_CACHE_SIZE = 20480;
     // Default lifetime of a session. 24 hours
-    final static int DEFAULT_SESSION_TIMEOUT = 86400;
+    static final int DEFAULT_SESSION_TIMEOUT = 86400;
 
     private final Cache<SessionId, SSLSessionImpl> sessionCache;
                                         // session cache, session id as key

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -112,7 +112,7 @@ final class SessionTicketExtension {
     }
 
     // Crypto key context for session state.  Used with stateless operation.
-    final static class StatelessKey {
+    static final class StatelessKey {
         final long timeout;
         final SecretKey key;
         final int num;

--- a/src/java.base/share/classes/sun/security/util/ResourcesMgr.java
+++ b/src/java.base/share/classes/sun/security/util/ResourcesMgr.java
@@ -34,7 +34,7 @@ import jdk.internal.misc.VM;
  */
 public class ResourcesMgr {
     // intended for java.security, javax.security and sun.security resources
-    private final static Map<String, ResourceBundle> bundles = new ConcurrentHashMap<>();
+    private static final Map<String, ResourceBundle> bundles = new ConcurrentHashMap<>();
 
     public static String getString(String s) {
         return getBundle("sun.security.util.Resources").getString(s);

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -195,9 +195,9 @@ public class SignatureUtil {
     }
 
     public static class EdDSADigestAlgHolder {
-        public final static AlgorithmId sha512;
-        public final static AlgorithmId shake256;
-        public final static AlgorithmId shake256$512;
+        public static final AlgorithmId sha512;
+        public static final AlgorithmId shake256;
+        public static final AlgorithmId shake256$512;
 
         static {
             try {
@@ -508,15 +508,15 @@ public class SignatureUtil {
 
     // Useful PSSParameterSpec objects
     private static class PSSParamsHolder {
-        final static PSSParameterSpec PSS_256_SPEC = new PSSParameterSpec(
+        static final PSSParameterSpec PSS_256_SPEC = new PSSParameterSpec(
                 "SHA-256", "MGF1",
                 MGF1ParameterSpec.SHA256,
                 32, PSSParameterSpec.TRAILER_FIELD_BC);
-        final static PSSParameterSpec PSS_384_SPEC = new PSSParameterSpec(
+        static final PSSParameterSpec PSS_384_SPEC = new PSSParameterSpec(
                 "SHA-384", "MGF1",
                 MGF1ParameterSpec.SHA384,
                 48, PSSParameterSpec.TRAILER_FIELD_BC);
-        final static PSSParameterSpec PSS_512_SPEC = new PSSParameterSpec(
+        static final PSSParameterSpec PSS_512_SPEC = new PSSParameterSpec(
                 "SHA-512", "MGF1",
                 MGF1ParameterSpec.SHA512,
                 64, PSSParameterSpec.TRAILER_FIELD_BC);


### PR DESCRIPTION
Sonar displays a warning message that modifiers should be declared in the order listed in the JLS; specifically, that isntead of using `final static` the `static final` should be preferred.

This fixes the issues in the `java.base` package for ease of reviewing.

https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=java&resolved=false&rules=java%3AS1124

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263658](https://bugs.openjdk.java.net/browse/JDK-8263658): Use the blessed modifier order in java.base


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 470f7066efb476b4f29105a167d46a75d0988a8b
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2993/head:pull/2993`
`$ git checkout pull/2993`

To update a local copy of the PR:
`$ git checkout pull/2993`
`$ git pull https://git.openjdk.java.net/jdk pull/2993/head`
