### PR TITLE
8254979: Class.getSimpleName() returns non-empty for lambda and method

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -779,10 +779,9 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     /**
-     * Returns {@code true} if and only if this class has the synthetic modifier
-     * bit set.
+     *{@return {@code true} if and only if this class has the synthetic modifier
+     * bit set}
      *
-     * @return {@code true} if and only if this class has the synthetic modifier bit set
      * @jls 13.1 The Form of a Binary
      * @jvms 4.1 The {@code ClassFile} Structure
      * @since 1.5
@@ -1620,12 +1619,15 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * Returns the simple name of the underlying class as given in the
-     * source code. Returns an empty string if the underlying class is
-     * anonymous.
+     * source code. An empty string is returned if the underlying class is
+     * {@linkplain #isAnonymousClass() anonymous}.
+     * A {@linkplain #isSynthetic() synthetic class}, one not present
+     * in source code, can have a non-empty name including special
+     * characters, such as "{@code $}".
      *
-     * <p>The simple name of an array is the simple name of the
+     * <p>The simple name of an {@linkplain isArray() array class} is the simple name of the
      * component type with "[]" appended.  In particular the simple
-     * name of an array whose component type is anonymous is "[]".
+     * name of an array class whose component type is anonymous is "[]".
      *
      * @return the simple name of the underlying class
      * @since 1.5


### PR DESCRIPTION
java.lang.Class has a number of methods to return some kind of textual token associated with the class, including a type name, canonical name, simple name, and separately the results of toString().

Bug 8254979 notes that getSimpleName mentions returning the name in source code, but operationally returns a non-null result for synthetic classes, ones without benefit of source code representation. Since it is useful to return a non-null result in such cases, I've updated the spec to mention this case. The names of synthetic classes are not covered by the JLS; using a "$" in such names is customary, but not strictly required. The synthetic classes used to implement lambdas and method references as cited in the bug report include "$"'s.

Looking over the other "getFooName" methods, I don't think they need to be updated to handle this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254979](https://bugs.openjdk.java.net/browse/JDK-8254979): Class.getSimpleName() returns non-empty for lambda and method


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3038/head:pull/3038`
`$ git checkout pull/3038`

To update a local copy of the PR:
`$ git checkout pull/3038`
`$ git pull https://git.openjdk.java.net/jdk pull/3038/head`
