### PR TITLE
8261966: macOS M1: report in hs_err log if we are running x86 code in emulation mode (Rosetta)

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1401,10 +1401,10 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
       strncpy(machine, "", sizeof(machine));
   }
 
-  char emulated[16] = "\0";
+  const char* emulated = "";
 #ifdef __APPLE__
   if (VM_Version::is_cpu_emulated()) {
-    strcpy(emulated, " (EMULATED)");
+    emulated = " (EMULATED)";
   }
 #endif
   snprintf(buf, buflen, "\"%s\" %s%s %d MHz", model, machine, emulated, mhz);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1400,8 +1400,14 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   if (sysctl(mib_machine, 2, machine, &size, NULL, 0) < 0) {
       strncpy(machine, "", sizeof(machine));
   }
-
-  snprintf(buf, buflen, "%s %s %d MHz", model, machine, mhz);
+  
+  char emulated[16] = "\0";
+#ifdef __APPLE__
+  if (VM_Version::is_cpu_emulated()) {
+    strcpy(emulated, " (EMULATED)");
+  }
+#endif
+  snprintf(buf, buflen, "\"%s\" %s%s %d MHz", model, machine, emulated, mhz);
 }
 
 void os::print_memory_info(outputStream* st) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1400,7 +1400,7 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   if (sysctl(mib_machine, 2, machine, &size, NULL, 0) < 0) {
       strncpy(machine, "", sizeof(machine));
   }
-  
+
   char emulated[16] = "\0";
 #ifdef __APPLE__
   if (VM_Version::is_cpu_emulated()) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1054,7 +1054,13 @@ void os::print_summary_info(outputStream* st, char* buf, size_t buflen) {
   }
 #endif // PRODUCT
   get_summary_cpu_info(buf, buflen);
-  st->print("%s, ", buf);
+  st->print("%s", buf);
+#ifdef __APPLE__
+  if (VM_Version::is_cpu_emulated()) {
+    st->print(" (EMULATED)");
+  }
+#endif
+  st->print(", ");
   size_t mem = physical_memory()/G;
   if (mem == 0) {  // for low memory systems
     mem = physical_memory()/M;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1059,13 +1059,7 @@ void os::print_summary_info(outputStream* st, char* buf, size_t buflen) {
   }
 #endif // PRODUCT
   get_summary_cpu_info(buf, buflen);
-  st->print("%s", buf);
-#ifdef __APPLE__
-  if (VM_Version::is_cpu_emulated()) {
-    st->print(" (EMULATED)");
-  }
-#endif
-  st->print(", ");
+  st->print("%s, ", buf);
   size_t mem = physical_memory()/G;
   if (mem == 0) {  // for low memory systems
     mem = physical_memory()/M;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1033,6 +1033,11 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
 void os::print_cpu_info(outputStream* st, char* buf, size_t buflen) {
   // cpu
   st->print("CPU:");
+#ifdef __APPLE__
+   if (VM_Version::is_cpu_emulated()) {
+     st->print(" (EMULATED)");
+   }
+#endif
   st->print(" total %d", os::processor_count());
   // It's not safe to query number of active processors after crash
   // st->print("(active %d)", os::active_processor_count()); but we can


### PR DESCRIPTION
Please review this simple enhancement where we indicate in hs_err log file whether the CPU is being emulated. Right now the only use case is for Apple's M1 aarch64 running x64 code, i.e. "Rosetta" emulation.

This enhancement will insert `(EMULATED)` label in the **Host** and **CPU** section, ex:


`Host: Oracles-MacBook-Pro-16.local, MacBookPro16,1 x86_64 2600 MHz, 12 cores, 32G, Darwin 19.6.0, macOS 10.15.7 (19H114)`

becomes

`Host: Oracles-MacBook-Pro-16.local, "MacBookPro16,1" x86_64 (EMULATED) 2600 MHz, 12 cores, 32G, Darwin 19.6.0, macOS 10.15.7 (19H114)`

and

`CPU: total 12 (initial active 12) (6 cores per cpu, 2 threads per core) family 6 model 158 stepping 10 microcode 0xde, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, fma, vzeroupper, clflush, clflushopt
`

becomes

`CPU: (EMULATED) total 12 (initial active 12) (6 cores per cpu, 2 threads per core) family 6 model 158 stepping 10 microcode 0xde, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, fma, vzeroupper, clflush, clflushopt
`

I also took the opportunity here to fix the model name by adding **"** around it as Apple uses commas in the name, which makes it harder to parse the **Host** section, since we also use commas to delineate, ex: `MacBookPro16,1` becomes `"MacBookPro16,1"`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261966](https://bugs.openjdk.java.net/browse/JDK-8261966): macOS M1: report in hs_err log if we are running x86 code in emulation mode (Rosetta)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3077/head:pull/3077`
`$ git checkout pull/3077`

To update a local copy of the PR:
`$ git checkout pull/3077`
`$ git pull https://git.openjdk.java.net/jdk pull/3077/head`
