### PR TITLE
8263352: assert(use == polladr) failed: the use should be a safepoint polling

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3705,17 +3705,15 @@ bool PhaseIdealLoop::match_fill_loop(IdealLoopTree* lpt, Node*& store, Node*& st
           // In strip-mined counted loops, the CountedLoopNode may be
           // used by the address polling node of the outer safepoint.
           // Skip this use because it's safe.
-#ifdef ASSERT
           Node* sfpt = n->as_CountedLoop()->outer_safepoint();
           Node* polladr = sfpt->in(TypeFunc::Parms+0);
-          assert(use == polladr, "the use should be a safepoint polling");
-#endif
-          continue;
-        } else {
-          msg = "node is used outside loop";
-          msg_node = n;
-          break;
+          if (use == polladr) {
+            continue;
+          }
         }
+        msg = "node is used outside loop";
+        msg_node = n;
+        break;
       }
     }
   }

--- a/test/hotspot/jtreg/compiler/c2/Test8263352.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8263352.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8263352
+ * @summary assert(use == polladr) failed: the use should be a safepoint polling
+ * @requires vm.flavor == "server"
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+OptimizeFill Test8263352
+ *
+ */
+public class Test8263352 {
+
+    class Wrap {
+      public int value;
+      public Wrap(int v) {
+        value = v;
+      }
+    }
+
+    public static int size = 1024;
+    public static int[] ia = new int[size];
+
+    public static void main(String[] args) throws Exception {
+      Test8263352 m = new Test8263352();
+      m.test();
+    }
+
+    public void test() throws Exception {
+      for(int i = 0; i < 20_000; i++) {
+        Wrap obj = null;
+        if (i % 113 != 0) {
+          obj = new Wrap(i);
+        }
+        foo(obj);
+      }
+    }
+
+    public int foo(Wrap obj) throws Exception {
+        boolean condition = false;
+        int first = -1;
+
+        if (obj == null) {
+          condition = true;
+          first = 24;
+        }
+
+        for (int i = 0; i < size; i++) {
+            ia[i] = condition ? first : obj.value;
+        }
+        return 0;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestOptimizeFillWithStripMinedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOptimizeFillWithStripMinedLoop.java
@@ -27,10 +27,14 @@
  * @summary assert(use == polladr) failed: the use should be a safepoint polling
  * @requires vm.flavor == "server"
  *
- * @run main/othervm -XX:-BackgroundCompilation -XX:+OptimizeFill Test8263352
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+OptimizeFill
+ *                   compiler.loopopts.TestOptimizeFillWithStripMinedLoop
  *
  */
-public class Test8263352 {
+
+package compiler.loopopts;
+
+public class TestOptimizeFillWithStripMinedLoop {
 
     class Wrap {
       public int value;
@@ -43,7 +47,7 @@ public class Test8263352 {
     public static int[] ia = new int[size];
 
     public static void main(String[] args) throws Exception {
-      Test8263352 m = new Test8263352();
+      TestOptimizeFillWithStripMinedLoop m = new TestOptimizeFillWithStripMinedLoop();
       m.test();
     }
 


### PR DESCRIPTION
The main reason of this failure has been shown in JDK-8263352.
* JDK-8260637 makes a CastPP unpinned, so it can be pull out of inner loop
* JDK-8247307 assert use == polladr and makes it crash here.
* I think we can only `intrinsify_fill` the array when it is *really* safe here, so I fix this bug by `return` other cases.
In this patch, I will give a small test case called `Test8263352.java` to reproduct this failure.
Thanks to @vnkozlov , who found this failure for the first time (to me).
Thanks to  @nsjian，who found the case which can reproduct this failure everytime.
Thanks to @pfustc, who changed notes with us.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263352](https://bugs.openjdk.java.net/browse/JDK-8263352): assert(use == polladr) failed: the use should be a safepoint polling


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 7acd73d561af4d6095e4104ea6531c2df1037de7


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Wu Yan `<wuyan34@huawei.com>`

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3061/head:pull/3061`
`$ git checkout pull/3061`

To update a local copy of the PR:
`$ git checkout pull/3061`
`$ git pull https://git.openjdk.java.net/jdk pull/3061/head`
