### PR TITLE
8263565: NPE was thrown when sun.jvm.hotspot.rmi.serverNamePrefix was set

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,7 @@ public class RMIHelper {
             }
         }
 
-        tmp = System.getProperty("sun.jvm.hotspot.rmi.serverNamePrefix");
-        serverNamePrefix = (tmp != null)? serverNamePrefix : "SARemoteDebugger";
+        serverNamePrefix = System.getProperty("sun.jvm.hotspot.rmi.serverNamePrefix", "SARemoteDebugger");
     }
 
     public static void rebind(String uniqueID, Remote object) throws DebuggerException {


### PR DESCRIPTION
NPE was thrown when I set server name prefix for debugd as following:

```
$ jhsdb -J-Dsun.jvm.hotspot.rmi.serverNamePrefix=test debugd --pid 781
Attaching to process ID 781 and starting RMI services, please wait...
Error attaching to process or starting server: sun.jvm.hotspot.debugger.DebuggerException: java.lang.NullPointerException: Cannot invoke "String.length()" because "this.input" is null
        at jdk.hotspot.agent/sun.jvm.hotspot.RMIHelper.rebind(RMIHelper.java:78)
        at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.setupDebugger(HotSpotAgent.java:379)
        at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.go(HotSpotAgent.java:329)
        at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotAgent.startServer(HotSpotAgent.java:215)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runDEBUGD(SALauncher.java:431)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:493)
Caused by: java.lang.NullPointerException: Cannot invoke "String.length()" because "this.input" is null
        at java.base/java.net.URI$Parser.parse(URI.java:3166)
        at java.base/java.net.URI.<init>(URI.java:623)
        at java.rmi/java.rmi.Naming.intParseURL(Naming.java:273)
        at java.rmi/java.rmi.Naming.parseURL(Naming.java:237)
        at java.rmi/java.rmi.Naming.rebind(Naming.java:171)
        at jdk.hotspot.agent/sun.jvm.hotspot.RMIHelper.rebind(RMIHelper.java:64)
        ... 5 more
```

`serverNamePrefix` would not affect due to trivial bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263565](https://bugs.openjdk.java.net/browse/JDK-8263565): NPE was thrown when sun.jvm.hotspot.rmi.serverNamePrefix was set


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3000/head:pull/3000` \
`$ git checkout pull/3000`

Update a local copy of the PR: \
`$ git checkout pull/3000` \
`$ git pull https://git.openjdk.java.net/jdk pull/3000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3000`

View PR using the GUI difftool: \
`$ git pr show -t 3000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3000.diff">https://git.openjdk.java.net/jdk/pull/3000.diff</a>

</details>
