### PR TITLE
JDK-8263559: Add missing initializers to VM_PopulateDumpSharedSpace

### DIFF
--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -386,8 +386,12 @@ private:
 
 public:
 
-  VM_PopulateDumpSharedSpace() : VM_GC_Operation(0, /* total collections, ignored */
-                                                 GCCause::_archive_time_gc)
+  VM_PopulateDumpSharedSpace() :
+    VM_GC_Operation(0 /* total collections, ignored */, GCCause::_archive_time_gc),
+    _closed_archive_heap_regions(NULL),
+    _open_archive_heap_regions(NULL),
+    _closed_archive_heap_oopmaps(NULL),
+    _open_archive_heap_oopmaps(NULL)
   { }
 
   bool skip_operation() const { return false; }

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -391,8 +391,7 @@ public:
     _closed_archive_heap_regions(NULL),
     _open_archive_heap_regions(NULL),
     _closed_archive_heap_oopmaps(NULL),
-    _open_archive_heap_oopmaps(NULL)
-  { }
+    _open_archive_heap_oopmaps(NULL) {}
 
   bool skip_operation() const { return false; }
 

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -436,8 +436,6 @@ char* VM_PopulateDumpSharedSpace::dump_read_only_tables() {
   MetaspaceShared::serialize(&wc);
 
   // Write the bitmaps for patching the archive heap regions
-  _closed_archive_heap_oopmaps = NULL;
-  _open_archive_heap_oopmaps = NULL;
   dump_archive_heap_oopmaps();
 
   return start;
@@ -483,8 +481,6 @@ void VM_PopulateDumpSharedSpace::doit() {
   builder.relocate_metaspaceobj_embedded_pointers();
 
   // Dump supported java heap objects
-  _closed_archive_heap_regions = NULL;
-  _open_archive_heap_regions = NULL;
   dump_java_heap_objects(builder.klasses());
 
   builder.relocate_roots();


### PR DESCRIPTION
Trivial.

Sonarcloud reports missing initializers in VM_PopulateDumpSharedSpace. I don't see how this could lead to an error, since these members are initialized later, but for cleanliness sake lets initialize them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263559](https://bugs.openjdk.java.net/browse/JDK-8263559): Add missing initializers to VM_PopulateDumpSharedSpace


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to fe44ca6467f169c76bc4c03a2e42c718c6421fd3
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to fe44ca6467f169c76bc4c03a2e42c718c6421fd3
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to fe44ca6467f169c76bc4c03a2e42c718c6421fd3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/2996/head:pull/2996`
`$ git checkout pull/2996`
