### PR TITLE
8263709: Cleanup THREAD/TRAPS/CHECK usage in JRT_ENTRY routines 

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -45,10 +45,10 @@ class InterpreterRuntime: AllStatic {
 
  private:
 
-  static void      set_bcp_and_mdp(address bcp, JavaThread*thread);
-  static void      note_trap_inner(JavaThread* thread, int reason,
-                                   const methodHandle& trap_method, int trap_bci, TRAPS);
-  static void      note_trap(JavaThread *thread, int reason, TRAPS);
+  static void      set_bcp_and_mdp(address bcp, JavaThread* current);
+  static void      note_trap_inner(JavaThread* current, int reason,
+                                   const methodHandle& trap_method, int trap_bci);
+  static void      note_trap(JavaThread *current, int reason);
 
   // Inner work method for Interpreter's frequency counter overflow.
   static nmethod* frequency_counter_overflow_inner(JavaThread* thread, address branch_bcp);
@@ -150,7 +150,7 @@ class InterpreterRuntime: AllStatic {
   static uint64_t normalize_fast_native_fingerprint(uint64_t fingerprint);
 
   // Interpreter's frequency counter overflow
-  static nmethod* frequency_counter_overflow(JavaThread* thread, address branch_bcp);
+  static nmethod* frequency_counter_overflow(JavaThread* current, address branch_bcp);
 
   // Interpreter profiling support
   static jint    bcp_to_di(Method* method, address cur_bcp);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -576,7 +576,7 @@ MethodCounters* Method::build_method_counters(Method* m, TRAPS) {
   }
 
   if (LogTouchedMethods) {
-    mh->log_touched(CHECK_NULL);
+    mh->log_touched(THREAD);
   }
 
   return mh->method_counters();
@@ -2375,7 +2375,7 @@ public:
 static const int TOUCHED_METHOD_TABLE_SIZE = 20011;
 static TouchedMethodRecord** _touched_method_table = NULL;
 
-void Method::log_touched(TRAPS) {
+void Method::log_touched(Thread* current) {
 
   const int table_size = TOUCHED_METHOD_TABLE_SIZE;
   Symbol* my_class = klass_name();
@@ -2387,7 +2387,7 @@ void Method::log_touched(TRAPS) {
                       my_sig->identity_hash();
   juint index = juint(hash) % table_size;
 
-  MutexLocker ml(THREAD, TouchedMethodLog_lock);
+  MutexLocker ml(current, TouchedMethodLog_lock);
   if (_touched_method_table == NULL) {
     _touched_method_table = NEW_C_HEAP_ARRAY2(TouchedMethodRecord*, table_size,
                                               mtTracing, CURRENT_PC);

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -236,14 +236,14 @@ class Method : public Metadata {
       return mcs->number_of_breakpoints();
     }
   }
-  void incr_number_of_breakpoints(TRAPS)         {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void incr_number_of_breakpoints(Thread* current)         {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->incr_number_of_breakpoints();
     }
   }
-  void decr_number_of_breakpoints(TRAPS)         {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void decr_number_of_breakpoints(Thread* current)         {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->decr_number_of_breakpoints();
     }
@@ -292,8 +292,8 @@ class Method : public Metadata {
 
 #if COMPILER2_OR_JVMCI
   // Count of times method was exited via exception while interpreting
-  void interpreter_throwout_increment(TRAPS) {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void interpreter_throwout_increment(Thread* current) {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->interpreter_throwout_increment();
     }
@@ -685,7 +685,7 @@ public:
   }
   static int size(bool is_native);
   int size() const                               { return method_size(); }
-  void log_touched(TRAPS);
+  void log_touched(Thread* current);
   static void print_touched_methods(outputStream* out);
 
   // interpreter support
@@ -944,8 +944,9 @@ public:
   void print_made_not_compilable(int comp_level, bool is_osr, bool report, const char* reason);
 
  public:
-  MethodCounters* get_method_counters(TRAPS) {
+  MethodCounters* get_method_counters(Thread* current) {
     if (_method_counters == NULL) {
+      Thread* THREAD = current;
       build_method_counters(this, CHECK_AND_CLEAR_NULL);
     }
     return _method_counters;

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -52,9 +52,7 @@ class SharedRuntime: AllStatic {
   static bool resolve_sub_helper_internal(methodHandle callee_method, const frame& caller_frame,
                                           CompiledMethod* caller_nm, bool is_virtual, bool is_optimized,
                                           Handle receiver, CallInfo& call_info, Bytecodes::Code invoke_code, TRAPS);
-  static methodHandle resolve_sub_helper(JavaThread *thread,
-                                         bool is_virtual,
-                                         bool is_optimized, TRAPS);
+  static methodHandle resolve_sub_helper(bool is_virtual, bool is_optimized, TRAPS);
 
   // Shared stub locations
 
@@ -316,9 +314,7 @@ class SharedRuntime: AllStatic {
 
   // Resolves a call site- may patch in the destination of the call into the
   // compiled code.
-  static methodHandle resolve_helper(JavaThread *thread,
-                                     bool is_virtual,
-                                     bool is_optimized, TRAPS);
+  static methodHandle resolve_helper(bool is_virtual, bool is_optimized, TRAPS);
 
  private:
   // deopt blob
@@ -332,25 +328,23 @@ class SharedRuntime: AllStatic {
   static DeoptimizationBlob* deopt_blob(void)      { return _deopt_blob; }
 
   // Resets a call-site in compiled code so it will get resolved again.
-  static methodHandle reresolve_call_site(JavaThread *thread, TRAPS);
+  static methodHandle reresolve_call_site(TRAPS);
 
   // In the code prolog, if the klass comparison fails, the inline cache
   // misses and the call site is patched to megamorphic
-  static methodHandle handle_ic_miss_helper(JavaThread* thread, TRAPS);
+  static methodHandle handle_ic_miss_helper(TRAPS);
 
   // Find the method that called us.
-  static methodHandle find_callee_method(JavaThread* thread, TRAPS);
+  static methodHandle find_callee_method(TRAPS);
 
   static void monitor_enter_helper(oopDesc* obj, BasicLock* lock, JavaThread* thread);
 
   static void monitor_exit_helper(oopDesc* obj, BasicLock* lock, JavaThread* current);
 
  private:
-  static Handle find_callee_info(JavaThread* thread,
-                                 Bytecodes::Code& bc,
+  static Handle find_callee_info(Bytecodes::Code& bc,
                                  CallInfo& callinfo, TRAPS);
-  static Handle find_callee_info_helper(JavaThread* thread,
-                                        vframeStream& vfst,
+  static Handle find_callee_info_helper(vframeStream& vfst,
                                         Bytecodes::Code& bc,
                                         CallInfo& callinfo, TRAPS);
 


### PR DESCRIPTION
All JRT_ENTRY routines are required to have a parameter, "JavaThread* thread", which must be the current thread. The JRT_ENTRY, and related macros, then use this parameter and also expose it as THREAD for use with exception macros. But the fact "thread" is the current thread is lost in some routines and we see strange calls to other code that pass both "thread" and "THREAD" as distinct parameters - primarily when a TRAPS method is involved.

This should be cleaned up along with a general check on misuse of TRAPS/THREAD. 

Testing: tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263709](https://bugs.openjdk.java.net/browse/JDK-8263709): Cleanup THREAD/TRAPS/CHECK usage in JRT_ENTRY routines


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3062/head:pull/3062`
`$ git checkout pull/3062`

To update a local copy of the PR:
`$ git checkout pull/3062`
`$ git pull https://git.openjdk.java.net/jdk pull/3062/head`
