### PR TITLE
8263743: redundant lock in SSLSocketImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1469,13 +1469,7 @@ public final class SSLSocketImpl
             }
 
             try {
-                Plaintext plainText;
-                socketLock.lock();
-                try {
-                    plainText = decode(buffer);
-                } finally {
-                    socketLock.unlock();
-                }
+                Plaintext plainText = decode(buffer);
                 if (plainText.contentType == ContentType.APPLICATION_DATA.id &&
                         buffer.position() > 0) {
                     return buffer;


### PR DESCRIPTION
Remove redundant lock in SSLSocketImpl.

In the SSLSocketImpl, there is a socket level lock while reading application data (see readApplicationRecord). 

```
                socketLock.lock(); 
                try { 
                    plainText = decode(buffer); 
                } finally { 
                    socketLock.unlock(); 
                } 
```
If an application data read is in progress, other calling to SSLSocket APIs (for example getUseClientMode() in a handshake complete listener) could be blocked if socket level locks are used. 

No new regression test.  Simple fix, hard to trigger the deadlock.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263743](https://bugs.openjdk.java.net/browse/JDK-8263743): redundant lock in SSLSocketImpl


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3053/head:pull/3053`
`$ git checkout pull/3053`

To update a local copy of the PR:
`$ git checkout pull/3053`
`$ git pull https://git.openjdk.java.net/jdk pull/3053/head`
