### PR TITLE
8263667: Avoid running GitHub actions on branches named pr/*

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+      - pr/*
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
When the Skara feature "dependent pull requests" is activated for the JDK repository, branches with the name "pr/<number>" will start to appear. These will not be synced into personal forks by the Skara sync command, but if they are synced manually, we should avoid running GitHub actions workflows on them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263667](https://bugs.openjdk.java.net/browse/JDK-8263667): Avoid running GitHub actions on branches named pr/*


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3024/head:pull/3024`
`$ git checkout pull/3024`
