### PR TITLE
8262739: String inflation C2 intrinsic prevents insertion of anti-dependencies

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -778,6 +778,7 @@ bool InstructForm::captures_bottom_type(FormDict &globals) const {
        !strcmp(_matrule->_rChild->_opType,"RotateLeft")   ||
        !strcmp(_matrule->_rChild->_opType,"RotateRight")   ||
 #if INCLUDE_SHENANDOAHGC
+       !strcmp(_matrule->_rChild->_opType,"StrInflatedCopy") ||
        !strcmp(_matrule->_rChild->_opType,"ShenandoahCompareAndExchangeP") ||
        !strcmp(_matrule->_rChild->_opType,"ShenandoahCompareAndExchangeN") ||
 #endif

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -778,10 +778,10 @@ bool InstructForm::captures_bottom_type(FormDict &globals) const {
        !strcmp(_matrule->_rChild->_opType,"RotateLeft")   ||
        !strcmp(_matrule->_rChild->_opType,"RotateRight")   ||
 #if INCLUDE_SHENANDOAHGC
-       !strcmp(_matrule->_rChild->_opType,"StrInflatedCopy") ||
        !strcmp(_matrule->_rChild->_opType,"ShenandoahCompareAndExchangeP") ||
        !strcmp(_matrule->_rChild->_opType,"ShenandoahCompareAndExchangeN") ||
 #endif
+       !strcmp(_matrule->_rChild->_opType,"StrInflatedCopy") ||
        !strcmp(_matrule->_rChild->_opType,"VectorMaskGen")||
        !strcmp(_matrule->_rChild->_opType,"CompareAndExchangeP") ||
        !strcmp(_matrule->_rChild->_opType,"CompareAndExchangeN"))) return true;

--- a/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyAfterStringInflation.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyAfterStringInflation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8262739
+ * @summary Test correct insertion of anti-dependencies after String inflation.
+ * @run main/othervm -Xbatch
+ *                   compiler.controldependency.TestAntiDependencyAfterStringInflation
+ */
+
+package compiler.controldependency;
+
+public class TestAntiDependencyAfterStringInflation {
+
+    static String reverseString(String str) {
+        int size = str.length();
+        char[] buffer = new char[size];
+        reverse(str, buffer, size);
+        return new String(buffer, 0, size);
+    }
+
+    static void reverse(String str, char[] buffer, int size) {
+        // Inflate String.value byte[] to char[]
+        str.getChars(0, size, buffer, 0);
+        // Reverse String by copying buffer elements. This will fail
+        // if C2 does not insert anti-dependencies between loads/stores.
+        int half = size / 2;
+        for (int l = 0, r = size - 1; l < half; l++, r--) {
+            char tmp = buffer[l];
+            buffer[l] = buffer[r];
+            buffer[r] = tmp;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 50_000; i++) {
+            String res = reverseString("0123456789");
+            if (!res.equals("9876543210")) {
+                throw new RuntimeException("Unexpected result: " + res);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The string inflation intrinsic `StrInflatedCopyNode` which converts the String internal byte[] to char[] has `bottom_type` `Type::MEMORY`:
https://github.com/openjdk/jdk/blob/f71e8a61988cc9f095a4f034636baf04c3f48f77/src/hotspot/share/opto/intrinsicnode.hpp#L143-L145

Memory users (i.e. loads) should therefore be checked for nearby anti-dependent stores:
https://github.com/openjdk/jdk/blob/f71e8a61988cc9f095a4f034636baf04c3f48f77/src/hotspot/share/opto/node.cpp#L1482-L1486

However, since `InstructForm::captures_bottom_type` returns `false` for `StrInflatedCopyNode`, after matching, the corresponding `MachNode` version will have `bottom_type` `Type::BOTTOM` and no anti-dependency analysis will be performed for its users. Scheduling then incorrectly orders loads from the char array with anti-dependent stores to the same array, leading to incorrect results.

`StrCompressedCopyNode` does not need this because it has `TypeInt::INT` as  `bottom_type` (the memory output is handled via a `SCMemProjNode`):
https://github.com/openjdk/jdk/blob/f71e8a61988cc9f095a4f034636baf04c3f48f77/src/hotspot/share/opto/intrinsicnode.hpp#L131-L133

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262739](https://bugs.openjdk.java.net/browse/JDK-8262739): String inflation C2 intrinsic prevents insertion of anti-dependencies


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to c132b1eb65ccea4f6c321a0afb8d71076359bb62
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3025/head:pull/3025`
`$ git checkout pull/3025`
