### PR TITLE
8263834: Work around gdb <incomplete type> for HashtableEntry

### DIFF
--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -42,7 +42,7 @@
 
 
 
-template <MEMFLAGS F> class BasicHashtableEntry : public CHeapObj<F> {
+template <MEMFLAGS F> class BasicHashtableEntry {
   friend class VMStructs;
 private:
   unsigned int         _hash;           // 32-bit hash for item


### PR DESCRIPTION
Please review this one liner to work around a gdb bug in printing subtypes of `HashtableEntry`:

```
(gdb) p this
$1 = (const PlaceholderEntry * const) 0x7ffff0242a30
(gdb) p *this
$2 = <incomplete type>
(gdb) ptype this
type = const class PlaceholderEntry {
    <incomplete type>
} * const
```

The fix is to no longer subclass `HashtableEntry` from `CHeapObj`. Apparently that makes gdb happy. None of our code requires this subclass relationship.

Tested with tiers 1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263834](https://bugs.openjdk.java.net/browse/JDK-8263834): Work around gdb <incomplete type> for HashtableEntry


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3084/head:pull/3084`
`$ git checkout pull/3084`

To update a local copy of the PR:
`$ git checkout pull/3084`
`$ git pull https://git.openjdk.java.net/jdk pull/3084/head`
