### PR TITLE
8252723: Run stack016.java also with C2-only

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack016.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack016.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@
  * @build nsk.share.Terminator
  * @run main/othervm/timeout=900 -Xint -Xss448K nsk.stress.stack.stack016 -eager
  * @run main/othervm/timeout=900 -Xcomp -Xss448K nsk.stress.stack.stack016 -eager
+ * @run main/othervm/timeout=900 -Xcomp -XX:-TieredCompilation -Xss448K nsk.stress.stack.stack016 -eager
  */
 
 package nsk.stress.stack;


### PR DESCRIPTION
Add C2-only execution, but don't enable all Xcomp modes. This test gets StackOverflowError twice and takes a while with all the Xcomp test options. There are other tests that exercise stack overflow in the -Xcomp modes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252723](https://bugs.openjdk.java.net/browse/JDK-8252723): Run stack016.java also with C2-only


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3058/head:pull/3058`
`$ git checkout pull/3058`

To update a local copy of the PR:
`$ git checkout pull/3058`
`$ git pull https://git.openjdk.java.net/jdk pull/3058/head`
