### PR TITLE
8263757: Remove serviceability/sa/ClhsdClasses.java from ZGC problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -29,7 +29,6 @@
 
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8220624   generic-all
 serviceability/sa/CDSJMapClstats.java                         8220624   generic-all
-serviceability/sa/ClhsdClasses.java                           8220624   generic-all
 serviceability/sa/ClhsdbDumpheap.java                         8220624   generic-all
 serviceability/sa/ClhsdbCDSJstackPrintAll.java                8220624   generic-all
 serviceability/sa/ClhsdbFindPC.java#id0                       8220624   generic-all


### PR DESCRIPTION
The test name has a typo (should be ClhsdbClasses - the 'b' is missing). Therefore it was not actually being excluded, and therefore it runs just fine with ZGC. This is expected since it is not a heap related test.

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263757](https://bugs.openjdk.java.net/browse/JDK-8263757): Remove serviceability/sa/ClhsdClasses.java from ZGC problem list


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3059/head:pull/3059`
`$ git checkout pull/3059`

To update a local copy of the PR:
`$ git checkout pull/3059`
`$ git pull https://git.openjdk.java.net/jdk pull/3059/head`
