### PR TITLE
JDK-8263871: On sem_destroy() failing we should assert

### DIFF
--- a/src/hotspot/os/posix/semaphore_posix.cpp
+++ b/src/hotspot/os/posix/semaphore_posix.cpp
@@ -46,7 +46,8 @@ PosixSemaphore::PosixSemaphore(uint value) {
 }
 
 PosixSemaphore::~PosixSemaphore() {
-  sem_destroy(&_semaphore);
+  int ret = sem_destroy(&_semaphore);
+  assert_with_errno(ret == 0, "sem_destroy failed");
 }
 
 void PosixSemaphore::signal(uint count) {


### PR DESCRIPTION
This is rather trivial.

We use anonymous Posix semaphores for some synchronization in hotspot. `sem_destroy()` can fail on some platforms with EBUSY if the semaphore has outstanding waiters. The glibc does not care, will happily wipe the sem_t structure and report success. But other Unices care (eg BSD, AIX, HP-UX) and refuse to close the semaphore, leaving the sem_t structure untouched.

It then happened for us that a new semaphore was created at the exact location of the old, still unclosed semaphore, and the unchanged sem_t structure was fed to sem_init(), which would fail with the same EBUSY error and trigger a guarantee.

One simple thing we should do is to assert success after closing a semaphore, as we do on all other semaphore operations. Granted, we won't see anything on Linux with glibc, but maybe shake loose errors on other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263871](https://bugs.openjdk.java.net/browse/JDK-8263871): On sem_destroy() failing we should assert


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3089/head:pull/3089`
`$ git checkout pull/3089`

To update a local copy of the PR:
`$ git checkout pull/3089`
`$ git pull https://git.openjdk.java.net/jdk pull/3089/head`
