### PR TITLE
8263439: getSupportedAttributeValues() throws NPE for Finishings attribute

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -569,6 +569,9 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                         Finishings[] fAll = (Finishings[])
                             (new ExtFinishing(100)).getAll();
                         for (int j=0; j<fAll.length; j++) {
+                            if (fAll[j] == null) {
+                                continue;
+                            }
                             if (finArray[i] == fAll[j].getValue()) {
                                 finSup[i] = fAll[j];
                                 break;

--- a/test/jdk/javax/print/attribute/AllSupportedValues/PrintValues.java
+++ b/test/jdk/javax/print/attribute/AllSupportedValues/PrintValues.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @key printer
+  @bug 4722616 8263439
+  @summary Verify no exception enumerating all attributes
+*/
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+
+public class PrintValues {
+
+    public static void main(String[] args) {
+
+        PrintService printer = PrintServiceLookup.lookupDefaultPrintService();
+        if (printer == null) {
+            System.out.println("No default printer configured. Cannot continue");
+            return;
+        }
+        Class[] categories = printer.getSupportedAttributeCategories();
+
+        for (int i=0; i<categories.length; i++) {
+            System.out.print("Class "+categories[i]);
+            System.out.print(' ');
+            Object value =
+                printer.getSupportedAttributeValues (categories[i], null, null);
+            if ((value != null) && (value.getClass().isArray())) {
+                Object[] v = (Object[])value;
+                for (int j=0; j<v.length; j++) {
+                    if (j > 0) {
+                        System.out.print(", ");
+                    }
+                    System.out.print(v[j]);
+                }
+            } else {
+                System.out.print(value);
+            }
+            System.out.println();
+        }
+    }
+}


### PR DESCRIPTION
This seems to be a code path that has has not been exercised.
We need to check for null values in the array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263439](https://bugs.openjdk.java.net/browse/JDK-8263439): getSupportedAttributeValues() throws NPE for Finishings attribute


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to c7b30e537feb5044ce62315e3b527de07b3215c3
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3055/head:pull/3055`
`$ git checkout pull/3055`

To update a local copy of the PR:
`$ git checkout pull/3055`
`$ git pull https://git.openjdk.java.net/jdk pull/3055/head`
