### PR TITLE
8260274: Cipher.init(int, key) does not use highest priority provider for random bytes

### DIFF
--- a/src/java.base/share/classes/java/security/AlgorithmParameterGenerator.java
+++ b/src/java.base/share/classes/java/security/AlgorithmParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -309,7 +309,7 @@ public class AlgorithmParameterGenerator {
      * @param size the size (number of bits).
      */
     public final void init(int size) {
-        paramGenSpi.engineInit(size, JCAUtil.getSecureRandom());
+        paramGenSpi.engineInit(size, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -340,7 +340,7 @@ public class AlgorithmParameterGenerator {
      */
     public final void init(AlgorithmParameterSpec genParamSpec)
         throws InvalidAlgorithmParameterException {
-            paramGenSpi.engineInit(genParamSpec, JCAUtil.getSecureRandom());
+            paramGenSpi.engineInit(genParamSpec, JCAUtil.getDefSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/java/security/KeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/KeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -373,7 +373,7 @@ public abstract class KeyPairGenerator extends KeyPairGeneratorSpi {
      * supported by this KeyPairGenerator object.
      */
     public void initialize(int keysize) {
-        initialize(keysize, JCAUtil.getSecureRandom());
+        initialize(keysize, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -433,7 +433,7 @@ public abstract class KeyPairGenerator extends KeyPairGeneratorSpi {
      */
     public void initialize(AlgorithmParameterSpec params)
             throws InvalidAlgorithmParameterException {
-        initialize(params, JCAUtil.getSecureRandom());
+        initialize(params, JCAUtil.getDefSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1233,7 +1233,7 @@ public class Cipher {
      * by the underlying {@code CipherSpi}.
      */
     public final void init(int opmode, Key key) throws InvalidKeyException {
-        init(opmode, key, JCAUtil.getSecureRandom());
+        init(opmode, key, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -1372,7 +1372,7 @@ public class Cipher {
     public final void init(int opmode, Key key, AlgorithmParameterSpec params)
             throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(opmode, key, params, JCAUtil.getSecureRandom());
+        init(opmode, key, params, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -1513,7 +1513,7 @@ public class Cipher {
     public final void init(int opmode, Key key, AlgorithmParameters params)
             throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(opmode, key, params, JCAUtil.getSecureRandom());
+        init(opmode, key, params, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -1659,7 +1659,7 @@ public class Cipher {
     public final void init(int opmode, Certificate certificate)
             throws InvalidKeyException
     {
-        init(opmode, certificate, JCAUtil.getSecureRandom());
+        init(opmode, certificate, JCAUtil.getDefSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/KeyAgreement.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreement.java
@@ -448,7 +448,7 @@ public class KeyAgreement {
      * has an incompatible algorithm type.
      */
     public final void init(Key key) throws InvalidKeyException {
-        init(key, JCAUtil.getSecureRandom());
+        init(key, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -516,7 +516,7 @@ public class KeyAgreement {
     public final void init(Key key, AlgorithmParameterSpec params)
         throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(key, params, JCAUtil.getSecureRandom());
+        init(key, params, JCAUtil.getDefSecureRandom());
     }
 
     private String getProviderName() {

--- a/src/java.base/share/classes/javax/crypto/KeyGenerator.java
+++ b/src/java.base/share/classes/javax/crypto/KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -449,7 +449,7 @@ public class KeyGenerator {
     public final void init(AlgorithmParameterSpec params)
         throws InvalidAlgorithmParameterException
     {
-        init(params, JCAUtil.getSecureRandom());
+        init(params, JCAUtil.getDefSecureRandom());
     }
 
     /**
@@ -513,7 +513,7 @@ public class KeyGenerator {
      * supported.
      */
     public final void init(int keysize) {
-        init(keysize, JCAUtil.getSecureRandom());
+        init(keysize, JCAUtil.getDefSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/jca/JCAUtil.java
+++ b/src/java.base/share/classes/sun/security/jca/JCAUtil.java
@@ -26,7 +26,6 @@
 package sun.security.jca;
 
 import java.lang.ref.*;
-import java.util.Arrays;
 import java.security.*;
 
 /**
@@ -82,14 +81,16 @@ public final class JCAUtil {
      * SecureRandom impl if the provider table is the same.
      */
     public static SecureRandom getDefSecureRandom() {
-        if (def == null) {
+        SecureRandom result = def;
+        if (result == null) {
             synchronized (JCAUtil.class) {
-                if (def == null) {
-                    def = new SecureRandom();
+                result = def;
+                if (result == null) {
+                    def = result = new SecureRandom();
                 }
             }
         }
-        return def;
+        return result;
 
     }
 }

--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,7 @@ public class Providers {
         } else {
             changeThreadProviderList(newList);
         }
+        JCAUtil.clearDefSecureRandom();
     }
 
     /**

--- a/test/jdk/java/security/misc/TestDefaultRandom.java
+++ b/test/jdk/java/security/misc/TestDefaultRandom.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260274
+ * @run main/othervm TestDefaultRandom APG 1
+ * @run main/othervm TestDefaultRandom APG 2
+ * @run main/othervm TestDefaultRandom KPG 1
+ * @run main/othervm TestDefaultRandom KPG 2
+ * @run main/othervm TestDefaultRandom CIP 1
+ * @run main/othervm TestDefaultRandom CIP 2
+ * @run main/othervm TestDefaultRandom CIP 3
+ * @run main/othervm TestDefaultRandom CIP 4
+ * @run main/othervm TestDefaultRandom KA 1
+ * @run main/othervm TestDefaultRandom KA 2
+ * @run main/othervm TestDefaultRandom KG 1
+ * @run main/othervm TestDefaultRandom KG 2
+ * @summary Ensure the default SecureRandom impl is used as the javadoc
+ * spec stated when none supplied.
+ */
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.DSAGenParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.spec.IvParameterSpec;
+
+public class TestDefaultRandom {
+
+    public static void main(String[] argv) throws Exception {
+        if (argv.length != 2) {
+            throw new RuntimeException("Error: missing test parameters");
+        }
+
+        switch (argv[0]) {
+            case "APG" ->
+                check(AlgorithmParameterGenerator.getInstance("DSA"), argv[1]);
+            case "KPG" ->
+                check(KeyPairGenerator.getInstance("RSA"), argv[1]);
+            case "CIP" ->
+                check(Cipher.getInstance("AES/CBC/NoPadding"), argv[1]);
+            case "KA" -> check(KeyAgreement.getInstance("DH"), argv[1]);
+            case "KG" -> check(KeyGenerator.getInstance("AES"), argv[1]);
+            default -> throw new RuntimeException
+                    ("Error: unsupported test type");
+        }
+    }
+
+    private static void check(Object obj, String testNum) {
+        if (obj == null) throw new NullPointerException();
+
+        SampleProvider prov = new SampleProvider();
+        Security.insertProviderAt(prov, 1);
+
+        int b4Cnt = SampleProvider.count;
+
+        System.out.println("before, count = " + b4Cnt);
+        // Note that the arguments may not be valid, they just need to be
+        // non-null to trigger the call for checking if the default
+        // SecureRandom impl is used
+        try {
+            if (obj instanceof AlgorithmParameterGenerator) {
+                AlgorithmParameterGenerator apg =
+                        (AlgorithmParameterGenerator) obj;
+                switch (testNum) {
+                    case "1" -> apg.init(123);
+                    case "2" -> apg.init((AlgorithmParameterSpec) null);
+                    default -> throw new RuntimeException
+                            ("Error: invalid test#");
+                }
+            } else if (obj instanceof KeyPairGenerator) {
+                KeyPairGenerator kpg = (KeyPairGenerator) obj;
+                switch (testNum) {
+                    case "1" -> kpg.initialize(123);
+                    case "2" -> kpg.initialize((AlgorithmParameterSpec) null);
+                    default -> throw new RuntimeException
+                            ("Error: invalid test#");
+                }
+            } else if (obj instanceof Cipher) {
+                Cipher c = (Cipher) obj;
+                switch (testNum) {
+                    case "1" -> c.init(Cipher.ENCRYPT_MODE, (Key) null);
+                    case "2" -> c.init(Cipher.ENCRYPT_MODE, (Key) null,
+                        (AlgorithmParameterSpec) null);
+                    case "3" -> c.init(Cipher.ENCRYPT_MODE, (Key) null,
+                        (AlgorithmParameters) null);
+                    case "4" -> c.init(Cipher.ENCRYPT_MODE, (Certificate)null);
+                    default -> throw new RuntimeException
+                            ("Error: invalid test#");
+                }
+            } else if (obj instanceof KeyAgreement) {
+                KeyAgreement ka = (KeyAgreement) obj;
+                switch (testNum) {
+                    case "1" -> ka.init((Key) null);
+                    case "2" -> ka.init((Key) null, (AlgorithmParameterSpec)
+                            null);
+                    default -> throw new RuntimeException
+                            ("Error: invalid test#");
+                }
+            } else if (obj instanceof KeyGenerator) {
+                KeyGenerator kg = (KeyGenerator) obj;
+                switch (testNum) {
+                    case "1" -> kg.init(123);
+                    case "2" -> kg.init((AlgorithmParameterSpec) null);
+                    default -> throw new RuntimeException
+                            ("Error: invalid test#");
+                }
+            } else {
+                throw new RuntimeException("Error: Unsupported type");
+            }
+        } catch (GeneralSecurityException | InvalidParameterException e) {
+            // expected; ignore
+        }
+        System.out.println("after, count = " + SampleProvider.count);
+        if (SampleProvider.count == b4Cnt) {
+            throw new RuntimeException("Test Failed");
+        }
+    }
+
+    private static class SampleProvider extends Provider {
+
+        static int count = 0;
+        static String SR_ALGO = "Custom";
+
+        SampleProvider() {
+            super("Sample", "1.0", "test provider with custom SR impl");
+            putService(new SampleService(this, "SecureRandom", SR_ALGO,
+                    "SampleSecureRandom.class" /* stub class name */,
+                    null, null));
+        }
+
+        private static class SampleService extends Service {
+
+            SampleService(Provider p, String type, String alg, String cn,
+                    List<String> aliases, Map<String,String> attrs) {
+                super(p, type, alg, cn, aliases, attrs);
+            }
+
+            @Override
+            public Object newInstance(Object param)
+                    throws NoSuchAlgorithmException {
+                String alg = getAlgorithm();
+                String type = getType();
+
+                if (type.equals("SecureRandom") && alg.equals(SR_ALGO)) {
+                    SampleProvider.count++;
+                    return new CustomSR();
+                } else {
+                    // should never happen
+                    throw new NoSuchAlgorithmException("No support for " + alg);
+                }
+            }
+        }
+
+        private static class CustomSR extends SecureRandomSpi {
+            @Override
+            protected void engineSetSeed(byte[] seed) {
+            }
+
+            @Override
+            protected void engineNextBytes(byte[] bytes) {
+            }
+
+            @Override
+            protected byte[] engineGenerateSeed(int numBytes) {
+                return new byte[numBytes];
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can someone help review this somewhat trivial change?

Updated JCAUtil class to return the cached SecureRandom object only when the provider configuration has not changed. 
Added a regression test to check the affected classes, i.e. AlgorithmParameterGenerator, KeyPairGenerator, Cipher, KeyAgreement, KeyGenerator. 

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260274](https://bugs.openjdk.java.net/browse/JDK-8260274): Cipher.init(int, key) does not use highest priority provider for random bytes


### Reviewers
 * @SalusaSecondus (no known github.com user name / role)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3018/head:pull/3018`
`$ git checkout pull/3018`

To update a local copy of the PR:
`$ git checkout pull/3018`
`$ git pull https://git.openjdk.java.net/jdk pull/3018/head`
