### PR TITLE
8263587: C2: JVMS not cloned when needs_clone_jvms() is true

### DIFF
--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -616,8 +616,9 @@ public:
   // For macro nodes, the JVMState gets modified during expansion. If calls
   // use MachConstantBase, it gets modified during matching. So when cloning
   // the node the JVMState must be cloned. Default is not to clone.
-  virtual void clone_jvms(Compile* C) {
-    if ((jvms() != NULL) && C->needs_clone_jvms()) {
+  virtual bool needs_clone_jvms(Compile* C) { return C->needs_clone_jvms(); }
+  void clone_jvms(Compile* C) {
+    if ((jvms() != NULL) && needs_clone_jvms(C)) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);
     }
@@ -737,11 +738,8 @@ public:
   }
   // Late inlining modifies the JVMState, so we need to clone it
   // when the call node is cloned (because it is macro node).
-  virtual void clone_jvms(Compile* C) {
-    if ((jvms() != NULL) && (is_boxing_method() || C->needs_clone_jvms())) {
-      set_jvms(jvms()->clone_deep(C));
-      jvms()->set_map_deep(this);
-    }
+  virtual bool needs_clone_jvms(Compile* C) {
+    return is_boxing_method() || CallNode::needs_clone_jvms(C);
   }
 
   virtual int         Opcode() const;
@@ -766,11 +764,8 @@ public:
 
   // Late inlining modifies the JVMState, so we need to clone it
   // when the call node is cloned.
-  virtual void clone_jvms(Compile* C) {
-    if ((jvms() != NULL) && (IncrementalInlineVirtual || C->needs_clone_jvms())) {
-      set_jvms(jvms()->clone_deep(C));
-      jvms()->set_map_deep(this);
-    }
+  virtual bool needs_clone_jvms(Compile* C) {
+    return IncrementalInlineVirtual || CallNode::needs_clone_jvms(C);
   }
 
   int _vtable_index;
@@ -923,12 +918,7 @@ public:
   AllocateNode(Compile* C, const TypeFunc *atype, Node *ctrl, Node *mem, Node *abio,
                Node *size, Node *klass_node, Node *initial_test);
   // Expansion modifies the JVMState, so we need to clone it
-  virtual void clone_jvms(Compile* C) {
-    if (jvms() != NULL) {
-      set_jvms(jvms()->clone_deep(C));
-      jvms()->set_map_deep(this);
-    }
-  }
+  virtual bool needs_clone_jvms(Compile* C) { return true; }
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegP; }
   virtual bool        guaranteed_safepoint()  { return false; }
@@ -1142,12 +1132,7 @@ public:
 
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   // Expansion modifies the JVMState, so we need to clone it
-  virtual void clone_jvms(Compile* C) {
-    if (jvms() != NULL) {
-      set_jvms(jvms()->clone_deep(C));
-      jvms()->set_map_deep(this);
-    }
-  }
+  virtual bool needs_clone_jvms(Compile* C) { return true; }
 
   bool is_nested_lock_region(); // Is this Lock nested?
   bool is_nested_lock_region(Compile * c); // Why isn't this Lock nested?

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -617,7 +617,7 @@ public:
   // use MachConstantBase, it gets modified during matching. So when cloning
   // the node the JVMState must be cloned. Default is not to clone.
   virtual void clone_jvms(Compile* C) {
-    if (C->needs_clone_jvms() && jvms() != NULL) {
+    if ((jvms() != NULL) && C->needs_clone_jvms()) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);
     }
@@ -737,8 +737,8 @@ public:
   }
   // Late inlining modifies the JVMState, so we need to clone it
   // when the call node is cloned (because it is macro node).
-  virtual void  clone_jvms(Compile* C) {
-    if ((jvms() != NULL) && is_boxing_method()) {
+  virtual void clone_jvms(Compile* C) {
+    if ((jvms() != NULL) && (is_boxing_method() || C->needs_clone_jvms())) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);
     }
@@ -767,7 +767,7 @@ public:
   // Late inlining modifies the JVMState, so we need to clone it
   // when the call node is cloned.
   virtual void clone_jvms(Compile* C) {
-    if ((jvms() != NULL) && IncrementalInlineVirtual) {
+    if ((jvms() != NULL) && (IncrementalInlineVirtual || C->needs_clone_jvms())) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);
     }
@@ -923,7 +923,7 @@ public:
   AllocateNode(Compile* C, const TypeFunc *atype, Node *ctrl, Node *mem, Node *abio,
                Node *size, Node *klass_node, Node *initial_test);
   // Expansion modifies the JVMState, so we need to clone it
-  virtual void  clone_jvms(Compile* C) {
+  virtual void clone_jvms(Compile* C) {
     if (jvms() != NULL) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);
@@ -1142,7 +1142,7 @@ public:
 
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   // Expansion modifies the JVMState, so we need to clone it
-  virtual void  clone_jvms(Compile* C) {
+  virtual void clone_jvms(Compile* C) {
     if (jvms() != NULL) {
       set_jvms(jvms()->clone_deep(C));
       jvms()->set_map_deep(this);


### PR DESCRIPTION
We need a C2 fix to prevent crashes because JVMS doesn't get cloned as needed. See linked issue for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263587](https://bugs.openjdk.java.net/browse/JDK-8263587): C2: JVMS not cloned when needs_clone_jvms() is true


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to bafcce9f1923af6deedf3c0fd23aefcac00c2f18
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3009/head:pull/3009`
`$ git checkout pull/3009`
