### PR TITLE
8263707: C1 RangeCheckEliminator support constant array and NewMultiArray

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -247,11 +247,10 @@ void Canonicalizer::do_ArrayLength    (ArrayLength*     x) {
         (length = na->length()->as_Constant()) != NULL) {
       assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
       set_constant(length->type()->as_IntConstant()->value());
-    } else if ((nma = x->array()->as_NewMultiArray()) != NULL) {
-      if ((length = nma->dims()->at(0)->as_Constant()) != NULL) {
-        assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
-        set_constant(length->type()->as_IntConstant()->value());
-      }
+    } else if ((nma = x->array()->as_NewMultiArray()) != NULL &&
+               (length = nma->dims()->at(0)->as_Constant()) != NULL) {
+      assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
+      set_constant(length->type()->as_IntConstant()->value());
     }
 
   } else if ((ct = x->array()->as_Constant()) != NULL) {

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,10 +242,16 @@ void Canonicalizer::do_ArrayLength    (ArrayLength*     x) {
     // with same value Otherwise a Constant is live over multiple
     // blocks without being registered in a state array.
     Constant* length;
+    NewMultiArray* nma;
     if (na->length() != NULL &&
         (length = na->length()->as_Constant()) != NULL) {
       assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
       set_constant(length->type()->as_IntConstant()->value());
+    } else if ((nma = x->array()->as_NewMultiArray()) != NULL) {
+      if ((length = nma->dims()->at(0)->as_Constant()) != NULL) {
+        assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
+        set_constant(length->type()->as_IntConstant()->value());
+      }
     }
 
   } else if ((ct = x->array()->as_Constant()) != NULL) {

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -984,8 +984,10 @@ void GraphBuilder::load_indexed(BasicType type) {
   Value array = apop();
   Value length = NULL;
   if (CSEArrayLength ||
+      (array->as_Constant() != NULL) ||
       (array->as_AccessField() && array->as_AccessField()->field()->is_constant()) ||
-      (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant())) {
+      (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant()) ||
+      (array->as_NewMultiArray() && array->as_NewMultiArray()->dims()->at(0)->type()->is_constant())) {
     length = append(new ArrayLength(array, state_before));
   }
   push(as_ValueType(type), append(new LoadIndexed(array, index, length, type, state_before)));
@@ -1001,8 +1003,10 @@ void GraphBuilder::store_indexed(BasicType type) {
   Value array = apop();
   Value length = NULL;
   if (CSEArrayLength ||
+      (array->as_Constant() != NULL) ||
       (array->as_AccessField() && array->as_AccessField()->field()->is_constant()) ||
-      (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant())) {
+      (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant()) ||
+      (array->as_NewMultiArray() && array->as_NewMultiArray()->dims()->at(0)->type()->is_constant())) {
     length = append(new ArrayLength(array, state_before));
   }
   ciType* array_type = array->declared_type();

--- a/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
+++ b/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8263707
+ * @summary Test range check for constant array and NewMultiArray is removed properly
+ * @requires vm.debug == true & vm.compiler1.enabled
+ *
+ * @library /test/lib
+ * @run main/othervm compiler.c1.TestRangeCheckEliminated
+ *
+ * @author Hui Shi
+*/
+
+package compiler.c1;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestRangeCheckEliminated {
+    static final String eliminated = "can be fully eliminated";
+    public static void main(String[] args) throws Throwable {
+        boolean error = false;
+        String[] procArgs = new String[] {
+            "-XX:CompileCommand=compileonly,*test_constant_array::constant_array_rc",
+            "-XX:TieredStopAtLevel=1",
+            "-XX:+TraceRangeCheckElimination",
+            "-XX:-BackgroundCompilation",
+            "compiler.c1.TestRangeCheckEliminated$test_constant_array"
+            };
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
+        String output = new OutputAnalyzer(pb.start()).getOutput();
+        // should have 2 "can be fully eliminated"
+        System.out.println(output);
+        if ((output.split(eliminated, -1).length - 1) == 2) {
+            System.out.println("test_constant_array pass");
+        } else {
+            System.out.println("test_constant_array fail");
+            error = true;
+        }
+
+        procArgs = new String[] {
+            "-XX:CompileCommand=compileonly,*test_multi_constant_array::multi_constant_array_rc",
+            "-XX:TieredStopAtLevel=1",
+            "-XX:+TraceRangeCheckElimination",
+            "-XX:-BackgroundCompilation",
+            "compiler.c1.TestRangeCheckEliminated$test_multi_constant_array"
+            };
+
+        pb = ProcessTools.createJavaProcessBuilder(procArgs);
+        output = new OutputAnalyzer(pb.start()).getOutput();
+        // should have 1 "can be fully eliminated"
+        System.out.println(output);
+        if ((output.split(eliminated, -1).length - 1) == 1) {
+            System.out.println("test_multi_constant_array pass");
+        } else {
+            System.out.println("test_multi_constant_array fail");
+            error = true;
+        }
+
+        procArgs = new String[] {
+            "-XX:CompileCommand=compileonly,*test_multi_new_array::multi_new_array_rc",
+            "-XX:TieredStopAtLevel=1",
+            "-XX:+TraceRangeCheckElimination",
+            "-XX:-BackgroundCompilation",
+            "compiler.c1.TestRangeCheckEliminated$test_multi_new_array"
+            };
+
+        pb = ProcessTools.createJavaProcessBuilder(procArgs);
+        output = new OutputAnalyzer(pb.start()).getOutput();
+        // should have 2 "can be fully eliminated"
+        System.out.println(output);
+        if ((output.split(eliminated, -1).length - 1) == 2) {
+            System.out.println("test_multi_new_array pass");
+        } else {
+            System.out.println("test_multi_new_array fail");
+            error = true;
+        }
+
+        if (error) {
+            throw new InternalError();
+        }
+    }
+
+    public static class test_constant_array {
+        static final int constant_array[] =
+            {50,60,55,67,70,62,65,70,70,81,72,66,77,80,69};
+        static void constant_array_rc() {
+            constant_array[1] += 5;
+        }
+
+        public static void main(String[] args) {
+            for(int i = 0; i < 1_000; i++) {
+                constant_array_rc();
+            }
+        }
+    }
+
+    public static class test_multi_constant_array {
+        static final int constant_multi_array[][] = {
+            {50,60,55,67,70}, {62,65,70,70,81}, {72,66,77,80,69}};
+        static void multi_constant_array_rc() {
+            constant_multi_array[2][3] += 5;
+        }
+
+        public static void main(String[] args) {
+            for(int i = 0; i < 1_000; i++) {
+                multi_constant_array_rc();
+            }
+        }
+    }
+
+    public static class test_multi_new_array {
+        static void foo(int i) {}
+        static void multi_new_array_rc(int index) {
+            int na[] = new int[800];
+            int nma[][] = new int[600][2];
+            nma[20][1] += 5;   // optimize rc on NewMultiArray first dimension
+            nma[index][0] = 0; // index < 600 after this statement
+            foo(na[index]);    // index must < 800, remove rc
+        }
+
+        public static void main(String[] args) {
+            for(int i = 0; i < 600; i++) {
+                multi_new_array_rc(i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…rray

C1 misses range check elimination opportunities for constant and NewMultiArray with fixed length now. This patch adds constant length node for load/store Indexed node when array is constant array or allocated with NewMultiArray  and its first dimension length is constant.

Tested on linux x64 release/fastdebug with tier1 and tier2.

Regards
Hui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263707](https://bugs.openjdk.java.net/browse/JDK-8263707): C1 RangeCheckEliminator support constant array and NewMultiArray


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to c7d28819568042f47b85ff28150997d9632ca99c
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3041/head:pull/3041` \
`$ git checkout pull/3041`

Update a local copy of the PR: \
`$ git checkout pull/3041` \
`$ git pull https://git.openjdk.java.net/jdk pull/3041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3041`

View PR using the GUI difftool: \
`$ git pr show -t 3041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3041.diff">https://git.openjdk.java.net/jdk/pull/3041.diff</a>

</details>
