### PR TITLE
8263861: Shenandoah: Remove unused member in ShenandoahGCStateResetter

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -43,8 +43,7 @@
 
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _heap(ShenandoahHeap::heap()),
-  _gc_state(_heap->gc_state()),
-  _concurrent_weak_root_in_progress(ShenandoahHeap::heap()->is_concurrent_weak_root_in_progress()) {
+  _gc_state(_heap->gc_state()) {
   _heap->_gc_state.clear();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2019, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ class ShenandoahGCStateResetter : public StackObj {
 private:
   ShenandoahHeap* const _heap;
   const char _gc_state;
-  const bool _concurrent_weak_root_in_progress;
 
 public:
   ShenandoahGCStateResetter();


### PR DESCRIPTION
Please review this trivial patch that removed unused member of ShenandoahGCStateResetter.

Test:
- [x] hotspot_gc_shenandoah with -XX:+ShenandoahVerify

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263861](https://bugs.openjdk.java.net/browse/JDK-8263861): Shenandoah: Remove unused member in ShenandoahGCStateResetter


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3088/head:pull/3088`
`$ git checkout pull/3088`

To update a local copy of the PR:
`$ git checkout pull/3088`
`$ git pull https://git.openjdk.java.net/jdk pull/3088/head`
