### PR TITLE
8263590: Rawtypes warnings should be produced for pattern matching in instanceof

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3963,6 +3963,7 @@ public class Attr extends JCTree.Visitor {
                 tree.expr.pos(), attribExpr(tree.expr, env));
         Type clazztype;
         JCTree typeTree;
+        boolean checkRawTypes;
         if (tree.pattern.getTag() == BINDINGPATTERN) {
             attribTree(tree.pattern, env, unknownExprInfo);
             clazztype = tree.pattern.type;
@@ -3975,9 +3976,11 @@ public class Attr extends JCTree.Visitor {
             if (!clazztype.hasTag(TYPEVAR)) {
                 clazztype = chk.checkClassOrArrayType(pattern.var.vartype.pos(), clazztype);
             }
+            checkRawTypes = true;
         } else {
             clazztype = attribType(tree.pattern, env);
             typeTree = tree.pattern;
+            checkRawTypes = false;
         }
         if (!clazztype.hasTag(TYPEVAR)) {
             clazztype = chk.checkClassOrArrayType(typeTree.pos(), clazztype);
@@ -4007,7 +4010,7 @@ public class Attr extends JCTree.Visitor {
                 clazztype = types.createErrorType(clazztype);
             }
         }
-        chk.validate(typeTree, env, false);
+        chk.validate(typeTree, env, checkRawTypes);
         chk.checkCastable(tree.expr.pos(), exprtype, clazztype);
         result = check(tree, syms.booleanType, KindSelector.VAL, resultInfo);
     }

--- a/test/langtools/tools/javac/patterns/RawTypeBindingWarning.java
+++ b/test/langtools/tools/javac/patterns/RawTypeBindingWarning.java
@@ -1,0 +1,11 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8263590
+ * @summary Verify correct warnings are produced for raw types in bindings
+ * @compile/ref=RawTypeBindingWarning.out -Xlint:rawtypes -XDrawDiagnostics RawTypeBindingWarning.java
+ */
+public class RawTypeBindingWarning<T> {
+    public static boolean t(Object o) {
+        return o instanceof RawTypeBindingWarning w;
+    }
+}

--- a/test/langtools/tools/javac/patterns/RawTypeBindingWarning.out
+++ b/test/langtools/tools/javac/patterns/RawTypeBindingWarning.out
@@ -1,0 +1,2 @@
+RawTypeBindingWarning.java:9:29: compiler.warn.raw.class.use: RawTypeBindingWarning, RawTypeBindingWarning<T>
+1 warning


### PR DESCRIPTION
For code like:
```
Object o = null;
boolean b = o instanceof List l;
```

There should be a raw-type warning for `List`, as we are effectively declaring a variable with a raw type.

Code like:
```
Object o = null;
boolean b = o instanceof List;
```

Will not produce a warning (as it doesn't so far), as the (raw) type is not used in a problematic context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263590](https://bugs.openjdk.java.net/browse/JDK-8263590): Rawtypes warnings should be produced for pattern matching in instanceof


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3016/head:pull/3016`
`$ git checkout pull/3016`
