### PR TITLE
8263622: The java.awt.color.ICC_Profile#setData invert the order of bytes for the "head" tag

### DIFF
--- a/src/java.desktop/share/native/liblcms/LCMS.c
+++ b/src/java.desktop/share/native/liblcms/LCMS.c
@@ -726,18 +726,18 @@ static cmsBool _setHeaderInfo(cmsHPROFILE pf, jbyte* pBuffer, jint bufferSize)
   memcpy(&pfHeader, pBuffer, sizeof(cmsICCHeader));
 
   // now set header fields, which we can access using the lcms2 public API
-    cmsSetHeaderFlags(pf, _cmsAdjustEndianess32(pfHeader.flags));
-    cmsSetHeaderManufacturer(pf, _cmsAdjustEndianess32(pfHeader.manufacturer));
-    cmsSetHeaderModel(pf, _cmsAdjustEndianess32(pfHeader.model));
-    cmsUInt64Number attributes;
-    _cmsAdjustEndianess64(&attributes, &pfHeader.attributes);
-    cmsSetHeaderAttributes(pf, attributes);
-    cmsSetHeaderProfileID(pf, (cmsUInt8Number*)&(pfHeader.profileID));
-    cmsSetHeaderRenderingIntent(pf, _cmsAdjustEndianess32(pfHeader.renderingIntent));
-    cmsSetPCS(pf, _cmsAdjustEndianess32(pfHeader.pcs));
-    cmsSetColorSpace(pf, _cmsAdjustEndianess32(pfHeader.colorSpace));
-    cmsSetDeviceClass(pf, _cmsAdjustEndianess32(pfHeader.deviceClass));
-    cmsSetEncodedICCversion(pf, _cmsAdjustEndianess32(pfHeader.version));
+  cmsSetHeaderFlags(pf, _cmsAdjustEndianess32(pfHeader.flags));
+  cmsSetHeaderManufacturer(pf, _cmsAdjustEndianess32(pfHeader.manufacturer));
+  cmsSetHeaderModel(pf, _cmsAdjustEndianess32(pfHeader.model));
+  cmsUInt64Number attributes;
+  _cmsAdjustEndianess64(&attributes, &pfHeader.attributes);
+  cmsSetHeaderAttributes(pf, attributes);
+  cmsSetHeaderProfileID(pf, (cmsUInt8Number*)&(pfHeader.profileID));
+  cmsSetHeaderRenderingIntent(pf, _cmsAdjustEndianess32(pfHeader.renderingIntent));
+  cmsSetPCS(pf, _cmsAdjustEndianess32(pfHeader.pcs));
+  cmsSetColorSpace(pf, _cmsAdjustEndianess32(pfHeader.colorSpace));
+  cmsSetDeviceClass(pf, _cmsAdjustEndianess32(pfHeader.deviceClass));
+  cmsSetEncodedICCversion(pf, _cmsAdjustEndianess32(pfHeader.version));
 
   return TRUE;
 }

--- a/test/jdk/java/awt/color/ICC_Profile/SetHeaderInfo.java
+++ b/test/jdk/java/awt/color/ICC_Profile/SetHeaderInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.util.Arrays;
+
+/**
+ * @test
+ * @bug 8263622
+ * @summary The ICC_Profile#setData invert the order of bytes for the "head" tag
+ */
+public final class SetHeaderInfo {
+
+    public static void main(String[] args) {
+        int[] cspaces = {ColorSpace.CS_sRGB, ColorSpace.CS_LINEAR_RGB,
+                ColorSpace.CS_CIEXYZ, ColorSpace.CS_PYCC, ColorSpace.CS_GRAY};
+        for (int cspace : cspaces) {
+            testSame(ICC_Profile.getInstance(cspace));
+            testCustom(ICC_Profile.getInstance(cspace));
+        }
+    }
+
+    private static void testSame(ICC_Profile icc) {
+        byte[] expected = icc.getData(ICC_Profile.icSigHead);
+        icc.setData(ICC_Profile.icSigHead, expected);
+        byte[] actual = icc.getData(ICC_Profile.icSigHead);
+        if (!Arrays.equals(expected, actual)) {
+            System.err.println("Expected: " + Arrays.toString(expected));
+            System.err.println("Actual:   " + Arrays.toString(actual));
+            throw new RuntimeException();
+        }
+    }
+
+    private static void testCustom(ICC_Profile icc) {
+        byte[] expected = icc.getData(ICC_Profile.icSigHead);
+        expected[ICC_Profile.icHdrFlags + 3] = 1;
+        expected[ICC_Profile.icHdrModel + 3] = 1;
+        icc.setData(ICC_Profile.icSigHead, expected);
+        byte[] actual = icc.getData(ICC_Profile.icSigHead);
+        if (!Arrays.equals(expected, actual)) {
+            System.err.println("Expected: " + Arrays.toString(expected));
+            System.err.println("Actual:   " + Arrays.toString(actual));
+            throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
The root cause is using the wrong endian, the ICC profile uses big-endian notation. We even have special methods to convert the data, but for some reason, their usage was dropped in the JDK-6523398.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263622](https://bugs.openjdk.java.net/browse/JDK-8263622): The java.awt.color.ICC_Profile#setData invert the order of bytes for the "head" tag


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3037/head:pull/3037`
`$ git checkout pull/3037`

To update a local copy of the PR:
`$ git checkout pull/3037`
`$ git pull https://git.openjdk.java.net/jdk pull/3037/head`
