### PR TITLE
8263589: Introduce JavaValue::get_oop/set_oop

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -585,7 +585,7 @@ Klass* ClassListParser::load_current_class(TRAPS) {
       THROW_NULL(vmSymbols::java_lang_ClassNotFoundException());
     }
     assert(result.get_type() == T_OBJECT, "just checking");
-    oop obj = (oop) result.get_jobject();
+    oop obj = result.get_oop();
     assert(obj != NULL, "jdk.internal.loader.BuiltinClassLoader::loadClass never returns null");
     klass = java_lang_Class::as_Klass(obj);
   } else {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2395,7 +2395,7 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
         CLEAR_PENDING_EXCEPTION;
         throwable = Handle();
       } else {
-        throwable = Handle(THREAD, (oop) cause.get_jobject());
+        throwable = Handle(THREAD, cause.get_oop());
         if (throwable.not_null()) {
           st->print("Caused by: ");
           print(throwable(), st);

--- a/src/hotspot/share/classfile/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.cpp
@@ -88,7 +88,7 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
     return;
   }
 
-  objArrayHandle h_array(THREAD, (objArrayOop)result.get_jobject());
+  objArrayHandle h_array(THREAD, (objArrayOop)result.get_oop());
   int sz = h_array->length();
   assert(sz % 2 == 0 && sz >= 2, "Must be even size of length");
   for (int i = 0; i < sz; i+= 2) {

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -127,7 +127,7 @@ void SystemDictionary::compute_java_loaders(TRAPS) {
                          vmSymbols::void_classloader_signature(),
                          CHECK);
 
-  _java_system_loader = OopHandle(Universe::vm_global(), (oop)result.get_jobject());
+  _java_system_loader = OopHandle(Universe::vm_global(), result.get_oop());
 
   JavaCalls::call_static(&result,
                          class_loader_klass,
@@ -135,7 +135,7 @@ void SystemDictionary::compute_java_loaders(TRAPS) {
                          vmSymbols::void_classloader_signature(),
                          CHECK);
 
-  _java_platform_loader = OopHandle(Universe::vm_global(), (oop)result.get_jobject());
+  _java_platform_loader = OopHandle(Universe::vm_global(), result.get_oop());
 }
 
 ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool create_mirror_cld) {
@@ -1501,7 +1501,7 @@ InstanceKlass* SystemDictionary::load_instance_class(Symbol* class_name, Handle 
                             CHECK_NULL);
 
     assert(result.get_type() == T_OBJECT, "just checking");
-    oop obj = (oop) result.get_jobject();
+    oop obj = result.get_oop();
 
     // Primitive classes return null since forName() can not be
     // used to obtain any of the Class objects representing primitives or void
@@ -2243,7 +2243,7 @@ Method* SystemDictionary::find_method_handle_invoker(Klass* klass,
                          vmSymbols::linkMethod_name(),
                          vmSymbols::linkMethod_signature(),
                          &args, CHECK_NULL);
-  Handle mname(THREAD, (oop) result.get_jobject());
+  Handle mname(THREAD, result.get_oop());
   return unpack_method_and_appendix(mname, accessing_klass, appendix_box, appendix_result, THREAD);
 }
 
@@ -2377,7 +2377,7 @@ Handle SystemDictionary::find_method_handle_type(Symbol* signature,
                          vmSymbols::findMethodHandleType_name(),
                          vmSymbols::findMethodHandleType_signature(),
                          &args, CHECK_(empty));
-  Handle method_type(THREAD, (oop) result.get_jobject());
+  Handle method_type(THREAD, result.get_oop());
 
   if (can_be_cached) {
     // We can cache this MethodType inside the JVM.
@@ -2463,7 +2463,7 @@ Handle SystemDictionary::link_method_handle_constant(Klass* caller,
                          vmSymbols::linkMethodHandleConstant_name(),
                          vmSymbols::linkMethodHandleConstant_signature(),
                          &args, CHECK_(empty));
-  return Handle(THREAD, (oop) result.get_jobject());
+  return Handle(THREAD, result.get_oop());
 }
 
 // Ask Java to run a bootstrap method, in order to create a dynamic call site
@@ -2505,7 +2505,7 @@ void SystemDictionary::invoke_bootstrap_method(BootstrapInfo& bootstrap_specifie
                          is_indy ? vmSymbols::linkCallSite_signature() : vmSymbols::linkDynamicConstant_signature(),
                          &args, CHECK);
 
-  Handle value(THREAD, (oop) result.get_jobject());
+  Handle value(THREAD, result.get_oop());
   if (is_indy) {
     Handle appendix;
     Method* method = unpack_method_and_appendix(value,

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -757,7 +757,7 @@ Handle SystemDictionaryShared::get_shared_jar_url(int shared_path_index, TRAPS) 
                            vmSymbols::toFileURL_signature(),
                            path_string, CHECK_(url_h));
 
-    atomic_set_shared_jar_url(shared_path_index, (oop)result.get_jobject());
+    atomic_set_shared_jar_url(shared_path_index, result.get_oop());
   }
 
   url_h = Handle(THREAD, shared_jar_url(shared_path_index));
@@ -819,7 +819,7 @@ Handle SystemDictionaryShared::get_protection_domain_from_classloader(Handle cla
                           vmSymbols::getProtectionDomain_name(),
                           vmSymbols::getProtectionDomain_signature(),
                           cs, CHECK_NH);
-  return Handle(THREAD, (oop)obj_result.get_jobject());
+  return Handle(THREAD, obj_result.get_oop());
 }
 
 // Returns the ProtectionDomain associated with the JAR file identified by the url.
