### PR TITLE
8263432: javac may report an invalid package/class clash on case insensitive filesystems

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -669,6 +669,10 @@ public class Symtab {
     }
 
     public PackageSymbol lookupPackage(ModuleSymbol msym, Name flatName) {
+        return lookupPackage(msym, flatName, false);
+    }
+
+    private PackageSymbol lookupPackage(ModuleSymbol msym, Name flatName, boolean onlyExisting) {
         Assert.checkNonNull(msym);
 
         if (flatName.isEmpty()) {
@@ -691,7 +695,7 @@ public class Symtab {
 
         pack = getPackage(msym, flatName);
 
-        if (pack != null && pack.exists())
+        if ((pack != null && pack.exists()) || onlyExisting)
             return pack;
 
         boolean dependsOnUnnamed = msym.requires != null &&
@@ -763,7 +767,8 @@ public class Symtab {
      */
     public boolean packageExists(ModuleSymbol msym, Name fullname) {
         Assert.checkNonNull(msym);
-        return lookupPackage(msym, fullname).exists();
+        PackageSymbol pack = lookupPackage(msym, fullname, true);
+        return pack != null && pack.exists();
     }
 
     /** Make a package, given its fully qualified name.

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747 8236842 8254023
+ * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747 8236842 8254023 8263432
  * @summary Verify that annotation processing works.
  * @library /tools/lib
  * @modules
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -78,8 +79,10 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.ElementScanner14;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
@@ -2028,6 +2031,101 @@ public class AnnotationProcessing extends ModuleTestBase {
         if (!log.equals(expected)) {
             throw new AssertionError("Expected output not found.");
         }
+    }
+
+    @Test
+    public void testClassPhantomPackageClash(Path base) throws Exception {
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src,
+                          "module m {}",
+                          "package api; public class Nested {}",
+                          "package api.nested; public class C {}");
+
+        class TestFileManager extends ForwardingJavaFileManager<JavaFileManager>
+                              implements StandardJavaFileManager {
+
+            public TestFileManager(StandardJavaFileManager fileManager) {
+                super(fileManager);
+            }
+
+            @Override
+            public Iterable<JavaFileObject> list(Location location, String packageName, Set<JavaFileObject.Kind> kinds, boolean recurse) throws IOException {
+                if ("api.Nested".equals(packageName)) {
+                    //simulate case insensitive filesystem:
+                    packageName = "api.nested";
+                }
+                return super.list(location, packageName, kinds, recurse);
+            }
+
+            @Override
+            public void setLocationFromPaths(Location location, Collection<? extends Path> paths) throws IOException {
+                ((StandardJavaFileManager) fileManager).setLocationFromPaths(location, paths);
+            }
+
+            @Override
+            public Iterable<? extends Path> getLocationAsPaths(Location location) {
+                return ((StandardJavaFileManager) fileManager).getLocationAsPaths(location);
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(Iterable<? extends File> files) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void setLocation(Location location, Iterable<? extends File> files) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends File> getLocation(Location location) {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        try (StandardJavaFileManager fm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null);
+             JavaFileManager testFM = new TestFileManager(fm)) {
+            new JavacTask(tb)
+                .fileManager(testFM)
+                .options("-processor", NoOpTestAP.class.getName(),
+                         "-sourcepath", src.toString())
+                .outdir(classes)
+                .files(src.resolve("module-info.java"),
+                       src.resolve("api").resolve("Nested.java"))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDERR);
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class NoOpTestAP extends AbstractProcessor {
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+
     }
 
     private static void assertNonNull(String msg, Object val) {


### PR DESCRIPTION
To implement the package/class clash check as per JLS 7.1, javac creates "phantom" packages with the same names as the classes and checks if these packages exist (implemented as a check if it has seen a source or class file in the corresponding directory). Every package created (phantom or not) gets registered to its enclosing `ModuleSymbol`, and when `ModuleSymbol.getEnclosedElements()` is called, the package is completed (i.e. its directory is listed).

This can cause an invalid package/class clash error to be reported in specific cases if there is a package and a class with names differing only in letter cases (like `org.jruby.runtime.callsite` and `org.jruby.runtime.CallSite`). What happens here is: the phantom package for the `org.jruby.runtime.CallSite` package is created, the package/class clash check is performed and passes (no errors). Then annotation processing calls `ModuleSymbol.getEnclosedElements()`, the phantom package's directory (`org/jruby/runtime/CallSite`) is listed from the filesystem, and contains some source files, so appears non-empty/existing (due to the case insensitive filesystem, the content of `org/jruby/runtime/callsite` directory is listed in fact). Then another round of annotation processing happens, and the package/class clash check is performed again. This time, the package appears to exist, and hence the check fails.

The proposal here is to avoid creating of the phantom packages (and hence registering them into `ModuleSymbol`) for the package/class clash check. That should prevent listing the package with the wrong name unnecessarily/unintentionally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263432](https://bugs.openjdk.java.net/browse/JDK-8263432): javac may report an invalid package/class clash on case insensitive filesystems


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3069/head:pull/3069` \
`$ git checkout pull/3069`

Update a local copy of the PR: \
`$ git checkout pull/3069` \
`$ git pull https://git.openjdk.java.net/jdk pull/3069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3069`

View PR using the GUI difftool: \
`$ git pr show -t 3069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3069.diff">https://git.openjdk.java.net/jdk/pull/3069.diff</a>

</details>
