### PR TITLE
8263832: Shenandoah: Fixing parallel thread iteration in final mark task

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -96,23 +96,19 @@ class ShenandoahSATBAndRemarkThreadsClosure : public ThreadClosure {
 private:
   SATBMarkQueueSet& _satb_qset;
   OopClosure* const _cl;
-  uintx _claim_token;
 
 public:
   ShenandoahSATBAndRemarkThreadsClosure(SATBMarkQueueSet& satb_qset, OopClosure* cl) :
     _satb_qset(satb_qset),
-    _cl(cl),
-    _claim_token(Threads::thread_claim_token()) {}
+    _cl(cl) {}
 
   void do_thread(Thread* thread) {
-    if (thread->claim_threads_do(true, _claim_token)) {
-      // Transfer any partial buffer to the qset for completed buffer processing.
-      _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
-      if (thread->is_Java_thread()) {
-        if (_cl != NULL) {
-          ResourceMark rm;
-          thread->oops_do(_cl, NULL);
-        }
+    // Transfer any partial buffer to the qset for completed buffer processing.
+    _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
+    if (thread->is_Java_thread()) {
+      if (_cl != NULL) {
+        ResourceMark rm;
+        thread->oops_do(_cl, NULL);
       }
     }
   }
@@ -147,7 +143,7 @@ public:
       ShenandoahMarkRefsClosure mark_cl(q, rp);
       ShenandoahSATBAndRemarkThreadsClosure tc(satb_mq_set,
                                                ShenandoahIUBarrier ? &mark_cl : NULL);
-      Threads::threads_do(&tc);
+      Threads::possibly_parallel_threads_do(true /*par*/, &tc);
     }
 
     _cm->mark_loop(worker_id, _terminator, rp,


### PR DESCRIPTION
Please review this trivial patch that parallelizes thread iteration in ShenandoahFinalMarkingTask

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263832](https://bugs.openjdk.java.net/browse/JDK-8263832): Shenandoah: Fixing parallel thread iteration in final mark task


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3080/head:pull/3080`
`$ git checkout pull/3080`

To update a local copy of the PR:
`$ git checkout pull/3080`
`$ git pull https://git.openjdk.java.net/jdk pull/3080/head`
