### PR TITLE
8263855: Use the blessed modifier order in java.management/naming

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
@@ -1720,53 +1720,53 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
     // Method IDs for doOperation
     //---------------------------
 
-    private final static int
+    private static final int
         ADD_NOTIFICATION_LISTENERS                              = 1;
-    private final static int
+    private static final int
         ADD_NOTIFICATION_LISTENER_OBJECTNAME                    = 2;
-    private final static int
+    private static final int
         CREATE_MBEAN                                            = 3;
-    private final static int
+    private static final int
         CREATE_MBEAN_PARAMS                                     = 4;
-    private final static int
+    private static final int
         CREATE_MBEAN_LOADER                                     = 5;
-    private final static int
+    private static final int
         CREATE_MBEAN_LOADER_PARAMS                              = 6;
-    private final static int
+    private static final int
         GET_ATTRIBUTE                                           = 7;
-    private final static int
+    private static final int
         GET_ATTRIBUTES                                          = 8;
-    private final static int
+    private static final int
         GET_DEFAULT_DOMAIN                                      = 9;
-    private final static int
+    private static final int
         GET_DOMAINS                                             = 10;
-    private final static int
+    private static final int
         GET_MBEAN_COUNT                                         = 11;
-    private final static int
+    private static final int
         GET_MBEAN_INFO                                          = 12;
-    private final static int
+    private static final int
         GET_OBJECT_INSTANCE                                     = 13;
-    private final static int
+    private static final int
         INVOKE                                                  = 14;
-    private final static int
+    private static final int
         IS_INSTANCE_OF                                          = 15;
-    private final static int
+    private static final int
         IS_REGISTERED                                           = 16;
-    private final static int
+    private static final int
         QUERY_MBEANS                                            = 17;
-    private final static int
+    private static final int
         QUERY_NAMES                                             = 18;
-    private final static int
+    private static final int
         REMOVE_NOTIFICATION_LISTENER                            = 19;
-    private final static int
+    private static final int
         REMOVE_NOTIFICATION_LISTENER_OBJECTNAME                 = 20;
-    private final static int
+    private static final int
         REMOVE_NOTIFICATION_LISTENER_OBJECTNAME_FILTER_HANDBACK = 21;
-    private final static int
+    private static final int
         SET_ATTRIBUTE                                           = 22;
-    private final static int
+    private static final int
         SET_ATTRIBUTES                                          = 23;
-    private final static int
+    private static final int
         UNREGISTER_MBEAN                                        = 24;
 
     // SERVER NOTIFICATION
