### PR TITLE
8176026: SA: Huge heap sizes cause a negative value to be displayed in the jhisto heap total

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
@@ -66,7 +66,7 @@ public class ObjectHistogram implements HeapVisitor {
     Iterator<ObjectHistogramElement> iterator = list.listIterator();
     int num=0;
     int totalCount=0;
-    int totalSize=0;
+    long totalSize=0;
     while (iterator.hasNext()) {
       ObjectHistogramElement el = iterator.next();
       num++;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class ObjectHistogram implements HeapVisitor {
     ObjectHistogramElement.titleOn(tty);
     Iterator<ObjectHistogramElement> iterator = list.listIterator();
     int num=0;
-    int totalCount=0;
+    long totalCount=0;
     long totalSize=0;
     while (iterator.hasNext()) {
       ObjectHistogramElement el = iterator.next();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
@@ -47,7 +47,7 @@ public class ObjectHistogramElement {
   }
 
   public int compare(ObjectHistogramElement other) {
-    return (int) (other.size - size);
+    return Long.compare(other.size, size);
   }
 
   /** Klass for this ObjectHistogramElement */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
When a heap is used more than about 2.1GB, clhsdb jhisto shows a negative number in the total field.

```
$ java -Xmx20g Sample

$ jhsdb clhsdb --pid 5773
Attaching to process 5773, please wait...
hsdb> jhisto
...
299:            1       16      jdk.internal.misc.Unsafe
300:            3402    10737610256     byte[]
Total :         15823   -2146661280
Heap traversal took 1.793 seconds.
```
(Incidentally, the Sample is a program that only allocates many objects.)

#### Details
This is because in ObjectHistogram class the totalSize variable is int type.

The total size is the total of ObjectHistogramElement#getSize() and getSize() returns long. So I changed int to long in the ObjectHistogram class.

Additionally, I changed the type of the totalCount. This doesn't cause a bug, but ObjectHistogramElement#getCount() also returns long. So it doesn't need to treat it as int, I think. ObjectHistogramElement#compare() also do the same thing, so a class that is a huge size show the bottom of the list.

#### Tests
The jtreg test was successful.
```
$ sudo make run-test TEST=serviceability/sa/ClhsdbJhisto.java

$ cat build/linux-x86_64-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_serviceability_sa_ClhsdbJhisto_java/text/summary.txt
serviceability/sa/ClhsdbJhisto.java  Passed. Execution successful
```

I confirmed the output with the same program.

```
$ ./jdk/build/linux-x86_64-server-fastdebug/jdk/bin/java -Xmx20g Sample
$ ./jdk/build/linux-x86_64-server-fastdebug/jdk/bin/jhsdb clhsdb --pid 10196
Attaching to process 10196, please wait...
hsdb> jhisto
Object Histogram:

num       #instances    #bytes  Class description
--------------------------------------------------------------------------
1:              3405    13958838400     byte[]
2:              887     109032  java.lang.Class
...
300:            1       16      jdk.internal.misc.Unsafe
Total :         15827   13959470288
Heap traversal took 1.72 seconds.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8176026](https://bugs.openjdk.java.net/browse/JDK-8176026): SA: Huge heap sizes cause a negative value to be displayed in the jhisto heap total


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 248d49fe336f8376001a42247643e709d30de453
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to a9447ca48b008efbd3799a3d92451b3d345f8bd0
 * @mgkwill (no known github.com user name / role) ⚠️ Review applies to 248d49fe336f8376001a42247643e709d30de453
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3087/head:pull/3087` \
`$ git checkout pull/3087`

Update a local copy of the PR: \
`$ git checkout pull/3087` \
`$ git pull https://git.openjdk.java.net/jdk pull/3087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3087`

View PR using the GUI difftool: \
`$ git pr show -t 3087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3087.diff">https://git.openjdk.java.net/jdk/pull/3087.diff</a>

</details>
