### PR TITLE
8263672: fatal error: no reachable node should have no use

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -182,14 +182,9 @@ Node *AddNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       addx->set_req(1, in(1));
       addx->set_req(2, add2->in(1));
       addx = phase->transform(addx);
-      set_req(1, addx);
-      set_req(2, a22);
+      set_req_X(1, addx, phase);
+      set_req_X(2, a22, phase);
       progress = this;
-      PhaseIterGVN* igvn = phase->is_IterGVN();
-      if (add2->outcnt() == 0 && igvn) {
-        // add disconnected.
-        igvn->_worklist.push(add2);
-      }
     }
   }
 


### PR DESCRIPTION
Follow up to 8263577 (C2: reachable nodes shouldn't have dead uses at
the end of optimizations), a case I missed where set_req needs to be
replaced by set_req_X.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263672](https://bugs.openjdk.java.net/browse/JDK-8263672): fatal error: no reachable node should have no use


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/3043/head:pull/3043`
`$ git checkout pull/3043`
