### PR TITLE
8263852: Unused method SoftRefPolicy::use_should_clear_all_soft_refs

### DIFF
--- a/src/hotspot/share/gc/shared/softRefPolicy.cpp
+++ b/src/hotspot/share/gc/shared/softRefPolicy.cpp
@@ -30,12 +30,6 @@ SoftRefPolicy::SoftRefPolicy() :
     _all_soft_refs_clear(false) {
 }
 
-bool SoftRefPolicy::use_should_clear_all_soft_refs(bool v) {
-  bool result = _should_clear_all_soft_refs;
-  set_should_clear_all_soft_refs(false);
-  return result;
-}
-
 void SoftRefPolicy::cleared_all_soft_refs() {
   _all_soft_refs_clear = true;
 }

--- a/src/hotspot/share/gc/shared/softRefPolicy.hpp
+++ b/src/hotspot/share/gc/shared/softRefPolicy.hpp
@@ -45,9 +45,7 @@ class SoftRefPolicy {
 
   bool should_clear_all_soft_refs() { return _should_clear_all_soft_refs; }
   void set_should_clear_all_soft_refs(bool v) { _should_clear_all_soft_refs = v; }
-  // Returns the current value of _should_clear_all_soft_refs.
-  // _should_clear_all_soft_refs is set to false as a side effect.
-  bool use_should_clear_all_soft_refs(bool v);
+
   bool all_soft_refs_clear() { return _all_soft_refs_clear; }
   void set_all_soft_refs_clear(bool v) { _all_soft_refs_clear = v; }
 


### PR DESCRIPTION
Trivial change of removing an unused method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263852](https://bugs.openjdk.java.net/browse/JDK-8263852): Unused method SoftRefPolicy::use_should_clear_all_soft_refs


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3085/head:pull/3085`
`$ git checkout pull/3085`

To update a local copy of the PR:
`$ git checkout pull/3085`
`$ git pull https://git.openjdk.java.net/jdk pull/3085/head`
