### PR TITLE
8263768: JFormattedTextField.AbstractFormatter.getDocumentFilter()/getNavigationFilter() spec doesn't mention what the default impls return and what does it mean

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1091,7 +1091,7 @@ public class JFormattedTextField extends JTextField {
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
          *
-         * @implNote The default implementation returns <code>null</code>.
+         * @implSpec The default implementation returns <code>null</code>.
          *
          * @return DocumentFilter to restrict edits
          */
@@ -1105,7 +1105,7 @@ public class JFormattedTextField extends JTextField {
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
          *
-         * @implNote The default implementation returns <code>null</code>.
+         * @implSpec The default implementation returns <code>null</code>.
          *
          * @return NavigationFilter to restrict navigation
          */

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1086,11 +1086,12 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * @implNote Default implementation returns null.
          * Subclass must override if you wish to provide a
          * <code>DocumentFilter</code> to restrict what can be input.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
+         *
+         * @implNote The default implementation returns <code>null</code>.
          *
          * @return DocumentFilter to restrict edits
          */
@@ -1099,11 +1100,12 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * @implNote Default implementation returns null.
          * Subclass must override if you wish to provide a filter to restrict
          * where the user can navigate to.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
+         *
+         * @implNote The default implementation returns <code>null</code>
          *
          * @return NavigationFilter to restrict navigation
          */

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1086,7 +1086,7 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * Subclass must override if you wish to provide a
+         * Subclass and override if you wish to provide a
          * <code>DocumentFilter</code> to restrict what can be input.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
@@ -1100,12 +1100,12 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * Subclass must override if you wish to provide a filter to restrict
+         * Subclass and override if you wish to provide a filter to restrict
          * where the user can navigate to.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
          *
-         * @implNote The default implementation returns <code>null</code>
+         * @implNote The default implementation returns <code>null</code>.
          *
          * @return NavigationFilter to restrict navigation
          */

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1086,7 +1086,8 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * Subclass and override if you wish to provide a
+         * @implNote Default implementation returns null.
+         * Subclass must override if you wish to provide a
          * <code>DocumentFilter</code> to restrict what can be input.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.
@@ -1098,7 +1099,8 @@ public class JFormattedTextField extends JTextField {
         }
 
         /**
-         * Subclass and override if you wish to provide a filter to restrict
+         * @implNote Default implementation returns null.
+         * Subclass must override if you wish to provide a filter to restrict
          * where the user can navigate to.
          * <code>install</code> will install the returned value onto
          * the <code>JFormattedTextField</code>.


### PR DESCRIPTION
Default implementation of JFormattedTextField.AbstractFormatter.getDocumentFilter()/getNavigationFilter() returns null but it is not mentioned in the spec.
It is now explicitly mentioned in the spec by @impNote tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263768](https://bugs.openjdk.java.net/browse/JDK-8263768): JFormattedTextField.AbstractFormatter.getDocumentFilter()/getNavigationFilter() spec doesn't mention what the default impls return and what does it mean


### Reviewers
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer) ⚠️ Review applies to e2b547b20c0b53d9f1ae9030b394ddaf1a79af16
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to cea2f17151f82cf3612d42283febe78120f4eda0
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3064/head:pull/3064`
`$ git checkout pull/3064`

To update a local copy of the PR:
`$ git checkout pull/3064`
`$ git pull https://git.openjdk.java.net/jdk pull/3064/head`
