### PR TITLE
8263562: Checking if proxy_klass_head is still lambda_proxy_is_available

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -2241,12 +2241,14 @@ public:
   SharedLambdaDictionaryPrinter(outputStream* st) : _st(st), _index(0) {}
 
   void do_value(const RunTimeLambdaProxyClassInfo* record) {
-    ResourceMark rm;
-    _st->print_cr("%4d:  %s", (_index++), record->proxy_klass_head()->external_name());
-    Klass* k = record->proxy_klass_head()->next_link();
-    while (k != NULL) {
-      _st->print_cr("%4d:  %s", (_index++), k->external_name());
-      k = k->next_link();
+    if (record->proxy_klass_head()->lambda_proxy_is_available()) {
+      ResourceMark rm;
+      _st->print_cr("%4d:  %s", (_index++), record->proxy_klass_head()->external_name());
+      Klass* k = record->proxy_klass_head()->next_link();
+      while (k != NULL) {
+        _st->print_cr("%4d:  %s", (_index++), k->external_name());
+        k = k->next_link();
+      }
     }
   }
 };


### PR DESCRIPTION
The `Shared Lambda Dictionary` section in the result of SharedLambdaDictionaryPrinter will mix normal klasses with lambda proxy klasses. Using the following commands can reproduce it:

Proc1: `./jshell`
Proc2: `jcmd <proc1> VM.systemdictionary -verbose`

When all archived lambda proxy classes are used, proxy_klass_head(in RunTimeLambdaProxyClassInfo) is still referring to an instance klass that is no longer lambda_proxy_is_available, and its next_link will be set by classloader to link another normal class. Simply checking if proxy_klass_head is lambda_proxy_is_available can solve this problem.

Best regards,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263562](https://bugs.openjdk.java.net/browse/JDK-8263562): Checking if proxy_klass_head is still lambda_proxy_is_available


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3001/head:pull/3001`
`$ git checkout pull/3001`
