### PR TITLE
8258753: StartTlsResponse.close() hangs due to synchronization issues

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1803,17 +1803,23 @@ public final class SSLSocketImpl
             SSLLogger.fine("wait for close_notify or alert");
         }
 
-        while (!conContext.isInboundClosed()) {
-            try {
-                Plaintext plainText = decode(null);
-                // discard and continue
-                if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.finest(
-                        "discard plaintext while waiting for close", plainText);
+        appInput.readLock.lock();
+        try {
+            while (!conContext.isInboundClosed()) {
+                try {
+                    Plaintext plainText = decode(null);
+                    // discard and continue
+                    if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+                        SSLLogger.finest(
+                                "discard plaintext while waiting for close",
+                                plainText);
+                    }
+                } catch (Exception e) {   // including RuntimeException
+                    handleException(e);
                 }
-            } catch (Exception e) {   // including RuntimeException
-                handleException(e);
             }
+        } finally {
+            appInput.readLock.unlock();
         }
     }
 }


### PR DESCRIPTION
**Scenario:**
1. Issue occurs in a muti-threaded environment where SSL socket read() and close() are invoked in parallel.
2. SSL socket read is already called.
2. close() calls waitForCloseNotify() -> decode() ->....-> socketRead0() to read the close_notify acknowledgment.
3. Since there is no synchronization between these read operations, the thread which had already invoked read(), reads the close_notify acknowledgment.
4. The thread (which calls waitForCloseNotify() -> read() ) waits indefinitely in socketRead0() and hangs.
5. Reproduced and tested the fix against a real time MS AD LDAP server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258753](https://bugs.openjdk.java.net/browse/JDK-8258753): StartTlsResponse.close() hangs due to synchronization issues


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3068/head:pull/3068`
`$ git checkout pull/3068`

To update a local copy of the PR:
`$ git checkout pull/3068`
`$ git pull https://git.openjdk.java.net/jdk pull/3068/head`
