### PR TITLE
8263583: Emoji rendering on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -583,3 +583,14 @@ JNI_COCOA_ENTER(env);
     CFRelease(fds);
 JNI_COCOA_EXIT(env);
 }
+
+static CFStringRef EMOJI_FONT_NAME = CFSTR("Apple Color Emoji");
+
+bool IsEmojiFont(CTFontRef font)
+{
+    CFStringRef name = CTFontCopyFullName(font);
+    if (name == NULL) return false;
+    bool isFixedColor = CFStringCompare(name, EMOJI_FONT_NAME, 0) == kCFCompareEqualTo;
+    CFRelease(name);
+    return isFixedColor;
+}

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -151,7 +151,7 @@ JNI_COCOA_ENTER(env);
     // to indicate we should use CoreText to substitute the character
     CGGlyph glyph;
     const CTFontRef fallback = CTS_CopyCTFallbackFontAndGlyphForJavaGlyphCode(awtFont, glyphCode, &glyph);
-    CTFontGetAdvancesForGlyphs(fallback, kCTFontDefaultOrientation, &glyph, &advance, 1);
+    CGGlyphImages_GetGlyphMetrics(fallback, &awtStrike->fAltTx, awtStrike->fStyle, &glyph, 1, NULL, &advance);
     CFRelease(fallback);
     advance = CGSizeApplyAffineTransform(advance, awtStrike->fFontTx);
     if (!JRSFontStyleUsesFractionalMetrics(awtStrike->fStyle)) {
@@ -188,7 +188,7 @@ JNI_COCOA_ENTER(env);
     const CTFontRef fallback = CTS_CopyCTFallbackFontAndGlyphForJavaGlyphCode(awtFont, glyphCode, &glyph);
 
     CGRect bbox;
-    JRSFontGetBoundingBoxesForGlyphsAndStyle(fallback, &tx, awtStrike->fStyle, &glyph, 1, &bbox);
+    CGGlyphImages_GetGlyphMetrics(fallback, &tx, awtStrike->fStyle, &glyph, 1, &bbox, NULL);
     CFRelease(fallback);
 
     // the origin of this bounding box is relative to the bottom-left corner baseline

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.h
@@ -33,5 +33,12 @@ void
 CGGlyphImages_GetGlyphImagePtrs(jlong glyphInfos[],
                                 const AWTStrike *strike,
                                 jint rawGlyphCodes[], const CFIndex len);
-
+void
+CGGlyphImages_GetGlyphMetrics(const CTFontRef font,
+                              const CGAffineTransform *tx,
+                              const JRSFontRenderingStyle style,
+                              const CGGlyph glyphs[],
+                              size_t count,
+                              CGRect bboxes[],
+                              CGSize advances[]);
 #endif /* __CGGLYPHIMAGES_H */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -324,6 +324,19 @@ void MTLTR_FreeGlyphCaches() {
     }
 }
 
+MTLPaint* storedPaint = nil;
+
+static void EnableColorGlyphPainting(MTLContext *mtlc) {
+    storedPaint = mtlc.paint;
+    mtlc.paint = [[MTLPaint alloc] init];
+}
+
+static void DisableColorGlyphPainting(MTLContext *mtlc) {
+    [mtlc.paint release];
+    mtlc.paint = storedPaint;
+    storedPaint = nil;
+}
+
 static jboolean
 MTLTR_DrawGrayscaleGlyphViaCache(MTLContext *mtlc,
                                  GlyphInfo *ginfo, jint x, jint y, BMTLSDOps *dstOps)
@@ -337,6 +350,8 @@ MTLTR_DrawGrayscaleGlyphViaCache(MTLContext *mtlc,
         } else if (glyphMode == MODE_USE_CACHE_LCD) {
             [mtlc.encoderManager endEncoder];
             lcdCacheEncoder = nil;
+        } else if (glyphMode == MODE_NO_CACHE_COLOR) {
+            DisableColorGlyphPainting(mtlc);
         }
         MTLTR_EnableGlyphVertexCache(mtlc, dstOps);
         glyphMode = MODE_USE_CACHE_GRAY;
