### PR TITLE
8263481: Specification of JComponent::setDefaultLocale doesn't mention that passing 'null' restores VM's default locale

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -2851,6 +2851,8 @@ public abstract class JComponent extends Container implements Serializable,
      * potentially multiple lightweight applications running in a single VM)
      * can have their own setting. An applet can safely alter its default
      * locale because it will have no affect on other applets (or the browser).
+     * Passing {@code null} will reset the current locale back
+     * to VM's default locale.
      *
      * @param l the desired default <code>Locale</code> for new components.
      * @see #getDefaultLocale

--- a/test/jdk/javax/swing/JComponent/TestNullLocale.java
+++ b/test/jdk/javax/swing/JComponent/TestNullLocale.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8263481
+   @summary Verifies calling setDefaultLocale(null) will reset
+            to VM's default locale
+   @run main TestNullLocale
+ */
+
+import javax.swing.JComponent;
+import java.util.Locale;
+
+public class TestNullLocale {
+    public static void main(String[] args) {
+        Locale defaultLocale = JComponent.getDefaultLocale();
+        JComponent.setDefaultLocale(Locale.GERMAN);
+        System.out.println(JComponent.getDefaultLocale());
+        JComponent.setDefaultLocale(null);
+        Locale currentLocale = JComponent.getDefaultLocale();
+        System.out.println(currentLocale);
+        if (defaultLocale != currentLocale) {
+            System.out.println("currentLocale " + currentLocale);
+            System.out.println("defaultLocale " + defaultLocale);
+            throw new RuntimeException("locale not reset to default locale");
+        }
+    }
+}
+
+

--- a/test/jdk/javax/swing/JComponent/TestNullLocale.java
+++ b/test/jdk/javax/swing/JComponent/TestNullLocale.java
@@ -35,10 +35,8 @@ public class TestNullLocale {
     public static void main(String[] args) {
         Locale defaultLocale = JComponent.getDefaultLocale();
         JComponent.setDefaultLocale(Locale.GERMAN);
-        System.out.println(JComponent.getDefaultLocale());
         JComponent.setDefaultLocale(null);
         Locale currentLocale = JComponent.getDefaultLocale();
-        System.out.println(currentLocale);
         if (defaultLocale != currentLocale) {
             System.out.println("currentLocale " + currentLocale);
             System.out.println("defaultLocale " + defaultLocale);


### PR DESCRIPTION
The current state of specification for
https://docs.oracle.com/en/java/javase/15/docs/api/java.desktop/javax/swing/JComponent.html#setDefaultLocale(java.util.Locale)
doesn't mention anything about passing 'null' as a new default locale.

In fact for OpenJDK implementation passing 'null' restores the default VM's locale. 
This is now explicitly stated in javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263481](https://bugs.openjdk.java.net/browse/JDK-8263481): Specification of JComponent::setDefaultLocale doesn't mention that passing 'null' restores VM's default locale


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3003/head:pull/3003`
`$ git checkout pull/3003`

To update a local copy of the PR:
`$ git checkout pull/3003`
`$ git pull https://git.openjdk.java.net/jdk pull/3003/head`