@@ -862,7 +862,7 @@ Handle SystemDictionaryShared::get_shared_protection_domain(Handle class_loader,
         JavaCalls::call_static(&result, classLoaders_klass, vmSymbols::toFileURL_name(),
                                vmSymbols::toFileURL_signature(),
                                location_string, CHECK_NH);
-        url = Handle(THREAD, (oop)result.get_jobject());
+        url = Handle(THREAD, result.get_oop());
       }
 
       Handle pd = get_protection_domain_from_classloader(class_loader, url,

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -175,7 +175,7 @@ static oop construct_dcmd_instance(JfrJavaArguments* args, TRAPS) {
   args->set_name("<init>");
   args->set_signature("()V");
   JfrJavaSupport::new_object(args, CHECK_NULL);
-  return (oop)args->result()->get_jobject();
+  return args->result()->get_oop();
 }
 
 JfrDumpFlightRecordingDCmd::JfrDumpFlightRecordingDCmd(outputStream* output,
@@ -276,7 +276,7 @@ void JfrDumpFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(path_to_gc_roots);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
-  handle_dcmd_result(output(), (oop)result.get_jobject(), source, THREAD);
+  handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
 JfrCheckFlightRecordingDCmd::JfrCheckFlightRecordingDCmd(outputStream* output, bool heap) : DCmdWithParser(output, heap),
@@ -337,7 +337,7 @@ void JfrCheckFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(verbose);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
-  handle_dcmd_result(output(), (oop)result.get_jobject(), source, THREAD);
+  handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
 JfrStartFlightRecordingDCmd::JfrStartFlightRecordingDCmd(outputStream* output,
@@ -490,7 +490,7 @@ void JfrStartFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(path_to_gc_roots);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
-  handle_dcmd_result(output(), (oop)result.get_jobject(), source, THREAD);
+  handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
 JfrStopFlightRecordingDCmd::JfrStopFlightRecordingDCmd(outputStream* output,
@@ -551,7 +551,7 @@ void JfrStopFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(filepath);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
-  handle_dcmd_result(output(), (oop)result.get_jobject(), source, THREAD);
+  handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
 JfrConfigureFlightRecorderDCmd::JfrConfigureFlightRecorderDCmd(outputStream* output,
@@ -672,7 +672,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(sample_threads);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
-  handle_dcmd_result(output(), (oop)result.get_jobject(), source, THREAD);
+  handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
 bool register_jfr_dcmds() {

--- a/src/hotspot/share/jfr/jni/jfrJavaCall.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaCall.cpp
@@ -73,7 +73,7 @@ void JfrJavaArguments::Parameters::set_receiver(const oop receiver) {
   assert(_storage != NULL, "invariant");
   assert(receiver != NULL, "invariant");
   JavaValue value(T_OBJECT);
-  value.set_jobject(cast_from_oop<jobject>(receiver));
+  value.set_oop(receiver);
   _storage[0] = value;
 }
 
@@ -84,7 +84,7 @@ void JfrJavaArguments::Parameters::set_receiver(Handle receiver) {
 oop JfrJavaArguments::Parameters::receiver() const {
   assert(has_receiver(), "invariant");
   assert(_storage[0].get_type() == T_OBJECT, "invariant");
-  return (oop)_storage[0].get_jobject();
+  return _storage[0].get_oop();
 }
 
 bool JfrJavaArguments::Parameters::has_receiver() const {
@@ -96,7 +96,7 @@ bool JfrJavaArguments::Parameters::has_receiver() const {
 
 void JfrJavaArguments::Parameters::push_oop(const oop obj) {
   JavaValue value(T_OBJECT);
-  value.set_jobject(cast_from_oop<jobject>(obj));
+  value.set_oop(obj);
   push(value);
 }
 
@@ -173,7 +173,7 @@ void JfrJavaArguments::Parameters::copy(JavaCallArguments& args, TRAPS) const {
         args.push_double(values(i).get_jdouble());
         break;
       case T_OBJECT:
-        args.push_oop(Handle(THREAD, (oop)values(i).get_jobject()));
+        args.push_oop(Handle(THREAD, values(i).get_oop()));
         break;
       case T_ADDRESS:
         args.push_jobject(values(i).get_jobject());

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -162,7 +162,7 @@ static void object_construction(JfrJavaArguments* args, JavaValue* result, Insta
   result->set_type(T_VOID); // constructor result type
   JfrJavaSupport::call_special(args, CHECK);
   result->set_type(T_OBJECT); // set back to original result type
-  result->set_jobject(cast_from_oop<jobject>(h_obj()));
+  result->set_oop(h_obj());
 }
 
 static void array_construction(JfrJavaArguments* args, JavaValue* result, InstanceKlass* klass, int array_length, TRAPS) {
@@ -175,7 +175,7 @@ static void array_construction(JfrJavaArguments* args, JavaValue* result, Instan
   ObjArrayKlass::cast(ak)->initialize(THREAD);
   HandleMark hm(THREAD);
   objArrayOop arr = ObjArrayKlass::cast(ak)->allocate(array_length, CHECK);
-  result->set_jobject(cast_from_oop<jobject>(arr));
+  result->set_oop(arr);
 }
 
 static void create_object(JfrJavaArguments* args, JavaValue* result, TRAPS) {
@@ -199,7 +199,7 @@ static void create_object(JfrJavaArguments* args, JavaValue* result, TRAPS) {
 static void handle_result(JavaValue* result, bool global_ref, Thread* t) {
   assert(result != NULL, "invariant");
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(t));
-  const oop result_oop = (const oop)result->get_jobject();
+  const oop result_oop = result->get_oop();
   if (result_oop == NULL) {
     return;
   }
@@ -343,7 +343,7 @@ static void write_specialized_field(JfrJavaArguments* args, const Handle& h_oop,
       write_long_field(h_oop, fd, args->param(1).get_jlong());
       break;
     case T_OBJECT:
-      write_oop_field(h_oop, fd, (oop)args->param(1).get_jobject());
+      write_oop_field(h_oop, fd, args->param(1).get_oop());
       break;
     case T_ADDRESS:
       write_oop_field(h_oop, fd, JfrJavaSupport::resolve_non_null(args->param(1).get_jobject()));
@@ -376,7 +376,7 @@ static void read_specialized_field(JavaValue* result, const Handle& h_oop, field
       result->set_jlong(h_oop->long_field(fd->offset()));
       break;
     case T_OBJECT:
-      result->set_jobject(cast_from_oop<jobject>(h_oop->obj_field(fd->offset())));
+      result->set_oop(h_oop->obj_field(fd->offset()));
       break;
     default:
       ShouldNotReachHere();
@@ -457,7 +457,7 @@ void JfrJavaSupport::get_field_local_ref(JfrJavaArguments* args, TRAPS) {
   assert(result->get_type() == T_OBJECT, "invariant");
 
   read_field(args, result, CHECK);
-  const oop obj = (const oop)result->get_jobject();
+  const oop obj = result->get_oop();
 
   if (obj != NULL) {
     result->set_jobject(local_jni_handle(obj, THREAD));
@@ -472,7 +472,7 @@ void JfrJavaSupport::get_field_global_ref(JfrJavaArguments* args, TRAPS) {
   assert(result != NULL, "invariant");
   assert(result->get_type() == T_OBJECT, "invariant");
   read_field(args, result, CHECK);
-  const oop obj = (const oop)result->get_jobject();
+  const oop obj = result->get_oop();
   if (obj != NULL) {
     result->set_jobject(global_jni_handle(obj, THREAD));
   }

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -86,7 +86,7 @@ static const typeArrayOop invoke(jlong trace_id,
     return NULL;
   }
   // The result should be a [B
-  const oop res = (oop)result.get_jobject();
+  const oop res = result.get_oop();
   assert(res != NULL, "invariant");
   assert(res->is_typeArray(), "invariant");
   assert(TypeArrayKlass::cast(res->klass())->element_type() == T_BYTE, "invariant");

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -97,7 +97,7 @@ bool JfrRecorderThread::start(JfrCheckpointManager* cp_manager, JfrPostBox* post
   create_thread_args.push_oop(SystemDictionary::java_system_loader());
 
   JfrJavaSupport::call_static(&create_thread_args, CHECK_false);
-  instanceHandle h_thread_oop(THREAD, (instanceOop)result.get_jobject());
+  instanceHandle h_thread_oop(THREAD, (instanceOop)result.get_oop());
   assert(h_thread_oop.not_null(), "invariant");
   // attempt thread start
   Thread* const t = start_thread(h_thread_oop, recorderthread_entry,THREAD);

--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -44,7 +44,7 @@ static oop new_java_util_arraylist(TRAPS) {
   JavaValue result(T_OBJECT);
   JfrJavaArguments args(&result, "java/util/ArrayList", "<init>", "()V", CHECK_NULL);
   JfrJavaSupport::new_object(&args, CHECK_NULL);
-  return (oop)result.get_jobject();
+  return result.get_oop();
 }
 
 static const int initial_array_size = 64;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1045,7 +1045,7 @@ C2V_VMENTRY_NULL(jobject, executeHotSpotNmethod, (JNIEnv* env, jobject, jobject 
   if (jap.return_type() == T_VOID) {
     return NULL;
   } else if (is_reference_type(jap.return_type())) {
-    return JNIHandles::make_local(THREAD, (oop) result.get_jobject());
+    return JNIHandles::make_local(THREAD, result.get_oop());
   } else {
     jvalue *value = (jvalue *) result.get_value_addr();
     // Narrow the value down if required (Important on big endian machines)
@@ -1329,8 +1329,8 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
         JavaCallArguments args(visitor);
         args.push_oop(frame_reference);
         call_interface(&result, HotSpotJVMCI::InspectedFrameVisitor::klass(), vmSymbols::visitFrame_name(), vmSymbols::visitFrame_signature(), &args, CHECK_NULL);
-        if (result.get_jobject() != NULL) {
-          return JNIHandles::make_local(thread, (oop) result.get_jobject());
+        if (result.get_oop() != NULL) {
+          return JNIHandles::make_local(thread, result.get_oop());
         }
         assert(initialSkip == 0, "There should be no match before initialSkip == 0");
         if (HotSpotJVMCI::HotSpotStackFrameReference::objectsMaterialized(JVMCIENV, frame_reference()) == JNI_TRUE) {
@@ -1832,7 +1832,7 @@ C2V_VMENTRY_NULL(jobject, boxPrimitive, (JNIEnv* env, jobject, jobject object))
                          box_klass,
                          vmSymbols::valueOf_name(),
                          box_signature, &jargs, CHECK_NULL);
-  oop hotspot_box = (oop) box_result.get_jobject();
+  oop hotspot_box = box_result.get_oop();
   JVMCIObject result = JVMCIENV->get_object_constant(hotspot_box, false);
   return JVMCIENV->get_jobject(result);
 C2V_END

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -121,7 +121,7 @@ void JVMCIEnv::copy_saved_properties() {
   if (HAS_PENDING_EXCEPTION) {
     JVMCIRuntime::fatal_exception(NULL, "Error calling jdk.vm.ci.services.Services.serializeSavedProperties");
   }
-  oop res = (oop) result.get_jobject();
+  oop res = result.get_oop();
   assert(res->is_typeArray(), "must be");
   assert(TypeArrayKlass::cast(res->klass())->element_type() == T_BYTE, "must be");
   typeArrayOop ba = typeArrayOop(res);
@@ -293,7 +293,7 @@ void JVMCIEnv::translate_hotspot_exception_to_jni_exception(JavaThread* THREAD, 
     JVMCIRuntime::fatal_exception(this, "HotSpotJVMCIRuntime.encodeThrowable should not throw an exception");
   }
 
-  oop encoded_throwable_string = (oop) result.get_jobject();
+  oop encoded_throwable_string = result.get_oop();
 
   ResourceMark rm;
   const char* encoded_throwable_chars = java_lang_String::as_utf8_string(encoded_throwable_string);
@@ -677,7 +677,7 @@ JVMCIObject JVMCIEnv::call_HotSpotJVMCIRuntime_compileMethod (JVMCIObject runtim
                             HotSpotJVMCI::HotSpotJVMCIRuntime::klass(),
                             vmSymbols::compileMethod_name(),
                             vmSymbols::compileMethod_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = jni()->CallNonvirtualObjectMethod(runtime.as_jobject(),
@@ -730,7 +730,7 @@ JVMCIObject JVMCIEnv::call_HotSpotJVMCIRuntime_runtime (JVMCIEnv* JVMCIENV) {
     JavaCallArguments jargs;
     JavaValue result(T_OBJECT);
     JavaCalls::call_static(&result, HotSpotJVMCI::HotSpotJVMCIRuntime::klass(), vmSymbols::runtime_name(), vmSymbols::runtime_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = jni()->CallStaticObjectMethod(JNIJVMCI::HotSpotJVMCIRuntime::clazz(), JNIJVMCI::HotSpotJVMCIRuntime::runtime_method());
@@ -747,7 +747,7 @@ JVMCIObject JVMCIEnv::call_JVMCI_getRuntime (JVMCIEnv* JVMCIENV) {
     JavaCallArguments jargs;
     JavaValue result(T_OBJECT);
     JavaCalls::call_static(&result, HotSpotJVMCI::JVMCI::klass(), vmSymbols::getRuntime_name(), vmSymbols::getRuntime_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = jni()->CallStaticObjectMethod(JNIJVMCI::JVMCI::clazz(), JNIJVMCI::JVMCI::getRuntime_method());
@@ -765,7 +765,7 @@ JVMCIObject JVMCIEnv::call_HotSpotJVMCIRuntime_getCompiler (JVMCIObject runtime,
     jargs.push_oop(Handle(THREAD, HotSpotJVMCI::resolve(runtime)));
     JavaValue result(T_OBJECT);
     JavaCalls::call_virtual(&result, HotSpotJVMCI::HotSpotJVMCIRuntime::klass(), vmSymbols::getCompiler_name(), vmSymbols::getCompiler_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = jni()->CallObjectMethod(runtime.as_jobject(), JNIJVMCI::HotSpotJVMCIRuntime::getCompiler_method());
@@ -787,7 +787,7 @@ JVMCIObject JVMCIEnv::call_HotSpotJVMCIRuntime_callToString(JVMCIObject object, 
                            HotSpotJVMCI::HotSpotJVMCIRuntime::klass(),
                            vmSymbols::callToString_name(),
                            vmSymbols::callToString_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = (jstring) jni()->CallStaticObjectMethod(JNIJVMCI::HotSpotJVMCIRuntime::clazz(),
@@ -812,7 +812,7 @@ JVMCIObject JVMCIEnv::call_PrimitiveConstant_forTypeChar(jchar kind, jlong value
                            HotSpotJVMCI::PrimitiveConstant::klass(),
                            vmSymbols::forTypeChar_name(),
                            vmSymbols::forTypeChar_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = (jstring) jni()->CallStaticObjectMethod(JNIJVMCI::PrimitiveConstant::clazz(),
@@ -835,7 +835,7 @@ JVMCIObject JVMCIEnv::call_JavaConstant_forFloat(float value, JVMCI_TRAPS) {
                            HotSpotJVMCI::JavaConstant::klass(),
                            vmSymbols::forFloat_name(),
                            vmSymbols::forFloat_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = (jstring) jni()->CallStaticObjectMethod(JNIJVMCI::JavaConstant::clazz(),
@@ -858,7 +858,7 @@ JVMCIObject JVMCIEnv::call_JavaConstant_forDouble(double value, JVMCI_TRAPS) {
                            HotSpotJVMCI::JavaConstant::klass(),
                            vmSymbols::forDouble_name(),
                            vmSymbols::forDouble_signature(), &jargs, CHECK_(JVMCIObject()));
-    return wrap((oop) result.get_jobject());
+    return wrap(result.get_oop());
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject result = (jstring) jni()->CallStaticObjectMethod(JNIJVMCI::JavaConstant::clazz(),
@@ -1046,7 +1046,7 @@ JVMCIObject JVMCIEnv::get_jvmci_method(const methodHandle& method, JVMCI_TRAPS) 
     if (HAS_PENDING_EXCEPTION) {
       exception = true;
     } else {
-      method_object = wrap((oop)result.get_jobject());
+      method_object = wrap(result.get_oop());
     }
   } else {
     JNIAccessMark jni(this, THREAD);
@@ -1092,7 +1092,7 @@ JVMCIObject JVMCIEnv::get_jvmci_type(const JVMCIKlassHandle& klass, JVMCI_TRAPS)
     if (HAS_PENDING_EXCEPTION) {
       exception = true;
     } else {
-      type = wrap((oop)result.get_jobject());
+      type = wrap(result.get_oop());
     }
   } else {
     JNIAccessMark jni(this, THREAD);
@@ -1127,7 +1127,7 @@ JVMCIObject JVMCIEnv::get_jvmci_constant_pool(const constantPoolHandle& cp, JVMC
     if (HAS_PENDING_EXCEPTION) {
       exception = true;
     } else {
-      cp_object = wrap((oop)result.get_jobject());
+      cp_object = wrap(result.get_oop());
     }
   } else {
     JNIAccessMark jni(this, THREAD);

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -990,7 +990,7 @@ JVMCIObject JVMCIRuntime::create_jvmci_primitive_type(BasicType type, JVMCI_TRAP
     args.push_int(type2char(type));
     JavaCalls::call_static(&result, HotSpotJVMCI::HotSpotResolvedPrimitiveType::klass(), vmSymbols::fromMetaspace_name(), vmSymbols::primitive_fromMetaspace_signature(), &args, CHECK_(JVMCIObject()));
 
-    return JVMCIENV->wrap(JNIHandles::make_local((oop)result.get_jobject()));
+    return JVMCIENV->wrap(JNIHandles::make_local(result.get_oop()));
   } else {
     JNIAccessMark jni(JVMCIENV);
     jobject result = jni()->CallStaticObjectMethod(JNIJVMCI::HotSpotResolvedPrimitiveType::clazz(),

--- a/src/hotspot/share/oops/oopsHierarchy.hpp
+++ b/src/hotspot/share/oops/oopsHierarchy.hpp
@@ -121,7 +121,7 @@ struct PrimitiveConversions::Translate<oop> : public TrueType {
        type##Oop() : oop() {}                                              \
        type##Oop(const type##Oop& o) : oop(o) {}                           \
        type##Oop(const oop& o) : oop(o) {}                                 \
-       type##Oop(const void* p) : oop(p) {}                                \
+       type##Oop(type##OopDesc* o) : oop((oopDesc*)o) {}                   \
        operator type##OopDesc* () const { return (type##OopDesc*)obj(); }  \
        type##OopDesc* operator->() const {                                 \
             return (type##OopDesc*)obj();                                  \

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -331,7 +331,7 @@ JNI_ENTRY(jclass, jni_FindClass(JNIEnv *env, const char *name))
       // When invoked from JNI_OnLoad, NativeLibraries::getFromClass returns
       // a non-NULL Class object.  When invoked from JNI_OnUnload,
       // it will return NULL to indicate no context.
-      oop mirror = (oop) result.get_jobject();
+      oop mirror = result.get_oop();
       if (mirror != NULL) {
         Klass* fromClass = java_lang_Class::as_Klass(mirror);
         loader = Handle(THREAD, fromClass->class_loader());
@@ -885,7 +885,7 @@ static void jni_invoke_static(JNIEnv *env, JavaValue* result, jobject receiver, 
 
   // Convert result
   if (is_reference_type(result->get_type())) {
-    result->set_jobject(JNIHandles::make_local(THREAD, (oop) result->get_jobject()));
+    result->set_jobject(JNIHandles::make_local(THREAD, result->get_oop()));
   }
 }
 
@@ -947,7 +947,7 @@ static void jni_invoke_nonstatic(JNIEnv *env, JavaValue* result, jobject receive
 
   // Convert result
   if (is_reference_type(result->get_type())) {
-    result->set_jobject(JNIHandles::make_local(THREAD, (oop) result->get_jobject()));
+    result->set_jobject(JNIHandles::make_local(THREAD, result->get_oop()));
   }
 }
 

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -242,7 +242,7 @@ oop LiveFrameStream::create_primitive_slot_instance(StackValueCollection* values
                          signature,
                          &args,
                          CHECK_NULL);
-  return (instanceOop) result.get_jobject();
+  return (instanceOop) result.get_oop();
 }
 
 objArrayHandle LiveFrameStream::values_to_object_array(StackValueCollection* values, TRAPS) {
@@ -443,7 +443,7 @@ oop StackWalk::fetchFirstBatch(BaseFrameStream& stream, Handle stackStream,
   }
 
   // Return normally
-  return (oop)result.get_jobject();
+  return result.get_oop();
 }
 
 // Walk the next batch of stack frames

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -438,7 +438,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
       result = link.result();  // circumvent MS C++ 5.0 compiler bug (result is clobbered across call)
       // Preserve oop return value across possible gc points
       if (oop_result_flag) {
-        thread->set_vm_result((oop) result->get_jobject());
+        thread->set_vm_result(result->get_oop());
       }
     }
   } // Exit JavaCallWrapper (can block - potential return oop must be preserved)
@@ -449,7 +449,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
 
   // Restore possible oop return
   if (oop_result_flag) {
-    result->set_jobject(cast_from_oop<jobject>(thread->vm_result()));
+    result->set_oop(thread->vm_result());
     thread->set_vm_result(NULL);
   }
 }

--- a/src/hotspot/share/runtime/statSampler.cpp
+++ b/src/hotspot/share/runtime/statSampler.cpp
@@ -195,7 +195,7 @@ void StatSampler::assert_system_property(const char* name, const char* value, TR
                          key_str,
                          CHECK);
 
-  oop value_oop = (oop)result.get_jobject();
+  oop value_oop = result.get_oop();
   assert(value_oop != NULL, "property must have a value");
 
   // convert Java String to utf8 string

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -95,7 +95,7 @@ static jint get_properties(AttachOperation* op, outputStream* out, Symbol* seria
   }
 
   // The result should be a [B
-  oop res = (oop)result.get_jobject();
+  oop res = result.get_oop();
   assert(res->is_typeArray(), "just checking");
   assert(TypeArrayKlass::cast(res->klass())->element_type() == T_BYTE, "just checking");
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -407,7 +407,7 @@ void PrintSystemPropertiesDCmd::execute(DCmdSource source, TRAPS) {
   }
 
   // The result should be a [B
-  oop res = (oop)result.get_jobject();
+  oop res = result.get_oop();
   assert(res->is_typeArray(), "just checking");
   assert(TypeArrayKlass::cast(res->klass())->element_type() == T_BYTE, "just checking");
 
@@ -479,7 +479,7 @@ void FinalizerInfoDCmd::execute(DCmdSource source, TRAPS) {
                          vmSymbols::get_finalizer_histogram_name(),
                          vmSymbols::void_finalizer_histogram_entry_array_signature(), CHECK);
 
-  objArrayOop result_oop = (objArrayOop) result.get_jobject();
+  objArrayOop result_oop = (objArrayOop) result.get_oop();
   if (result_oop->length() == 0) {
     output()->print_cr("No instances waiting for finalization found");
     return;

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -471,7 +471,7 @@ void DCmdFactory::send_notification_internal(TRAPS) {
             vmSymbols::getDiagnosticCommandMBean_signature(),
             CHECK);
 
-    instanceOop m = (instanceOop) result.get_jobject();
+    instanceOop m = (instanceOop) result.get_oop();
     instanceHandle dcmd_mbean_h(THREAD, m);
 
     if (!dcmd_mbean_h->is_a(k)) {

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -95,7 +95,7 @@ static Handle getGcInfoBuilder(GCMemoryManager *gcManager,TRAPS) {
                           vmSymbols::getGcInfoBuilder_signature(),
                           &args,
                           CHECK_NH);
-  return Handle(THREAD,(oop)result.get_jobject());
+  return Handle(THREAD, result.get_oop());
 }
 
 static Handle createGcInfo(GCMemoryManager *gcManager, GCStatInfo *gcStatInfo,TRAPS) {

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -108,7 +108,7 @@ instanceOop MemoryManager::get_memory_manager_instance(TRAPS) {
                            &args,
                            CHECK_NULL);
 
-    instanceOop m = (instanceOop) result.get_jobject();
+    instanceOop m = (instanceOop) result.get_oop();
     instanceHandle mgr(THREAD, m);
 
     {

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -112,7 +112,7 @@ instanceOop MemoryPool::get_memory_pool_instance(TRAPS) {
                            &args,
                            CHECK_NULL);
 
-    instanceOop p = (instanceOop) result.get_jobject();
+    instanceOop p = (instanceOop) result.get_oop();
     instanceHandle pool(THREAD, p);
 
     {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -34,6 +34,8 @@
 
 #include COMPILER_HEADER(utilities/globalDefinitions)
 
+class oopDesc;
+
 // Defaults for macros that might be defined per compiler.
 #ifndef NOINLINE
 #define NOINLINE
@@ -830,7 +832,7 @@ class JavaValue {
  jint get_jint() const { return _value.i; }
  jlong get_jlong() const { return _value.l; }
  jobject get_jobject() const { return _value.h; }
- oop get_oop() const { return _value.o; }
+ oopDesc* get_oop() const { return _value.o; }
  JavaCallValue* get_value_addr() { return &_value; }
  BasicType get_type() const { return _type; }
 
@@ -839,7 +841,7 @@ class JavaValue {
  void set_jint(jint i) { _value.i = i;}
  void set_jlong(jlong l) { _value.l = l;}
  void set_jobject(jobject h) { _value.h = h;}
- void set_oop(oop o) { _value.o = o;}
+ void set_oop(oopDesc* o) { _value.o = o;}
  void set_type(BasicType t) { _type = t; }
 
  jboolean get_jboolean() const { return (jboolean) (_value.i);}

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -805,6 +805,7 @@ class JavaValue {
     jint     i;
     jlong    l;
     jobject  h;
+    oopDesc* o;
   } JavaCallValue;
 
  private:
@@ -829,6 +830,7 @@ class JavaValue {
  jint get_jint() const { return _value.i; }
  jlong get_jlong() const { return _value.l; }
  jobject get_jobject() const { return _value.h; }
+ oop get_oop() const { return _value.o; }
  JavaCallValue* get_value_addr() { return &_value; }
  BasicType get_type() const { return _type; }
 
@@ -837,6 +839,7 @@ class JavaValue {
  void set_jint(jint i) { _value.i = i;}
  void set_jlong(jlong l) { _value.l = l;}
  void set_jobject(jobject h) { _value.h = h;}
+ void set_oop(oop o) { _value.o = o;}
  void set_type(BasicType t) { _type = t; }
 
  jboolean get_jboolean() const { return (jboolean) (_value.i);}


### PR DESCRIPTION
JavaValue is a small wrapper class that wraps values used to pass arguments and results between native and Java.

When JavaCalls::call returns an object, the value stored in the JavaValue is not a handliezed jobject. Instead it's a raw oop. So, most of the code handling the `result`, fetches the result as a jobject, and then immediately casts it to an oop. For example:
  oop res = (oop)result.get_jobject();

I'd like to change this code to be:
  oop res = result.get_oop();

The motivations for this patch is:

1) Minimize the places where we pass around oops in jobject variables. Maybe at some point we'll have converted the JVM to only use the jobject type when passing around JNI handle. We need to be stricter with the types when we continue develop our GCs and their barriers.

2) Limit the number of places in the code where we perform raw oop casts. We have a helper cast function for that, cast_to_oop, but not all code use it. I have future patches where the compiler will completely forbid raw cast to oops (in fastdebug builds). With that in place, I can then add more stricter oop verification code when oops are created. This helps catching bugs earlier.

---

When reviewing this patch, take an extra look at the change  to oopsHierarchy.hpp. This was done to support jvmciEnv.cpp code:
```
  JVMCIObject wrap(oop obj)...
  JVMCIObjectArray wrap(objArrayOop obj)...
  JVMCIPrimitiveArray wrap(typeArrayOop obj) ...
```
Previously, `wrap((oop)result.get_jobject())` called the first function. When the code was changed to `wrap(result.get_oop())`, where `get_oop()` returns a `oopDesc*`, the compiler didn't know what conversion in oopsHierarchy.hpp to use. Therefore, I replaced the overly permissive `void*` constructor with a constructor that only takes the corresponding `type##OopDesc*`.

An alternative would be to let get_oop() return an oop, but then that would add an unwanted a dependency between globalDefinitions.hpp and  oopsHierarchy.hpp. An earlier version of this patch did return an oop instead of oopDesc*, but it also moved entire JavaValue class out of globalDefinitions.hpp into a new javaValue.hpp file, and had a corresponding javaValue.inline.hpp file.

Even if we end up using the proposed `oopDesc* get_oop()` version, maybe moving the class to javaValues.hpp would still makes sense?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263589](https://bugs.openjdk.java.net/browse/JDK-8263589): Introduce JavaValue::get_oop/set_oop


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3013/head:pull/3013`
`$ git checkout pull/3013`
