### PR TITLE
8263763: Synthetic constructor parameters of enum are not considered for annotation indices

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -605,9 +605,14 @@ public final class Constructor<T> extends Executable {
     }
 
     @Override
-    boolean handleParameterNumberMismatch(int resultLength, int numParameters) {
+    boolean handleParameterNumberMismatch(int resultLength, Class<?>[] parameterTypes) {
+        int numParameters = parameterTypes.length;
         Class<?> declaringClass = getDeclaringClass();
-        if (declaringClass.isEnum() ||
+        if (declaringClass.isEnum()) {
+            return resultLength + 2 == numParameters &&
+                    parameterTypes[0] == String.class &&
+                    parameterTypes[1] == int.class;
+        } else if (
             declaringClass.isAnonymousClass() ||
             declaringClass.isLocalClass() )
             return false; // Can't do reliable parameter counting

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -566,17 +566,19 @@ public abstract class Executable extends AccessibleObject
         Annotation[][] result = parseParameterAnnotations(parameterAnnotations);
 
         if (result.length != numParameters &&
-            handleParameterNumberMismatch(result.length, numParameters)) {
-            Annotation[][] tmp = new Annotation[result.length+1][];
-            // Shift annotations down one to account for an implicit leading parameter
-            System.arraycopy(result, 0, tmp, 1, result.length);
-            tmp[0] = new Annotation[0];
+            handleParameterNumberMismatch(result.length, parameterTypes)) {
+            Annotation[][] tmp = new Annotation[numParameters][];
+            // Shift annotations down to account for any implicit leading parameters
+            System.arraycopy(result, 0, tmp, numParameters - result.length, result.length);
+            for (int i = 0; i < numParameters - result.length; i++) {
+                tmp[i] = new Annotation[0];
+            }
             result = tmp;
         }
         return result;
     }
 
-    abstract boolean handleParameterNumberMismatch(int resultLength, int numParameters);
+    abstract boolean handleParameterNumberMismatch(int resultLength, Class<?>[] parameterTypes);
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -761,7 +761,7 @@ public final class Method extends Executable {
     }
 
     @Override
-    boolean handleParameterNumberMismatch(int resultLength, int numParameters) {
+    boolean handleParameterNumberMismatch(int resultLength, Class<?>[] parameterTypes) {
         throw new AnnotationFormatError("Parameter annotations don't match number of parameters");
     }
 }

--- a/test/jdk/java/lang/annotation/EnumConstructorAnnotation.java
+++ b/test/jdk/java/lang/annotation/EnumConstructorAnnotation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8263763
+ * @summary Check that annotations on an enum constructor are indexed correctly.
+ */
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+
+public class EnumConstructorAnnotation {
+
+    public static void main(String[] args) {
+        Constructor<?> c = SampleEnum.class.getDeclaredConstructors()[0];
+        Annotation[] a1 = c.getParameters()[2].getAnnotations(), a2 = c.getParameterAnnotations()[2];
+        for (Annotation[] a : Arrays.asList(a1, a2)) {
+            if (a.length != 1) {
+                throw new RuntimeException("Unexpected length " + a.length);
+            } else if (a[0].annotationType() != SampleAnnotation.class) {
+                throw new RuntimeException("Unexpected type " + a[0]);
+            }
+        }
+    }
+
+    enum SampleEnum {
+        INSTANCE("foo");
+        SampleEnum(@SampleAnnotation String value) { }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SampleAnnotation { }
+}


### PR DESCRIPTION
8263763: The constructor of an enumeration prefixes with two synthetic arguments for constant name and ordinal index. For this reason, the constructor annotations need to be shifted two indices to the right, such that the annotation indices match with the parameter indices.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263763](https://bugs.openjdk.java.net/browse/JDK-8263763): Synthetic constructor parameters of enum are not considered for annotation indices


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to d50d5f4c13cf237dcd4742591911ca7439640362
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3082/head:pull/3082` \
`$ git checkout pull/3082`

Update a local copy of the PR: \
`$ git checkout pull/3082` \
`$ git pull https://git.openjdk.java.net/jdk pull/3082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3082`

View PR using the GUI difftool: \
`$ git pr show -t 3082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3082.diff">https://git.openjdk.java.net/jdk/pull/3082.diff</a>

</details>
