### PR TITLE
8263725: JFR oldobject tests are not run when GCs are specified explicitly

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestAllocationTime.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestAllocationTime.java
@@ -41,7 +41,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm  -XX:TLABSize=2k jdk.jfr.event.oldobject.TestAllocationTime

--- a/test/jdk/jdk/jfr/event/oldobject/TestArrayInformation.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestArrayInformation.java
@@ -40,7 +40,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestArrayInformation

--- a/test/jdk/jdk/jfr/event/oldobject/TestCircularReference.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestCircularReference.java
@@ -37,7 +37,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestCircularReference

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -42,7 +42,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
+ * @requires vm.gc != "Serial"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak

--- a/test/jdk/jdk/jfr/event/oldobject/TestFieldInformation.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestFieldInformation.java
@@ -42,7 +42,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k -Xlog:gc+tlab=trace jdk.jfr.event.oldobject.TestFieldInformation

--- a/test/jdk/jdk/jfr/event/oldobject/TestG1.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestG1.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
+ * @requires vm.gc.G1
  * @summary Test leak profiler with G1 GC
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test

--- a/test/jdk/jdk/jfr/event/oldobject/TestHeapDeep.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestHeapDeep.java
@@ -37,7 +37,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestHeapDeep

--- a/test/jdk/jdk/jfr/event/oldobject/TestHeapShallow.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestHeapShallow.java
@@ -36,7 +36,6 @@ import jdk.test.lib.jfr.EventNames;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestHeapShallow

--- a/test/jdk/jdk/jfr/event/oldobject/TestLargeRootSet.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestLargeRootSet.java
@@ -47,7 +47,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestLargeRootSet

--- a/test/jdk/jdk/jfr/event/oldobject/TestLastKnownHeapUsage.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestLastKnownHeapUsage.java
@@ -41,7 +41,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestLastKnownHeapUsage

--- a/test/jdk/jdk/jfr/event/oldobject/TestListenerLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestListenerLeak.java
@@ -38,7 +38,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestListenerLeak

--- a/test/jdk/jdk/jfr/event/oldobject/TestMetadataRetention.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestMetadataRetention.java
@@ -45,7 +45,6 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @test
  * @summary The test verifies that an old object sample maintains references to "stale" metadata
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @key jfr
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @library /test/lib /test/jdk

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectAge.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectAge.java
@@ -39,7 +39,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectAge

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -43,7 +43,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
+ * @requires vm.gc != "Z"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectDescription

--- a/test/jdk/jdk/jfr/event/oldobject/TestParallel.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestParallel.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
+ * @requires vm.gc.Parallel
  * @summary Test leak profiler with Parallel GC
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test

--- a/test/jdk/jdk/jfr/event/oldobject/TestReferenceChainLimit.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestReferenceChainLimit.java
@@ -36,7 +36,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestReferenceChainLimit

--- a/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
@@ -37,7 +37,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @summary Purpose of this test is to run leak profiler without command line tweaks or WhiteBox hacks until we succeed
  * @run main/othervm jdk.jfr.event.oldobject.TestSanityDefault

--- a/test/jdk/jdk/jfr/event/oldobject/TestSerial.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestSerial.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
+ * @requires vm.gc.Serial
  * @summary Test leak profiler with Serial GC
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test

--- a/test/jdk/jdk/jfr/event/oldobject/TestZ.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestZ.java
@@ -38,7 +38,6 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR & vm.gc.Z
- * @requires vm.gc == "null"
  * @summary Test leak profiler with ZGC
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test


### PR DESCRIPTION
The tests are tagged with @requires == "null", which has the effect that if you run with GC explicitly set, like:
make -C ../build/fastdebug test TEST=test/jdk/jdk/jfr/event/oldobject/TestZ.java JTREG="JAVA_OPTIONS=-XX:+UseG1GC"

then the tests won't run. The intention has probably been to only run the test with the default GC. I propose that we remove this and run the tests with other GCs as well. 

I've tested this locally with ZGC, G1, Parallel and Serial.

The following test doesn't work with ZGC and has been disabled for that GC:
test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java

The following test doesn't work with Serial and has been disabled for that GC
test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263725](https://bugs.openjdk.java.net/browse/JDK-8263725): JFR oldobject tests are not run when GCs are specified explicitly


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3046/head:pull/3046`
`$ git checkout pull/3046`

To update a local copy of the PR:
`$ git checkout pull/3046`
`$ git pull https://git.openjdk.java.net/jdk pull/3046/head`
