### PR TITLE
8263756: Fix ZGC ProblemList entry for serviceability/sa/ClhsdbSymbol.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -47,6 +47,7 @@ serviceability/sa/ClhsdbPrintStatics.java                     8220624   generic-
 serviceability/sa/ClhsdbPstack.java#id0                       8220624   generic-all
 serviceability/sa/ClhsdbPstack.java#id1                       8220624   generic-all
 serviceability/sa/ClhsdbSource.java                           8220624   generic-all
+serviceability/sa/ClhsdbSymbol.java                           8220624   generic-all
 serviceability/sa/ClhsdbThread.java                           8220624   generic-all
 serviceability/sa/ClhsdbWhere.java                            8220624   generic-all
 serviceability/sa/DeadlockDetectionTest.java                  8220624   generic-all
@@ -61,4 +62,3 @@ serviceability/sa/TestJmapCore.java                           8220624   generic-
 serviceability/sa/TestJmapCoreMetaspace.java                  8220624   generic-all
 serviceability/sa/TestSysProps.java                           8220624   generic-all
 serviceability/sa/sadebugd/DebugdConnectTest.java             8220624   generic-all
-serviceability/sa/ClhsdbSymbol.java                           8263730   generic-all


### PR DESCRIPTION
I'd like to push this as a trivial change. serviceability/sa/ClhsdbSymbol.java was problem listed with the wrong CR. This PR will correct that and also put the entry in sorted order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263756](https://bugs.openjdk.java.net/browse/JDK-8263756): Fix ZGC ProblemList entry for serviceability/sa/ClhsdbSymbol.java


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3056/head:pull/3056`
`$ git checkout pull/3056`

To update a local copy of the PR:
`$ git checkout pull/3056`
`$ git pull https://git.openjdk.java.net/jdk pull/3056/head`
