### PR TITLE
8263821: Remove unused MethodTypeForm canonicalization codes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -742,7 +742,7 @@ class MethodType
         MethodType wt = (MethodType)pt.wrapAlt;
         if (wt == null) {
             // fill in lazily
-            wt = MethodTypeForm.canonicalize(pt, MethodTypeForm.WRAP, MethodTypeForm.WRAP);
+            wt = MethodTypeForm.canonicalize(pt, MethodTypeForm.WRAP);
             assert(wt != null);
             pt.wrapAlt = wt;
         }
@@ -754,7 +754,7 @@ class MethodType
         MethodType uwt = (MethodType)wt.wrapAlt;
         if (uwt == null) {
             // fill in lazily
-            uwt = MethodTypeForm.canonicalize(wt, MethodTypeForm.UNWRAP, MethodTypeForm.UNWRAP);
+            uwt = MethodTypeForm.canonicalize(wt, MethodTypeForm.UNWRAP);
             if (uwt == null)
                 uwt = wt;    // type has no wrappers or prims at all
             wt.wrapAlt = uwt;

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -230,13 +230,8 @@ final class MethodTypeForm {
      * ERASE means change every reference to {@code Object}.
      * WRAP means convert primitives (including {@code void} to their
      * corresponding wrapper types.  UNWRAP means the reverse of WRAP.
-     * INTS means convert all non-void primitive types to int or long,
-     * according to size.  LONGS means convert all non-void primitives
-     * to long, regardless of size.  RAW_RETURN means convert a type
-     * (assumed to be a return type) to int if it is smaller than an int,
-     * or if it is void.
      */
-    public static final int ERASE = 1, WRAP = 2, UNWRAP = 3, INTS = 4, LONGS = 5, RAW_RETURN = 6;
+    public static final int ERASE = 1, WRAP = 2, UNWRAP = 3;
 
     /** Canonicalize the types in the given method type.
      * If any types change, intern the new type, and return it.
@@ -270,40 +265,11 @@ final class MethodTypeForm {
                     ct = Wrapper.asPrimitiveType(t);
                     if (ct != t)  return ct;
                     break;
-                case RAW_RETURN:
                 case ERASE:
                     return Object.class;
             }
-        } else if (t == void.class) {
-            // no change, usually
-            switch (how) {
-                case RAW_RETURN:
-                    return int.class;
-                case WRAP:
-                    return Void.class;
-            }
-        } else {
-            // non-void primitive
-            switch (how) {
-                case WRAP:
-                    return Wrapper.asWrapperType(t);
-                case INTS:
-                    if (t == int.class || t == long.class)
-                        return null;  // no change
-                    if (t == double.class)
-                        return long.class;
-                    return int.class;
-                case LONGS:
-                    if (t == long.class)
-                        return null;  // no change
-                    return long.class;
-                case RAW_RETURN:
-                    if (t == int.class || t == long.class ||
-                        t == float.class || t == double.class)
-                        return null;  // no change
-                    // everything else returns as an int
-                    return int.class;
-            }
+        } else if (how == WRAP) {
+            return Wrapper.asWrapperType(t);
         }
         // no change; return null to signify
         return null;

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -216,7 +216,7 @@ final class MethodTypeForm {
     }
 
     static MethodTypeForm findForm(MethodType mt) {
-        MethodType erased = canonicalize(mt, ERASE, ERASE);
+        MethodType erased = canonicalize(mt, ERASE);
         if (erased == null) {
             // It is already erased.  Make a new MethodTypeForm.
             return new MethodTypeForm(mt);
@@ -237,11 +237,11 @@ final class MethodTypeForm {
      * If any types change, intern the new type, and return it.
      * Otherwise return null.
      */
-    public static MethodType canonicalize(MethodType mt, int howRet, int howArgs) {
+    public static MethodType canonicalize(MethodType mt, int how) {
         Class<?>[] ptypes = mt.ptypes();
-        Class<?>[] ptypesCanonical = canonicalizeAll(ptypes, howArgs);
+        Class<?>[] ptypesCanonical = canonicalizeAll(ptypes, how);
         Class<?> rtype = mt.returnType();
-        Class<?> rtypeCanonical = canonicalize(rtype, howRet);
+        Class<?> rtypeCanonical = canonicalize(rtype, how);
         if (ptypesCanonical == null && rtypeCanonical == null) {
             // It is already canonical.
             return null;
@@ -256,13 +256,12 @@ final class MethodTypeForm {
      *  Return null if the type is already canonicalized.
      */
     static Class<?> canonicalize(Class<?> t, int how) {
-        Class<?> ct;
         if (t == Object.class) {
             // no change, ever
         } else if (!t.isPrimitive()) {
             switch (how) {
                 case UNWRAP:
-                    ct = Wrapper.asPrimitiveType(t);
+                    Class<?> ct = Wrapper.asPrimitiveType(t);
                     if (ct != t)  return ct;
                     break;
                 case ERASE:


### PR DESCRIPTION
MethodTypeForm.INTS, LONGS and RAW_RETURN are effectively unused. This removes these canonicalization codes and cleans up related code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263821](https://bugs.openjdk.java.net/browse/JDK-8263821): Remove unused MethodTypeForm canonicalization codes


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3075/head:pull/3075`
`$ git checkout pull/3075`

To update a local copy of the PR:
`$ git checkout pull/3075`
`$ git pull https://git.openjdk.java.net/jdk pull/3075/head`
