### PR TITLE
8263772: Typo in @implnote in java/awt/TrayIcon.java

### DIFF
--- a/src/java.desktop/share/classes/java/awt/TrayIcon.java
+++ b/src/java.desktop/share/classes/java/awt/TrayIcon.java
@@ -72,7 +72,7 @@ import java.security.AccessController;
  * SecurityException.
  *
  * <p>
- * @implnote
+ * @implNote
  * When the {@systemProperty apple.awt.enableTemplateImages} property is
  * set, all images associated with instances of this class are treated
  * as template images by the native desktop system. This means all color


### PR DESCRIPTION
@implNote tag is used to show Implementation Note but @implnote tag is used instead which does not show the corresponding sentence in javadoc. Rectified to use correct tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263772](https://bugs.openjdk.java.net/browse/JDK-8263772): Typo in @implnote in java/awt/TrayIcon.java


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3063/head:pull/3063`
`$ git checkout pull/3063`

To update a local copy of the PR:
`$ git checkout pull/3063`
`$ git pull https://git.openjdk.java.net/jdk pull/3063/head`
