### PR TITLE
8262235: Remove unnecessary logic in hugetlbfs_sanity_check()

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3487,7 +3487,7 @@ bool os::Linux::hugetlbfs_sanity_check(bool warn, size_t page_size) {
   void *p = mmap(NULL, page_size, PROT_READ|PROT_WRITE, flags, -1, 0);
 
   if (p != MAP_FAILED) {
-    // Mapping succeede, sanity check passed.
+    // Mapping succeeded, sanity check passed.
     munmap(p, page_size);
     return true;
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3493,7 +3493,7 @@ bool os::Linux::hugetlbfs_sanity_check(bool warn, size_t page_size) {
   }
 
   if (warn) {
-    warning("HugeTLBFS is not supported or configured by the operating system.");
+    warning("HugeTLBFS is not configured or not supported by the operating system.");
   }
 
   return false;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3482,39 +3482,21 @@ int os::Linux::hugetlbfs_page_size_flag(size_t page_size) {
 }
 
 bool os::Linux::hugetlbfs_sanity_check(bool warn, size_t page_size) {
-  bool result = false;
-
   // Include the page size flag to ensure we sanity check the correct page size.
   int flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB | hugetlbfs_page_size_flag(page_size);
   void *p = mmap(NULL, page_size, PROT_READ|PROT_WRITE, flags, -1, 0);
 
   if (p != MAP_FAILED) {
-    // We don't know if this really is a huge page or not.
-    FILE *fp = fopen("/proc/self/maps", "r");
-    if (fp) {
-      while (!feof(fp)) {
-        char chars[257];
-        long x = 0;
-        if (fgets(chars, sizeof(chars), fp)) {
-          if (sscanf(chars, "%lx-%*x", &x) == 1
-              && x == (long)p) {
-            if (strstr (chars, "hugepage")) {
-              result = true;
-              break;
-            }
-          }
-        }
-      }
-      fclose(fp);
-    }
+    // Mapping succeede, sanity check passed.
     munmap(p, page_size);
+    return true;
   }
 
-  if (warn && !result) {
-    warning("HugeTLBFS is not supported by the operating system.");
+  if (warn) {
+    warning("HugeTLBFS is not supported or configured by the operating system.");
   }
 
-  return result;
+  return false;
 }
 
 bool os::Linux::shm_hugetlbfs_sanity_check(bool warn, size_t page_size) {


### PR DESCRIPTION
Please review this change that removes some additional verification not really needed when doing the sanity check for hugetlbfs-pages.

**Summary**
The call to `mmap` in `hugetlbfs_sanity_check()` will only succeed if it can satisfy the mapping using large pages. If this was not the case, we would have to double check all large page mappings not just this sanity check. So the reading of `/proc/self/maps` is safe to remove.

**Testing**
Sanity run through mach 5 and local testing with and without large pages configured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262235](https://bugs.openjdk.java.net/browse/JDK-8262235): Remove unnecessary logic in hugetlbfs_sanity_check()


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 2ef2316c91e8ff4b59f47b9e827d18de0e1e0fac
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3048/head:pull/3048`
`$ git checkout pull/3048`

To update a local copy of the PR:
`$ git checkout pull/3048`
`$ git pull https://git.openjdk.java.net/jdk pull/3048/head`
