### PR TITLE
8261352: Create implementation for component peer for all the components who should be ignored in a11y interactions

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -84,9 +84,6 @@ static jclass sjc_CAccessible = NULL;
 #define GET_CACCESSIBLE_CLASS_RETURN(ret) \
     GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
 
-
-static jobject sAccessibilityClass = NULL;
-
 // sAttributeNamesForRoleCache holds the names of the attributes to which each java
 // AccessibleRole responds (see AccessibleRole.java).
 // This cache is queried before attempting to access a given attribute for a particular role.
@@ -285,39 +282,6 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     if (sRoles == nil) {
         initializeRoles();
-    }
-
-    if (sAccessibilityClass == NULL) {
-        JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-        GET_CACCESSIBILITY_CLASS();
-        DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
-
-#ifdef JAVA_AX_NO_IGNORES
-        NSArray *ignoredKeys = [NSArray array];
-#else
-        NSArray *ignoredKeys = [sRoles allKeysForObject:JavaAccessibilityIgnore];
-#endif
-        jobjectArray result = NULL;
-        jsize count = [ignoredKeys count];
-
-        DECLARE_CLASS(jc_String, "java/lang/String");
-        result = (*env)->NewObjectArray(env, count, jc_String, NULL);
-        CHECK_EXCEPTION();
-        if (!result) {
-            NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
-            return;
-        }
-
-        NSInteger i;
-        for (i = 0; i < count; i++) {
-            jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
-            (*env)->SetObjectArrayElement(env, result, i, jString);
-            (*env)->DeleteLocalRef(env, jString);
-        }
-
-        sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
-        CHECK_EXCEPTION();
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -36,6 +36,8 @@ static jmethodID sjm_getAccessibleComponent = NULL;
            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;", ret);
 
 static NSMutableDictionary * _Nullable rolesMap;
+NSString *const IgnoreClassName = @"IgnoreAccessibility";
+static jobject sAccessibilityClass = NULL;
 
 /*
  * Common ancestor for all the accessibility peers that implements the new method-based accessibility API
@@ -46,7 +48,7 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:8];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -56,6 +58,63 @@ static NSMutableDictionary * _Nullable rolesMap;
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
+
+    /*
+     * All the components below should be ignored by the accessibility subsystem,
+     * If any of the enclosed component asks for a parent the first ancestor
+     * participating in accessibility exchange should be returned.
+     */
+    [rolesMap setObject:IgnoreClassName forKey:@"alert"];
+    [rolesMap setObject:IgnoreClassName forKey:@"colorchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"desktoppane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"dialog"];
+    [rolesMap setObject:IgnoreClassName forKey:@"directorypane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filechooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filler"];
+    [rolesMap setObject:IgnoreClassName forKey:@"fontchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"frame"];
+    [rolesMap setObject:IgnoreClassName forKey:@"glasspane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"layeredpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"optionpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"panel"];
+    [rolesMap setObject:IgnoreClassName forKey:@"rootpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"separator"];
+    [rolesMap setObject:IgnoreClassName forKey:@"tooltip"];
+    [rolesMap setObject:IgnoreClassName forKey:@"viewport"];
+    [rolesMap setObject:IgnoreClassName forKey:@"window"];
+
+    /*
+     * Initialize CAccessibility instance
+     */
+#ifdef JAVA_AX_NO_IGNORES
+    NSArray *ignoredKeys = [NSArray array];
+#else
+    NSArray *ignoredKeys = [rolesMap allKeysForObject:IgnoreClassName];
+#endif
+
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
+    jobjectArray result = NULL;
+    jsize count = [ignoredKeys count];
+
+    DECLARE_CLASS(jc_String, "java/lang/String");
+    result = (*env)->NewObjectArray(env, count, jc_String, NULL);
+    CHECK_EXCEPTION();
+    if (!result) {
+        NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
+        return;
+    }
+
+    NSInteger i;
+    for (i = 0; i < count; i++) {
+        jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
+        (*env)->SetObjectArrayElement(env, result, i, jString);
+        (*env)->DeleteLocalRef(env, jString);
+    }
+
+    sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result);
+    CHECK_EXCEPTION();
 }
 
 /*
@@ -115,6 +174,10 @@ static NSMutableDictionary * _Nullable rolesMap;
     CHECK_EXCEPTION();
 
     return TRUE;
+}
+
+- (BOOL)isAccessibilityElement {
+    return YES;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
@@ -23,21 +23,13 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
-
 #import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "CommonComponentAccessibility.h"
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+#import <AppKit/AppKit.h>
 
-}
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
+@interface IgnoreAccessibility : CommonComponentAccessibility {
+
+};
 - (BOOL)isAccessibilityElement;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
@@ -23,21 +23,15 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
+#import "IgnoreAccessibility.h"
 
-#import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
-
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
-
+/*
+ * Indicates that component does not participate in accessibility exchange
+ */
+@implementation IgnoreAccessibility
+- (BOOL)isAccessibilityElement
+{
+    return NO;
 }
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-- (BOOL)isAccessibilityElement;
-@end
 
-#endif
+@end


### PR DESCRIPTION
Initial implementation
Moved the CAccessibility ignore list initialization to the new code
Some cleanup
Expose a new API - isAccessibilityElement instead of deprecated accessibilityIsIgnored

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261352](https://bugs.openjdk.java.net/browse/JDK-8261352): Create implementation for component peer for all the components who should be ignored in a11y interactions


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3015/head:pull/3015`
`$ git checkout pull/3015`

To update a local copy of the PR:
`$ git checkout pull/3015`
`$ git pull https://git.openjdk.java.net/jdk pull/3015/head`
