### PR TITLE
8263705: Two shenandoah tests fail due to can't find ClassFileInstaller

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
@@ -52,7 +52,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -65,7 +65,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceShortcutCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceShortcutCycle.java
@@ -28,7 +28,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -41,7 +41,7 @@ package gc.shenandoah;
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @modules java.base
- * @run main ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI


### PR DESCRIPTION
Hi all,

gc/shenandoah/TestReferenceRefersToShenandoah.java and gc/shenandoah/TestReferenceShortcutCycle.java fail due to can't find ClassFileInstaller.
Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263705](https://bugs.openjdk.java.net/browse/JDK-8263705): Two shenandoah tests fail due to can't find ClassFileInstaller


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3039/head:pull/3039`
`$ git checkout pull/3039`
