### PR TITLE
JDK-8263557: Possible NULL dereference in Arena::destruct_contents()

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -310,7 +310,9 @@ void Arena::destruct_contents() {
   // reset size before chop to avoid a rare racing condition
   // that can have total arena memory exceed total chunk memory
   set_size_in_bytes(0);
-  _first->chop();
+  if (_first != NULL) {
+    _first->chop();
+  }
   reset();
 }
 


### PR DESCRIPTION
Sonarcloud reports a possible access to a NULL C++ object in Arena::destruct_contents():

```
_first->chop();
```

I have found no code path where this could happen but _first could conceivably be NULL after a call to Arena::reset(). Lets fix that.

GA test error on windows seems unrelated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263557](https://bugs.openjdk.java.net/browse/JDK-8263557): Possible NULL dereference in Arena::destruct_contents()


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2994/head:pull/2994`
`$ git checkout pull/2994`
