### PR TITLE
8263612: Unused variables in C1 runtime

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -116,7 +116,6 @@ const char *Runtime1::_blob_names[] = {
 
 #ifndef PRODUCT
 // statistics
-int Runtime1::_generic_arraycopy_cnt = 0;
 int Runtime1::_generic_arraycopystub_cnt = 0;
 int Runtime1::_arraycopy_slowcase_cnt = 0;
 int Runtime1::_arraycopy_checkcast_cnt = 0;
@@ -134,7 +133,6 @@ int Runtime1::_throw_div0_exception_count = 0;
 int Runtime1::_throw_null_pointer_exception_count = 0;
 int Runtime1::_throw_class_cast_exception_count = 0;
 int Runtime1::_throw_incompatible_class_change_error_count = 0;
-int Runtime1::_throw_array_store_exception_count = 0;
 int Runtime1::_throw_count = 0;
 
 static int _byte_arraycopy_stub_cnt = 0;
@@ -1451,7 +1449,6 @@ void Runtime1::print_statistics() {
   tty->print_cr(" _resolve_invoke_static_cnt:      %d", SharedRuntime::_resolve_static_ctr);
   tty->print_cr(" _handle_wrong_method_cnt:        %d", SharedRuntime::_wrong_method_ctr);
   tty->print_cr(" _ic_miss_cnt:                    %d", SharedRuntime::_ic_miss_ctr);
-  tty->print_cr(" _generic_arraycopy_cnt:          %d", _generic_arraycopy_cnt);
   tty->print_cr(" _generic_arraycopystub_cnt:      %d", _generic_arraycopystub_cnt);
   tty->print_cr(" _byte_arraycopy_cnt:             %d", _byte_arraycopy_stub_cnt);
   tty->print_cr(" _short_arraycopy_cnt:            %d", _short_arraycopy_stub_cnt);
@@ -1476,7 +1473,6 @@ void Runtime1::print_statistics() {
   tty->print_cr(" _throw_null_pointer_exception_count:           %d:", _throw_null_pointer_exception_count);
   tty->print_cr(" _throw_class_cast_exception_count:             %d:", _throw_class_cast_exception_count);
   tty->print_cr(" _throw_incompatible_class_change_error_count:  %d:", _throw_incompatible_class_change_error_count);
-  tty->print_cr(" _throw_array_store_exception_count:            %d:", _throw_array_store_exception_count);
   tty->print_cr(" _throw_count:                                  %d:", _throw_count);
 
   SharedRuntime::print_ic_miss_histogram();

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -94,10 +94,6 @@ class Runtime1: public AllStatic {
 
   // statistics
 #ifndef PRODUCT
-  static int _resolve_invoke_cnt;
-  static int _handle_wrong_method_cnt;
-  static int _ic_miss_cnt;
-  static int _generic_arraycopy_cnt;
   static int _generic_arraycopystub_cnt;
   static int _arraycopy_slowcase_cnt;
   static int _arraycopy_checkcast_cnt;
@@ -115,7 +111,6 @@ class Runtime1: public AllStatic {
   static int _throw_null_pointer_exception_count;
   static int _throw_class_cast_exception_count;
   static int _throw_incompatible_class_change_error_count;
-  static int _throw_array_store_exception_count;
   static int _throw_count;
 #endif
 


### PR DESCRIPTION
Please review this small patch removing some unused variables in the C1 runtime.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263612](https://bugs.openjdk.java.net/browse/JDK-8263612): Unused variables in C1 runtime


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3017/head:pull/3017`
`$ git checkout pull/3017`
