### PR TITLE
8263616: 'Deprecatd' typo in src/hotspot/share/classfile/classFileParser.cpp

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3766,7 +3766,7 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
       }
       parse_classfile_synthetic_attribute(CHECK);
     } else if (tag == vmSymbols::tag_deprecated()) {
-      // Check for Deprecatd tag - 4276120
+      // Check for Deprecated tag - 4276120
       if (attribute_length != 0) {
         classfile_parse_error(
           "Invalid Deprecated classfile attribute length %u in class file %s",


### PR DESCRIPTION
Fix typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263616](https://bugs.openjdk.java.net/browse/JDK-8263616): 'Deprecatd' typo in src/hotspot/share/classfile/classFileParser.cpp


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3019/head:pull/3019`
`$ git checkout pull/3019`
