### PR TITLE
8263189: C2: assert(!had_error) failed: bad dominance

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3493,7 +3493,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     }
     break;
   case Op_Loop:
-    assert(!n->as_Loop()->is_transformed_long_loop() || _loop_opts_cnt == 0, "should have been turned into a counted loop");
+    assert(!n->as_Loop()->is_transformed_long_inner_loop() || _loop_opts_cnt == 0, "should have been turned into a counted loop");
   case Op_CountedLoop:
   case Op_LongCountedLoop:
   case Op_OuterStripMinedLoop:

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -764,7 +764,7 @@ SafePointNode* PhaseIdealLoop::find_safepoint(Node* back_control, Node* x, Ideal
 bool PhaseIdealLoop::transform_long_counted_loop(IdealLoopTree* loop, Node_List &old_new) {
   Node* x = loop->_head;
   // Only for inner loops
-  if (loop->_child != NULL || !x->is_LongCountedLoop()) {
+  if (loop->_child != NULL || !x->is_LongCountedLoop() || x->as_Loop()->is_transformed_long_outer_loop()) {
     return false;
   }
 
@@ -812,7 +812,8 @@ bool PhaseIdealLoop::transform_long_counted_loop(IdealLoopTree* loop, Node_List 
     return false;
   }
 
-  const TypeLong* phi_t = _igvn.type(phi)->is_long();
+  // May not have gone thru igvn yet so don't use _igvn.type(phi) (PhaseIdealLoop::is_counted_loop() sets the iv phi's type)
+  const TypeLong* phi_t = phi->bottom_type()->is_long();
   assert(phi_t->_hi >= phi_t->_lo, "dead phi?");
   iters_limit = (int)MIN2((julong)iters_limit, (julong)(phi_t->_hi - phi_t->_lo));
 
@@ -832,8 +833,8 @@ bool PhaseIdealLoop::transform_long_counted_loop(IdealLoopTree* loop, Node_List 
   Node* outer_exit_test = new IfNode(exit_test->in(0), exit_test->in(1), exit_test->_prob, exit_test->_fcnt);
   Node* inner_exit_branch = exit_branch->clone();
 
-  Node* outer_head = new LoopNode(entry_control, outer_back_branch);
-  IdealLoopTree* outer_ilt = insert_outer_loop(loop, outer_head->as_Loop(), outer_back_branch);
+  LoopNode* outer_head = new LoopNode(entry_control, outer_back_branch);
+  IdealLoopTree* outer_ilt = insert_outer_loop(loop, outer_head, outer_back_branch);
 
   const bool body_populated = true;
   register_control(outer_head, outer_ilt, entry_control, body_populated);
@@ -1005,7 +1006,8 @@ bool PhaseIdealLoop::transform_long_counted_loop(IdealLoopTree* loop, Node_List 
   Atomic::inc(&_long_loop_nests);
 #endif
 
-  inner_head->mark_transformed_long_loop();
+  inner_head->mark_transformed_long_inner_loop();
+  outer_head->mark_transformed_long_outer_loop();
 
   return true;
 }
@@ -1389,7 +1391,7 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
     if (sov < 0) {
       return false;  // Bailout: integer overflow is certain.
     }
-    assert(!x->as_Loop()->is_transformed_long_loop(), "long loop was transformed");
+    assert(!x->as_Loop()->is_transformed_long_inner_loop(), "long loop was transformed");
     // Generate loop's limit check.
     // Loop limit check predicate should be near the loop.
     ProjNode *limit_check_proj = find_predicate_insertion_point(init_control, Deoptimization::Reason_loop_limit_check);
@@ -1479,7 +1481,7 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
 
 #ifdef ASSERT
   if (iv_bt == T_INT &&
-      !x->as_Loop()->is_transformed_long_loop() &&
+      !x->as_Loop()->is_transformed_long_inner_loop() &&
       StressLongCountedLoop > 0 &&
       trunc1 == NULL &&
       convert_to_long_loop(cmp, phi, loop)) {
@@ -1674,10 +1676,13 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
   }
 
 #ifndef PRODUCT
-  if (x->as_Loop()->is_transformed_long_loop()) {
+  if (x->as_Loop()->is_transformed_long_inner_loop()) {
     Atomic::inc(&_long_loop_counted_loops);
   }
 #endif
+  if (iv_bt == T_LONG && x->as_Loop()->is_transformed_long_outer_loop()) {
+    l->mark_transformed_long_outer_loop();
+  }
 
   return true;
 }
@@ -3313,7 +3318,7 @@ void IdealLoopTree::counted_loop( PhaseIdealLoop *phase ) {
              phase->is_counted_loop(_head, loop, T_LONG)) {
     remove_safepoints(phase, true);
   } else {
-    assert(!_head->is_Loop() || !_head->as_Loop()->is_transformed_long_loop(), "transformation to counted loop should not fail");
+    assert(!_head->is_Loop() || !_head->as_Loop()->is_transformed_long_inner_loop(), "transformation to counted loop should not fail");
     if (_parent != NULL && !_irreducible) {
       // Not a counted loop. Keep one safepoint.
       bool keep_one_sfpt = true;

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -77,7 +77,8 @@ protected:
          StripMined          = 1<<15,
          SubwordLoop         = 1<<16,
          ProfileTripFailed   = 1<<17,
-         TransformedLongLoop = 1<<18 };
+         TransformedLongInnerLoop = 1<<18,
+         TransformedLongOuterLoop = 1<<19};
   char _unswitch_count;
   enum { _unswitch_max=3 };
   char _postloop_flags;
@@ -102,7 +103,8 @@ public:
   bool is_strip_mined() const { return _loop_flags & StripMined; }
   bool is_profile_trip_failed() const { return _loop_flags & ProfileTripFailed; }
   bool is_subword_loop() const { return _loop_flags & SubwordLoop; }
-  bool is_transformed_long_loop() const { return _loop_flags & TransformedLongLoop; }
+  bool is_transformed_long_inner_loop() const { return _loop_flags & TransformedLongInnerLoop; }
+  bool is_transformed_long_outer_loop() const { return _loop_flags & TransformedLongOuterLoop; }
 
   void mark_partial_peel_failed() { _loop_flags |= PartialPeelFailed; }
   void mark_has_reductions() { _loop_flags |= HasReductions; }
@@ -117,7 +119,8 @@ public:
   void clear_strip_mined() { _loop_flags &= ~StripMined; }
   void mark_profile_trip_failed() { _loop_flags |= ProfileTripFailed; }
   void mark_subword_loop() { _loop_flags |= SubwordLoop; }
-  void mark_transformed_long_loop() { _loop_flags |= TransformedLongLoop; }
+  void mark_transformed_long_inner_loop() { _loop_flags |= TransformedLongInnerLoop; }
+  void mark_transformed_long_outer_loop() { _loop_flags |= TransformedLongOuterLoop; }
 
   int unswitch_max() { return _unswitch_max; }
   int unswitch_count() { return _unswitch_count; }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1043,7 +1043,7 @@ Node *PhaseIdealLoop::split_if_with_blocks_pre( Node *n ) {
 
   // Do not clone the trip counter through on a CountedLoop
   // (messes up the canonical shape).
-  if (((n_blk->is_CountedLoop() || (n_blk->is_Loop() && n_blk->as_Loop()->is_transformed_long_loop())) && n->Opcode() == Op_AddI) ||
+  if (((n_blk->is_CountedLoop() || (n_blk->is_Loop() && n_blk->as_Loop()->is_transformed_long_inner_loop())) && n->Opcode() == Op_AddI) ||
       (n_blk->is_LongCountedLoop() && n->Opcode() == Op_AddL)) {
     return n;
   }

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestDeadLongPhi.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestDeadLongPhi.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8263189
+ * @summary C2: assert(!had_error) failed: bad dominance
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestDeadLongPhi TestDeadLongPhi
+ *
+ */
+
+public class TestDeadLongPhi {
+    static int N = 400;
+    static long instanceCount;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10 ; i++) {
+            mainTest();
+        }
+    }
+
+    static void mainTest() {
+        vMeth();
+    }
+
+    static void vMeth() {
+        int i17 = 89, i18, i19 = 44, i20 = 2, iArr3[] = new int[N];
+        long l2, lArr[] = new long[N];
+        byte by = 22;
+        init(iArr3, 131);
+        for (i18 = 2; i18 < 350; ++i18) {
+            i17 /= 8;
+            for (l2 = 5; l2 > i18; l2 -= 2) {
+                switch ((i18 % 3)) {
+                    case 8:
+                        iArr3[i18] |= i17;
+                        break;
+                    case 9:
+                        i20 += (((l2) + by) - i19);
+                        i19 += instanceCount;
+                    case 10:
+                }
+            }
+        }
+    }
+
+    public static void init(int[] a, int seed) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = (j % 2 == 0) ? seed + j : seed - j;
+        }
+    }
+
+}
+


### PR DESCRIPTION
A long counted loop has a Phi that depends on the iv
Phi. PhaseIdealLoop::is_counted_loop() is able to compute a narrow
type for the iv Phi (the loop only runs for a few iterations). As a
consequence the Phi that depends on the iv Phi also gets a narrow
type. When the long counted loop is transformed into a loop nest, even
though the long loop is known to run for only a few iterations, the
inner int counted loop that's created gets a wide type: the narrow
type of the long counted loop iv Phi should result in a narrow type
for the int counted loop iv Phi but doesn't. C2 then creates
pre/main/post loops for the inner int counted loop. It wouldn't have
proceeded with this step, had the number of iterations of the loop not
been lost. In the process, it creates Phi to merge the values from the
pre/main/post loop. Two of those Phis are for the dependent Phi, the
one that captured the narrow type. The type of one of the 2 Phis
becomes top because we get in an impossible situation where the loop
that's known to have very few iterations was cloned twice. One of the
just created Phi becomes top and dominance is broken.

The reason the iv Phi narrow type is lost at long loop transformation
time is because it's queried from the igvn but it was not yet recorded
with the igvn and instead set when the long counted loop was created
in the same loop pass. The fix for that is to query the type stored in
the Phi rather than from the igvn.

Now it's not right that we end up with a dependent Phi that captures
the narrow type (which happens at igvn time) before the loop is even
created (I said that happens in the same loop opts pass so igvn has
not had a chance to run). The reason for that is that the same loop is
transformed multiple times:

1- the long counted loop is created

2- the long counted loop is transformed to a loop nest with an inner
  int counted loop. The outer loop is transformed back to a regular
  loop.

3- the inner int counted loop is found to be empty and so optimized out

4- the long counted loop for the same loop is created again

5- a loop nest is created again

This looks wrong and I added code to prevent retransforming a long
counted loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263189](https://bugs.openjdk.java.net/browse/JDK-8263189): C2: assert(!had_error) failed: bad dominance


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3005/head:pull/3005`
`$ git checkout pull/3005`

To update a local copy of the PR:
`$ git checkout pull/3005`
`$ git pull https://git.openjdk.java.net/jdk pull/3005/head`
