### PR TITLE
JDK-8263558: Possible NULL dereference in fast path arena free if ZapResourceArea is true

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -366,6 +366,10 @@ void* Arena::grow(size_t x, AllocFailType alloc_failmode) {
 // Reallocate storage in Arena.
 void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFailType alloc_failmode) {
   if (new_size == 0) return NULL;
+  if (old_ptr == NULL) {
+    assert(old_size == 0, "sanity");
+    return Amalloc(new_size, alloc_failmode); // as with realloc(3), a NULL old ptr is equivalent to malloc(3)
+  }
 #ifdef ASSERT
   if (UseMallocOnly) {
     // always allocate a new object  (otherwise we'll free this one twice)

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -365,7 +365,10 @@ void* Arena::grow(size_t x, AllocFailType alloc_failmode) {
 
 // Reallocate storage in Arena.
 void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFailType alloc_failmode) {
-  if (new_size == 0) return NULL;
+  if (new_size == 0) {
+    Afree(old_ptr, old_size); // like realloc(3)
+    return NULL;
+  }
   if (old_ptr == NULL) {
     assert(old_size == 0, "sanity");
     return Amalloc(new_size, alloc_failmode); // as with realloc(3), a NULL old ptr is equivalent to malloc(3)

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -184,8 +184,9 @@ protected:
 
   // Fast delete in area.  Common case is: NOP (except for storage reclaimed)
   bool Afree(void *ptr, size_t size) {
+    assert(ptr != NULL, "Sanity");
 #ifdef ASSERT
-    if (ZapResourceArea && ptr != NULL) {
+    if (ZapResourceArea) {
       memset(ptr, badResourceValue, size); // zap freed memory
     }
     if (UseMallocOnly) return true;

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -185,7 +185,9 @@ protected:
   // Fast delete in area.  Common case is: NOP (except for storage reclaimed)
   bool Afree(void *ptr, size_t size) {
 #ifdef ASSERT
-    if (ZapResourceArea) memset(ptr, badResourceValue, size); // zap freed memory
+    if (ZapResourceArea && ptr != NULL) {
+      memset(ptr, badResourceValue, size); // zap freed memory
+    }
     if (UseMallocOnly) return true;
 #endif
     if (((char*)ptr) + size == _hwm) {

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -184,7 +184,9 @@ protected:
 
   // Fast delete in area.  Common case is: NOP (except for storage reclaimed)
   bool Afree(void *ptr, size_t size) {
-    assert(ptr != NULL, "Sanity");
+    if (ptr == NULL) {
+      return true; // as with free(3), freeing NULL is a noop.
+    }
 #ifdef ASSERT
     if (ZapResourceArea) memset(ptr, badResourceValue, size); // zap freed memory
     if (UseMallocOnly) return true;

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -186,9 +186,7 @@ protected:
   bool Afree(void *ptr, size_t size) {
     assert(ptr != NULL, "Sanity");
 #ifdef ASSERT
-    if (ZapResourceArea) {
-      memset(ptr, badResourceValue, size); // zap freed memory
-    }
+    if (ZapResourceArea) memset(ptr, badResourceValue, size); // zap freed memory
     if (UseMallocOnly) return true;
 #endif
     if (((char*)ptr) + size == _hwm) {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -619,7 +619,7 @@ void Node::destruct(PhaseValues* phase) {
   int node_size = size_of();
 
   // Free the output edge array
-  if (out_array != NULL && out_edge_size > 0) {
+  if (out_edge_size > 0) {
     compile->node_arena()->Afree(out_array, out_edge_size);
   }
 

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -619,7 +619,7 @@ void Node::destruct(PhaseValues* phase) {
   int node_size = size_of();
 
   // Free the output edge array
-  if (out_edge_size > 0) {
+  if (out_array != NULL && out_edge_size > 0) {
     compile->node_arena()->Afree(out_array, out_edge_size);
   }
 


### PR DESCRIPTION
Sonarcloud reports a possible NULL dereference when zapping the to-be-freed area in fast-path arena free. Possible call stack for this to happen starts in Node::destruct(PhaseValues* phase).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263558](https://bugs.openjdk.java.net/browse/JDK-8263558): Possible NULL dereference in fast path arena free if ZapResourceArea is true


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to ceaef852bc00274c46e97d27735c651588254e07


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2995/head:pull/2995`
`$ git checkout pull/2995`

To update a local copy of the PR:
`$ git checkout pull/2995`
`$ git pull https://git.openjdk.java.net/jdk pull/2995/head`
