### PR TITLE
8263742: (bf) MappedByteBuffer.force() should use the capacity as its upper bound

### DIFF
--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -232,9 +232,9 @@ public abstract class MappedByteBuffer
         if (fd == null) {
             return this;
         }
-        int limit = limit();
-        if (isSync || ((address != 0) && (limit != 0))) {
-            return force(0, limit);
+        int capacity = capacity();
+        if (isSync || ((address != 0) && (capacity != 0))) {
+            return force(0, capacity);
         }
         return this;
     }
@@ -267,11 +267,11 @@ public abstract class MappedByteBuffer
      * @param  index
      *         The index of the first byte in the buffer region that is
      *         to be written back to storage; must be non-negative
-     *         and less than limit()
+     *         and less than {@code capacity()}
      *
      * @param  length
      *         The length of the region in bytes; must be non-negative
-     *         and no larger than limit() - index
+     *         and no larger than {@code capacity() - index}
      *
      * @throws IndexOutOfBoundsException
      *         if the preconditions on the index and length do not
@@ -289,10 +289,10 @@ public abstract class MappedByteBuffer
         if (fd == null) {
             return this;
         }
-        int limit = limit();
-        if ((address != 0) && (limit != 0)) {
+        int capacity = capacity();
+        if ((address != 0) && (capacity != 0)) {
             // check inputs
-            Objects.checkFromIndexSize(index, length, limit);
+            Objects.checkFromIndexSize(index, length, capacity);
             SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
         }
         return this;


### PR DESCRIPTION
Prior to JDK 15, the method `java.nio.MappedByteBuffer.force()` wrote back the entire contents of the buffer, i.e., the half-open range `[0,capacity())`. In JDK 15 the upper bound of the write-back changed from `capacity()` to `limit()`. The change was inadvertent through a chain of fixes outlined in the description of the associated issue. This request is to change back to the previous behavior and use the capacity instead of the limit as the upper bound of the write-back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263742](https://bugs.openjdk.java.net/browse/JDK-8263742): (bf) MappedByteBuffer.force() should use the capacity as its upper bound


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3052/head:pull/3052`
`$ git checkout pull/3052`

To update a local copy of the PR:
`$ git checkout pull/3052`
`$ git pull https://git.openjdk.java.net/jdk pull/3052/head`
