### PR TITLE
8262083: vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001/TestDescription.java failed with "No notification: event JVMTI_EVENT_FRAME_POP (61)"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class setnotif001 {
         }
     }
 
-    native static void enableEv();
+    native static void enableEv(Thread notifyFramePopThread);
     native static int getRes();
 
     static int fld = 1;
@@ -55,7 +55,7 @@ public class setnotif001 {
     public static int run(String argv[], PrintStream ref) {
         setnotif001 t = new setnotif001();
         fld++;
-        enableEv();
+        enableEv(Thread.currentThread());
         t.meth();
         Thread thr = new Thread(new setnotif001a());
         thr.start();


### PR DESCRIPTION
The test requests NotifyFrame event from MethodEntry handler expecting that 1st MethodEntry event is generated for main thread.
The fix adds a check that the thread is correct and skips event from other threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262083](https://bugs.openjdk.java.net/browse/JDK-8262083): vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001/TestDescription.java failed with "No notification: event JVMTI_EVENT_FRAME_POP (61)"


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3060/head:pull/3060`
`$ git checkout pull/3060`

To update a local copy of the PR:
`$ git checkout pull/3060`
`$ git pull https://git.openjdk.java.net/jdk pull/3060/head`
