### PR TITLE
8262298 : G1BarrierSetC2::step_over_gc_barrier fails with assert "bad barrier shape"

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -759,7 +759,7 @@ Node* G1BarrierSetC2::step_over_gc_barrier(Node* c) const {
               r->in(j)->in(0)->as_Call()->entry_point() == CAST_FROM_FN_PTR(address, G1BarrierSetRuntime::write_ref_field_post_entry)) {
             Node* call = r->in(j)->in(0);
             c = c->in(i == 1 ? 2 : 1);
-            if (c != NULL) {
+            if (c != NULL && c->Opcode() != Op_Parm) {
               c = c->in(0);
               if (c != NULL) {
                 c = c->in(0);


### PR DESCRIPTION
During eliminate_macro_nodes an allocation and a tightly coupled arraycopy is eliminated. The gc barrier is still there but the entry condition is always false. During the subsequent igvn we can hit an assert depending on what order the barrier nodes are removed. 

If the entry to the gc barrier is removed first - the exit region node will have Parm-control as in(2). This is a sign that it is a barrier during teardown. I add a check for that in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262298](https://bugs.openjdk.java.net/browse/JDK-8262298): G1BarrierSetC2::step_over_gc_barrier fails with assert "bad barrier shape"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3029/head:pull/3029`
`$ git checkout pull/3029`

To update a local copy of the PR:
`$ git checkout pull/3029`
`$ git pull https://git.openjdk.java.net/jdk pull/3029/head`
