### PR TITLE
8263732: ProblemList serviceability/sa/ClhsdbSymbol.java on ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -61,3 +61,4 @@ serviceability/sa/TestJmapCore.java                           8220624   generic-
 serviceability/sa/TestJmapCoreMetaspace.java                  8220624   generic-all
 serviceability/sa/TestSysProps.java                           8220624   generic-all
 serviceability/sa/sadebugd/DebugdConnectTest.java             8220624   generic-all
+serviceability/sa/ClhsdbSymbol.java                           8263730   generic-all


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/ClhsdbSymbol.java on ZGC in
order to reduce the noise in the JDK17 CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263732](https://bugs.openjdk.java.net/browse/JDK-8263732): ProblemList serviceability/sa/ClhsdbSymbol.java on ZGC


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3050/head:pull/3050`
`$ git checkout pull/3050`

To update a local copy of the PR:
`$ git checkout pull/3050`
`$ git pull https://git.openjdk.java.net/jdk pull/3050/head`
