### PR TITLE
8263775: C2: igv_print() crash unexpectedly when called from debugger

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4797,7 +4797,7 @@ void Compile::igv_print_method_to_file(const char* phase_name, bool append) {
     _debug_file_printer->update_compiled_method(C->method());
   }
   tty->print_cr("Method %s to %s", append ? "appended" : "printed", file_name);
-  _debug_file_printer->print_method(phase_name, 0);
+  _debug_file_printer->print(phase_name, (Node*)C->root());
 }
 
 void Compile::igv_print_method_to_network(const char* phase_name) {
@@ -4807,7 +4807,7 @@ void Compile::igv_print_method_to_network(const char* phase_name) {
     _debug_network_printer->update_compiled_method(C->method());
   }
   tty->print_cr("Method printed over network stream to IGV");
-  _debug_network_printer->print_method(phase_name, 0);
+  _debug_network_printer->print(phase_name, (Node*)C->root());
 }
 #endif
 


### PR DESCRIPTION
When investigating another c2 crash, I found igv_print crashed unexpectedly when called from the debugger. The problem is no matter whether we have created an igv printer in `Compile::igv_print_method_to_file`:

https://github.com/openjdk/jdk/blob/444a80b920f7cb61b4607d9d245d410bf872b27f/src/hotspot/share/opto/compile.cpp#L4792-L4800

`Compile:: should_print`(called by `print_method()`) is not aware of _debug_file_printer, it would create a new one, and entering into unexpected network_stream initialization(See hs_err on JBS):

https://github.com/openjdk/jdk/blob/444a80b920f7cb61b4607d9d245d410bf872b27f/src/hotspot/share/opto/compile.hpp#L628-L638

For debugging purposes, we can skip checking should_print(), printing graph directly. (But even if applying this patch, igv_print can not work well since it seems produces an ill-formed ideal graph whose tags are not enclosed, thus can not be recognized by idealgraphvisualizer, this looks like a related by different fix, so I might create another PR to address this?)

Thanks!
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263775](https://bugs.openjdk.java.net/browse/JDK-8263775): C2: igv_print() crash unexpectedly when called from debugger


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3065/head:pull/3065`
`$ git checkout pull/3065`

To update a local copy of the PR:
`$ git checkout pull/3065`
`$ git pull https://git.openjdk.java.net/jdk pull/3065/head`
