### PR TITLE
8263579: ZGC: Concurrent mark hangs with debug loglevel

### DIFF
--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@
 
 static const ZStatSubPhase ZSubPhaseConcurrentMark("Concurrent Mark");
 static const ZStatSubPhase ZSubPhaseConcurrentMarkTryFlush("Concurrent Mark Try Flush");
-static const ZStatSubPhase ZSubPhaseConcurrentMarkIdle("Concurrent Mark Idle");
 static const ZStatSubPhase ZSubPhaseConcurrentMarkTryTerminate("Concurrent Mark Try Terminate");
 static const ZStatSubPhase ZSubPhaseMarkTryComplete("Pause Mark Try Complete");
 
@@ -378,7 +377,6 @@ bool ZMark::try_steal(ZMarkStripe* stripe, ZMarkThreadLocalStacks* stacks) {
 }
 
 void ZMark::idle() const {
-  ZStatTimer timer(ZSubPhaseConcurrentMarkIdle);
   os::naked_short_sleep(1);
 }
 


### PR DESCRIPTION
Do not leave terminate stage 1 when there is nothing to do. This helps eliminate the concurrent mark hang with debug log level, and reduce total mark time without impact the performance.

The following is the performance data of specjbb2015 with stressed zgc:
Current patch:
RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 102168, max-jOPS = 104194, critical-jOPS = 90630
[2021-03-12T17:20:37.072+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             383.026 / 383.026    1222.317 / 1811.813    766.530 / 1811.813    766.530 / 1811.813    ms

RUN RESULT: hbIR (max attempted) = 118234, hbIR (settled) = 108389, max-jOPS = 102864, critical-jOPS = 93572
[2021-03-12T19:28:01.032+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             407.483 / 407.483    1243.775 / 1773.463    756.956 / 1773.463    756.956 / 1773.463    ms

RUN RESULT: hbIR (max attempted) = 111999, hbIR (settled) = 110683, max-jOPS = 104159, critical-jOPS = 92600
[2021-03-12T21:48:09.729+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             412.954 / 412.954    1216.900 / 1927.552    762.315 / 1927.552    762.315 / 1927.552    ms


Original:
RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 109863, max-jOPS = 102968, critical-jOPS = 90836
[2021-03-13T01:59:35.160+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             414.845 / 414.845    1168.357 / 1817.015    795.806 / 1837.452    795.806 / 1837.452    ms

RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 102168, max-jOPS = 102968, critical-jOPS = 89227
[2021-03-12T23:49:17.322+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             405.709 / 405.709    1250.672 / 1724.725    783.993 / 1739.099    783.993 / 1739.099    ms

RUN RESULT: hbIR (max attempted) = 102168, hbIR (settled) = 85156, max-jOPS = 104211, critical-jOPS = 91693
[2021-03-13T04:22:14.338+0800][info ][gc,stats       ]       Phase: Concurrent Mark                             415.444 / 415.444    1254.256 / 1896.037    768.536 / 1896.037    768.536 / 1896.037    ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263579](https://bugs.openjdk.java.net/browse/JDK-8263579): ZGC: Concurrent mark hangs with debug loglevel


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3011/head:pull/3011`
`$ git checkout pull/3011`

To update a local copy of the PR:
`$ git checkout pull/3011`
`$ git pull https://git.openjdk.java.net/jdk pull/3011/head`
