### PR TITLE
8262476: Add filter to speed up CompileCommand lookup

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -104,10 +104,10 @@ static bool any_set = false;
 // A filter for quick lookup if an option is set
 static bool option_filter[static_cast<int>(CompileCommand::Unknown) + 1] = { 0 };
 
-void filter_set(enum CompileCommand option) {
-  if (option == CompileCommand::Unknown) {
-    return;
-  }
+void command_set_in_filter(enum CompileCommand option) {
+  assert(option != CompileCommand::Unknown, "sanity");
+  assert(option2type(option) != OptionType::Unknown, "sanity");
+
   if ((option != CompileCommand::DontInline) &&
       (option != CompileCommand::Inline) &&
       (option != CompileCommand::Log)) {
@@ -116,7 +116,7 @@ void filter_set(enum CompileCommand option) {
   option_filter[static_cast<int>(option)] = true;
 }
 
-bool filter_check(enum CompileCommand option) {
+bool has_command(enum CompileCommand option) {
   return option_filter[static_cast<int>(option)];
 }
 
@@ -309,7 +309,7 @@ static void register_command(TypedMethodOptionMatcher* matcher,
   matcher->init(option, option_list);
   matcher->set_value<T>(value);
   option_list = matcher;
-  filter_set(option);
+  command_set_in_filter(option);
 
   if (!CompilerOracle::be_quiet()) {
     // Print out the successful registration of a compile command
@@ -323,7 +323,7 @@ static void register_command(TypedMethodOptionMatcher* matcher,
 template<typename T>
 bool CompilerOracle::has_option_value(const methodHandle& method, enum CompileCommand option, T& value) {
   assert(option_matches_type(option, value), "Value must match option type");
-  if (!filter_check(option)) {
+  if (!has_command(option)) {
     return false;
   }
   if (option_list != NULL) {
@@ -340,18 +340,6 @@ static bool check_predicate(enum CompileCommand option, const methodHandle& meth
   bool value = false;
   if (CompilerOracle::has_option_value(method, option, value)) {
     return value;
-  }
-  return false;
-}
-
-static bool has_command(enum CompileCommand option) {
-  TypedMethodOptionMatcher* m = option_list;
-  while (m != NULL) {
-    if (m->option() == option) {
-      return true;
-    } else {
-      m = m->next();
-    }
   }
   return false;
 }


### PR DESCRIPTION
This was reported as "Regression in class loading micro in 16-b27"

When adding Improving the CompileCommand flag in JDK-8256508 all commands was put in the same list (instead of an array of lists that would have been long and sparsely populated). Since commands are very uncommon that seemed like a reasonable thing - but I forgot about the JMH use case that adds a lot of inlining commands. With all commands in the same list, 1000 inlining commands will cause look-ups of all commands to take a lot of time.

This PR adds a filter so that we can quickly check if a command is present or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262476](https://bugs.openjdk.java.net/browse/JDK-8262476): Add filter to speed up CompileCommand lookup


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3057/head:pull/3057`
`$ git checkout pull/3057`

To update a local copy of the PR:
`$ git checkout pull/3057`
`$ git pull https://git.openjdk.java.net/jdk pull/3057/head`
