### PR TITLE
8263753: two new tests from JDK-8261671 fail with "Error. can not find ClassFileInstaller in test directory or libraries"

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
@@ -30,7 +30,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI compiler.intrinsics.bmi.TestBzhiI2L
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -29,7 +29,7 @@
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/bootclasspath/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+AbortVMOnCompilationFailure
  *      -XX:+IgnoreUnrecognizedVMOptions -XX:+UseBMI2Instructions
  *      compiler.intrinsics.bmi.verifycode.BzhiTestI2L


### PR DESCRIPTION
These new tests were not adapted to JDK-8263412 changes. The failure is the same as JDK-8263549.

Applied fix from JDK-8263549: "replaces ClassFileInstaller w/ jdk.test.lib.helpers.ClassFileInstaller in failing tests descriptions to ensure we won't get split testlibrary".

Tested tier1, hs-tier2 (where tests failed), running failing tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263753](https://bugs.openjdk.java.net/browse/JDK-8263753): two new tests from JDK-8261671 fail with "Error. can not find ClassFileInstaller in test directory or libraries"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3054/head:pull/3054`
`$ git checkout pull/3054`

To update a local copy of the PR:
`$ git checkout pull/3054`
`$ git pull https://git.openjdk.java.net/jdk pull/3054/head`