@@ -383,6 +398,8 @@ MTLTR_DrawLCDGlyphViaCache(MTLContext *mtlc, BMTLSDOps *dstOps,
             MTLVertexCache_DisableMaskCache(mtlc);
         } else if (glyphMode == MODE_USE_CACHE_GRAY) {
             MTLTR_DisableGlyphVertexCache(mtlc);
+        } else if (glyphMode == MODE_NO_CACHE_COLOR) {
+            DisableColorGlyphPainting(mtlc);
         }
 
         if (glyphCacheLCD == NULL) {
@@ -455,6 +472,8 @@ MTLTR_DrawGrayscaleGlyphNoCache(MTLContext *mtlc,
         } else if (glyphMode == MODE_USE_CACHE_LCD) {
             [mtlc.encoderManager endEncoder];
             lcdCacheEncoder = nil;
+        } else if (glyphMode == MODE_NO_CACHE_COLOR) {
+            DisableColorGlyphPainting(mtlc);
         }
         MTLVertexCache_EnableMaskCache(mtlc, dstOps);
         glyphMode = MODE_NO_CACHE_GRAY;
@@ -517,6 +536,8 @@ MTLTR_DrawLCDGlyphNoCache(MTLContext *mtlc, BMTLSDOps *dstOps,
         } else if (glyphMode == MODE_USE_CACHE_LCD) {
             [mtlc.encoderManager endEncoder];
             lcdCacheEncoder = nil;
+        } else if (glyphMode == MODE_NO_CACHE_COLOR) {
+            DisableColorGlyphPainting(mtlc);
         }
 
         if (blitTexture == nil) {
@@ -586,6 +607,51 @@ MTLTR_DrawLCDGlyphNoCache(MTLContext *mtlc, BMTLSDOps *dstOps,
     return JNI_TRUE;
 }
 
+static jboolean
+MTLTR_DrawColorGlyphNoCache(MTLContext *mtlc,
+                            GlyphInfo *ginfo, jint x, jint y, BMTLSDOps *dstOps)
+{
+    id<MTLTexture> dest = dstOps->pTexture;
+    const void *src = ginfo->image;
+    jint w = ginfo->width;
+    jint h = ginfo->height;
+    jint rowBytes = ginfo->rowBytes;
+    unsigned int imageSize = rowBytes * h;
+
+    J2dTraceLn(J2D_TRACE_INFO, "MTLTR_DrawColorGlyphNoCache");
+
+    if (glyphMode != MODE_NO_CACHE_COLOR) {
+        if (glyphMode == MODE_NO_CACHE_GRAY) {
+            MTLVertexCache_DisableMaskCache(mtlc);
+        } else if (glyphMode == MODE_USE_CACHE_GRAY) {
+            MTLTR_DisableGlyphVertexCache(mtlc);
+        } else if (glyphMode == MODE_USE_CACHE_LCD) {
+            [mtlc.encoderManager endEncoder];
+            lcdCacheEncoder = nil;
+        }
+        glyphMode = MODE_NO_CACHE_COLOR;
+        EnableColorGlyphPainting(mtlc);
+    }
+
+    MTLPooledTextureHandle* texHandle = [mtlc.texturePool getTexture:w height:h format:MTLPixelFormatBGRA8Unorm];
+    if (texHandle == nil) {
+        J2dTraceLn(J2D_TRACE_ERROR, "MTLTR_DrawColorGlyphNoCache: can't obtain temporary texture object from pool");
+        return JNI_FALSE;
+    }
+
+    [[mtlc getCommandBufferWrapper] registerPooledTexture:texHandle];
+
+    [texHandle.texture replaceRegion:MTLRegionMake2D(0, 0, w, h)
+                         mipmapLevel:0
+                           withBytes:src
+                         bytesPerRow:rowBytes];
+
+    drawTex2Tex(mtlc, texHandle.texture, dest, JNI_FALSE, dstOps->isOpaque, INTERPOLATION_NEAREST_NEIGHBOR,
+                0, 0, w, h, x, y, x + w, y + h);
+
+    return JNI_TRUE;
+}
+
 // see DrawGlyphList.c for more on this macro...
 #define FLOOR_ASSIGN(l, r) \
     if ((r)<0) (l) = ((int)floor(r)); else (l) = ((int)(r))
@@ -616,7 +682,7 @@ MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
         J2dTraceLn(J2D_TRACE_INFO, "Entered for loop for glyph list");
         jint x, y;
         jfloat glyphx, glyphy;
-        jboolean grayscale, ok;
+        jboolean ok;
         GlyphInfo *ginfo = (GlyphInfo *)jlong_to_ptr(NEXT_LONG(images));
 
         if (ginfo == NULL) {
@@ -625,8 +691,6 @@ MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
                           "MTLTR_DrawGlyphList: glyph info is null");
             break;
         }
-
-        grayscale = (ginfo->rowBytes == ginfo->width);
 
         if (usePositions) {
             jfloat posx = NEXT_FLOAT(positions);
@@ -651,7 +715,7 @@ MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
 
         J2dTraceLn2(J2D_TRACE_INFO, "Glyph width = %d height = %d", ginfo->width, ginfo->height);
         J2dTraceLn1(J2D_TRACE_INFO, "rowBytes = %d", ginfo->rowBytes);
-        if (grayscale) {
+        if (ginfo->rowBytes == ginfo->width) {
             // grayscale or monochrome glyph data
             if (ginfo->width <= MTLTR_CACHE_CELL_WIDTH &&
                 ginfo->height <= MTLTR_CACHE_CELL_HEIGHT)
@@ -662,6 +726,10 @@ MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
                 J2dTraceLn(J2D_TRACE_INFO, "MTLTR_DrawGlyphList Grayscale no cache");
                 ok = MTLTR_DrawGrayscaleGlyphNoCache(mtlc, ginfo, x, y, dstOps);
             }
+        } else if (ginfo->rowBytes == ginfo->width * 4) {
+            J2dTraceLn(J2D_TRACE_INFO, "MTLTR_DrawGlyphList color glyph no cache");
+            ok = MTLTR_DrawColorGlyphNoCache(mtlc, ginfo, x, y, dstOps);
+            flushBeforeLCD = JNI_FALSE;
         } else {
             if (!flushBeforeLCD) {
                 [mtlc.encoderManager endEncoder];
@@ -720,6 +788,8 @@ MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
     } else if (glyphMode == MODE_USE_CACHE_LCD) {
         [mtlc.encoderManager endEncoder];
         lcdCacheEncoder = nil;
+    } else if (glyphMode == MODE_NO_CACHE_COLOR) {
+        DisableColorGlyphPainting(mtlc);
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -324,7 +324,7 @@ void MTLTR_FreeGlyphCaches() {
     }
 }
 
-MTLPaint* storedPaint = nil;
+static MTLPaint* storedPaint = nil;
 
 static void EnableColorGlyphPainting(MTLContext *mtlc) {
     storedPaint = mtlc.paint;

--- a/src/java.desktop/share/classes/sun/font/ColorGlyphSurfaceData.java
+++ b/src/java.desktop/share/classes/sun/font/ColorGlyphSurfaceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2021 JetBrains s.r.o.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +23,49 @@
  * questions.
  */
 
-#import <Cocoa/Cocoa.h>
-#import <JavaRuntimeSupport/JavaRuntimeSupport.h>
+package sun.font;
 
-#define MAX_STACK_ALLOC_GLYPH_BUFFER_SIZE 256
+import sun.java2d.SurfaceData;
 
-@interface AWTFont : NSObject {
-@public
-    NSFont    *fFont;
-    CGFontRef  fNativeCGFont;
-    BOOL       fIsFakeItalic;
+import java.awt.GraphicsConfiguration;
+import java.awt.Rectangle;
+import java.awt.image.Raster;
+
+/**
+ * SurfaceData view for a color glyph from glyph cache
+ */
+class ColorGlyphSurfaceData extends SurfaceData {
+    ColorGlyphSurfaceData() {
+        super(State.UNTRACKABLE);
+        initOps();
+    }
+
+    private native void initOps();
+
+    native void setCurrentGlyph(long imgPtr);
+
+    @Override
+    public SurfaceData getReplacement() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GraphicsConfiguration getDeviceConfiguration() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Raster getRaster(int x, int y, int w, int h) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getDestination() {
+        throw new UnsupportedOperationException();
+    }
 }
-
-+ (AWTFont *) awtFontForName:(NSString *)name
-    style:(int)style isFakeItalic:(BOOL)isFakeItalic;
-
-+ (NSFont *) nsFontForJavaFont:(jobject)javaFont env:(JNIEnv *)env;
-
-@end
-
-bool IsEmojiFont(CTFontRef font);

--- a/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
+++ b/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
@@ -53,6 +53,7 @@ import sun.java2d.loops.FontInfo;
 import sun.java2d.loops.DrawGlyphList;
 import sun.java2d.loops.DrawGlyphListAA;
 import sun.java2d.loops.DrawGlyphListLCD;
+import sun.java2d.loops.DrawGlyphListColor;
 import sun.java2d.pipe.LoopPipe;
 import sun.java2d.pipe.ShapeDrawPipe;
 import sun.java2d.pipe.ParallelogramPipe;
@@ -892,6 +893,8 @@ public abstract class SurfaceData
         loops.drawGlyphListLoop = DrawGlyphList.locate(src, comp, dst);
         loops.drawGlyphListAALoop = DrawGlyphListAA.locate(src, comp, dst);
         loops.drawGlyphListLCDLoop = DrawGlyphListLCD.locate(src, comp, dst);
+        loops.drawGlyphListColorLoop =
+                DrawGlyphListColor.locate(src, comp, dst);
         /*
         System.out.println("drawLine: "+loops.drawLineLoop);
         System.out.println("fillRect: "+loops.fillRectLoop);

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListAA.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListAA.java
@@ -67,7 +67,8 @@ public class DrawGlyphListAA extends GraphicsPrimitive {
     }
 
     public native void DrawGlyphListAA(SunGraphics2D sg2d, SurfaceData dest,
-                                       GlyphList srcData);
+                                       GlyphList srcData,
+                                       int fromGlyph, int toGlyph);
 
     static {
         GraphicsPrimitiveMgr.registerGeneral(
@@ -92,16 +93,14 @@ public class DrawGlyphListAA extends GraphicsPrimitive {
         }
 
         public void DrawGlyphListAA(SunGraphics2D sg2d, SurfaceData dest,
-                                    GlyphList gl)
+                                    GlyphList gl, int fromGlyph, int toGlyph)
         {
-            gl.getBounds(); // Don't delete, bug 4895493
-            int num = gl.getNumGlyphs();
             Region clip = sg2d.getCompClip();
             int cx1 = clip.getLoX();
             int cy1 = clip.getLoY();
             int cx2 = clip.getHiX();
             int cy2 = clip.getHiY();
-            for (int i = 0; i < num; i++) {
+            for (int i = fromGlyph; i < toGlyph; i++) {
                 gl.setGlyphIndex(i);
                 int[] metrics = gl.getMetrics();
                 int gx1 = metrics[0];
@@ -149,10 +148,11 @@ public class DrawGlyphListAA extends GraphicsPrimitive {
         }
 
         public void DrawGlyphListAA(SunGraphics2D sg2d, SurfaceData dest,
-                                    GlyphList glyphs)
+                                    GlyphList glyphs,
+                                    int fromGlyph, int toGlyph)
         {
             tracePrimitive(target);
-            target.DrawGlyphListAA(sg2d, dest, glyphs);
+            target.DrawGlyphListAA(sg2d, dest, glyphs, fromGlyph, toGlyph);
         }
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListLCD.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListLCD.java
@@ -68,7 +68,8 @@ public class DrawGlyphListLCD extends GraphicsPrimitive {
     }
 
     public native void DrawGlyphListLCD(SunGraphics2D sg2d, SurfaceData dest,
-                                         GlyphList srcData);
+                                        GlyphList srcData,
+                                        int fromGlyph, int toGlyph);
 
     public GraphicsPrimitive traceWrap() {
         return new TraceDrawGlyphListLCD(this);
@@ -89,10 +90,11 @@ public class DrawGlyphListLCD extends GraphicsPrimitive {
         }
 
         public void DrawGlyphListLCD(SunGraphics2D sg2d, SurfaceData dest,
-                                      GlyphList glyphs)
+                                     GlyphList glyphs,
+                                     int fromGlyph, int toGlyph)
         {
             tracePrimitive(target);
-            target.DrawGlyphListLCD(sg2d, dest, glyphs);
+            target.DrawGlyphListLCD(sg2d, dest, glyphs, fromGlyph, toGlyph);
         }
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/loops/GeneralRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/GeneralRenderer.java
@@ -365,9 +365,10 @@ public final class GeneralRenderer {
      * reset the glyphs to non-AA after construction.
      */
     static void doDrawGlyphList(SurfaceData sData, PixelWriter pw,
-                                GlyphList gl, Region clip)
+                                GlyphList gl, int fromGlyph, int toGlyph,
+                                Region clip)
     {
-        int[] bounds = gl.getBounds();
+        int[] bounds = gl.getBounds(toGlyph);
         clip.clipBoxToBounds(bounds);
         int cx1 = bounds[0];
         int cy1 = bounds[1];
@@ -378,8 +379,7 @@ public final class GeneralRenderer {
             (WritableRaster) sData.getRaster(cx1, cy1, cx2 - cx1, cy2 - cy1);
         pw.setRaster(dstRast);
 
-        int num = gl.getNumGlyphs();
-        for (int i = 0; i < num; i++) {
+        for (int i = fromGlyph; i < toGlyph; i++) {
             gl.setGlyphIndex(i);
             int[] metrics = gl.getMetrics();
             int gx1 = metrics[0];
@@ -971,10 +971,11 @@ class XorDrawGlyphListANY extends DrawGlyphList {
     }
 
     public void DrawGlyphList(SunGraphics2D sg2d, SurfaceData sData,
-                              GlyphList gl)
+                              GlyphList gl, int fromGlyph, int toGlyph)
     {
         PixelWriter pw = GeneralRenderer.createXorPixelWriter(sg2d, sData);
-        GeneralRenderer.doDrawGlyphList(sData, pw, gl, sg2d.getCompClip());
+        GeneralRenderer.doDrawGlyphList(sData, pw, gl, fromGlyph, toGlyph,
+                sg2d.getCompClip());
     }
 }
 
@@ -986,10 +987,11 @@ class XorDrawGlyphListAAANY extends DrawGlyphListAA {
     }
 
     public void DrawGlyphListAA(SunGraphics2D sg2d, SurfaceData sData,
-                                GlyphList gl)
+                                GlyphList gl, int fromGlyph, int toGlyph)
     {
         PixelWriter pw = GeneralRenderer.createXorPixelWriter(sg2d, sData);
-        GeneralRenderer.doDrawGlyphList(sData, pw, gl, sg2d.getCompClip());
+        GeneralRenderer.doDrawGlyphList(sData, pw, gl, fromGlyph, toGlyph,
+                sg2d.getCompClip());
     }
 }
 

--- a/src/java.desktop/share/classes/sun/java2d/loops/RenderLoops.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/RenderLoops.java
@@ -52,4 +52,5 @@ public class RenderLoops {
     public DrawGlyphList        drawGlyphListLoop;
     public DrawGlyphListAA      drawGlyphListAALoop;
     public DrawGlyphListLCD     drawGlyphListLCDLoop;
+    public DrawGlyphListColor   drawGlyphListColorLoop;
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/AATextRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/AATextRenderer.java
@@ -25,6 +25,7 @@
 
 package sun.java2d.pipe;
 
+import sun.awt.SunHints;
 import sun.java2d.SunGraphics2D;
 import sun.font.GlyphList;
 
@@ -37,8 +38,7 @@ public class AATextRenderer extends GlyphListLoopPipe
     implements LoopBasedPipe
 {
    protected void drawGlyphList(SunGraphics2D sg2d, GlyphList gl) {
-       sg2d.loops.drawGlyphListAALoop.DrawGlyphListAA(sg2d, sg2d.surfaceData,
-                                                      gl);
+       drawGlyphList(sg2d, gl, SunHints.INTVAL_TEXT_ANTIALIAS_ON);
    }
 
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/GlyphListLoopPipe.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/GlyphListLoopPipe.java
@@ -40,20 +40,51 @@ public abstract class GlyphListLoopPipe extends GlyphListPipe
 {
     protected void drawGlyphList(SunGraphics2D sg2d, GlyphList gl,
                                  int aaHint) {
-        switch (aaHint) {
-         case SunHints.INTVAL_TEXT_ANTIALIAS_OFF:
-             sg2d.loops.drawGlyphListLoop.
-                 DrawGlyphList(sg2d, sg2d.surfaceData, gl);
-             return;
-         case SunHints.INTVAL_TEXT_ANTIALIAS_ON:
-             sg2d.loops.drawGlyphListAALoop.
-                 DrawGlyphListAA(sg2d, sg2d.surfaceData, gl);
-             return;
-        case SunHints.INTVAL_TEXT_ANTIALIAS_LCD_HRGB:
-        case SunHints.INTVAL_TEXT_ANTIALIAS_LCD_VRGB:
-            sg2d.loops.drawGlyphListLCDLoop.
-                DrawGlyphListLCD(sg2d,sg2d.surfaceData, gl);
-            return;
+        int prevLimit = 0;
+        boolean isColor = false;
+        int len = gl.getNumGlyphs();
+        gl.startGlyphIteration();
+        if (GlyphList.canContainColorGlyphs()) {
+            for (int i = 0; i < len; i++) {
+                boolean newIsColor = gl.isColorGlyph(i);
+                if (newIsColor != isColor) {
+                    drawGlyphListSegment(sg2d, gl, prevLimit, i, aaHint,
+                            isColor);
+                    prevLimit = i;
+                    isColor = newIsColor;
+                }
+            }
+        }
+        drawGlyphListSegment(sg2d, gl, prevLimit, len, aaHint, isColor);
+    }
+
+    private void drawGlyphListSegment(SunGraphics2D sg2d, GlyphList gl,
+                                      int fromglyph, int toGlyph,
+                                      int aaHint, boolean isColor) {
+        if (fromglyph >= toGlyph) return;
+        if (isColor) {
+            sg2d.loops.drawGlyphListColorLoop.
+                    DrawGlyphListColor(sg2d, sg2d.surfaceData,
+                            gl, fromglyph, toGlyph);
+        } else {
+            switch (aaHint) {
+                case SunHints.INTVAL_TEXT_ANTIALIAS_OFF:
+                    sg2d.loops.drawGlyphListLoop.
+                            DrawGlyphList(sg2d, sg2d.surfaceData,
+                                    gl, fromglyph, toGlyph);
+                    return;
+                case SunHints.INTVAL_TEXT_ANTIALIAS_ON:
+                    sg2d.loops.drawGlyphListAALoop.
+                            DrawGlyphListAA(sg2d, sg2d.surfaceData,
+                                    gl, fromglyph, toGlyph);
+                    return;
+                case SunHints.INTVAL_TEXT_ANTIALIAS_LCD_HRGB:
+                case SunHints.INTVAL_TEXT_ANTIALIAS_LCD_VRGB:
+                    sg2d.loops.drawGlyphListLCDLoop.
+                            DrawGlyphListLCD(sg2d, sg2d.surfaceData,
+                                    gl, fromglyph, toGlyph);
+                    return;
+            }
         }
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/LCDTextRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/LCDTextRenderer.java
@@ -25,10 +25,9 @@
 
 package sun.java2d.pipe;
 
-import java.awt.font.GlyphVector;
+import sun.awt.SunHints;
 import sun.java2d.SunGraphics2D;
 import sun.font.GlyphList;
-import static sun.awt.SunHints.*;
 
 /**
  * A delegate pipe of SG2D for drawing LCD text with
@@ -38,7 +37,7 @@ import static sun.awt.SunHints.*;
 public class LCDTextRenderer extends GlyphListLoopPipe {
 
     protected void drawGlyphList(SunGraphics2D sg2d, GlyphList gl) {
-        sg2d.loops.drawGlyphListLCDLoop.
-            DrawGlyphListLCD(sg2d, sg2d.surfaceData, gl);
+        drawGlyphList(sg2d, gl, SunHints.INTVAL_TEXT_ANTIALIAS_LCD_HRGB);
+
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/SolidTextRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/SolidTextRenderer.java
@@ -25,6 +25,7 @@
 
 package sun.java2d.pipe;
 
+import sun.awt.SunHints;
 import sun.java2d.SunGraphics2D;
 import sun.font.GlyphList;
 
@@ -37,6 +38,6 @@ public class SolidTextRenderer extends GlyphListLoopPipe
     implements LoopBasedPipe
 {
     protected void drawGlyphList(SunGraphics2D sg2d, GlyphList gl) {
-        sg2d.loops.drawGlyphListLoop.DrawGlyphList(sg2d, sg2d.surfaceData, gl);
+        drawGlyphList(sg2d, gl, SunHints.INTVAL_TEXT_ANTIALIAS_OFF);
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/TextRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/TextRenderer.java
@@ -51,7 +51,8 @@ public class TextRenderer extends GlyphListPipe {
         int cy2 = clipRegion.getHiY();
         Object ctx = null;
         try {
-            int[] bounds = gl.getBounds();
+            gl.startGlyphIteration();
+            int[] bounds = gl.getBounds(num);
             Rectangle r = new Rectangle(bounds[0], bounds[1],
                                         bounds[2] - bounds[0],
                                         bounds[3] - bounds[1]);
@@ -76,7 +77,7 @@ public class TextRenderer extends GlyphListPipe {
                 }
                 if (gx2 > cx2) gx2 = cx2;
                 if (gy2 > cy2) gy2 = cy2;
-                if (gx2 > gx1 && gy2 > gy1 &&
+                if (gx2 > gx1 && gy2 > gy1 && !gl.isColorGlyph(i) &&
                     outpipe.needTile(ctx, gx1, gy1, gx2 - gx1, gy2 - gy1))
                 {
                     byte[] alpha = gl.getGrayBits();

--- a/src/java.desktop/share/native/common/java2d/opengl/OGLTextRenderer.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLTextRenderer.c
@@ -63,7 +63,8 @@ typedef enum {
     MODE_USE_CACHE_GRAY,
     MODE_USE_CACHE_LCD,
     MODE_NO_CACHE_GRAY,
-    MODE_NO_CACHE_LCD
+    MODE_NO_CACHE_LCD,
+    MODE_NO_CACHE_COLOR
 } GlyphMode;
 static GlyphMode glyphMode = MODE_NOT_INITED;
 
@@ -526,6 +527,7 @@ OGLTR_DisableGlyphModeState()
         j2d_glDisable(GL_TEXTURE_2D);
         break;
 
+    case MODE_NO_CACHE_COLOR:
     case MODE_NO_CACHE_GRAY:
     case MODE_USE_CACHE_GRAY:
     case MODE_NOT_INITED:
@@ -978,6 +980,33 @@ OGLTR_DrawLCDGlyphNoCache(OGLContext *oglc, OGLSDOps *dstOps,
     return JNI_TRUE;
 }
 
+static jboolean
+OGLTR_DrawColorGlyphNoCache(OGLContext *oglc, GlyphInfo *ginfo, jint x, jint y)
+{
+    if (glyphMode != MODE_NO_CACHE_COLOR) {
+        OGLTR_DisableGlyphModeState();
+        RESET_PREVIOUS_OP();
+        glyphMode = MODE_NO_CACHE_COLOR;
+    }
+
+    // see OGLBlitSwToSurface() in OGLBlitLoops.c
+    // for more info on the following two lines
+    j2d_glRasterPos2i(0, 0);
+    j2d_glBitmap(0, 0, 0, 0, (GLfloat) x, (GLfloat) (-y), NULL);
+
+    // in OpenGL image data is assumed to contain lines from bottom to top
+    j2d_glPixelZoom(1, -1);
+
+    j2d_glDrawPixels(ginfo->width, ginfo->height, GL_BGRA, GL_UNSIGNED_BYTE,
+                     ginfo->image);
+
+    // restoring state
+    j2d_glPixelZoom(1, 1);
+
+    return JNI_TRUE;
+}
+
+
 // see DrawGlyphList.c for more on this macro...
 #define FLOOR_ASSIGN(l, r) \
     if ((r)<0) (l) = ((int)floor(r)); else (l) = ((int)(r))
@@ -1028,7 +1057,7 @@ OGLTR_DrawGlyphList(JNIEnv *env, OGLContext *oglc, OGLSDOps *dstOps,
     for (glyphCounter = 0; glyphCounter < totalGlyphs; glyphCounter++) {
         jint x, y;
         jfloat glyphx, glyphy;
-        jboolean grayscale, ok;
+        jboolean ok;
         GlyphInfo *ginfo = (GlyphInfo *)jlong_to_ptr(NEXT_LONG(images));
 
         if (ginfo == NULL) {
@@ -1037,8 +1066,6 @@ OGLTR_DrawGlyphList(JNIEnv *env, OGLContext *oglc, OGLSDOps *dstOps,
                           "OGLTR_DrawGlyphList: glyph info is null");
             break;
         }
-
-        grayscale = (ginfo->rowBytes == ginfo->width);
 
         if (usePositions) {
             jfloat posx = NEXT_FLOAT(positions);
@@ -1060,7 +1087,7 @@ OGLTR_DrawGlyphList(JNIEnv *env, OGLContext *oglc, OGLSDOps *dstOps,
             continue;
         }
 
-        if (grayscale) {
+        if (ginfo->rowBytes == ginfo->width) {
             // grayscale or monochrome glyph data
             if (ginfo->width <= OGLTR_CACHE_CELL_WIDTH &&
                 ginfo->height <= OGLTR_CACHE_CELL_HEIGHT)
@@ -1069,6 +1096,9 @@ OGLTR_DrawGlyphList(JNIEnv *env, OGLContext *oglc, OGLSDOps *dstOps,
             } else {
                 ok = OGLTR_DrawGrayscaleGlyphNoCache(oglc, ginfo, x, y);
             }
+        } else if (ginfo->rowBytes == ginfo->width * 4) {
+            // color glyph data
+            ok = OGLTR_DrawColorGlyphNoCache(oglc, ginfo, x, y);
         } else {
             // LCD-optimized glyph data
             jint rowBytesOffset = 0;

--- a/src/java.desktop/share/native/libfontmanager/ColorGlyphSurfaceData.c
+++ b/src/java.desktop/share/native/libfontmanager/ColorGlyphSurfaceData.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni_util.h"
+#include "fontscalerdefs.h"
+#include "SurfaceData.h"
+
+typedef struct _GlyphOps {
+    SurfaceDataOps sdOps;
+    GlyphInfo*     glyph;
+} GlyphOps;
+
+static jint Glyph_Lock(JNIEnv *env,
+                       SurfaceDataOps *ops,
+                       SurfaceDataRasInfo *pRasInfo,
+                       jint lockflags)
+{
+    SurfaceDataBounds bounds;
+    GlyphInfo *glyph;
+    if (lockflags &
+        (SD_LOCK_WRITE | SD_LOCK_LUT | SD_LOCK_INVCOLOR | SD_LOCK_INVGRAY)) {
+        JNU_ThrowInternalError(env, "Unsupported mode for glyph image surface");
+        return SD_FAILURE;
+    }
+    glyph = ((GlyphOps*)ops)->glyph;
+    bounds.x1 = 0;
+    bounds.y1 = 0;
+    bounds.x2 = glyph->width;
+    bounds.y2 = glyph->height;
+    SurfaceData_IntersectBounds(&pRasInfo->bounds, &bounds);
+    return SD_SUCCESS;
+}
+
+static void Glyph_GetRasInfo(JNIEnv *env,
+                             SurfaceDataOps *ops,
+                             SurfaceDataRasInfo *pRasInfo)
+{
+    GlyphInfo *glyph = ((GlyphOps*)ops)->glyph;
+
+    pRasInfo->rasBase = glyph->image;
+    pRasInfo->pixelBitOffset = 0;
+    pRasInfo->pixelStride = 4;
+    pRasInfo->scanStride = glyph->rowBytes;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_font_ColorGlyphSurfaceData_initOps(JNIEnv *env,
+                                            jobject sData)
+{
+    GlyphOps *ops =
+        (GlyphOps*) SurfaceData_InitOps(env, sData, sizeof(GlyphOps));
+    if (ops == NULL) {
+        JNU_ThrowOutOfMemoryError(env,
+            "Initialization of ColorGlyphSurfaceData failed");
+        return;
+    }
+    ops->sdOps.Lock = Glyph_Lock;
+    ops->sdOps.GetRasInfo = Glyph_GetRasInfo;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_font_ColorGlyphSurfaceData_setCurrentGlyph(JNIEnv *env,
+                                                    jobject sData,
+                                                    jlong imgPtr)
+{
+    GlyphOps *ops = (GlyphOps*) SurfaceData_GetOps(env, sData);
+    if (ops == NULL) {
+        return;
+    }
+    ops->glyph = (GlyphInfo*) jlong_to_ptr(imgPtr);
+}

--- a/src/java.desktop/share/native/libfontmanager/glyphblitting.h
+++ b/src/java.desktop/share/native/libfontmanager/glyphblitting.h
@@ -40,8 +40,10 @@ typedef struct {
 } GlyphBlitVector;
 
 extern jint RefineBounds(GlyphBlitVector *gbv, SurfaceDataBounds *bounds);
-extern GlyphBlitVector* setupBlitVector(JNIEnv *env, jobject glyphlist);
-extern GlyphBlitVector* setupLCDBlitVector(JNIEnv *env, jobject glyphlist);
+extern GlyphBlitVector* setupBlitVector(JNIEnv *env, jobject glyphlist,
+                                        jint fromGlyph, jint toGlyph);
+extern GlyphBlitVector* setupLCDBlitVector(JNIEnv *env, jobject glyphlist,
+                                           jint fromGlyph, jint toGlyph);
 
 #ifdef  __cplusplus
 }

--- a/src/java.desktop/share/native/libfontmanager/sunFont.c
+++ b/src/java.desktop/share/native/libfontmanager/sunFont.c
@@ -173,9 +173,9 @@ static void initFontIDs(JNIEnv *env) {
 
      CHECK_NULL(tmpClass = (*env)->FindClass(env, "sun/font/GlyphList"));
      CHECK_NULL(sunFontIDs.glyphListX =
-         (*env)->GetFieldID(env, tmpClass, "x", "F"));
+         (*env)->GetFieldID(env, tmpClass, "gposx", "F"));
      CHECK_NULL(sunFontIDs.glyphListY =
-         (*env)->GetFieldID(env, tmpClass, "y", "F"));
+         (*env)->GetFieldID(env, tmpClass, "gposy", "F"));
      CHECK_NULL(sunFontIDs.glyphListLen =
          (*env)->GetFieldID(env, tmpClass, "len", "I"));
      CHECK_NULL(sunFontIDs.glyphImages =

--- a/src/java.desktop/unix/classes/sun/font/X11TextRenderer.java
+++ b/src/java.desktop/unix/classes/sun/font/X11TextRenderer.java
@@ -77,6 +77,7 @@ public class X11TextRenderer extends GlyphListPipe {
             Region clip = sg2d.getCompClip();
             long xgc = x11sd.getRenderGC(clip, SunGraphics2D.COMP_ISCOPY,
                                          null, sg2d.pixel);
+            gl.startGlyphIteration();
             doDrawGlyphList(x11sd.getNativeOps(), xgc, clip, gl);
         } finally {
             SunToolkit.awtUnlock();

--- a/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
+++ b/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
@@ -83,7 +83,7 @@ public class XRTextRenderer extends GlyphListPipe {
             int activeGlyphSet = cachedGlyphs[0].getGlyphSet();
 
             int eltIndex = -1;
-            gl.getBounds();
+            gl.startGlyphIteration();
             float[] positions = gl.getPositions();
             for (int i = 0; i < gl.getNumGlyphs(); i++) {
                 gl.setGlyphIndex(i);

--- a/src/java.desktop/unix/native/libfontmanager/X11TextRenderer.c
+++ b/src/java.desktop/unix/native/libfontmanager/X11TextRenderer.c
@@ -57,11 +57,13 @@ JNIEXPORT void JNICALL Java_sun_font_X11TextRenderer_doDrawGlyphList
      jlong dstData, jlong xgc, jobject clip,
      jobject glyphlist)
 {
+    jint glyphCount;
     GlyphBlitVector* gbv;
     SurfaceDataBounds bounds;
     Region_GetBounds(env, clip, &bounds);
 
-    if ((gbv = setupBlitVector(env, glyphlist)) == NULL) {
+    glyphCount =  (*env)->GetIntField(env, glyphlist, sunFontIDs.glyphListLen);
+    if ((gbv = setupBlitVector(env, glyphlist, 0, glyphCount)) == NULL) {
         return;
     }
     if (!RefineBounds(gbv, &bounds)) {

--- a/test/jdk/java/awt/font/MacEmoji.java
+++ b/test/jdk/java/awt/font/MacEmoji.java
@@ -23,33 +23,48 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8263583
- * @summary Checks that emoji characters are rendered
+ * @summary Checks that emoji character has a non-empty and identical
+ *          representation when rendered to different types of images,
+ *          including an accelerated (OpenGL or Metal) surface.
  * @requires (os.family == "mac")
+ * @run main/othervm -Dsun.java2d.uiScale=1 MacEmoji
  */
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+import java.util.List;
 
 public class MacEmoji {
     private static final int IMG_WIDTH = 20;
     private static final int IMG_HEIGHT = 20;
 
     public static void main(String[] args) {
-        BufferedImage img = new BufferedImage(IMG_WIDTH, IMG_HEIGHT,
-                                              BufferedImage.TYPE_INT_RGB);
+        GraphicsConfiguration cfg
+                = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
 
-        Graphics2D g = img.createGraphics();
-        g.setColor(Color.white);
-        g.fillRect(0, 0, IMG_WIDTH, IMG_HEIGHT);
-        g.setFont(new Font(Font.DIALOG, Font.PLAIN, 12));
-        g.drawString("\uD83D\uDE00" /* U+1F600 'GRINNING FACE' */, 2, 15);
-        g.dispose();
+        VolatileImage vImg = cfg.createCompatibleVolatileImage(IMG_WIDTH,
+                                                               IMG_HEIGHT);
+        BufferedImage refImg;
+        int attempt = 0;
+        do {
+            if (++attempt > 10) {
+                throw new RuntimeException("Failed to render to VolatileImage");
+            }
+            if (vImg.validate(cfg) == VolatileImage.IMAGE_INCOMPATIBLE) {
+                throw new RuntimeException("Unexpected validation failure");
+            }
+            drawEmoji(vImg);
+            refImg = vImg.getSnapshot();
+        } while (vImg.contentsLost());
 
         boolean rendered = false;
         for (int x = 0; x < IMG_WIDTH; x++) {
             for (int y = 0; y < IMG_HEIGHT; y++) {
-                if (img.getRGB(x, y) != 0xFFFFFFFF) {
+                if (refImg.getRGB(x, y) != 0xFFFFFFFF) {
                     rendered = true;
                     break;
                 }
@@ -58,5 +73,36 @@ public class MacEmoji {
         if (!rendered) {
             throw new RuntimeException("Emoji character wasn't rendered");
         }
+
+        List<Integer> imageTypes = List.of(
+                BufferedImage.TYPE_INT_RGB,
+                BufferedImage.TYPE_INT_ARGB,
+                BufferedImage.TYPE_INT_ARGB_PRE,
+                BufferedImage.TYPE_INT_BGR,
+                BufferedImage.TYPE_3BYTE_BGR,
+                BufferedImage.TYPE_4BYTE_ABGR,
+                BufferedImage.TYPE_4BYTE_ABGR_PRE
+        );
+        for (Integer type : imageTypes) {
+            BufferedImage img = new BufferedImage(IMG_WIDTH, IMG_HEIGHT, type);
+            drawEmoji(img);
+            for (int x = 0; x < IMG_WIDTH; x++) {
+                for (int y = 0; y < IMG_HEIGHT; y++) {
+                    if (refImg.getRGB(x, y) != img.getRGB(x, y)) {
+                        throw new RuntimeException(
+                                "Rendering differs for image type " + type);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void drawEmoji(Image img) {
+        Graphics g = img.getGraphics();
+        g.setColor(Color.white);
+        g.fillRect(0, 0, IMG_WIDTH, IMG_HEIGHT);
+        g.setFont(new Font(Font.DIALOG, Font.PLAIN, 12));
+        g.drawString("\uD83D\uDE00" /* U+1F600 'GRINNING FACE' */, 2, 15);
+        g.dispose();
     }
 }

--- a/test/jdk/java/awt/font/MacEmoji.java
+++ b/test/jdk/java/awt/font/MacEmoji.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8263583
+ * @summary Checks that emoji characters are rendered
+ * @requires (os.family == "mac")
+ */
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+public class MacEmoji {
+    private static final int IMG_WIDTH = 20;
+    private static final int IMG_HEIGHT = 20;
+
+    public static void main(String[] args) {
+        BufferedImage img = new BufferedImage(IMG_WIDTH, IMG_HEIGHT,
+                                              BufferedImage.TYPE_INT_RGB);
+
+        Graphics2D g = img.createGraphics();
+        g.setColor(Color.white);
+        g.fillRect(0, 0, IMG_WIDTH, IMG_HEIGHT);
+        g.setFont(new Font(Font.DIALOG, Font.PLAIN, 12));
+        g.drawString("\uD83D\uDE00" /* U+1F600 'GRINNING FACE' */, 2, 15);
+        g.dispose();
+
+        boolean rendered = false;
+        for (int x = 0; x < IMG_WIDTH; x++) {
+            for (int y = 0; y < IMG_HEIGHT; y++) {
+                if (img.getRGB(x, y) != 0xFFFFFFFF) {
+                    rendered = true;
+                    break;
+                }
+            }
+        }
+        if (!rendered) {
+            throw new RuntimeException("Emoji character wasn't rendered");
+        }
+    }
+}


### PR DESCRIPTION
This is the implementation used by JetBrains Runtime for the last 4 years, after some cleanup, and with one problem,
found while preparing the pull request, fixed.
Even though typical scenarios for a UI application should be covered, it's not a complete solution. In particular, emoji-s
still won't be rendered for large font sizes (more than 100pt), and for non-trivial composite/painting modes.
Notable implementation details are listed below.

**Glyph image generation**

Deprecated CGContextShowGlyphsAtPoint function, used by JDK on macOS to render text, cannot render emojis,
CTFontDrawGlyphs is used instead. It ignores the scale component of text transformation matrix, so a 'real-sized'
CTFont object should be passed to it. The same sizing procedure is done when calculating glyph metrics, because they
are not scaled proportionally with font size (as they do for vector fonts).

**Glyph image storage**

Existing GlyphInfo structure is used to store color glyph image. Color glyph can be distinguished by having 4 bytes
of storage per pixel. Color components are stored in pre-multiplied alpha format.

**Glyph rendering**

Previously, GlyphList instance always contained glyphs in the same format (solid, grayscale or LCD), determined by the
effective rendering hint. Now the renderers must be prepared to GlyphList having 'normal' glyphs interspersed with
color glyphs (they can appear due to font fallback). This isn't a problem for OpenGL renderer (used for on-screen painting),
but GlyphListLoopPipe-based renderers (used for off-screen painting) needed an adjustment to be able to operate on
specific segments of GlyphList.
As an incidental optimization, calculation of GlyphList bounds ('getBounds' method) is performed now only when needed
(most text renderers don't need this information).
Speaking of the actual rendering of the glyph image, it's done by the straightforward glDrawPixels call in OpenGL renderer,
and by re-using existing Blit primitive in off-screen renderers.

**Testing**

There's no good way to test the new functionality automatically, but I've added a test verifying that 'something' is
rendered for the emoji character, when painting to BufferedImage.

Existing tests pass after the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263583](https://bugs.openjdk.java.net/browse/JDK-8263583): Emoji rendering on macOS


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3007/head:pull/3007` \
`$ git checkout pull/3007`

Update a local copy of the PR: \
`$ git checkout pull/3007` \
`$ git pull https://git.openjdk.java.net/jdk pull/3007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3007`

View PR using the GUI difftool: \
`$ git pr show -t 3007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3007.diff">https://git.openjdk.java.net/jdk/pull/3007.diff</a>

</details>