@@ -1794,7 +1794,7 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
 
     private static final class CombinedClassLoader extends ClassLoader {
 
-        private final static class ClassLoaderWrapper extends ClassLoader {
+        private static final class ClassLoaderWrapper extends ClassLoader {
             ClassLoaderWrapper(ClassLoader cl) {
                 super(cl);
             }

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
@@ -855,6 +855,6 @@ public class RMIConnectorServer extends JMXConnectorServer {
     private static final int STOPPED = 2;
 
     private int state = CREATED;
-    private final static Set<RMIConnectorServer> openedServers =
+    private static final Set<RMIConnectorServer> openedServers =
             new HashSet<RMIConnectorServer>();
 }

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
@@ -1516,6 +1516,6 @@ public class DefaultMXBeanMappingFactory extends MXBeanMappingFactory {
         return rest;
     }
 
-    private final static Map<Type, Type> inProgress = newIdentityHashMap();
+    private static final Map<Type, Type> inProgress = newIdentityHashMap();
     // really an IdentityHashSet but that doesn't exist
 }

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/DescriptorCache.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/DescriptorCache.java
@@ -59,7 +59,7 @@ public class DescriptorCache {
         return get(ImmutableDescriptor.union(descriptors));
     }
 
-    private final static DescriptorCache instance = new DescriptorCache();
+    private static final DescriptorCache instance = new DescriptorCache();
     private final WeakHashMap<ImmutableDescriptor,
                               WeakReference<ImmutableDescriptor>>
         map = new WeakHashMap<ImmutableDescriptor,

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanAnalyzer.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanAnalyzer.java
@@ -225,7 +225,7 @@ class MBeanAnalyzer<M> {
                 return -1;
             return +1;      // could assert bret.isAssignableFrom(aret)
         }
-        public final static MethodOrder instance = new MethodOrder();
+        public static final MethodOrder instance = new MethodOrder();
     }
 
 

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
@@ -108,7 +108,7 @@ public class Repository {
     // Private methods --------------------------------------------->
 
     /* This class is used to match an ObjectName against a pattern. */
-    private final static class ObjectNamePattern {
+    private static final class ObjectNamePattern {
         private final String[] keys;
         private final String[] values;
         private final String   properties;

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ClientCommunicatorAdmin.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ClientCommunicatorAdmin.java
@@ -243,10 +243,10 @@ public abstract class ClientCommunicatorAdmin {
     private long period;
 
     // state
-    private final static int CONNECTED = 0;
-    private final static int RE_CONNECTING = 1;
-    private final static int FAILED = 2;
-    private final static int TERMINATED = 3;
+    private static final int CONNECTED = 0;
+    private static final int RE_CONNECTING = 1;
+    private static final int FAILED = 2;
+    private static final int TERMINATED = 3;
 
     private int state = CONNECTED;
 

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
@@ -485,7 +485,7 @@ public class ServerNotifForwarder {
     private final long connectionTimeout;
 
     private static int listenerCounter = 0;
-    private final static int[] listenerCounterLock = new int[0];
+    private static final int[] listenerCounterLock = new int[0];
 
     private NotificationBuffer notifBuffer;
     private final Map<ObjectName, Set<IdAndFilter>> listenerMap =

--- a/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java
@@ -398,7 +398,7 @@ public class MBeanServerFileAccessController
     }
 
     private static class Parser {
-        private final static int EOS = -1;  // pseudo-codepoint "end of string"
+        private static final int EOS = -1;  // pseudo-codepoint "end of string"
         static {
             assert !Character.isWhitespace(EOS);
         }

--- a/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -254,42 +254,42 @@ public class ManagementFactory {
      * String representation of the
      * {@code ObjectName} for the {@link ClassLoadingMXBean}.
      */
-    public final static String CLASS_LOADING_MXBEAN_NAME =
+    public static final String CLASS_LOADING_MXBEAN_NAME =
         "java.lang:type=ClassLoading";
 
     /**
      * String representation of the
      * {@code ObjectName} for the {@link CompilationMXBean}.
      */
-    public final static String COMPILATION_MXBEAN_NAME =
+    public static final String COMPILATION_MXBEAN_NAME =
         "java.lang:type=Compilation";
 
     /**
      * String representation of the
      * {@code ObjectName} for the {@link MemoryMXBean}.
      */
-    public final static String MEMORY_MXBEAN_NAME =
+    public static final String MEMORY_MXBEAN_NAME =
         "java.lang:type=Memory";
 
     /**
      * String representation of the
      * {@code ObjectName} for the {@link OperatingSystemMXBean}.
      */
-    public final static String OPERATING_SYSTEM_MXBEAN_NAME =
+    public static final String OPERATING_SYSTEM_MXBEAN_NAME =
         "java.lang:type=OperatingSystem";
 
     /**
      * String representation of the
      * {@code ObjectName} for the {@link RuntimeMXBean}.
      */
-    public final static String RUNTIME_MXBEAN_NAME =
+    public static final String RUNTIME_MXBEAN_NAME =
         "java.lang:type=Runtime";
 
     /**
      * String representation of the
      * {@code ObjectName} for the {@link ThreadMXBean}.
      */
-    public final static String THREAD_MXBEAN_NAME =
+    public static final String THREAD_MXBEAN_NAME =
         "java.lang:type=Threading";
 
     /**
@@ -299,7 +299,7 @@ public class ManagementFactory {
      * can be formed by appending this string with
      * "{@code ,name=}<i>collector's name</i>".
      */
-    public final static String GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE =
+    public static final String GARBAGE_COLLECTOR_MXBEAN_DOMAIN_TYPE =
         "java.lang:type=GarbageCollector";
 
     /**
@@ -309,7 +309,7 @@ public class ManagementFactory {
      * can be formed by appending this string with
      * "{@code ,name=}<i>manager's name</i>".
      */
-    public final static String MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE=
+    public static final String MEMORY_MANAGER_MXBEAN_DOMAIN_TYPE=
         "java.lang:type=MemoryManager";
 
     /**
@@ -319,7 +319,7 @@ public class ManagementFactory {
      * can be formed by appending this string with
      * {@code ,name=}<i>pool's name</i>.
      */
-    public final static String MEMORY_POOL_MXBEAN_DOMAIN_TYPE=
+    public static final String MEMORY_POOL_MXBEAN_DOMAIN_TYPE=
         "java.lang:type=MemoryPool";
 
     /**

--- a/src/java.management/share/classes/javax/management/MBeanServerPermission.java
+++ b/src/java.management/share/classes/javax/management/MBeanServerPermission.java
@@ -69,21 +69,21 @@ import java.util.StringTokenizer;
 public class MBeanServerPermission extends BasicPermission {
     private static final long serialVersionUID = -5661980843569388590L;
 
-    private final static int
+    private static final int
         CREATE = 0,
         FIND = 1,
         NEW = 2,
         RELEASE = 3,
         N_NAMES = 4;
 
-    private final static String[] names = {
+    private static final String[] names = {
         "createMBeanServer",
         "findMBeanServer",
         "newMBeanServer",
         "releaseMBeanServer",
     };
 
-    private final static int
+    private static final int
         CREATE_MASK = 1<<CREATE,
         FIND_MASK = 1<<FIND,
         NEW_MASK = 1<<NEW,
@@ -98,7 +98,7 @@ public class MBeanServerPermission extends BasicPermission {
      * permissions, we should consider doing this differently,
      * e.g. with a Map.
      */
-    private final static String[] canonicalNames = new String[1 << N_NAMES];
+    private static final String[] canonicalNames = new String[1 << N_NAMES];
 
     /*
      * The target names mask.  This is not private to avoid having to

--- a/src/java.management/share/classes/javax/management/NotificationBroadcasterSupport.java
+++ b/src/java.management/share/classes/javax/management/NotificationBroadcasterSupport.java
@@ -331,7 +331,7 @@ public class NotificationBroadcasterSupport implements NotificationEmitter {
     private final Executor executor;
     private final MBeanNotificationInfo[] notifInfo;
 
-    private final static Executor defaultExecutor = new Executor() {
+    private static final Executor defaultExecutor = new Executor() {
             // DirectExecutor using caller thread
             public void execute(Runnable r) {
                 r.run();

--- a/src/java.management/share/classes/javax/management/StandardMBean.java
+++ b/src/java.management/share/classes/javax/management/StandardMBean.java
@@ -125,7 +125,7 @@ import javax.management.openmbean.OpenMBeanParameterInfoSupport;
  */
 public class StandardMBean implements DynamicMBean, MBeanRegistration {
 
-    private final static DescriptorCache descriptors =
+    private static final DescriptorCache descriptors =
         DescriptorCache.getInstance(JMX.proof);
 
     /**

--- a/src/java.management/share/classes/javax/management/modelmbean/ModelMBeanAttributeInfo.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/ModelMBeanAttributeInfo.java
@@ -179,7 +179,7 @@ public class ModelMBeanAttributeInfo
          */
         private Descriptor attrDescriptor = validDescriptor(null);
 
-        private final static String currClass = "ModelMBeanAttributeInfo";
+        private static final String currClass = "ModelMBeanAttributeInfo";
 
         /**
          * Constructs a ModelMBeanAttributeInfo object with a default

--- a/src/java.management/share/classes/javax/management/modelmbean/ModelMBeanConstructorInfo.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/ModelMBeanConstructorInfo.java
@@ -151,7 +151,7 @@ public class ModelMBeanConstructorInfo
          */
         private Descriptor consDescriptor = validDescriptor(null);
 
-        private final static String currClass = "ModelMBeanConstructorInfo";
+        private static final String currClass = "ModelMBeanConstructorInfo";
 
 
         /**

--- a/src/java.management/share/classes/javax/management/modelmbean/RequiredModelMBean.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/RequiredModelMBean.java
@@ -142,7 +142,7 @@ public class RequiredModelMBean
     private boolean registered = false;
     private transient MBeanServer server = null;
 
-    private final static JavaSecurityAccess javaSecurityAccess = SharedSecrets.getJavaSecurityAccess();
+    private static final JavaSecurityAccess javaSecurityAccess = SharedSecrets.getJavaSecurityAccess();
     final private AccessControlContext acc = AccessController.getContext();
 
     /*************************************/

--- a/src/java.management/share/classes/javax/management/monitor/Monitor.java
+++ b/src/java.management/share/classes/javax/management/monitor/Monitor.java
@@ -253,7 +253,7 @@ public abstract class Monitor
      * automatically incremented when their size becomes greater than
      * their capacity.
      */
-    protected final static int capacityIncrement = 16;
+    protected static final int capacityIncrement = 16;
 
     /**
      * The number of valid components in the vector of observed objects.

--- a/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
@@ -727,11 +727,11 @@ public class JMXServiceURL implements Serializable {
         return i;
     }
 
-    private final static BitSet alphaBitSet = new BitSet(128);
-    private final static BitSet numericBitSet = new BitSet(128);
-    private final static BitSet alphaNumericBitSet = new BitSet(128);
-    private final static BitSet protocolBitSet = new BitSet(128);
-    private final static BitSet hostNameBitSet = new BitSet(128);
+    private static final BitSet alphaBitSet = new BitSet(128);
+    private static final BitSet numericBitSet = new BitSet(128);
+    private static final BitSet alphaNumericBitSet = new BitSet(128);
+    private static final BitSet protocolBitSet = new BitSet(128);
+    private static final BitSet hostNameBitSet = new BitSet(128);
     static {
         /* J2SE 1.4 adds lots of handy methods to BitSet that would
            allow us to simplify here, e.g. by not writing loops, but

--- a/src/java.management/share/classes/sun/management/HotspotInternal.java
+++ b/src/java.management/share/classes/sun/management/HotspotInternal.java
@@ -39,7 +39,7 @@ import javax.management.ObjectName;
 public class HotspotInternal
     implements HotspotInternalMBean, MBeanRegistration {
 
-    private final static String HOTSPOT_INTERNAL_MBEAN_NAME =
+    private static final String HOTSPOT_INTERNAL_MBEAN_NAME =
         "sun.management:type=HotspotInternal";
     private static ObjectName objName = Util.newObjectName(HOTSPOT_INTERNAL_MBEAN_NAME);
     private MBeanServer server = null;

--- a/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
+++ b/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
@@ -183,9 +183,9 @@ public class ManagementFactoryHelper {
     //
     static final class LoggingMXBeanAccess {
 
-        final static String LOG_MANAGER_CLASS_NAME = "java.util.logging.LogManager";
-        final static String LOGGING_MXBEAN_CLASS_NAME = "java.util.logging.LoggingMXBean";
-        final static Class<?> LOG_MANAGER_CLASS = loadLoggingClass(LOG_MANAGER_CLASS_NAME);
+        static final String LOG_MANAGER_CLASS_NAME = "java.util.logging.LogManager";
+        static final String LOGGING_MXBEAN_CLASS_NAME = "java.util.logging.LoggingMXBean";
+        static final Class<?> LOG_MANAGER_CLASS = loadLoggingClass(LOG_MANAGER_CLASS_NAME);
 
         static boolean isAvailable() {
             return LOG_MANAGER_CLASS != null;
@@ -355,7 +355,7 @@ public class ManagementFactoryHelper {
         return bufferPools;
     }
 
-    private final static String BUFFER_POOL_MXBEAN_NAME = "java.nio:type=BufferPool";
+    private static final String BUFFER_POOL_MXBEAN_NAME = "java.nio:type=BufferPool";
 
     /**
      * Creates management interface for the given buffer pool.
@@ -484,19 +484,19 @@ public class ManagementFactoryHelper {
         }
     }
 
-    private final static String HOTSPOT_CLASS_LOADING_MBEAN_NAME =
+    private static final String HOTSPOT_CLASS_LOADING_MBEAN_NAME =
         "sun.management:type=HotspotClassLoading";
 
-    private final static String HOTSPOT_COMPILATION_MBEAN_NAME =
+    private static final String HOTSPOT_COMPILATION_MBEAN_NAME =
         "sun.management:type=HotspotCompilation";
 
-    private final static String HOTSPOT_MEMORY_MBEAN_NAME =
+    private static final String HOTSPOT_MEMORY_MBEAN_NAME =
         "sun.management:type=HotspotMemory";
 
     private static final String HOTSPOT_RUNTIME_MBEAN_NAME =
         "sun.management:type=HotspotRuntime";
 
-    private final static String HOTSPOT_THREAD_MBEAN_NAME =
+    private static final String HOTSPOT_THREAD_MBEAN_NAME =
         "sun.management:type=HotspotThreading";
 
     static void registerInternalMBeans(MBeanServer mbs) {

--- a/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -104,13 +104,13 @@ class MemoryImpl extends NotificationEmitterSupport
     private native MemoryUsage getMemoryUsage0(boolean heap);
     private native void setVerboseGC(boolean value);
 
-    private final static String notifName =
+    private static final String notifName =
         "javax.management.Notification";
-    private final static String[] notifTypes = {
+    private static final String[] notifTypes = {
         MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED,
         MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED
     };
-    private final static String[] notifMsgs  = {
+    private static final String[] notifMsgs  = {
         "Memory usage exceeds usage threshold",
         "Memory usage exceeds collection usage threshold"
     };

--- a/src/java.management/share/classes/sun/management/counter/perf/PerfDataEntry.java
+++ b/src/java.management/share/classes/sun/management/counter/perf/PerfDataEntry.java
@@ -31,27 +31,27 @@ import java.io.UnsupportedEncodingException;
 
 class PerfDataEntry {
     private class EntryFieldOffset {
-        private final static int SIZEOF_BYTE = 1;
-        private final static int SIZEOF_INT  = 4;
-        private final static int SIZEOF_LONG = 8;
+        private static final int SIZEOF_BYTE = 1;
+        private static final int SIZEOF_INT  = 4;
+        private static final int SIZEOF_LONG = 8;
 
-        private final static int ENTRY_LENGTH_SIZE    = SIZEOF_INT;
-        private final static int NAME_OFFSET_SIZE     = SIZEOF_INT;
-        private final static int VECTOR_LENGTH_SIZE   = SIZEOF_INT;
-        private final static int DATA_TYPE_SIZE       = SIZEOF_BYTE;
-        private final static int FLAGS_SIZE           = SIZEOF_BYTE;
-        private final static int DATA_UNIT_SIZE       = SIZEOF_BYTE;
-        private final static int DATA_VAR_SIZE        = SIZEOF_BYTE;
-        private final static int DATA_OFFSET_SIZE     = SIZEOF_INT;
+        private static final int ENTRY_LENGTH_SIZE    = SIZEOF_INT;
+        private static final int NAME_OFFSET_SIZE     = SIZEOF_INT;
+        private static final int VECTOR_LENGTH_SIZE   = SIZEOF_INT;
+        private static final int DATA_TYPE_SIZE       = SIZEOF_BYTE;
+        private static final int FLAGS_SIZE           = SIZEOF_BYTE;
+        private static final int DATA_UNIT_SIZE       = SIZEOF_BYTE;
+        private static final int DATA_VAR_SIZE        = SIZEOF_BYTE;
+        private static final int DATA_OFFSET_SIZE     = SIZEOF_INT;
 
-        final static int ENTRY_LENGTH  = 0;
-        final static int NAME_OFFSET   = ENTRY_LENGTH + ENTRY_LENGTH_SIZE;
-        final static int VECTOR_LENGTH = NAME_OFFSET + NAME_OFFSET_SIZE;;
-        final static int DATA_TYPE     = VECTOR_LENGTH + VECTOR_LENGTH_SIZE;
-        final static int FLAGS         = DATA_TYPE + DATA_TYPE_SIZE;
-        final static int DATA_UNIT     = FLAGS + FLAGS_SIZE;
-        final static int DATA_VAR      = DATA_UNIT + DATA_UNIT_SIZE;
-        final static int DATA_OFFSET   = DATA_VAR + DATA_VAR_SIZE;
+        static final int ENTRY_LENGTH  = 0;
+        static final int NAME_OFFSET   = ENTRY_LENGTH + ENTRY_LENGTH_SIZE;
+        static final int VECTOR_LENGTH = NAME_OFFSET + NAME_OFFSET_SIZE;;
+        static final int DATA_TYPE     = VECTOR_LENGTH + VECTOR_LENGTH_SIZE;
+        static final int FLAGS         = DATA_TYPE + DATA_TYPE_SIZE;
+        static final int DATA_UNIT     = FLAGS + FLAGS_SIZE;
+        static final int DATA_VAR      = DATA_UNIT + DATA_UNIT_SIZE;
+        static final int DATA_OFFSET   = DATA_VAR + DATA_VAR_SIZE;
     }
 
     private String       name;

--- a/src/java.management/share/classes/sun/management/counter/perf/Prologue.java
+++ b/src/java.management/share/classes/sun/management/counter/perf/Prologue.java
@@ -30,39 +30,39 @@ import java.nio.*;
 
 class Prologue {
     // these constants should match their #define counterparts in vmdata.hpp
-    private final static byte PERFDATA_BIG_ENDIAN    = 0;
-    private final static byte PERFDATA_LITTLE_ENDIAN = 1;
-    private final static int  PERFDATA_MAGIC         = 0xcafec0c0;
+    private static final byte PERFDATA_BIG_ENDIAN    = 0;
+    private static final byte PERFDATA_LITTLE_ENDIAN = 1;
+    private static final int  PERFDATA_MAGIC         = 0xcafec0c0;
 
     private class PrologueFieldOffset {
-        private final static int SIZEOF_BYTE = 1;
-        private final static int SIZEOF_INT  = 4;
-        private final static int SIZEOF_LONG = 8;
+        private static final int SIZEOF_BYTE = 1;
+        private static final int SIZEOF_INT  = 4;
+        private static final int SIZEOF_LONG = 8;
 
-        private final static int MAGIC_SIZE            = SIZEOF_INT;
-        private final static int BYTE_ORDER_SIZE       = SIZEOF_BYTE;
-        private final static int MAJOR_SIZE            = SIZEOF_BYTE;
-        private final static int MINOR_SIZE            = SIZEOF_BYTE;
-        private final static int ACCESSIBLE_SIZE       = SIZEOF_BYTE;
-        private final static int USED_SIZE             = SIZEOF_INT;
-        private final static int OVERFLOW_SIZE         = SIZEOF_INT;
-        private final static int MOD_TIMESTAMP_SIZE    = SIZEOF_LONG;
-        private final static int ENTRY_OFFSET_SIZE     = SIZEOF_INT;
-        private final static int NUM_ENTRIES_SIZE      = SIZEOF_INT;
+        private static final int MAGIC_SIZE            = SIZEOF_INT;
+        private static final int BYTE_ORDER_SIZE       = SIZEOF_BYTE;
+        private static final int MAJOR_SIZE            = SIZEOF_BYTE;
+        private static final int MINOR_SIZE            = SIZEOF_BYTE;
+        private static final int ACCESSIBLE_SIZE       = SIZEOF_BYTE;
+        private static final int USED_SIZE             = SIZEOF_INT;
+        private static final int OVERFLOW_SIZE         = SIZEOF_INT;
+        private static final int MOD_TIMESTAMP_SIZE    = SIZEOF_LONG;
+        private static final int ENTRY_OFFSET_SIZE     = SIZEOF_INT;
+        private static final int NUM_ENTRIES_SIZE      = SIZEOF_INT;
 
         // these constants must match the field offsets and sizes
         // in the PerfDataPrologue structure in perfMemory.hpp
-        final static int MAGIC          = 0;
-        final static int BYTE_ORDER     = MAGIC + MAGIC_SIZE;
-        final static int MAJOR_VERSION  = BYTE_ORDER + BYTE_ORDER_SIZE;
-        final static int MINOR_VERSION  = MAJOR_VERSION + MAJOR_SIZE;
-        final static int ACCESSIBLE     = MINOR_VERSION + MINOR_SIZE;
-        final static int USED           = ACCESSIBLE + ACCESSIBLE_SIZE;
-        final static int OVERFLOW       = USED + USED_SIZE;
-        final static int MOD_TIMESTAMP  = OVERFLOW + OVERFLOW_SIZE;
-        final static int ENTRY_OFFSET   = MOD_TIMESTAMP + MOD_TIMESTAMP_SIZE;
-        final static int NUM_ENTRIES    = ENTRY_OFFSET + ENTRY_OFFSET_SIZE;
-        final static int PROLOGUE_2_0_SIZE = NUM_ENTRIES + NUM_ENTRIES_SIZE;
+        static final int MAGIC          = 0;
+        static final int BYTE_ORDER     = MAGIC + MAGIC_SIZE;
+        static final int MAJOR_VERSION  = BYTE_ORDER + BYTE_ORDER_SIZE;
+        static final int MINOR_VERSION  = MAJOR_VERSION + MAJOR_SIZE;
+        static final int ACCESSIBLE     = MINOR_VERSION + MINOR_SIZE;
+        static final int USED           = ACCESSIBLE + ACCESSIBLE_SIZE;
+        static final int OVERFLOW       = USED + USED_SIZE;
+        static final int MOD_TIMESTAMP  = OVERFLOW + OVERFLOW_SIZE;
+        static final int ENTRY_OFFSET   = MOD_TIMESTAMP + MOD_TIMESTAMP_SIZE;
+        static final int NUM_ENTRIES    = ENTRY_OFFSET + ENTRY_OFFSET_SIZE;
+        static final int PROLOGUE_2_0_SIZE = NUM_ENTRIES + NUM_ENTRIES_SIZE;
     }
 
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Ber.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Ber.java
@@ -93,14 +93,14 @@ public abstract class Ber {
 
     public static final int ASN_ENUMERATED      = 0x0a;
 
-    final static class EncodeException extends IOException {
+    static final class EncodeException extends IOException {
         private static final long serialVersionUID = -5247359637775781768L;
         EncodeException(String msg) {
             super(msg);
         }
     }
 
-    final static class DecodeException extends IOException {
+    static final class DecodeException extends IOException {
         private static final long serialVersionUID = 8735036969244425583L;
         DecodeException(String msg) {
             super(msg);

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ClientId.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ClientId.java
@@ -54,20 +54,20 @@ import javax.net.SocketFactory;
  * @author Rosanna Lee
  */
 class ClientId {
-    final private int version;
-    final private String hostname;
-    final private int port;
-    final private String protocol;
-    final private Control[] bindCtls;
-    final private OutputStream trace;
-    final private String socketFactory;
-    final private int myHash;
-    final private int ctlHash;
+    private final int version;
+    private final String hostname;
+    private final int port;
+    private final String protocol;
+    private final Control[] bindCtls;
+    private final OutputStream trace;
+    private final String socketFactory;
+    private final int myHash;
+    private final int ctlHash;
 
     private SocketFactory factory = null;
     private Method sockComparator = null;
     private boolean isDefaultSockFactory = false;
-    final public static boolean debug = false;
+    public static final boolean debug = false;
 
     ClientId(int version, String hostname, int port, String protocol,
             Control[] bindCtls, OutputStream trace, String socketFactory) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -123,13 +123,13 @@ public final class Connection implements Runnable {
     private static final int dump = 0; // > 0 r, > 1 rw
 
 
-    final private Thread worker;    // Initialized in constructor
+    private final Thread worker;    // Initialized in constructor
 
     private boolean v3 = true;       // Set in setV3()
 
-    final public String host;  // used by LdapClient for generating exception messages
+    public final String host;  // used by LdapClient for generating exception messages
                          // used by StartTlsResponse when creating an SSL socket
-    final public int port;     // used by LdapClient for generating exception messages
+    public final int port;     // used by LdapClient for generating exception messages
                          // used by StartTlsResponse when creating an SSL socket
 
     private boolean bound = false;   // Set in setBound()
@@ -153,7 +153,7 @@ public final class Connection implements Runnable {
 
     // For processing "disconnect" unsolicited notification
     // Initialized in constructor
-    final private LdapClient parent;
+    private final LdapClient parent;
 
     // Incremented and returned in sync getMsgId()
     private int outMsgId = 0;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/DigestClientId.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/DigestClientId.java
@@ -58,8 +58,8 @@ class DigestClientId extends SimpleClientId {
         "javax.security.sasl.policy.credentials",
     };
 
-    final private String[] propvals;
-    final private int myHash;
+    private final String[] propvals;
+    private final int myHash;
 
     DigestClientId(int version, String hostname, int port,
         String protocol, Control[] bindCtls, OutputStream trace,

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EntryChangeResponseControl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EntryChangeResponseControl.java
@@ -54,7 +54,7 @@ import javax.naming.directory.*;
  * @see com.sun.jndi.ldap.ctl.ResponseControlFactory ResponseControlFactory
  * @author Vincent Ryan
  */
-final public class EntryChangeResponseControl extends BasicControl {
+public final class EntryChangeResponseControl extends BasicControl {
 
     /**
      * The entry-change response control's assigned object identifier

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EventQueue.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EventQueue.java
@@ -45,7 +45,7 @@ import javax.naming.ldap.UnsolicitedNotificationListener;
  * @author      Rosanna Lee (modified for JNDI-related events)
  */
 final class EventQueue implements Runnable {
-    static final private boolean debug = false;
+    private static final boolean debug = false;
 
     private static class QueueElement {
         QueueElement next = null;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EventQueue.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EventQueue.java
@@ -45,7 +45,7 @@ import javax.naming.ldap.UnsolicitedNotificationListener;
  * @author      Rosanna Lee (modified for JNDI-related events)
  */
 final class EventQueue implements Runnable {
-    final static private boolean debug = false;
+    static final private boolean debug = false;
 
     private static class QueueElement {
         QueueElement next = null;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
@@ -113,7 +113,7 @@ import javax.naming.ldap.UnsolicitedNotification;
  * @author Rosanna Lee
  */
 final class EventSupport {
-    static final private boolean debug = false;
+    private static final boolean debug = false;
 
     private LdapCtx ctx;
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
@@ -113,7 +113,7 @@ import javax.naming.ldap.UnsolicitedNotification;
  * @author Rosanna Lee
  */
 final class EventSupport {
-    final static private boolean debug = false;
+    static final private boolean debug = false;
 
     private LdapCtx ctx;
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -118,8 +118,8 @@ public final class LdapClient implements PooledConnection {
     final Connection conn;  // Connection to server; has reader thread
                       // used by LdapCtx for StartTLS
 
-    final private PoolCallback pcb;
-    final private boolean pooled;
+    private final PoolCallback pcb;
+    private final boolean pooled;
     private boolean authenticateCalled = false;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
@@ -42,12 +42,12 @@ import com.sun.jndi.ldap.pool.PooledConnectionFactory;
  * @author Rosanna Lee
  */
 final class LdapClientFactory implements PooledConnectionFactory {
-    final private String host;
-    final private int port;
-    final private String socketFactory;
-    final private int connTimeout;
-    final private int readTimeout;
-    final private OutputStream trace;
+    private final String host;
+    private final int port;
+    private final String socketFactory;
+    private final int connTimeout;
+    private final int readTimeout;
+    private final OutputStream trace;
 
     LdapClientFactory(String host, int port, String socketFactory,
         int connTimeout, int readTimeout, OutputStream trace) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
@@ -102,7 +102,7 @@ final public class LdapCtx extends ComponentDirContext
     /*
      * Used to store arguments to the search method.
      */
-    final static class SearchArgs {
+    static final class SearchArgs {
         Name name;
         String filter;
         SearchControls cons;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
@@ -96,7 +96,7 @@ import com.sun.jndi.ldap.ext.StartTlsResponseImpl;
  * @author Rosanna Lee
  */
 
-final public class LdapCtx extends ComponentDirContext
+public final class LdapCtx extends ComponentDirContext
     implements EventDirContext, LdapContext {
 
     /*

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
@@ -42,7 +42,7 @@ final public class LdapCtxFactory implements ObjectFactory, InitialContextFactor
     /**
      * The type of each address in an LDAP reference.
      */
-    public final static String ADDRESS_TYPE = "URL";
+    public static final String ADDRESS_TYPE = "URL";
 
     // ----------------- ObjectFactory interface --------------------
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
@@ -38,7 +38,7 @@ import javax.naming.ldap.Control;
 
 import com.sun.jndi.url.ldap.ldapURLContextFactory;
 
-final public class LdapCtxFactory implements ObjectFactory, InitialContextFactory {
+public final class LdapCtxFactory implements ObjectFactory, InitialContextFactory {
     /**
      * The type of each address in an LDAP reference.
      */

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapReferralException.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapReferralException.java
@@ -64,7 +64,7 @@ import java.util.Vector;
   *
   * @author Vincent Ryan
   */
-final public class LdapReferralException extends
+public final class LdapReferralException extends
     javax.naming.ldap.LdapReferralException {
     private static final long serialVersionUID = 627059076356906399L;
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapRequest.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapRequest.java
@@ -34,9 +34,9 @@ import java.util.concurrent.TimeUnit;
 
 final class LdapRequest {
 
-    private final static BerDecoder EOF = new BerDecoder(new byte[]{}, -1, 0);
-    private final static String CLOSE_MSG = "LDAP connection has been closed";
-    private final static String TIMEOUT_MSG_FMT = "LDAP response read timed out, timeout used: %d ms.";
+    private static final BerDecoder EOF = new BerDecoder(new byte[]{}, -1, 0);
+    private static final String CLOSE_MSG = "LDAP connection has been closed";
+    private static final String TIMEOUT_MSG_FMT = "LDAP response read timed out, timeout used: %d ms.";
 
     LdapRequest next;   // Set/read in synchronized Connection methods
     final int msgId;          // read-only

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaCtx.java
@@ -386,7 +386,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         info.modifyAttributes(myEnv, mods);
     }
 
-    final static private class SchemaInfo {
+    static final private class SchemaInfo {
         private LdapCtx schemaEntry;
         private String schemaEntryName;
         LdapSchemaParser parser;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaCtx.java
@@ -43,7 +43,7 @@ import com.sun.jndi.toolkit.dir.HierMemDirCtx;
 
 final class LdapSchemaCtx extends HierMemDirCtx {
 
-    static private final boolean debug = false;
+    private static final boolean debug = false;
 
     private static final int LEAF = 0;  // schema object (e.g. attribute type defn)
     private static final int SCHEMA_ROOT = 1;   // schema tree root
@@ -96,7 +96,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
 
     // override to ignore obj and use attrs
     // treat same as createSubcontext
-    final public void bind(Name name, Object obj, Attributes attrs)
+    public final void bind(Name name, Object obj, Attributes attrs)
         throws NamingException {
         if (!setupMode) {
             if (obj != null) {
@@ -112,7 +112,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
             (LdapSchemaCtx)super.doCreateSubcontext(name, attrs);
     }
 
-    final protected void doBind(Name name, Object obj, Attributes attrs,
+    protected final void doBind(Name name, Object obj, Attributes attrs,
         boolean useFactory) throws NamingException {
         if (!setupMode) {
             throw new SchemaViolationException(
@@ -123,7 +123,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
     }
 
     // override to use bind() instead
-    final public void rebind(Name name, Object obj, Attributes attrs)
+    public final void rebind(Name name, Object obj, Attributes attrs)
         throws NamingException {
         try {
             doLookup(name, false);
@@ -134,7 +134,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         }
     }
 
-    final protected void doRebind(Name name, Object obj, Attributes attrs,
+    protected final void doRebind(Name name, Object obj, Attributes attrs,
         boolean useFactory) throws NamingException {
         if (!setupMode) {
             throw new SchemaViolationException(
@@ -144,7 +144,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         }
     }
 
-    final protected void doUnbind(Name name) throws NamingException {
+    protected final void doUnbind(Name name) throws NamingException {
         if (!setupMode) {
             // Update server
             try {
@@ -160,7 +160,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         super.doUnbind(name);
     }
 
-    final protected void doRename(Name oldname, Name newname)
+    protected final void doRename(Name oldname, Name newname)
         throws NamingException {
         if (!setupMode) {
             throw new SchemaViolationException("Cannot rename a schema object");
@@ -169,7 +169,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         }
     }
 
-    final protected void doDestroySubcontext(Name name) throws NamingException {
+    protected final void doDestroySubcontext(Name name) throws NamingException {
         if (!setupMode) {
             // Update server
             try {
@@ -203,7 +203,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
             }
     }
 
-    final protected DirContext doCreateSubcontext(Name name, Attributes attrs)
+    protected final DirContext doCreateSubcontext(Name name, Attributes attrs)
         throws NamingException {
 
         if (attrs == null || attrs.size() == 0) {
@@ -222,7 +222,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         return newEntry;
     }
 
-    final private static Attributes deepClone(Attributes orig)
+    private static final Attributes deepClone(Attributes orig)
         throws NamingException {
         BasicAttributes copy = new BasicAttributes(true);
         NamingEnumeration<? extends Attribute> attrs = orig.getAll();
@@ -232,7 +232,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         return copy;
     }
 
-    final protected void doModifyAttributes(ModificationItem[] mods)
+    protected final void doModifyAttributes(ModificationItem[] mods)
         throws NamingException {
         if (setupMode) {
             super.doModifyAttributes(mods);
@@ -253,13 +253,13 @@ final class LdapSchemaCtx extends HierMemDirCtx {
     // we override this so the superclass creates the right kind of contexts
     // Default is to create LEAF objects; caller will change after creation
     // if necessary
-    final protected HierMemDirCtx createNewCtx() {
+    protected final HierMemDirCtx createNewCtx() {
         LdapSchemaCtx ctx = new LdapSchemaCtx(LEAF, myEnv, info);
         return ctx;
     }
 
 
-    final private void addServerSchema(Attributes attrs)
+    private final void addServerSchema(Attributes attrs)
         throws NamingException {
         Attribute schemaAttr;
 
@@ -304,7 +304,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
       * on the server and there might not be any checks for extra spaces
       * or parens.
       */
-    final private void deleteServerSchema(Attributes origAttrs)
+    private final void deleteServerSchema(Attributes origAttrs)
         throws NamingException {
 
         Attribute origAttrVal;
@@ -347,7 +347,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
       * are eliminated. A modification is done by deleting the original
       * value and adding a new value with the modification.
       */
-    final private void modifyServerSchema(Attributes origAttrs,
+    private final void modifyServerSchema(Attributes origAttrs,
         Attributes newAttrs) throws NamingException {
 
         Attribute newAttrVal;
@@ -386,7 +386,7 @@ final class LdapSchemaCtx extends HierMemDirCtx {
         info.modifyAttributes(myEnv, mods);
     }
 
-    static final private class SchemaInfo {
+    private static final class SchemaInfo {
         private LdapCtx schemaEntry;
         private String schemaEntryName;
         LdapSchemaParser parser;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
@@ -108,7 +108,7 @@ final class LdapSchemaParser {
         this.netscapeBug = netscapeBug;
     }
 
-    final static void LDAP2JNDISchema(Attributes schemaAttrs,
+    static final void LDAP2JNDISchema(Attributes schemaAttrs,
         LdapSchemaCtx schemaRoot) throws NamingException {
         Attribute               objectClassesAttr = null;
         Attribute               attributeDefAttr = null;
@@ -477,7 +477,7 @@ final class LdapSchemaParser {
     * qdstringlist    = [ qdstring *( qdstring ) ]
     * qdstrings       = qdstring / ( whsp "(" qdstringlist ")" whsp )
     */
-    private final static String[] readQDStrings(String string, int[] pos)
+    private static final String[] readQDStrings(String string, int[] pos)
         throws NamingException {
 
         return readQDescrs(string, pos);

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
@@ -136,7 +136,7 @@ final class LdapSchemaParser {
         }
     }
 
-    final private static DirContext objectDescs2ClassDefs(Attribute objDescsAttr,
+    private static final DirContext objectDescs2ClassDefs(Attribute objDescsAttr,
                                                    LdapSchemaCtx schemaRoot)
         throws NamingException {
 
@@ -168,7 +168,7 @@ final class LdapSchemaParser {
         return classDefTree;
     }
 
-    final private static DirContext attrDescs2AttrDefs(Attribute attributeDescAttr,
+    private static final DirContext attrDescs2AttrDefs(Attribute attributeDescAttr,
                                                 LdapSchemaCtx schemaRoot)
         throws NamingException {
 
@@ -200,7 +200,7 @@ final class LdapSchemaParser {
         return attrDefTree;
     }
 
-    final private static DirContext syntaxDescs2SyntaxDefs(
+    private static final DirContext syntaxDescs2SyntaxDefs(
                                                 Attribute syntaxDescAttr,
                                                 LdapSchemaCtx schemaRoot)
         throws NamingException {
@@ -233,7 +233,7 @@ final class LdapSchemaParser {
         return syntaxDefTree;
     }
 
-    final private static DirContext matchRuleDescs2MatchRuleDefs(
+    private static final DirContext matchRuleDescs2MatchRuleDefs(
                                                 Attribute matchRuleDescAttr,
                                                 LdapSchemaCtx schemaRoot)
         throws NamingException {
@@ -266,7 +266,7 @@ final class LdapSchemaParser {
         return matchRuleDefTree;
     }
 
-    final private static Object[] desc2Def(String desc)
+    private static final Object[] desc2Def(String desc)
         throws NamingException {
             //System.err.println(desc);
 
@@ -302,7 +302,7 @@ final class LdapSchemaParser {
 
     // returns the index of the first whitespace char of a linear whitespace
     // sequence ending at the given position.
-    final private static int findTrailingWhitespace(String string, int pos) {
+    private static final int findTrailingWhitespace(String string, int pos) {
         for(int i = pos; i > 0; i--) {
             if(string.charAt(i) != WHSP) {
                 return i + 1;
@@ -311,7 +311,7 @@ final class LdapSchemaParser {
         return 0;
     }
 
-    final private static void skipWhitespace(String string, int[] pos) {
+    private static final void skipWhitespace(String string, int[] pos) {
         for(int i=pos[0]; i < string.length(); i++) {
             if(string.charAt(i) != WHSP) {
                 pos[0] = i;
@@ -323,7 +323,7 @@ final class LdapSchemaParser {
         }
     }
 
-    final private static Attribute readNumericOID(String string, int[] pos)
+    private static final Attribute readNumericOID(String string, int[] pos)
         throws NamingException {
 
         if (debug) {
@@ -350,7 +350,7 @@ final class LdapSchemaParser {
         return new BasicAttribute(NUMERICOID_ID, value);
     }
 
-    final private static Attribute readNextTag(String string, int[] pos)
+    private static final Attribute readNextTag(String string, int[] pos)
         throws NamingException {
 
         Attribute       attr = null;
@@ -393,7 +393,7 @@ final class LdapSchemaParser {
         return attr;
     }
 
-    final private static String[] readTag(String tag, String string, int[] pos)
+    private static final String[] readTag(String tag, String string, int[] pos)
         throws NamingException {
 
         if (debug) {
@@ -441,7 +441,7 @@ final class LdapSchemaParser {
         return readQDStrings(string, pos);
     }
 
-    final private static String[] readQDString(String string, int[] pos)
+    private static final String[] readQDString(String string, int[] pos)
         throws NamingException {
 
         int begin, end;
@@ -490,7 +490,7 @@ final class LdapSchemaParser {
      * qdescr          = whsp "'" descr "'" whsp
      * descr           = keystring
      */
-    final private static String[] readQDescrs(String string, int[] pos)
+    private static final String[] readQDescrs(String string, int[] pos)
         throws NamingException {
 
         if (debug) {
@@ -515,7 +515,7 @@ final class LdapSchemaParser {
      * qdescr          = whsp "'" descr "'" whsp
      * descr           = keystring
      */
-    final private static String[] readQDescrList(String string, int[] pos)
+    private static final String[] readQDescrList(String string, int[] pos)
         throws NamingException {
 
         int begin, end;
@@ -557,7 +557,7 @@ final class LdapSchemaParser {
         return answer;
     }
 
-    final private static String[] readWOID(String string, int[] pos)
+    private static final String[] readWOID(String string, int[] pos)
         throws NamingException {
 
         if (debug) {
@@ -595,7 +595,7 @@ final class LdapSchemaParser {
      * oids            = woid / ( "(" oidlist ")" )
      * oidlist         = woid *( "$" woid )
      */
-    final private static String[] readOIDs(String string, int[] pos)
+    private static final String[] readOIDs(String string, int[] pos)
         throws NamingException {
 
         if (debug) {
@@ -764,7 +764,7 @@ final class LdapSchemaParser {
       * Translate attributes that describe an object class into the
       * string description as defined in RFC 2252.
       */
-    final private String classDef2ObjectDesc(Attributes attrs)
+    private final String classDef2ObjectDesc(Attributes attrs)
         throws NamingException {
 
         StringBuilder objectDesc = new StringBuilder("( ");
@@ -876,7 +876,7 @@ final class LdapSchemaParser {
       * Translate attributes that describe an attribute definition into the
       * string description as defined in RFC 2252.
       */
-    final private String attrDef2AttrDesc(Attributes attrs)
+    private final String attrDef2AttrDesc(Attributes attrs)
         throws NamingException {
 
         StringBuilder attrDesc = new StringBuilder("( "); // opening parens
@@ -1009,7 +1009,7 @@ final class LdapSchemaParser {
       * Translate attributes that describe an attribute syntax definition into the
       * string description as defined in RFC 2252.
       */
-    final private String syntaxDef2SyntaxDesc(Attributes attrs)
+    private final String syntaxDef2SyntaxDesc(Attributes attrs)
         throws NamingException {
 
         StringBuilder syntaxDesc = new StringBuilder("( "); // opening parens
@@ -1065,7 +1065,7 @@ final class LdapSchemaParser {
       * Translate attributes that describe an attribute matching rule
       * definition into the string description as defined in RFC 2252.
       */
-    final private String matchRuleDef2MatchRuleDesc(Attributes attrs)
+    private final String matchRuleDef2MatchRuleDesc(Attributes attrs)
         throws NamingException {
 
         StringBuilder matchRuleDesc = new StringBuilder("( "); // opening parens
@@ -1141,7 +1141,7 @@ final class LdapSchemaParser {
         return matchRuleDesc.toString();
     }
 
-    final private String writeNumericOID(Attribute nOIDAttr)
+    private final String writeNumericOID(Attribute nOIDAttr)
         throws NamingException {
         if(nOIDAttr.size() != 1) {
             throw new InvalidAttributeValueException(
@@ -1150,7 +1150,7 @@ final class LdapSchemaParser {
         return (String)(nOIDAttr.get()) + WHSP;
     }
 
-    final private String writeWOID(Attribute attr) throws NamingException {
+    private final String writeWOID(Attribute attr) throws NamingException {
         if (netscapeBug)
             return writeQDString(attr);
         else
@@ -1158,7 +1158,7 @@ final class LdapSchemaParser {
     }
 
     /*  qdescr          = whsp "'" descr "'" whsp */
-    final private String writeQDString(Attribute qdStringAttr)
+    private final String writeQDString(Attribute qdStringAttr)
         throws NamingException {
         if(qdStringAttr.size() != 1) {
             throw new InvalidAttributeValueException(
@@ -1216,7 +1216,7 @@ final class LdapSchemaParser {
         return qdList.toString();
     }
 
-    final private String writeOIDs(Attribute oidsAttr)
+    private final String writeOIDs(Attribute oidsAttr)
         throws NamingException {
 
         switch(oidsAttr.size()) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapURL.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapURL.java
@@ -62,7 +62,7 @@ import com.sun.jndi.toolkit.url.UrlUtil;
  * This class also supports ldaps URLs.
  */
 
-final public class LdapURL extends Uri {
+public final class LdapURL extends Uri {
 
     private boolean useSsl = false;
     private String DN = null;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ManageReferralControl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ManageReferralControl.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  *
  * @author Vincent Ryan
  */
-final public class ManageReferralControl extends BasicControl {
+public final class ManageReferralControl extends BasicControl {
 
     /**
      * The manage referral control's assigned object identifier

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/NamingEventNotifier.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/NamingEventNotifier.java
@@ -48,7 +48,7 @@ import com.sun.jndi.toolkit.ctx.Continuation;
   * @author Rosanna Lee
   */
 final class NamingEventNotifier implements Runnable {
-    private final static boolean debug = false;
+    private static final boolean debug = false;
 
     private Vector<NamingListener> namingListeners;
     private Thread worker;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/PersistentSearchControl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/PersistentSearchControl.java
@@ -46,7 +46,7 @@ import java.io.IOException;
  * @see EntryChangeResponseControl
  * @author Vincent Ryan
  */
-final public class PersistentSearchControl extends BasicControl {
+public final class PersistentSearchControl extends BasicControl {
 
     /**
      * The persistent search control's assigned object identifier

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/SimpleClientId.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/SimpleClientId.java
@@ -37,9 +37,9 @@ import javax.naming.ldap.Control;
  * @author Rosanna Lee
  */
 class SimpleClientId extends ClientId {
-    final private String username;
-    final private Object passwd;
-    final private int myHash;
+    private final String username;
+    private final Object passwd;
+    private final int myHash;
 
     SimpleClientId(int version, String hostname, int port,
         String protocol, Control[] bindCtls, OutputStream trace,

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -60,7 +60,7 @@ import com.sun.jndi.ldap.Connection;
  * @see StartTlsRequest
  * @author Vincent Ryan
  */
-final public class StartTlsResponseImpl extends StartTlsResponse {
+public final class StartTlsResponseImpl extends StartTlsResponse {
 
     private static final boolean debug = false;
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
@@ -34,7 +34,7 @@ package com.sun.jndi.ldap.pool;
  * @author Rosanna Lee
  */
 final class ConnectionDesc {
-    private final static boolean debug = Pool.debug;
+    private static final boolean debug = Pool.debug;
 
     // Package private because used by Pool.showStats()
     static final byte BUSY = (byte)0;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
@@ -41,7 +41,7 @@ final class ConnectionDesc {
     static final byte IDLE = (byte)1;
     static final byte EXPIRED = (byte)2;
 
-    final private PooledConnection conn;
+    private final PooledConnection conn;
 
     private byte state = IDLE;  // initial state
     private long idleSince;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Connections.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Connections.java
@@ -68,9 +68,9 @@ final class Connections implements PoolCallback {
         com.sun.jndi.ldap.LdapPoolManager.trace;
     private static final int DEFAULT_SIZE = 10;
 
-    final private int maxSize;
-    final private int prefSize;
-    final private List<ConnectionDesc> conns;
+    private final int maxSize;
+    private final int prefSize;
+    private final List<ConnectionDesc> conns;
 
     private boolean closed = false;   // Closed for business
     private Reference<Object> ref; // maintains reference to id to prevent premature GC

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionsRef.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionsRef.java
@@ -46,7 +46,7 @@ package com.sun.jndi.ldap.pool;
  * when they are returned to the pool.
  */
 final class ConnectionsRef {
-    final private Connections conns;
+    private final Connections conns;
 
     ConnectionsRef(Connections conns) {
         this.conns = conns;

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
@@ -75,7 +75,7 @@ import javax.naming.NamingException;
  * @author Rosanna Lee
  */
 
-final public class Pool {
+public final class Pool {
 
     static final boolean debug = com.sun.jndi.ldap.LdapPoolManager.debug;
 
@@ -87,10 +87,10 @@ final public class Pool {
     private static final Collection<Reference<ConnectionsRef>> weakRefs =
         Collections.synchronizedList(new LinkedList<Reference<ConnectionsRef>>());
 
-    final private int maxSize;    // max num of identical conn per pool
-    final private int prefSize;   // preferred num of identical conn per pool
-    final private int initSize;   // initial number of identical conn to create
-    final private Map<Object, ConnectionsRef> map;
+    private final int maxSize;    // max num of identical conn per pool
+    private final int prefSize;   // preferred num of identical conn per pool
+    private final int initSize;   // initial number of identical conn to create
+    private final Map<Object, ConnectionsRef> map;
 
     public Pool(int initSize, int prefSize, int maxSize) {
         map = new WeakHashMap<>();

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PoolCleaner.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PoolCleaner.java
@@ -30,9 +30,9 @@ package com.sun.jndi.ldap.pool;
  *
  * @author Rosanna Lee
  */
-final public class PoolCleaner implements Runnable {
-    final private Pool[] pools;
-    final private long period;
+public final class PoolCleaner implements Runnable {
+    private final Pool[] pools;
+    private final long period;
 
     /**
      * @param period ms to wait between cleaning

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
@@ -51,7 +51,7 @@ import com.sun.jndi.ldap.sasl.TlsChannelBinding.TlsChannelBindingType;
   * @author Rosanna Lee
   */
 
-final public class LdapSasl {
+public final class LdapSasl {
     // SASL stuff
     private static final String SASL_CALLBACK = "java.naming.security.sasl.callback";
     private static final String SASL_AUTHZ_ID =

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/TlsChannelBinding.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/TlsChannelBinding.java
@@ -73,7 +73,7 @@ public class TlsChannelBinding {
             return name;
         }
 
-        final private String name;
+        private final String name;
         TlsChannelBindingType(String name) {
             this.name = name;
         }
@@ -98,8 +98,8 @@ public class TlsChannelBinding {
         return null;
     }
 
-    final private TlsChannelBindingType cbType;
-    final private byte[] cbData;
+    private final TlsChannelBindingType cbType;
+    private final byte[] cbData;
 
     /**
      * Construct tls-server-end-point Channel Binding data

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/dir/HierMemDirCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/dir/HierMemDirCtx.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 public class HierMemDirCtx implements DirContext {
 
-    static private final boolean debug = false;
+    private static final boolean debug = false;
     private static final NameParser defaultParser = new HierarchicalNameParser();
 
     protected Hashtable<String, Object> myEnv;

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/dir/LazySearchEnumerationImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/dir/LazySearchEnumerationImpl.java
@@ -47,7 +47,7 @@ import javax.naming.spi.DirectoryManager;
 import java.util.NoSuchElementException;
 import java.util.Hashtable;
 
-final public class LazySearchEnumerationImpl
+public final class LazySearchEnumerationImpl
         implements NamingEnumeration<SearchResult> {
     private NamingEnumeration<Binding> candidates;
     private SearchResult nextMatch = null;

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/GenericURLContext.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/GenericURLContext.java
@@ -47,7 +47,7 @@ import java.net.MalformedURLException;
  * @author Scott Seligman
  * @author Rosanna Lee
  */
-abstract public class GenericURLContext implements Context {
+public abstract class GenericURLContext implements Context {
     protected Hashtable<String, Object> myEnv = null;
 
     @SuppressWarnings("unchecked") // Expect Hashtable<String, Object>
@@ -76,7 +76,7 @@ abstract public class GenericURLContext implements Context {
       * getRootURLContext(), getURLPrefix(), and getURLSuffix()
       * must be in sync wrt how URLs are parsed and returned.
       */
-    abstract protected ResolveResult getRootURLContext(String url,
+    protected abstract ResolveResult getRootURLContext(String url,
         Hashtable<?,?> env) throws NamingException;
 
     /**

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/GenericURLDirContext.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/GenericURLDirContext.java
@@ -47,7 +47,7 @@ import java.util.Hashtable;
  * @author Rosanna Lee
  */
 
-abstract public class GenericURLDirContext extends GenericURLContext
+public abstract class GenericURLDirContext extends GenericURLContext
 implements DirContext {
 
     protected GenericURLDirContext(Hashtable<?,?> env) {

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/url/UrlUtil.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/url/UrlUtil.java
@@ -34,7 +34,7 @@ import java.net.URLDecoder;
  * @author Vincent Ryan
  */
 
-final public class UrlUtil {
+public final class UrlUtil {
 
     // To prevent creation of this static class
     private UrlUtil() {

--- a/src/java.naming/share/classes/com/sun/jndi/url/ldap/ldapURLContext.java
+++ b/src/java.naming/share/classes/com/sun/jndi/url/ldap/ldapURLContext.java
@@ -39,7 +39,7 @@ import com.sun.jndi.ldap.LdapURL;
  * @author Scott Seligman
  */
 
-final public class ldapURLContext
+public final class ldapURLContext
         extends com.sun.jndi.toolkit.url.GenericURLDirContext {
 
     ldapURLContext(Hashtable<?,?> env) {

--- a/src/java.naming/share/classes/com/sun/jndi/url/ldaps/ldapsURLContextFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/url/ldaps/ldapsURLContextFactory.java
@@ -33,5 +33,5 @@ import com.sun.jndi.url.ldap.*;
  * @author Vincent Ryan
  */
 
-final public class ldapsURLContextFactory extends ldapURLContextFactory {
+public final class ldapsURLContextFactory extends ldapURLContextFactory {
 }

--- a/src/java.naming/share/classes/com/sun/naming/internal/VersionHelper.java
+++ b/src/java.naming/share/classes/com/sun/naming/internal/VersionHelper.java
@@ -67,7 +67,7 @@ public final class VersionHelper {
         TRUST_URL_CODE_BASE = "true".equalsIgnoreCase(trust);
     }
 
-    final static String[] PROPS = new String[]{
+    static final String[] PROPS = new String[]{
         javax.naming.Context.INITIAL_CONTEXT_FACTORY,
         javax.naming.Context.OBJECT_FACTORIES,
         javax.naming.Context.URL_PKG_PREFIXES,
@@ -78,13 +78,13 @@ public final class VersionHelper {
         javax.naming.ldap.LdapContext.CONTROL_FACTORIES
     };
 
-    public final static int INITIAL_CONTEXT_FACTORY = 0;
-    public final static int OBJECT_FACTORIES = 1;
-    public final static int URL_PKG_PREFIXES = 2;
-    public final static int STATE_FACTORIES = 3;
-    public final static int PROVIDER_URL = 4;
-    public final static int DNS_URL = 5;
-    public final static int CONTROL_FACTORIES = 6;
+    public static final int INITIAL_CONTEXT_FACTORY = 0;
+    public static final int OBJECT_FACTORIES = 1;
+    public static final int URL_PKG_PREFIXES = 2;
+    public static final int STATE_FACTORIES = 3;
+    public static final int PROVIDER_URL = 4;
+    public static final int DNS_URL = 5;
+    public static final int CONTROL_FACTORIES = 6;
 
     private VersionHelper() {} // Disallow anyone from creating one of these.
 

--- a/src/java.naming/share/classes/javax/naming/directory/DirContext.java
+++ b/src/java.naming/share/classes/javax/naming/directory/DirContext.java
@@ -259,7 +259,7 @@ public interface DirContext extends Context {
      * @see ModificationItem
      * @see #modifyAttributes
      */
-    public final static int ADD_ATTRIBUTE = 1;
+    public static final int ADD_ATTRIBUTE = 1;
 
     /**
      * This constant specifies to replace an attribute with specified values.
@@ -278,7 +278,7 @@ public interface DirContext extends Context {
      * @see ModificationItem
      * @see #modifyAttributes
      */
-    public final static int REPLACE_ATTRIBUTE = 2;
+    public static final int REPLACE_ATTRIBUTE = 2;
 
     /**
      * This constant specifies to delete
@@ -299,7 +299,7 @@ public interface DirContext extends Context {
      * @see ModificationItem
      * @see #modifyAttributes
      */
-    public final static int REMOVE_ATTRIBUTE = 3;
+    public static final int REMOVE_ATTRIBUTE = 3;
 
     /**
      * Modifies the attributes associated with a named object.

--- a/src/java.naming/share/classes/javax/naming/directory/SearchControls.java
+++ b/src/java.naming/share/classes/javax/naming/directory/SearchControls.java
@@ -56,7 +56,7 @@ public class SearchControls implements java.io.Serializable {
      * <p>
      * The value of this constant is {@code 0}.
      */
-    public final static int OBJECT_SCOPE = 0;
+    public static final int OBJECT_SCOPE = 0;
 
     /**
      * Search one level of the named context.
@@ -70,7 +70,7 @@ public class SearchControls implements java.io.Serializable {
      * <p>
      * The value of this constant is {@code 1}.
      */
-    public final static int ONELEVEL_SCOPE = 1;
+    public static final int ONELEVEL_SCOPE = 1;
     /**
      * Search the entire subtree rooted at the named object.
      *<p>
@@ -92,7 +92,7 @@ public class SearchControls implements java.io.Serializable {
      * <p>
      * The value of this constant is {@code 2}.
      */
-    public final static int SUBTREE_SCOPE = 2;
+    public static final int SUBTREE_SCOPE = 2;
 
     /**
      * Contains the scope with which to apply the search. One of

--- a/src/java.naming/share/classes/javax/naming/event/EventContext.java
+++ b/src/java.naming/share/classes/javax/naming/event/EventContext.java
@@ -140,7 +140,7 @@ public interface EventContext extends Context {
      *<p>
      * The value of this constant is {@code 0}.
      */
-    public final static int OBJECT_SCOPE = 0;
+    public static final int OBJECT_SCOPE = 0;
 
     /**
      * Constant for expressing interest in events concerning objects
@@ -149,7 +149,7 @@ public interface EventContext extends Context {
      *<p>
      * The value of this constant is {@code 1}.
      */
-    public final static int ONELEVEL_SCOPE = 1;
+    public static final int ONELEVEL_SCOPE = 1;
 
     /**
      * Constant for expressing interest in events concerning objects
@@ -158,7 +158,7 @@ public interface EventContext extends Context {
      *<p>
      * The value of this constant is {@code 2}.
      */
-    public final static int SUBTREE_SCOPE = 2;
+    public static final int SUBTREE_SCOPE = 2;
 
 
     /**

--- a/src/java.naming/share/classes/javax/naming/ldap/ManageReferralControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/ManageReferralControl.java
@@ -39,7 +39,7 @@ package javax.naming.ldap;
  * @since 1.5
  * @author Vincent Ryan
  */
-final public class ManageReferralControl extends BasicControl {
+public final class ManageReferralControl extends BasicControl {
 
     /**
      * The ManageReferral control's assigned object identifier

--- a/src/java.naming/share/classes/javax/naming/ldap/PagedResultsControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/PagedResultsControl.java
@@ -110,7 +110,7 @@ import com.sun.jndi.ldap.BerEncoder;
  * @see PagedResultsResponseControl
  * @author Vincent Ryan
  */
-final public class PagedResultsControl extends BasicControl {
+public final class PagedResultsControl extends BasicControl {
 
     /**
      * The paged-results control's assigned object identifier

--- a/src/java.naming/share/classes/javax/naming/ldap/PagedResultsResponseControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/PagedResultsResponseControl.java
@@ -58,7 +58,7 @@ import com.sun.jndi.ldap.BerDecoder;
  * @see PagedResultsControl
  * @author Vincent Ryan
  */
-final public class PagedResultsResponseControl extends BasicControl {
+public final class PagedResultsResponseControl extends BasicControl {
 
     /**
      * The paged-results response control's assigned object identifier

--- a/src/java.naming/share/classes/javax/naming/ldap/SortControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/SortControl.java
@@ -106,7 +106,7 @@ import com.sun.jndi.ldap.BerEncoder;
  * @see SortResponseControl
  * @author Vincent Ryan
  */
-final public class SortControl extends BasicControl {
+public final class SortControl extends BasicControl {
 
     /**
      * The server-side sort control's assigned object identifier

--- a/src/java.naming/share/classes/javax/naming/ldap/SortResponseControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/SortResponseControl.java
@@ -77,7 +77,7 @@ import com.sun.jndi.ldap.LdapCtx;
  * @see SortControl
  * @author Vincent Ryan
  */
-final public class SortResponseControl extends BasicControl {
+public final class SortResponseControl extends BasicControl {
 
     /**
      * The server-side sort response control's assigned object identifier

--- a/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
@@ -229,7 +229,7 @@ public class StartTlsRequest implements ExtendedRequest {
         );
     }
 
-    private final static boolean privilegedHasNext(final Iterator<StartTlsResponse> iter) {
+    private static final boolean privilegedHasNext(final Iterator<StartTlsResponse> iter) {
         Boolean answer = AccessController.doPrivileged(
             new PrivilegedAction<Boolean>() {
             public Boolean run() {

--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
@@ -72,19 +72,19 @@ final class LDAPCertStoreImpl {
     private static final String ARL = "authorityRevocationList;binary";
 
     // Constants for various empty values
-    private final static String[] STRING0 = new String[0];
+    private static final String[] STRING0 = new String[0];
 
-    private final static byte[][] BB0 = new byte[0][];
+    private static final byte[][] BB0 = new byte[0][];
 
-    private final static Attributes EMPTY_ATTRIBUTES = new BasicAttributes();
+    private static final Attributes EMPTY_ATTRIBUTES = new BasicAttributes();
 
     // cache related constants
-    private final static int DEFAULT_CACHE_SIZE = 750;
-    private final static int DEFAULT_CACHE_LIFETIME = 30;
+    private static final int DEFAULT_CACHE_SIZE = 750;
+    private static final int DEFAULT_CACHE_LIFETIME = 30;
 
-    private final static int LIFETIME;
+    private static final int LIFETIME;
 
-    private final static String PROP_LIFETIME =
+    private static final String PROP_LIFETIME =
                             "sun.security.certpath.ldap.cache.lifetime";
 
     /*
@@ -92,7 +92,7 @@ final class LDAPCertStoreImpl {
      * JNDI application resource files lookup to prevent recursion issues
      * when validating signed JARs with LDAP URLs in certificates.
      */
-    private final static String PROP_DISABLE_APP_RESOURCE_FILES =
+    private static final String PROP_DISABLE_APP_RESOURCE_FILES =
         "sun.security.certpath.ldap.disable.app.resource.files";
 
     static {


### PR DESCRIPTION
As with #2993 changing the order of `final static` to `static final` for the `java.management`, `java.management.rmi` and `java.naming` modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263855](https://bugs.openjdk.java.net/browse/JDK-8263855): Use the blessed modifier order in java.management/naming


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3078/head:pull/3078`
`$ git checkout pull/3078`

To update a local copy of the PR:
`$ git checkout pull/3078`
`$ git pull https://git.openjdk.java.net/jdk pull/3078/head`
