### PR TITLE
8263572: Output from jstack mixed mode is misaligned

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class PStack extends Tool {
            return;
         }
          final boolean cdbgCanDemangle = cdbg.canDemangle();
-         String fillerForAddress = " ".repeat(2 + (2 << VM.getVM().getLogAddressSize())) + "\t";
+         String fillerForAddress = " ".repeat(2 + 2 * (int) VM.getVM().getAddressSize()) + "\t";
          for (Iterator<ThreadProxy> itr = l.iterator() ; itr.hasNext();) {
             ThreadProxy th = itr.next();
             try {
@@ -169,7 +169,7 @@ public class PStack extends Tool {
                       if (names != null && names.length != 0) {
                          // print java frame(s)
                          for (int i = 0; i < names.length; i++) {
-                             if (0 < i) {
+                             if (i > 0) {
                                  out.print(fillerForAddress);
                              }
                              out.println(names[i]);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -82,6 +82,7 @@ public class PStack extends Tool {
            return;
         }
          final boolean cdbgCanDemangle = cdbg.canDemangle();
+         String fillerForAddress = " ".repeat(2 + (2 << VM.getVM().getLogAddressSize())) + "\t";
          for (Iterator<ThreadProxy> itr = l.iterator() ; itr.hasNext();) {
             ThreadProxy th = itr.next();
             try {
@@ -168,6 +169,9 @@ public class PStack extends Tool {
                       if (names != null && names.length != 0) {
                          // print java frame(s)
                          for (int i = 0; i < names.length; i++) {
+                             if (0 < i) {
+                                 out.print(fillerForAddress);
+                             }
                              out.println(names[i]);
                          }
                       }


### PR DESCRIPTION
When running jstack with mixed option, the output of the lines that doesn't have an address are misaligned as followings. 

```
$ sudo jhsdb jstack --mixed --pid 8281
----------------- 8330 -----------------
"event-handler" #20 daemon prio=5 tid=0x00007f2384838490 nid=0x208a in Object.wait() [0x00007f23585ec000]
   java.lang.Thread.State: WAITING (on object monitor)
   JavaThread state: _thread_blocked
0x00007f238da899f3      __pthread_cond_wait + 0x243
0x00007f238c63a26b      os::PlatformEvent::park() + 0x8b
0x00007f238c5e689d      ObjectMonitor::wait(long, bool, Thread*) + 0xfed
0x00007f238ca1f1d6      ObjectSynchronizer::wait(Handle, long, Thread*) + 0x96
0x00007f238c0b4d71      JVM_MonitorWait + 0x241
0x00007f237cb246b7      java.lang.Object.wait(long) + 0xd7 (Native method)
0x00007f2375777344      * java.lang.Object.wait() bci:2 line:338 (Compiled frame)
* com.sun.tools.jdi.EventQueueImpl.removeUnfiltered(long) bci:64 line:190 (Compiled frame)
* com.sun.tools.jdi.EventQueueImpl.remove(long) bci:18 line:97 (Interpreted frame)
0x00007f2375009543      * com.sun.tools.jdi.EventQueueImpl.remove() bci:2 line:83 (Interpreted frame)
```

This pull request aligns the indentation. So It will be able to improve readability.

In this pull request the address part is filled with white spaces. The amount of space is calculated from VM's address size and lastly 2, which is the length of "0x", is added.

### jtreg test

```
$ sudo make run-test TEST=serviceability/sa/TestJhsdbJstackMixed.java

$ cat ./jdk/build/linux-x86_64-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_serviceability_sa_TestJhsdbJstackMixed_java/text/summary.txt
serviceability/sa/TestJhsdbJstackMixed.java  Passed. Execution successful
```

### Output Confirmation

I checked the output on 64-bit and 32-bit JDK.

First, I ran JShell. Next, on another shell, I ran jstack with mixed option for the JShell process and checked the output.

#### Linux 64-bit JDK
```
 $ ./jdk/build/linux-x86_64-server-fastdebug/jdk/bin/jshell
|  Welcome to JShell -- Version 16-internal
|  For an introduction type: /help intro

jshell>

$ ./jdk/build/linux-x86_64-server-fastdebug/jdk/bin/jhsdb jstack --mixed --pid 19272
...
----------------- 19324 -----------------
"output reader" #21 daemon prio=5 tid=0x00007f2ae4783760 nid=0x4b7c runnable [0x00007f2a86efd000]
   java.lang.Thread.State: RUNNABLE
   JavaThread state: _thread_in_native
0x00007f2aed5d2394      __libc_read + 0x44
0x00007f2ac450f93b      Java_sun_nio_ch_SocketDispatcher_read0 + 0x2b
0x00007f2adcb2045a      sun.nio.ch.SocketDispatcher.read0(java.io.FileDescriptor, long, int) + 0xfa (Native method)
0x00007f2ad573e024      * sun.nio.ch.SocketDispatcher.read(java.io.FileDescriptor, long, int) bci:4 line:47 (Compiled frame)
                        * sun.nio.ch.NioSocketImpl.tryRead(java.io.FileDescriptor, byte[], int, int) bci:45 line:261 (Compiled frame)
                        * sun.nio.ch.NioSocketImpl.implRead(byte[], int, int) bci:99 line:312 (Compiled frame)
                        * sun.nio.ch.NioSocketImpl.read(byte[], int, int) bci:54 line:350 (Compiled frame)
                        * sun.nio.ch.NioSocketImpl$1.read(byte[], int, int) bci:7 line:803 (Compiled frame)
                        * java.net.Socket$SocketInputStream.read(byte[], int, int) bci:7 line:961 (Compiled frame)
                        * java.net.Socket$SocketInputStream.read() bci:8 line:956 (Compiled frame)
                        * java.io.FilterInputStream.read() bci:4 line:82 (Interpreted frame)
0x00007f2ad50094fe      * jdk.jshell.execution.DemultiplexInput.run() bci:4 line:58 (Interpreted frame)
0x00007f2ad5000d4a      <StubRoutines>
...
```

#### Windows 32-bit JDK
```
$ ./jdk/build/windows-x86-server-fastdebug/jdk/bin/jhsdb.exe jstack --mixed --pid 78808
...
----------------- 29 -----------------
"output reader" #17 daemon prio=5 tid=0x2711c3b8 nid=0x13178 runnable [0x27d6f000]
   java.lang.Thread.State: RUNNABLE
   JavaThread state: _thread_in_native
0x77ae2f5c      ntdll!NtWaitForSingleObject + 0xc
0x6dc5cb18      mswsock!sethostname + 0xbdc8
0x753cdecc      WS2_32!WSARecv + 0x11c
0x6c0d35f8      nio!Java_sun_nio_ch_SocketDispatcher_read0 + 0x48
0x02d15ee9      sun.nio.ch.SocketDispatcher.read0(java.io.FileDescriptor, long, int) + 0xa9 (Native method)
0x02d16540      * sun.nio.ch.SocketDispatcher.read(java.io.FileDescriptor, long, int) bci:4 line:46 (Compiled frame)
                * sun.nio.ch.NioSocketImpl.tryRead(java.io.FileDescriptor, byte[], int, int) bci:45 line:261 (Compiled frame)
                * sun.nio.ch.NioSocketImpl.implRead(byte[], int, int) bci:99 line:312 (Compiled frame)
                * sun.nio.ch.NioSocketImpl.read(byte[], int, int) bci:54 line:350 (Compiled frame)
                * sun.nio.ch.NioSocketImpl$1.read(byte[], int, int) bci:7 line:803 (Compiled frame)
                * java.net.Socket$SocketInputStream.read(byte[], int, int) bci:7 line:961 (Compiled frame)
                * java.net.Socket$SocketInputStream.read() bci:8 line:956 (Compiled frame)
                * java.io.FilterInputStream.read() bci:4 line:82 (Interpreted frame)
0x02ac6804      * jdk.jshell.execution.DemultiplexInput.run() bci:4 line:58 (Interpreted frame)
0x02ac0cdc      <StubRoutines>
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263572](https://bugs.openjdk.java.net/browse/JDK-8263572): Output from jstack mixed mode is misaligned


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3004/head:pull/3004`
`$ git checkout pull/3004`

To update a local copy of the PR:
`$ git checkout pull/3004`
`$ git pull https://git.openjdk.java.net/jdk pull/3004/head`
