### PR TITLE
8263833: Stop disabling warnings for sunFont.c with gcc

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -506,12 +506,6 @@ endif
 
 LIBFONTMANAGER_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
 
-ifeq ($(TOOLCHAIN_TYPE), gcc)
-  # Turn off all warnings for sunFont.c. This is needed because the specific warning
-  # about discarding 'const' qualifier cannot be turned off individually.
-  BUILD_LIBFONTMANAGER_sunFont.c_CFLAGS := -w
-endif
-
 # LDFLAGS clarification:
 #   Filter relevant linker flags disallowing unresolved symbols as we cannot
 #   build-time decide to which library to link against (libawt_headless or


### PR DESCRIPTION
As per the bug report the code that was the reason for disabling warnings on this file was removed in November 2019
as part of https://bugs.openjdk.java.net/browse/JDK-8220231 so we can get rid of the need to disable warnings.

Longer history in the bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263833](https://bugs.openjdk.java.net/browse/JDK-8263833): Stop disabling warnings for sunFont.c with gcc


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3081/head:pull/3081`
`$ git checkout pull/3081`

To update a local copy of the PR:
`$ git checkout pull/3081`
`$ git pull https://git.openjdk.java.net/jdk pull/3081/head`
