### PR TITLE
8263781: C2: Cannot hoist independent load above arraycopy

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -533,7 +533,8 @@ bool MemNode::detect_ptr_independence(Node* p1, AllocateNode* a1,
 // (a) can_see_stored_value=true  and ac must have set the value for this load or if
 // (b) can_see_stored_value=false and ac could have set the value for this load or if
 // (c) can_see_stored_value=false and ac cannot have set the value for this load.
-// In (c) also change the parameter mem to the memory input of ac.
+// In case (c) change the parameter mem to the memory input of ac to skip it
+// when searching stored value.
 // Otherwise return NULL.
 Node* LoadNode::find_previous_arraycopy(PhaseTransform* phase, Node* ld_alloc, Node*& mem, bool can_see_stored_value) const {
   ArrayCopyNode* ac = find_array_copy_clone(phase, ld_alloc, mem);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -528,8 +528,13 @@ bool MemNode::detect_ptr_independence(Node* p1, AllocateNode* a1,
 }
 
 
-// Find an arraycopy that must have set (can_see_stored_value=true) or
-// could have set (can_see_stored_value=false) the value for this load
+// Find an arraycopy ac that produces the memory state represented by parameter mem.
+// Return ac if
+// (a) can_see_stored_value=true  and ac must have set the value for this load or if
+// (b) can_see_stored_value=false and ac could have set the value for this load or if
+// (c) can_see_stored_value=false and ac cannot have set the value for this load.
+// In (c) also change the parameter mem to the memory input of ac.
+// Otherwise return NULL.
 Node* LoadNode::find_previous_arraycopy(PhaseTransform* phase, Node* ld_alloc, Node*& mem, bool can_see_stored_value) const {
   ArrayCopyNode* ac = find_array_copy_clone(phase, ld_alloc, mem);
   if (ac != NULL) {
@@ -554,6 +559,7 @@ Node* LoadNode::find_previous_arraycopy(PhaseTransform* phase, Node* ld_alloc, N
           }
           if (!can_see_stored_value) {
             mem = ac->in(TypeFunc::Memory);
+            return ac;
           }
         }
       }


### PR DESCRIPTION
This change adds the following comment to the method LoadNode::find_previous_arraycopy()

```
// Find an arraycopy ac that produces the memory state represented by parameter mem.
// Return ac if
// (a) can_see_stored_value=true  and ac must have set the value for this load or if
// (b) can_see_stored_value=false and ac could have set the value for this load or if
// (c) can_see_stored_value=false and ac cannot have set the value for this load.
// In (c) also change the parameter mem to the memory input of ac.
// Otherwise return NULL.
```

It also repairs case (c) to let it return ac again as this was lost in previous refactoring (see issue).

The fix passed our CI testing: JCK and JTREG, also in Xcomp mode, SPECjvm2008, SPECjbb2015, Renaissance Suite,
SAP specific tests with fastdebug and release builds on all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263781](https://bugs.openjdk.java.net/browse/JDK-8263781): C2: Cannot hoist independent load above arraycopy


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to d5507a8acec48755affd3a188774ce423cb103c5
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3070/head:pull/3070`
`$ git checkout pull/3070`

To update a local copy of the PR:
`$ git checkout pull/3070`
`$ git pull https://git.openjdk.java.net/jdk pull/3070/head`
