### PR TITLE
8263670: pmap and pstack in jhsdb do not work on debug server

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -443,16 +443,12 @@ public class HotSpotAgent {
             db.getJShortType().getSize());
         }
 
-        if (!isServer) {
-            // Do not initialize the VM on the server (unnecessary, since it's
-            // instantiated on the client)
-            try {
-                VM.initialize(db, debugger);
-            } catch (DebuggerException e) {
-                throw (e);
-            } catch (Exception e) {
-                throw new DebuggerException(e);
-            }
+        try {
+            VM.initialize(db, debugger);
+        } catch (DebuggerException e) {
+            throw (e);
+        } catch (Exception e) {
+            throw new DebuggerException(e);
         }
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package sun.jvm.hotspot.debugger.remote;
 
 import java.rmi.*;
+import java.util.*;
 
 import sun.jvm.hotspot.debugger.*;
 
@@ -76,4 +77,8 @@ public interface RemoteDebugger extends Remote {
                                    long addrOrId2, boolean isAddress2) throws RemoteException;
   public int       getThreadHashCode(long addrOrId, boolean isAddress) throws RemoteException;
   public long[]    getThreadIntegerRegisterSet(long addrOrId, boolean isAddress) throws RemoteException;
+
+  public default String execCommandOnServer(String command, Map<String, Object> options) throws RemoteException {
+    throw new DebuggerException("Command execution is not supported");
+  }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -414,5 +414,13 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
 
   public void writeBytesToProcess(long a, long b, byte[] c) {
      throw new DebuggerException("Unimplemented!");
+  }
+
+  public String execCommandOnServer(String command, Map<String, Object> options) {
+    try {
+      return remoteDebugger.execCommandOnServer(command, options);
+    } catch (RemoteException e) {
+      throw new DebuggerException(e);
+    }
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
@@ -78,7 +78,7 @@ public class PMap extends Tool {
          }
       } else {
           if (getDebugeeType() == DEBUGEE_REMOTE) {
-            out.print(((RemoteDebuggerClient)dbg).execCommandOnServer("pmap", null));
+              out.print(((RemoteDebuggerClient)dbg).execCommandOnServer("pmap", null));
           } else {
               out.println("not yet implemented (debugger does not support CDebugger)!");
           }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PMap.java
@@ -29,6 +29,7 @@ import java.util.*;
 import sun.jvm.hotspot.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
+import sun.jvm.hotspot.debugger.remote.*;
 import sun.jvm.hotspot.utilities.PlatformInfo;
 
 public class PMap extends Tool {
@@ -77,7 +78,7 @@ public class PMap extends Tool {
          }
       } else {
           if (getDebugeeType() == DEBUGEE_REMOTE) {
-              out.println("remote configuration is not yet implemented");
+            out.print(((RemoteDebuggerClient)dbg).execCommandOnServer("pmap", null));
           } else {
               out.println("not yet implemented (debugger does not support CDebugger)!");
           }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -31,6 +31,7 @@ import sun.jvm.hotspot.code.*;
 import sun.jvm.hotspot.interpreter.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
+import sun.jvm.hotspot.debugger.remote.*;
 import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.utilities.PlatformInfo;
@@ -193,7 +194,7 @@ public class PStack extends Tool {
          } // for threads
       } else {
           if (getDebugeeType() == DEBUGEE_REMOTE) {
-              out.println("remote configuration is not yet implemented");
+              out.print(((RemoteDebuggerClient)dbg).execCommandOnServer("pstack", Map.of("concurrentLocks", concurrentLocks)));
           } else {
               out.println("not yet implemented (debugger does not support CDebugger)!");
           }
@@ -284,5 +285,13 @@ public class PStack extends Tool {
       String[] res = new String[names.size()];
       System.arraycopy(names.toArray(), 0, res, 0, res.length);
       return res;
+   }
+
+   public void setVerbose(boolean verbose) {
+       this.verbose = verbose;
+   }
+
+   public void setConcurrentLocks(boolean concurrentLocks) {
+       this.concurrentLocks = concurrentLocks;
    }
 }

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
@@ -45,18 +45,7 @@ public class ClhsdbAttachToDebugServer {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
-
-        if (SATestUtils.needsPrivileges()) {
-            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
-            // be killed if you do this (because it is a root process and the test is not), so the destroy()
-            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
-            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
-            // attached to in a stuck state for some unknown reason, causing the stopApp() call
-            // to timeout. For that reason we don't run this test when privileges are needed. Note
-            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
-            // are not required.
-            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
-        }
+        SATestUtils.validateSADebugDPrivileges();
 
         System.out.println("Starting ClhsdbAttachToDebugServer test");
 

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
+
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8263670
+ * @requires vm.hasSA
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm PmapOnDebugdTest
+ */
+
+public class PmapOnDebugdTest {
+
+    public static void main(String[] args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+
+        if (SATestUtils.needsPrivileges()) {
+            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
+            // be killed if you do this (because it is a root process and the test is not), so the destroy()
+            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
+            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
+            // attached to in a stuck state for some unknown reason, causing the stopApp() call
+            // to timeout. For that reason we don't run this test when privileges are needed. Note
+            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
+            // are not required.
+            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
+        }
+
+        LingeredApp theApp = null;
+        DebugdUtils debugd = null;
+        try {
+            theApp = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+            debugd = new DebugdUtils(null);
+            debugd.attach(theApp.getPid());
+
+            JDKToolLauncher jhsdbLauncher = JDKToolLauncher.createUsingTestJDK("jhsdb");
+            jhsdbLauncher.addToolArg("jmap");
+            jhsdbLauncher.addToolArg("--connect");
+            jhsdbLauncher.addToolArg("localhost");
+
+            Process jhsdb = (SATestUtils.createProcessBuilder(jhsdbLauncher)).start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            jhsdb.waitFor();
+            System.out.println(out.getStdout());
+            System.err.println(out.getStderr());
+
+            out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+            out.shouldMatch("^0x[0-9a-f]+.+jvm\\.(dll|dylib|so)$"); // Find libjvm from output
+            out.shouldHaveExitValue(0);
+
+            // This will detect most SA failures, including during the attach.
+            out.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            if (debugd != null) {
+                debugd.detach();
+            }
+            LingeredApp.stopApp(theApp);
+        }
+        System.out.println("Test PASSED");
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
@@ -33,7 +33,7 @@ import jtreg.SkippedException;
  * @test
  * @bug 8263670
  * @requires vm.hasSA
- * @requires os.family != "windows"
+ * @requires (os.family != "windows") & (os.family != "mac")
  * @library /test/lib
  * @run main/othervm PmapOnDebugdTest
  */
@@ -42,18 +42,7 @@ public class PmapOnDebugdTest {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
-
-        if (SATestUtils.needsPrivileges()) {
-            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
-            // be killed if you do this (because it is a root process and the test is not), so the destroy()
-            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
-            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
-            // attached to in a stuck state for some unknown reason, causing the stopApp() call
-            // to timeout. For that reason we don't run this test when privileges are needed. Note
-            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
-            // are not required.
-            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
-        }
+        SATestUtils.validateSADebugDPrivileges();
 
         LingeredApp theApp = null;
         DebugdUtils debugd = null;
@@ -76,7 +65,7 @@ public class PmapOnDebugdTest {
             System.err.println(out.getStderr());
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
-            out.shouldMatch("^0x[0-9a-f]+.+jvm\\.(dll|dylib|so)$"); // Find libjvm from output
+            out.shouldMatch("^0x[0-9a-f]+.+libjvm\\.so$"); // Find libjvm from output
             out.shouldHaveExitValue(0);
 
             // This will detect most SA failures, including during the attach.

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,18 +56,7 @@ public class SADebugDTest {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
-
-        if (SATestUtils.needsPrivileges()) {
-            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
-            // be killed if you do this (because it is a root process and the test is not), so the destroy()
-            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
-            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
-            // attached to in a stuck state for some unknown reason, causing the stopApp() call
-            // to timeout. For that reason we don't run this test when privileges are needed. Note
-            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
-            // are not required.
-            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
-        }
+        SATestUtils.validateSADebugDPrivileges();
         runTests();
     }
 

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,5 +206,21 @@ public class SATestUtils {
         }
         // Otherwise expect to be permitted:
         return true;
+    }
+
+    /**
+     * This tests has issues if you try adding privileges on OSX. The debugd process cannot
+     * be killed if you do this (because it is a root process and the test is not), so the destroy()
+     * call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
+     * a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
+     * attached to in a stuck state for some unknown reason, causing the stopApp() call
+     * to timeout. For that reason we don't run this test when privileges are needed. Note
+     * it does appear to run fine as root, so we still allow it to run on OSX when privileges
+     * are not required.
+     */
+    public static void validateSADebugDPrivileges() {
+        if (needsPrivileges()) {
+            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
+        }
     }
 }


### PR DESCRIPTION
jhsdb supports pmap (jhsdb jmap) and pstack (jhsdb jstack --mixed), and they work fine if they attach to live process or to coredump, however they do not work on debug server as following:

```
$ jhsdb jmap --connect localhost
Attaching to remote server localhost, please wait...
Debugger attached successfully.
Server compiler detected.
JVM version is 11.0.10+9
remote configuration is not yet implemented
```

pmap and pstack depend on CDebugger in SA, however it would not be set in case of remote debugger client. We can avoid it if we can delegate the process to debug server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263670](https://bugs.openjdk.java.net/browse/JDK-8263670): pmap and pstack in jhsdb do not work on debug server


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 57149ae1f861cc73604b168a4f1de6d4d7ca5d6d
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 57149ae1f861cc73604b168a4f1de6d4d7ca5d6d


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3027/head:pull/3027`
`$ git checkout pull/3027`

To update a local copy of the PR:
`$ git checkout pull/3027`
`$ git pull https://git.openjdk.java.net/jdk pull/3027/head`
