### PR TITLE
8263595: Remove oop type punning in JavaCallArguments

### DIFF
--- a/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
@@ -66,9 +66,8 @@ public:
   }
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void    put_obj(oop  from, intptr_t *to)           { *(oop *)(to +   0  ) =  from; }
-  static inline void    put_obj(oop  from, intptr_t *to, int& pos) { *(oop *)(to + pos++) =  from; }
-  static inline void    put_obj(oop *from, intptr_t *to, int& pos) { *(oop *)(to + pos++) = *from; }
+  static inline void    put_obj(const Handle& from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle.raw_value(); }
+  static inline void    put_obj(jobject       from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle; }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.
   static inline void    put_float(jfloat  from, intptr_t *to)           { *(jfloat *)(to +   0  ) =  from;  }

--- a/src/hotspot/cpu/arm/jniTypes_arm.hpp
+++ b/src/hotspot/cpu/arm/jniTypes_arm.hpp
@@ -62,9 +62,8 @@ public:
   static inline void put_long(jlong *from, intptr_t *to, int& pos) { put_int2r((jint *) from, to, pos); }
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void put_obj(oop  from, intptr_t *to)           { *(oop *)(to +   0  ) =  from; }
-  static inline void put_obj(oop  from, intptr_t *to, int& pos) { *(oop *)(to + pos++) =  from; }
-  static inline void put_obj(oop *from, intptr_t *to, int& pos) { *(oop *)(to + pos++) = *from; }
+  static inline void put_obj(const Handle& from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle.raw_value(); }
+  static inline void put_obj(jobject       from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle; }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.
   static inline void put_float(jfloat  from, intptr_t *to)           { *(jfloat *)(to +   0  ) =  from;  }

--- a/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
@@ -72,9 +72,8 @@ class JNITypes : AllStatic {
   }
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void put_obj(oop  from, intptr_t *to)           { *(oop *)(to +   0  ) =  from; }
-  static inline void put_obj(oop  from, intptr_t *to, int& pos) { *(oop *)(to + pos++) =  from; }
-  static inline void put_obj(oop *from, intptr_t *to, int& pos) { *(oop *)(to + pos++) = *from; }
+  static inline void put_obj(const Handle& from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle.raw_value(); }
+  static inline void put_obj(jobject       from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle; }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.
   static inline void put_float(jfloat  from, intptr_t *to)           { *(jfloat *)(to +   0  ) =  from;  }

--- a/src/hotspot/cpu/s390/jniTypes_s390.hpp
+++ b/src/hotspot/cpu/s390/jniTypes_s390.hpp
@@ -73,16 +73,12 @@ class JNITypes : AllStatic {
   }
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void put_obj(oop  from, intptr_t *to) {
-    *(oop*) to = from;
+  static inline void put_obj(const Handle& from_handle, intptr_t *to, int& pos) {
+    *(to + pos++) = (intptr_t)from_handle.raw_value();
   }
 
-  static inline void put_obj(oop  from, intptr_t *to, int& pos) {
-    *(oop*) (to + pos++) = from;
-  }
-
-  static inline void put_obj(oop *from, intptr_t *to, int& pos) {
-    *(oop*) (to + pos++) = *from;
+  static inline void put_obj(jobject from_handle, intptr_t *to, int& pos) {
+    *(to + pos++) =  (intptr_t)from_handle;
   }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.

--- a/src/hotspot/cpu/x86/jniTypes_x86.hpp
+++ b/src/hotspot/cpu/x86/jniTypes_x86.hpp
@@ -82,9 +82,8 @@ public:
 #endif // AMD64
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void    put_obj(oop  from, intptr_t *to)           { *(oop *)(to +   0  ) =  from; }
-  static inline void    put_obj(oop  from, intptr_t *to, int& pos) { *(oop *)(to + pos++) =  from; }
-  static inline void    put_obj(oop *from, intptr_t *to, int& pos) { *(oop *)(to + pos++) = *from; }
+  static inline void    put_obj(const Handle& from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle.raw_value(); }
+  static inline void    put_obj(jobject       from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle; }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.
   static inline void    put_float(jfloat  from, intptr_t *to)           { *(jfloat *)(to +   0  ) =  from;  }

--- a/src/hotspot/cpu/zero/jniTypes_zero.hpp
+++ b/src/hotspot/cpu/zero/jniTypes_zero.hpp
@@ -69,9 +69,8 @@ public:
 #endif
 
   // Oops are stored in native format in one JavaCallArgument slot at *to.
-  static inline void    put_obj(oop  from, intptr_t *to)                { *(oop *)(to +   0  ) =  from; }
-  static inline void    put_obj(oop  from, intptr_t *to, int& pos)      { *(oop *)(to + pos++) =  from; }
-  static inline void    put_obj(oop *from, intptr_t *to, int& pos)      { *(oop *)(to + pos++) = *from; }
+  static inline void    put_obj(const Handle& from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle.raw_value(); }
+  static inline void    put_obj(jobject       from_handle, intptr_t *to, int& pos) { *(to + pos++) =  (intptr_t)from_handle; }
 
   // Floats are stored in native format in one JavaCallArgument slot at *to.
   static inline void    put_float(jfloat  from, intptr_t *to)           { *(jfloat *)(to +   0  ) =  from; }

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -98,7 +98,7 @@ class Handle {
 
   // Raw handle access. Allows easy duplication of Handles. This can be very unsafe
   // since duplicates is only valid as long as original handle is alive.
-  oop* raw_value()                               { return _handle; }
+  oop* raw_value() const                         { return _handle; }
   static oop raw_resolve(oop *handle)            { return handle == NULL ? (oop)NULL : *handle; }
 };
 


### PR DESCRIPTION
JavaCallArguments has this code and comment:

```
// Helper for push_oop and the like. The value argument is a
// "handle" that refers to an oop. We record the address of the
// handle rather than the designated oop. The handle is later
// resolved to the oop by parameters(). This delays the exposure of
// naked oops until it is GC-safe.
template<typename T>
inline int push_oop_impl(T handle, int size) {
  // JNITypes::put_obj expects an oop value, so we play fast and
  // loose with the type system. The cast from handle type to oop
  // *must* use a C-style cast. In a product build it performs a
  // reinterpret_cast. In a debug build (more accurately, in a
  // CHECK_UNHANDLED_OOPS build) it performs a static_cast, invoking
  // the debug-only oop class's conversion from void* constructor.
  JNITypes::put_obj((oop)handle, _value, size); // Updates size.
  return size; // Return the updated size.
}
```
The type T is either an oop* or jobject (JNI handle). This puts something that isn't an oop inside an oop.

I propose that we don't do this. Instead we could pass the handle (address containing the oop), and then in put_obj convert that address to an intptr_t, which matches well with the `to` argument of those functions.

I've been running this (and some other changes) with ZGC on Linux x64 through tier1-tier7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263595](https://bugs.openjdk.java.net/browse/JDK-8263595): Remove oop type punning in JavaCallArguments


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3014/head:pull/3014`
`$ git checkout pull/3014`
