### PR TITLE
8263825: Remove unused and commented out member from NTLMException

### DIFF
--- a/src/java.base/share/classes/com/sun/security/ntlm/NTLMException.java
+++ b/src/java.base/share/classes/com/sun/security/ntlm/NTLMException.java
@@ -46,12 +46,6 @@ public final class NTLMException extends GeneralSecurityException {
     public static final int NO_DOMAIN_INFO = 2;
 
     /**
-     * If the domain provided by the client does not match the one received
-     * from server.
-     */
-    //public final static int DOMAIN_UNMATCH = 3;
-
-    /**
      * If the client name is not found on server's user database.
      */
     public static final int USER_UNKNOWN = 3;


### PR DESCRIPTION
Removed commented out value from `NTLMException`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263825](https://bugs.openjdk.java.net/browse/JDK-8263825): Remove unused and commented out member from NTLMException


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3076/head:pull/3076`
`$ git checkout pull/3076`

To update a local copy of the PR:
`$ git checkout pull/3076`
`$ git pull https://git.openjdk.java.net/jdk pull/3076/head`
