### PR TITLE
8263790: C2: new igv_print_immediately() for debugging purpose

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -649,6 +649,7 @@ class Compile : public Phase {
 
 #ifndef PRODUCT
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);
+  void igv_print_method_to_file_immediately(const char* phase_name = "Debug");
   void igv_print_method_to_network(const char* phase_name = "Debug");
   static IdealGraphPrinter* debug_file_printer() { return _debug_file_printer; }
   static IdealGraphPrinter* debug_network_printer() { return _debug_network_printer; }

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -88,7 +88,13 @@ IdealGraphPrinter *IdealGraphPrinter::printer() {
   return compiler_thread->ideal_graph_printer();
 }
 
-void IdealGraphPrinter::clean_up() {
+void IdealGraphPrinter::clean_up(IdealGraphPrinter* printer) {
+  // clean the given ones
+  if (printer != NULL) {
+    delete printer;
+    return;
+  }
+  // otherwise, clean all others
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread* p = jtiwh.next(); ) {
     if (p->is_Compiler_thread()) {
       CompilerThread* c = (CompilerThread*)p;

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -117,7 +117,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
 
  public:
   IdealGraphPrinter(Compile* compile, const char* file_name = NULL, bool append = false);
-  static void clean_up();
+  static void clean_up(IdealGraphPrinter* printer = NULL);
   static IdealGraphPrinter *printer();
 
   bool traverse_outs();


### PR DESCRIPTION
Add a new igv_print_immediately, it prints the current method immediately. This differs from other igv_print* methods, it creates a well-formed and complete ideal graph xml immediately, while others accomplish their ideal graph xml when VM exists (i.e. destructor of `IdealGraphPrinter::_xx_printer`). If VM crashes before VM exit, the ideal graph xml will be ill-formed, this is fairly a common case when debugging another crash.

Test manually!

Cheers,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263790](https://bugs.openjdk.java.net/browse/JDK-8263790): C2: new igv_print_immediately() for debugging purpose


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3071/head:pull/3071`
`$ git checkout pull/3071`

To update a local copy of the PR:
`$ git checkout pull/3071`
`$ git pull https://git.openjdk.java.net/jdk pull/3071/head`
