### PR TITLE
8263376: CTW (Shenandoah): assert(mems <= 1) failed: No node right after call if multiple mem projections

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5037,7 +5037,8 @@ Node *PhaseIdealLoop::get_late_ctrl( Node *n, Node *early ) {
             for (uint j = 1; j < s->req(); j++) {
               Node* in = s->in(j);
               Node* r_in = r->in(j);
-              if ((worklist.member(in) || in == mem) && is_dominator(early, r_in)) {
+              // We can't reach any node from a Phi because we don't enqueue Phi's uses above
+              if (((worklist.member(in) && !in->is_Phi()) || in == mem) && is_dominator(early, r_in)) {
                 LCA = dom_lca_for_get_late_ctrl(LCA, r_in, n);
               }
             }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
@@ -38,13 +38,17 @@ public class TestBadRawMemoryAfterCall {
         B b = new B();
         C c = new C();
         for (int i = 0; i < 20_000; i++) {
-            test(a);
-            test(b);
-            test(c);
+            test1(a);
+            test1(b);
+            test1(c);
+
+            test2(a, i);
+            test2(b, i);
+            test2(c, i);
         }
     }
 
-    private static Object test(A a) {
+    private static Object test1(A a) {
         if (a.getClass() == A.class) {
         }
 
@@ -54,6 +58,25 @@ public class TestBadRawMemoryAfterCall {
             o = a.getClass();
         } catch (Exception e) {
 
+        }
+        return o;
+    }
+
+    static int field;
+
+    private static Object test2(A a, int i) {
+        if (a.getClass() == A.class) {
+        }
+
+        Object o = null;
+        try {
+            a.m();
+            o = a.getClass();
+        } catch (Exception e) {
+            i = 42;
+        }
+        if (i == 42) {
+            field = 42;
         }
         return o;
     }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBadRawMemoryAfterCall.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8258393
+ * @bug 8258393 8263376
  * @summary Shenandoah: "graph should be schedulable" assert failure
  * @requires vm.flavor == "server"
  * @requires vm.gc.Shenandoah


### PR DESCRIPTION
This is another case of anti-dependence analysis being too conservative.

In TestBadRawMemoryAfterCall.test2(), test

if (i == 42) {

is split thru the Phi that merges values from the fallthru and
exception paths. As a consequence, control flow at the call is
roughly:
```
a.m() call
|         \       
fallthru  exception
|             |
if (i == 42)  |
|      \      |
|       Region1
\        /
  Region2
```
When anti-dependence analysis runs for the load after the call, it
starts from the memory state out of the call on the fallthru path. One
use is a memory Phi at Region2 (say Phi2). Another path leads to
Region1 at, say, Phi1.

When anti-dependence analysis then goes over Phis, it processes Phi2,
goes over the its inputs and finds that 2 are reachable: the one that
has a direct edge to the memory state on the fallthru path and the one
from Phi1. As a consequence, control for the load is set to be right
after the call, which is too conservative.

When following the memory edges, the code stops at Phi1. It doesn't
process uses of Phi1. Any anti-dependence that's needed between the
load and Phi1 is then taken into account when Phis are processed. When
inputs to Phi2 are processed, considering the Phi2->Phi1 is too
conservative. As mentioned above, anti-dependences for Phi1 are taken
into account separately. I think it's true for all Phi->Phi edges that
they can be safely ignored. That's what I propose as a fix.


/cc shenandoah,hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263376](https://bugs.openjdk.java.net/browse/JDK-8263376): CTW (Shenandoah): assert(mems <= 1) failed: No node right after call if multiple mem projections


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to a47fa7b72268ecbc43cd26a85dfdfd8fa53bbb32
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to a47fa7b72268ecbc43cd26a85dfdfd8fa53bbb32


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3006/head:pull/3006`
`$ git checkout pull/3006`

To update a local copy of the PR:
`$ git checkout pull/3006`
`$ git pull https://git.openjdk.java.net/jdk pull/3006/head`
