### PR TITLE
8259863: doc: JShell snippet doesn't compile

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/package-info.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/package-info.java
@@ -68,7 +68,7 @@
  * fixed strings, but would come from the user. Below is a very simplified
  * example of how the API might be used to implement a REPL.
  * <pre>
-* {@code
+ * {@code
  *     import java.io.ByteArrayInputStream;
  *     import java.io.Console;
  *     import java.util.List;
@@ -88,9 +88,9 @@
  *                     List<SnippetEvent> events = js.eval(input);
  *                     for (SnippetEvent e : events) {
  *                         StringBuilder sb = new StringBuilder();
- *                         if (e.causeSnippet == null) {
+ *                         if (e.causeSnippet() == null) {
  *                             //  We have a snippet creation event
- *                             switch (e.status) {
+ *                             switch (e.status()) {
  *                                 case VALID:
  *                                     sb.append("Successful ");
  *                                     break;
@@ -104,16 +104,16 @@
  *                                     sb.append("Failed ");
  *                                     break;
  *                             }
- *                             if (e.previousStatus == Status.NONEXISTENT) {
+ *                             if (e.previousStatus() == Status.NONEXISTENT) {
  *                                 sb.append("addition");
  *                             } else {
  *                                 sb.append("modification");
  *                             }
  *                             sb.append(" of ");
- *                             sb.append(e.snippet.source());
+ *                             sb.append(e.snippet().source());
  *                             System.out.println(sb);
- *                             if (e.value != null) {
- *                                 System.out.printf("Value is: %s\n", e.value);
+ *                             if (e.value() != null) {
+ *                                 System.out.printf("Value is: %s\n", e.value());
  *                             }
  *                             System.out.flush();
  *                         }


### PR DESCRIPTION
Fixing the snippet in `src/jdk.jshell/share/classes/jdk/jshell/package-info.java` so that it compiles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259863](https://bugs.openjdk.java.net/browse/JDK-8259863): doc: JShell snippet doesn't compile


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3023/head:pull/3023`
`$ git checkout pull/3023`
