### PR TITLE
JDK-8263545: Convert jpackage to use Stream.toList()

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/DesktopIntegration.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/DesktopIntegration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ final class DesktopIntegration {
     List<String> requiredPackages() {
         return Stream.of(List.of(this), nestedIntegrations).flatMap(
                 List::stream).map(DesktopIntegration::requiredPackagesSelf).flatMap(
-                List::stream).distinct().collect(Collectors.toList());
+                List::stream).distinct().toList();
     }
 
     Map<String, String> create() throws IOException {
@@ -525,7 +525,7 @@ final class DesktopIntegration {
 
     private static String stringifyShellCommands(List<String> commands) {
         return String.join(System.lineSeparator(), commands.stream().filter(
-                s -> s != null && !s.isEmpty()).collect(Collectors.toList()));
+                s -> s != null && !s.isEmpty()).toList());
     }
 
     private static class LinuxFileAssociation {

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LibProvidersLookup.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LibProvidersLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ final public class LibProvidersLookup {
                 List<String> packageNames = Collections.emptyList();
                 return packageNames;
             }
-        }).flatMap(List::stream).sorted().distinct().collect(Collectors.toList());
+        }).flatMap(List::stream).sorted().distinct().toList();
 
         return neededPackages;
     }

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public class LinuxDebBundler extends LinuxPackageBundler {
     protected List<ToolValidator> getToolValidators(
             Map<String, ? super Object> params) {
         return Stream.of(TOOL_DPKG_DEB, TOOL_DPKG, TOOL_FAKEROOT).map(
-                ToolValidator::new).collect(Collectors.toList());
+                ToolValidator::new).toList();
     }
 
     @Override

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackageBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackageBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,8 +205,7 @@ abstract class LinuxPackageBundler extends AbstractBundler {
         // Merge all package lists together.
         // Filter out empty names, sort and remove duplicates.
         List<String> result = Stream.of(xdgUtilsPackage, neededLibPackages).flatMap(
-                List::stream).filter(Predicate.not(String::isEmpty)).sorted().distinct().collect(
-                Collectors.toList());
+                List::stream).filter(Predicate.not(String::isEmpty)).sorted().distinct().toList();
 
         Log.verbose(String.format("Required packages: %s", result));
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class DeployParams {
         if (!Files.isSymbolicLink(root)) {
             if (Files.isDirectory(root)) {
                 try (Stream<Path> stream = Files.list(root)) {
-                    List<Path> children = stream.collect(Collectors.toList());
+                    List<Path> children = stream.toList();
                     if (children != null && children.size() > 0) {
                         children.forEach(f -> {
                             try {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DottedVersion.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DottedVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,8 +148,7 @@ final class DottedVersion implements Comparable<String> {
         if (components.isEmpty()) {
             components.add(BigInteger.ZERO);
         }
-        return components.stream()
-                .collect(Collectors.toList()).toArray(BigInteger[]::new);
+        return components.stream().toList().toArray(BigInteger[]::new);
     }
 
     @Override

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DottedVersion.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DottedVersion.java
@@ -148,7 +148,7 @@ final class DottedVersion implements Comparable<String> {
         if (components.isEmpty()) {
             components.add(BigInteger.ZERO);
         }
-        return components.stream().toList().toArray(BigInteger[]::new);
+        return components.toArray(BigInteger[]::new);
     }
 
     @Override

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ final public class Executor {
 
                     if ((outputConsumer != null || Log.isVerbose())
                             || saveOutput) {
-                        savedOutput = br.lines().collect(Collectors.toList());
+                        savedOutput = br.lines().toList();
                     } else {
                         savedOutput = null;
                     }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FileAssociation.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FileAssociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ final class FileAssociation {
                     }
 
                     return assoc;
-                }).collect(Collectors.toList());
+                }).toList();
     }
 
     Path launcherPath;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -238,7 +238,7 @@ final class LauncherData {
                                   .relativize(p.toAbsolutePath()))
                         .collect(Collectors.toSet());
                 jars.remove(mainJarName);
-                classPath = jars.stream().sorted().collect(Collectors.toList());
+                classPath = jars.stream().sorted().toList();
             }
         }
     }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/OverridableResource.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/OverridableResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ final class OverridableResource {
     OverridableResource setSourceOrder(Source... v) {
         sources = Stream.of(v)
                 .map(source -> Map.entry(source, getHandler(source)))
-                .collect(Collectors.toList());
+                .toList();
         return this;
     }
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/PathGroup.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/PathGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ final class PathGroup {
      * All configured entries.
      */
     List<Path> paths() {
-        return entries.values().stream().collect(Collectors.toList());
+        return entries.values().stream().toList();
     }
 
     /**
@@ -74,8 +74,7 @@ final class PathGroup {
     List<Path> roots() {
         // Sort by the number of path components in ascending order.
         List<Map.Entry<Path, Path>> sorted = normalizedPaths().stream().sorted(
-                (a, b) -> a.getKey().getNameCount() - b.getKey().getNameCount()).collect(
-                        Collectors.toList());
+                (a, b) -> a.getKey().getNameCount() - b.getKey().getNameCount()).toList();
 
         // Returns `true` if `a` is a parent of `b`
         BiFunction<Map.Entry<Path, Path>, Map.Entry<Path, Path>, Boolean> isParentOrSelf = (a, b) -> {
@@ -85,7 +84,7 @@ final class PathGroup {
         return sorted.stream().filter(
                 v -> v == sorted.stream().sequential().filter(
                         v2 -> isParentOrSelf.apply(v2, v)).findFirst().get()).map(
-                        v -> v.getValue()).collect(Collectors.toList());
+                        v -> v.getValue()).toList();
     }
 
     long sizeInBytes() throws IOException {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,7 +387,7 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
                     (s, p) -> {
                         List<Path> modulePath = Stream.of(s.split(File.pathSeparator))
                                 .map(Path::of)
-                                .collect(Collectors.toList());
+                                .toList();
                         Path javaBasePath = findPathOfModule(modulePath, JAVABASEJMOD);
 
                         // Add the default JDK module path to the module path.
@@ -395,7 +395,8 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
                             List<Path> jdkModulePath = getDefaultModulePath();
 
                             if (jdkModulePath != null) {
-                                modulePath.addAll(jdkModulePath);
+                                modulePath = Stream.concat(modulePath.stream(),
+                                        jdkModulePath.stream()).toList();
                                 javaBasePath = findPathOfModule(modulePath, JAVABASEJMOD);
                             }
                         }

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
@@ -197,8 +197,8 @@ public class WinMsiBundler  extends AbstractBundler {
                 Map.entry("ui.wxf", new WixUiFragmentBuilder())
         ).map(e -> {
             e.getValue().setOutputFileName(e.getKey());
-            return e.getValue();
-        }).collect(Collectors.toList());
+            return (WixFragmentBuilder) e.getValue();
+        }).toList();
     }
 
     @Override
@@ -520,7 +520,7 @@ public class WinMsiBundler  extends AbstractBundler {
                     .filter(Files::isReadable)
                     .filter(pathMatcher::matches)
                     .sorted((a, b) -> a.getFileName().toString().compareToIgnoreCase(b.getFileName().toString()))
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
@@ -195,9 +195,9 @@ public class WinMsiBundler  extends AbstractBundler {
         wixFragments = Stream.of(
                 Map.entry("bundle.wxf", new WixAppImageFragmentBuilder()),
                 Map.entry("ui.wxf", new WixUiFragmentBuilder())
-        ).map(e -> {
+        ).<WixFragmentBuilder>map(e -> {
             e.getValue().setOutputFileName(e.getKey());
-            return (WixFragmentBuilder) e.getValue();
+            return e.getValue();
         }).toList();
     }
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
             launcherPaths = AppImageFile.getLauncherNames(appImageRoot, params).stream()
                     .map(name -> installedAppImage.launchersDirectory().resolve(name))
                     .map(WixAppImageFragmentBuilder::addExeSuffixToPath)
-                    .collect(Collectors.toList());
+                    .toList();
         }
 
         programMenuFolderName = MENU_GROUP.fetchFrom(params);
@@ -162,7 +162,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
 
         // Filter out empty extensions.
         fa.extensions = fa.extensions.stream().filter(Predicate.not(
-                String::isEmpty)).collect(Collectors.toList());
+                String::isEmpty)).toList();
     }
 
     private static Path addExeSuffixToPath(Path path) {
@@ -179,7 +179,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
                 .peek(this::normalizeFileAssociation)
                 // Filter out file associations without extensions.
                 .filter(fa -> !fa.extensions.isEmpty())
-                .collect(Collectors.toList());
+                .toList();
 
         associations.stream().filter(fa -> fa.iconPath != null).forEach(fa -> {
             // Need to add fa icon in the image.
@@ -600,7 +600,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
             for (var dir : allDirs.stream()
                     .filter(Predicate.not(emptyDirs::contains))
                     .filter(Predicate.not(removeFolderItems::containsKey))
-                    .collect(Collectors.toList())) {
+                    .toList()) {
                 componentIds.add(addRemoveDirectoryComponent(xml, dir));
             }
         }

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixTool.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ public enum WixTool {
         return Stream.of(programFiles, programFilesX86).map(path -> {
             List<Path> result;
             try (var paths = Files.walk(path, 1)) {
-                result = paths.collect(Collectors.toList());
+                result = paths.toList();
             } catch (IOException ex) {
                 Log.verbose(ex);
                 result = Collections.emptyList();
@@ -169,6 +169,6 @@ public enum WixTool {
         .filter(path -> wixInstallDirMatcher.matches(path.getFileName()))
         .sorted(Comparator.comparing(Path::getFileName).reversed())
         .map(path -> path.resolve("bin"))
-        .collect(Collectors.toList());
+        .toList();
     }
 }

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixUiFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixUiFragmentBuilder.java
@@ -68,7 +68,7 @@ final class WixUiFragmentBuilder extends WixFragmentBuilder {
                 ShortcutsFolder.values()).filter(shortcutFolder -> {
             return shortcutFolder.requested(params)
                     && SHORTCUT_PROMPT.fetchFrom(params);
-        }).collect(Collectors.toList());
+        }).toList();
 
         withShortcutPromptDlg = !shortcutFolders.isEmpty();
 
@@ -265,10 +265,10 @@ final class WixUiFragmentBuilder extends WixFragmentBuilder {
             var pair = new DialogPair(firstId, secondId);
             return Map.of(pair, nextBuilders.stream().map(b -> {
                 return buildPublish(b.create()).next().create();
-            }).collect(Collectors.toList()), pair.flip(),
+            }).toList(), pair.flip(),
                     prevBuilders.stream().map(b -> {
                         return buildPublish(b.create()).back().create();
-                    }).collect(Collectors.toList()));
+                    }).toList());
         }
 
         static Map<DialogPair, List<Publish>> createPair(Dialog firstId,

--- a/test/jdk/tools/jpackage/junit/jdk/jpackage/internal/PathGroupTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk/jpackage/internal/PathGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class PathGroupTest {
                 PATH_FOO, "root", PATH_EMPTY));
 
         List<Path> paths = pg.paths();
-        Collections.sort(paths);
+        paths = paths.stream().sorted().toList();
 
         assertEquals(3, paths.size());
         assertEquals(PATH_EMPTY, paths.get(0));


### PR DESCRIPTION
This converts jpackage to use `Stream.toList()` instead of `Stream.collect(Collectors.toList())`. One piece of code was modified to not mutate a list in addition to one test that used a mutating sort on a list. The rest of the changes are simple substitutions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263545](https://bugs.openjdk.java.net/browse/JDK-8263545): Convert jpackage to use Stream.toList()


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer) ⚠️ Review applies to ce11489b1a134f727191a68b71456cfa61a2d231


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2997/head:pull/2997`
`$ git checkout pull/2997`

To update a local copy of the PR:
`$ git checkout pull/2997`
`$ git pull https://git.openjdk.java.net/jdk pull/2997/head`
