### PR TITLE
8263688: Coordinate equals, hashCode and compareTo of JavacFileManager.PathAndContainer

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1106,7 +1106,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
           PathAndContainer that = (PathAndContainer) o;
           return path.equals(that.path)
               && container.equals(that.container)
-              && index == this.index;
+              && index == that.index;
         }
 
         @Override


### PR DESCRIPTION
Please review this trivial change. Note that the change is not accompanied by a dedicated test. I don't think such a test would be warranted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263688](https://bugs.openjdk.java.net/browse/JDK-8263688): Coordinate equals, hashCode and compareTo of JavacFileManager.PathAndContainer


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3034/head:pull/3034`
`$ git checkout pull/3034`
