### PR TITLE
8261785: Calling "main" method in anonymous nested class crashes the JVM

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -827,7 +827,7 @@ SetMainClassForAWT(JNIEnv *env, jclass mainClass) {
     NULL_CHECK(getCanonicalNameMID = (*env)->GetMethodID(env, classClass, "getCanonicalName", "()Ljava/lang/String;"));
 
     jstring mainClassString = (*env)->CallObjectMethod(env, mainClass, getCanonicalNameMID);
-    if ((*env)->ExceptionCheck(env)) {
+    if ((*env)->ExceptionCheck(env) || NULL == mainClassString) {
         /*
          * Clears all errors caused by getCanonicalName() on the mainclass and
          * leaves the JAVA_MAIN_CLASS__<pid> empty.

--- a/test/jdk/tools/launcher/8261785/CrashTheJVM.java
+++ b/test/jdk/tools/launcher/8261785/CrashTheJVM.java
@@ -1,0 +1,43 @@
+import java.io.IOException;
+
+public class CrashTheJVM {
+    public static void main(String... args) throws IOException {
+        System.out.println("Fine 1: from the outer class");
+
+        new Object() {
+            public static void main(String... args) throws IOException {
+                System.out.println("Crash Before Fix 1: from anonymous nested class");
+            }
+        };
+        class LocalNestedClass {
+            public static void main(String... args) throws IOException {
+                System.out.println("Crash Before Fix 2: from local nested class");
+            }
+        }
+    }
+
+    public void fromMethod() {
+        new Object() {
+            public static void main(String... args) throws IOException {
+                System.out.println("Crash Before Fix 3: from local anonymous class");
+            }
+        };
+        class LocalInnerClass {
+            public static void main(String... args) throws IOException {
+                System.out.println("Crash Before Fix 4: from local inner class");
+            }
+        }
+    }
+
+    public class InnerClass {
+        public static void main(String... args) throws IOException {
+            System.out.println("Fine 2: from inner class");
+        }
+    }
+
+    public static class NestedClass {
+        public static void main(String... args) throws IOException {
+            System.out.println("Fine 3: from nested class");
+        }
+    }
+}

--- a/test/jdk/tools/launcher/8261785/CrashTheJVM.java
+++ b/test/jdk/tools/launcher/8261785/CrashTheJVM.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import java.io.IOException;
 
 public class CrashTheJVM {
@@ -40,4 +63,10 @@ public class CrashTheJVM {
             System.out.println("Fine 3: from nested class");
         }
     }
+
+    Object foo = new Object() {
+        public static void main(String... args) throws IOException {
+            System.out.println("Anonymous inner class");
+        }
+    };
 }

--- a/test/jdk/tools/launcher/8261785/Test8261785.java
+++ b/test/jdk/tools/launcher/8261785/Test8261785.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved. DO NOT ALTER OR REMOVE
+ * COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License version 2 only, as published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version 2 along with this work;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA or visit www.oracle.com
+ * if you need additional information or have any questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @bug 8261785
+ * @summary Test static main methods in anonymous/local class won't cause launcher crash
+ * @modules jdk.compiler jdk.zipfs
+ * @compile ../TestHelper.java
+ * @run testng Test8261785
+ */
+public class Test8261785 {
+    private final Path inputDir;
+
+    public Test8261785() {
+        inputDir = Paths.get(System.getProperty("test.src", "."));
+    }
+
+    public void compile() {
+        Path file = inputDir.resolve("CrashTheJVM.java");
+        TestHelper.compile("-d", ".", file.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void run() throws IOException {
+        System.out.println("Current folder: " + Paths.get(".").toAbsolutePath().toString());
+        compile();
+        String[] clz = Files.list(Paths.get("."))
+            .peek(p -> System.out.println("Found " + p.toString()))
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .filter(f -> f.endsWith(".class"))
+            .map(f -> f.substring(0, f.length() - 6))
+            .toArray(String[]::new);
+        assertEquals(clz.length, 7);
+        for (String f: clz) {
+            System.out.println("Running class " + f);
+            var result = TestHelper.doExec(TestHelper.javaCmd, "-cp", ".", f);
+            assertTrue(result.isOK());
+        };
+    }
+}

--- a/test/jdk/tools/launcher/8261785/Test8261785.java
+++ b/test/jdk/tools/launcher/8261785/Test8261785.java
@@ -1,21 +1,24 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved. DO NOT ALTER OR REMOVE
- * COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * This code is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License version 2 only, as published by the Free Software Foundation.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
  *
- * This code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License version 2 for more details (a copy is included in the LICENSE file that
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License version 2 along with this work;
- * if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA.
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA or visit www.oracle.com
- * if you need additional information or have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 import java.io.IOException;

--- a/test/jdk/tools/launcher/8261785/Test8261785.java
+++ b/test/jdk/tools/launcher/8261785/Test8261785.java
@@ -60,7 +60,7 @@ public class Test8261785 {
             .filter(f -> f.endsWith(".class"))
             .map(f -> f.substring(0, f.length() - 6))
             .toArray(String[]::new);
-        assertEquals(clz.length, 7);
+        assertEquals(clz.length, 8);
         for (String f: clz) {
             System.out.println("Running class " + f);
             var result = TestHelper.doExec(TestHelper.javaCmd, "-cp", ".", f);


### PR DESCRIPTION
This patch ensure launcher won't crash JVM for the new static Methods from local/anonymous class on MacOS.

As @dholmes-ora pointed out in the analysis, this is a MacOS specific bug when the launcher trying to grab class name to be displayed as the Application name on the menu.

The fix is to not setting name, test shows that GUI java application shows 'bin' as the application name. It's possible for us to set the name to something more friendly, for example, "Java", but I am not sure that should be launcher's responsibility to choose such a default name. It seems to me the consumer of the JAVA_MAIN_CLASS_%d environment variable should be responsible to pick such name in case the environment variable is not set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261785](https://bugs.openjdk.java.net/browse/JDK-8261785): Calling "main" method in anonymous nested class crashes the JVM


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/2999/head:pull/2999`
`$ git checkout pull/2999`

To update a local copy of the PR:
`$ git checkout pull/2999`
`$ git pull https://git.openjdk.java.net/jdk pull/2999/head`
