### PR TITLE
8263488: Verify CWarningWindow works with metal rendering pipeline

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
@@ -92,8 +92,10 @@ public class MTLLayer extends CFRetainedResource {
         MTLGraphicsConfig gc = (MTLGraphicsConfig)getGraphicsConfiguration();
         surfaceData = gc.createSurfaceData(this);
         setScale(gc.getDevice().getScaleFactor());
-        Insets insets = peer.getInsets();
-        execute(ptr -> nativeSetInsets(ptr, insets.top, insets.left));
+        if (peer != null) {
+            Insets insets = peer.getInsets();
+            execute(ptr -> nativeSetInsets(ptr, insets.top, insets.left));
+        }
         // the layer holds a reference to the buffer, which in
         // turn has a reference back to this layer
         if (surfaceData instanceof MTLSurfaceData) {


### PR DESCRIPTION
Root cause : 
CWarningWindow creates a MTLLayer with null peer.
In MTLLayer.replaceSurfaceData() method, insets should be set only if peer is not null.

Fix : 
Added the required null check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263488](https://bugs.openjdk.java.net/browse/JDK-8263488): Verify CWarningWindow works with metal rendering pipeline


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexey Ushakov](https://openjdk.java.net/census#avu) (@avu - no project role)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3086/head:pull/3086`
`$ git checkout pull/3086`

To update a local copy of the PR:
`$ git checkout pull/3086`
`$ git pull https://git.openjdk.java.net/jdk pull/3086/head`
