### PR TITLE
8263885: Use the blessed modifier order in java.sql/rowset/transation.xa

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
@@ -119,143 +119,143 @@ public class XmlReaderContentHandler extends DefaultHandler {
     /**
      * A constant representing the tag for the command property.
      */
-    private final static int CommandTag = 0;
+    private static final int CommandTag = 0;
 
     /**
      * A constant representing the tag for the concurrency property.
      */
-    private final static int ConcurrencyTag = 1;
+    private static final int ConcurrencyTag = 1;
 
     /**
      * A constant representing the tag for the datasource property.
      */
-    private final static int DatasourceTag = 2;
+    private static final int DatasourceTag = 2;
 
     /**
      * A constant representing the tag for the escape-processing property.
      */
-    private final static int EscapeProcessingTag = 3;
+    private static final int EscapeProcessingTag = 3;
 
     /**
      * A constant representing the tag for the fetch-direction property.
      */
-    private final static int FetchDirectionTag = 4;
+    private static final int FetchDirectionTag = 4;
 
     /**
      * A constant representing the tag for the fetch-size property.
      */
-    private final static int FetchSizeTag = 5;
+    private static final int FetchSizeTag = 5;
 
     /**
      * A constant representing the tag for the isolation-level property
      */
-    private final static int IsolationLevelTag = 6;
+    private static final int IsolationLevelTag = 6;
 
     /**
      * A constant representing the tag for the key-columns property.
      */
-    private final static int KeycolsTag = 7;
+    private static final int KeycolsTag = 7;
 
     /**
      * A constant representing the tag for the map property.
      * This map is the type map that specifies the custom mapping
      * for an SQL user-defined type.
      */
-    private final static int MapTag = 8;
+    private static final int MapTag = 8;
 
     /**
      * A constant representing the tag for the max-field-size property.
      */
-    private final static int MaxFieldSizeTag = 9;
+    private static final int MaxFieldSizeTag = 9;
 
     /**
      * A constant representing the tag for the max-rows property.
      */
-    private final static int MaxRowsTag = 10;
+    private static final int MaxRowsTag = 10;
 
     /**
      * A constant representing the tag for the query-timeout property.
      */
-    private final static int QueryTimeoutTag = 11;
+    private static final int QueryTimeoutTag = 11;
 
     /**
      * A constant representing the tag for the read-only property.
      */
-    private final static int ReadOnlyTag = 12;
+    private static final int ReadOnlyTag = 12;
 
     /**
      * A constant representing the tag for the rowset-type property.
      */
-    private final static int RowsetTypeTag = 13;
+    private static final int RowsetTypeTag = 13;
 
     /**
      * A constant representing the tag for the show-deleted property.
      */
-    private final static int ShowDeletedTag = 14;
+    private static final int ShowDeletedTag = 14;
 
     /**
      * A constant representing the tag for the table-name property.
      */
-    private final static int TableNameTag = 15;
+    private static final int TableNameTag = 15;
 
     /**
      * A constant representing the tag for the URL property.
      */
-    private final static int UrlTag = 16;
+    private static final int UrlTag = 16;
 
     /**
      * A constant representing the tag for the null property.
      */
-    private final static int PropNullTag = 17;
+    private static final int PropNullTag = 17;
 
     /**
      * A constant representing the tag for the column property.
      */
-    private final static int PropColumnTag = 18;
+    private static final int PropColumnTag = 18;
 
     /**
      * A constant representing the tag for the type property.
      */
-    private final static int PropTypeTag = 19;
+    private static final int PropTypeTag = 19;
 
     /**
      * A constant representing the tag for the class property.
      */
-    private final static int PropClassTag = 20;
+    private static final int PropClassTag = 20;
 
     /**
      * A constant representing the tag for the sync-provider.
      */
-    private final static int SyncProviderTag = 21;
+    private static final int SyncProviderTag = 21;
 
     /**
      * A constant representing the tag for the sync-provider
      * name
      */
-    private final static int SyncProviderNameTag = 22;
+    private static final int SyncProviderNameTag = 22;
 
     /**
      * A constant representing the tag for the sync-provider
      * vendor tag.
      */
-    private final static int SyncProviderVendorTag = 23;
+    private static final int SyncProviderVendorTag = 23;
 
     /**
      * A constant representing the tag for the sync-provider
      * version tag.
      */
-    private final static int SyncProviderVersionTag = 24;
+    private static final int SyncProviderVersionTag = 24;
 
     /**
      * A constant representing the tag for the sync-provider
      * grade tag.
      */
-    private final static int SyncProviderGradeTag = 25;
+    private static final int SyncProviderGradeTag = 25;
 
     /**
      * A constant representing the tag for the data source lock.
      */
-    private final static int DataSourceLock = 26;
+    private static final int DataSourceLock = 26;
 
     /**
      * A listing of the kinds of metadata information available about
@@ -273,113 +273,113 @@ public class XmlReaderContentHandler extends DefaultHandler {
     /**
      * A constant representing the tag for column-count.
      */
-    private final static int ColumnCountTag = 0;
+    private static final int ColumnCountTag = 0;
 
     /**
      * A constant representing the tag for column-definition.
      */
-    private final static int ColumnDefinitionTag = 1;
+    private static final int ColumnDefinitionTag = 1;
 
     /**
      * A constant representing the tag for column-index.
      */
-    private final static int ColumnIndexTag = 2;
+    private static final int ColumnIndexTag = 2;
 
     /**
      * A constant representing the tag for auto-increment.
      */
-    private final static int AutoIncrementTag = 3;
+    private static final int AutoIncrementTag = 3;
 
     /**
      * A constant representing the tag for case-sensitive.
      */
-    private final static int CaseSensitiveTag = 4;
+    private static final int CaseSensitiveTag = 4;
 
     /**
      * A constant representing the tag for currency.
      */
-    private final static int CurrencyTag = 5;
+    private static final int CurrencyTag = 5;
 
     /**
      * A constant representing the tag for nullable.
      */
-    private final static int NullableTag = 6;
+    private static final int NullableTag = 6;
 
     /**
      * A constant representing the tag for signed.
      */
-    private final static int SignedTag = 7;
+    private static final int SignedTag = 7;
 
     /**
      * A constant representing the tag for searchable.
      */
-    private final static int SearchableTag = 8;
+    private static final int SearchableTag = 8;
 
     /**
      * A constant representing the tag for column-display-size.
      */
-    private final static int ColumnDisplaySizeTag = 9;
+    private static final int ColumnDisplaySizeTag = 9;
 
     /**
      * A constant representing the tag for column-label.
      */
-    private final static int ColumnLabelTag = 10;
+    private static final int ColumnLabelTag = 10;
 
     /**
      * A constant representing the tag for column-name.
      */
-    private final static int ColumnNameTag = 11;
+    private static final int ColumnNameTag = 11;
 
     /**
      * A constant representing the tag for schema-name.
      */
-    private final static int SchemaNameTag = 12;
+    private static final int SchemaNameTag = 12;
 
     /**
      * A constant representing the tag for column-precision.
      */
-    private final static int ColumnPrecisionTag = 13;
+    private static final int ColumnPrecisionTag = 13;
 
     /**
      * A constant representing the tag for column-scale.
      */
-    private final static int ColumnScaleTag = 14;
+    private static final int ColumnScaleTag = 14;
 
     /**
      * A constant representing the tag for table-name.
      */
-    private final static int MetaTableNameTag = 15;
+    private static final int MetaTableNameTag = 15;
 
     /**
      * A constant representing the tag for catalog-name.
      */
-    private final static int CatalogNameTag = 16;
+    private static final int CatalogNameTag = 16;
 
     /**
      * A constant representing the tag for column-type.
      */
-    private final static int ColumnTypeTag = 17;
+    private static final int ColumnTypeTag = 17;
 
     /**
      * A constant representing the tag for column-type-name.
      */
-    private final static int ColumnTypeNameTag = 18;
+    private static final int ColumnTypeNameTag = 18;
 
     /**
      * A constant representing the tag for null.
      */
-    private final static int MetaNullTag = 19;
+    private static final int MetaNullTag = 19;
 
     private String [] data = {"currentRow", "columnValue", "insertRow", "deleteRow", "insdel", "updateRow", "null" , "emptyString"};
 
-    private final static int RowTag = 0;
-    private final static int ColTag = 1;
-    private final static int InsTag = 2;
-    private final static int DelTag = 3;
-    private final static int InsDelTag = 4;
-    private final static int UpdTag = 5;
-    private final static int NullTag = 6;
-    private final static int EmptyStringTag = 7;
+    private static final int RowTag = 0;
+    private static final int ColTag = 1;
+    private static final int InsTag = 2;
+    private static final int DelTag = 3;
+    private static final int InsDelTag = 4;
+    private static final int UpdTag = 5;
+    private static final int NullTag = 6;
+    private static final int EmptyStringTag = 7;
 
     /**
      * A constant indicating the state of this <code>XmlReaderContentHandler</code>
@@ -391,7 +391,7 @@ public class XmlReaderContentHandler extends DefaultHandler {
      * still be parsed correctly (except that metadata must be
      * set before data values can be set).
      */
-    private final static int INITIAL = 0;
+    private static final int INITIAL = 0;
 
     /**
      * A constant indicating the state in which this <code>XmlReaderContentHandler</code>
@@ -399,7 +399,7 @@ public class XmlReaderContentHandler extends DefaultHandler {
      * SAX parser to be a string corresponding to one of the elements in
      * <code>properties</code>.
      */
-    private final static int PROPERTIES = 1;
+    private static final int PROPERTIES = 1;
 
     /**
      * A constant indicating the state in which this <code>XmlReaderContentHandler</code>
@@ -407,7 +407,7 @@ public class XmlReaderContentHandler extends DefaultHandler {
      * SAX parser to be a string corresponding to one of the elements in
      * <code>colDef</code>.
      */
-    private final static int METADATA = 2;
+    private static final int METADATA = 2;
 
     /**
      * A constant indicating the state in which this <code>XmlReaderContentHandler</code>
@@ -415,7 +415,7 @@ public class XmlReaderContentHandler extends DefaultHandler {
      * SAX parser to be a string corresponding to one of the elements in
      * <code>data</code>.
      */
-    private final static int DATA = 3;
+    private static final int DATA = 3;
 
     private  JdbcRowSetResourceBundle resBundle;
 

--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -83,14 +83,14 @@ public class DriverManager {
 
 
     // List of registered JDBC drivers
-    private final static CopyOnWriteArrayList<DriverInfo> registeredDrivers = new CopyOnWriteArrayList<>();
+    private static final CopyOnWriteArrayList<DriverInfo> registeredDrivers = new CopyOnWriteArrayList<>();
     private static volatile int loginTimeout = 0;
     private static volatile java.io.PrintWriter logWriter = null;
     private static volatile java.io.PrintStream logStream = null;
     // Used in println() to synchronize logWriter
-    private final static Object logSync = new Object();
+    private static final Object logSync = new Object();
     // Used in ensureDriversInitialized() to synchronize driversInitialized
-    private final static Object lockForInitDrivers = new Object();
+    private static final Object lockForInitDrivers = new Object();
     private static volatile boolean driversInitialized;
     private static final String JDBC_DRIVERS_PROPERTY = "jdbc.drivers";
 
@@ -102,7 +102,7 @@ public class DriverManager {
      * setting of the logging stream.
      * @since 1.3
      */
-    final static SQLPermission SET_LOG_PERMISSION =
+    static final SQLPermission SET_LOG_PERMISSION =
         new SQLPermission("setLog");
 
     /**
@@ -110,7 +110,7 @@ public class DriverManager {
      * un-register a registered JDBC driver.
      * @since 1.8
      */
-    final static SQLPermission DEREGISTER_DRIVER_PERMISSION =
+    static final SQLPermission DEREGISTER_DRIVER_PERMISSION =
         new SQLPermission("deregisterDriver");
 
     //--------------------------JDBC 2.0-----------------------------

--- a/src/java.sql/share/classes/java/sql/Types.java
+++ b/src/java.sql/share/classes/java/sql/Types.java
@@ -40,49 +40,49 @@ public class Types {
  * to as a type code, that identifies the generic SQL type
  * {@code BIT}.
  */
-        public final static int BIT             =  -7;
+        public static final int BIT             =  -7;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code TINYINT}.
  */
-        public final static int TINYINT         =  -6;
+        public static final int TINYINT         =  -6;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code SMALLINT}.
  */
-        public final static int SMALLINT        =   5;
+        public static final int SMALLINT        =   5;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code INTEGER}.
  */
-        public final static int INTEGER         =   4;
+        public static final int INTEGER         =   4;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code BIGINT}.
  */
-        public final static int BIGINT          =  -5;
+        public static final int BIGINT          =  -5;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code FLOAT}.
  */
-        public final static int FLOAT           =   6;
+        public static final int FLOAT           =   6;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code REAL}.
  */
-        public final static int REAL            =   7;
+        public static final int REAL            =   7;
 
 
 /**
@@ -90,42 +90,42 @@ public class Types {
  * to as a type code, that identifies the generic SQL type
  * {@code DOUBLE}.
  */
-        public final static int DOUBLE          =   8;
+        public static final int DOUBLE          =   8;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code NUMERIC}.
  */
-        public final static int NUMERIC         =   2;
+        public static final int NUMERIC         =   2;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code DECIMAL}.
  */
-        public final static int DECIMAL         =   3;
+        public static final int DECIMAL         =   3;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code CHAR}.
  */
-        public final static int CHAR            =   1;
+        public static final int CHAR            =   1;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code VARCHAR}.
  */
-        public final static int VARCHAR         =  12;
+        public static final int VARCHAR         =  12;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code LONGVARCHAR}.
  */
-        public final static int LONGVARCHAR     =  -1;
+        public static final int LONGVARCHAR     =  -1;
 
 
 /**
@@ -133,21 +133,21 @@ public class Types {
  * to as a type code, that identifies the generic SQL type
  * {@code DATE}.
  */
-        public final static int DATE            =  91;
+        public static final int DATE            =  91;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code TIME}.
  */
-        public final static int TIME            =  92;
+        public static final int TIME            =  92;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code TIMESTAMP}.
  */
-        public final static int TIMESTAMP       =  93;
+        public static final int TIMESTAMP       =  93;
 
 
 /**
@@ -155,28 +155,28 @@ public class Types {
  * to as a type code, that identifies the generic SQL type
  * {@code BINARY}.
  */
-        public final static int BINARY          =  -2;
+        public static final int BINARY          =  -2;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code VARBINARY}.
  */
-        public final static int VARBINARY       =  -3;
+        public static final int VARBINARY       =  -3;
 
 /**
  * <P>The constant in the Java programming language, sometimes referred
  * to as a type code, that identifies the generic SQL type
  * {@code LONGVARBINARY}.
  */
-        public final static int LONGVARBINARY   =  -4;
+        public static final int LONGVARBINARY   =  -4;
 
 /**
  * <P>The constant in the Java programming language
  * that identifies the generic SQL value
  * {@code NULL}.
  */
-        public final static int NULL            =   0;
+        public static final int NULL            =   0;
 
     /**
      * The constant in the Java programming language that indicates
@@ -184,7 +184,7 @@ public class Types {
      * gets mapped to a Java object that can be accessed via
      * the methods {@code getObject} and {@code setObject}.
      */
-        public final static int OTHER           = 1111;
+        public static final int OTHER           = 1111;
 
 
 
@@ -194,7 +194,7 @@ public class Types {
      * {@code JAVA_OBJECT}.
      * @since 1.2
      */
-        public final static int JAVA_OBJECT         = 2000;
+        public static final int JAVA_OBJECT         = 2000;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -202,7 +202,7 @@ public class Types {
      * {@code DISTINCT}.
      * @since 1.2
      */
-        public final static int DISTINCT            = 2001;
+        public static final int DISTINCT            = 2001;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -210,7 +210,7 @@ public class Types {
      * {@code STRUCT}.
      * @since 1.2
      */
-        public final static int STRUCT              = 2002;
+        public static final int STRUCT              = 2002;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -218,7 +218,7 @@ public class Types {
      * {@code ARRAY}.
      * @since 1.2
      */
-        public final static int ARRAY               = 2003;
+        public static final int ARRAY               = 2003;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -226,7 +226,7 @@ public class Types {
      * {@code BLOB}.
      * @since 1.2
      */
-        public final static int BLOB                = 2004;
+        public static final int BLOB                = 2004;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -234,7 +234,7 @@ public class Types {
      * {@code CLOB}.
      * @since 1.2
      */
-        public final static int CLOB                = 2005;
+        public static final int CLOB                = 2005;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -242,7 +242,7 @@ public class Types {
      * {@code REF}.
      * @since 1.2
      */
-        public final static int REF                 = 2006;
+        public static final int REF                 = 2006;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -250,7 +250,7 @@ public class Types {
      *
      * @since 1.4
      */
-    public final static int DATALINK = 70;
+    public static final int DATALINK = 70;
 
     /**
      * The constant in the Java programming language, sometimes referred to
@@ -258,7 +258,7 @@ public class Types {
      *
      * @since 1.4
      */
-    public final static int BOOLEAN = 16;
+    public static final int BOOLEAN = 16;
 
     //------------------------- JDBC 4.0 -----------------------------------
 
@@ -269,7 +269,7 @@ public class Types {
      * @since 1.6
      *
      */
-    public final static int ROWID = -8;
+    public static final int ROWID = -8;
 
     /**
      * The constant in the Java programming language, sometimes referred to

--- a/src/java.transaction.xa/share/classes/javax/transaction/xa/XAException.java
+++ b/src/java.transaction.xa/share/classes/javax/transaction/xa/XAException.java
@@ -75,127 +75,127 @@ public class XAException extends Exception {
     /**
      * The inclusive lower bound of the rollback codes.
      */
-    public final static int XA_RBBASE = 100;
+    public static final int XA_RBBASE = 100;
 
     /**
      * Indicates that the rollback was caused by an unspecified reason.
      */
-    public final static int XA_RBROLLBACK = XA_RBBASE;
+    public static final int XA_RBROLLBACK = XA_RBBASE;
 
     /**
      * Indicates that the rollback was caused by a communication failure.
      */
-    public final static int XA_RBCOMMFAIL = XA_RBBASE + 1;
+    public static final int XA_RBCOMMFAIL = XA_RBBASE + 1;
 
     /**
      * A deadlock was detected.
      */
-    public final static int XA_RBDEADLOCK = XA_RBBASE + 2;
+    public static final int XA_RBDEADLOCK = XA_RBBASE + 2;
 
     /**
      * A condition that violates the integrity of the resource was detected.
      */
-    public final static int XA_RBINTEGRITY = XA_RBBASE + 3;
+    public static final int XA_RBINTEGRITY = XA_RBBASE + 3;
 
     /**
      * The resource manager rolled back the transaction branch for a reason
      * not on this list.
      */
-    public final static int XA_RBOTHER = XA_RBBASE + 4;
+    public static final int XA_RBOTHER = XA_RBBASE + 4;
 
     /**
      * A protocol error occurred in the resource manager.
      */
-    public final static int XA_RBPROTO = XA_RBBASE + 5;
+    public static final int XA_RBPROTO = XA_RBBASE + 5;
 
     /**
      * A transaction branch took too long.
      */
-    public final static int XA_RBTIMEOUT = XA_RBBASE + 6;
+    public static final int XA_RBTIMEOUT = XA_RBBASE + 6;
 
     /**
      * May retry the transaction branch.
      */
-    public final static int XA_RBTRANSIENT = XA_RBBASE + 7;
+    public static final int XA_RBTRANSIENT = XA_RBBASE + 7;
 
     /**
      * The inclusive upper bound of the rollback error code.
      */
-    public final static int XA_RBEND = XA_RBTRANSIENT;
+    public static final int XA_RBEND = XA_RBTRANSIENT;
 
     /**
      * Resumption must occur where the suspension occurred.
      */
-    public final static int XA_NOMIGRATE = 9;
+    public static final int XA_NOMIGRATE = 9;
 
     /**
      * The transaction branch may have been heuristically completed.
      */
-    public final static int XA_HEURHAZ = 8;
+    public static final int XA_HEURHAZ = 8;
 
     /**
      * The transaction branch has been heuristically committed.
      */
-    public final static int XA_HEURCOM = 7;
+    public static final int XA_HEURCOM = 7;
 
     /**
      * The transaction branch has been heuristically rolled back.
      */
-    public final static int XA_HEURRB = 6;
+    public static final int XA_HEURRB = 6;
 
     /**
      * The transaction branch has been heuristically committed and
      * rolled back.
      */
-    public final static int XA_HEURMIX = 5;
+    public static final int XA_HEURMIX = 5;
 
     /**
      * Routine returned with no effect and may be reissued.
      */
-    public final static int XA_RETRY = 4;
+    public static final int XA_RETRY = 4;
 
     /**
      * The transaction branch was read-only and has been committed.
      */
-    public final static int XA_RDONLY = 3;
+    public static final int XA_RDONLY = 3;
 
     /**
      * There is an asynchronous operation already outstanding.
      */
-    public final static int XAER_ASYNC = -2;
+    public static final int XAER_ASYNC = -2;
 
     /**
      * A resource manager error has occurred in the transaction branch.
      */
-    public final static int XAER_RMERR = -3;
+    public static final int XAER_RMERR = -3;
 
     /**
      * The XID is not valid.
      */
-    public final static int XAER_NOTA = -4;
+    public static final int XAER_NOTA = -4;
 
     /**
      * Invalid arguments were given.
      */
-    public final static int XAER_INVAL = -5;
+    public static final int XAER_INVAL = -5;
 
     /**
      * Routine was invoked in an inproper context.
      */
-    public final static int XAER_PROTO = -6;
+    public static final int XAER_PROTO = -6;
 
     /**
      * Resource manager is unavailable.
      */
-    public final static int XAER_RMFAIL = -7;
+    public static final int XAER_RMFAIL = -7;
 
     /**
      * The XID already exists.
      */
-    public final static int XAER_DUPID = -8;
+    public static final int XAER_DUPID = -8;
 
     /**
      * The resource manager is doing work outside a global transaction.
      */
-    public final static int XAER_OUTSIDE = -9;
+    public static final int XAER_OUTSIDE = -9;
 }

--- a/src/java.transaction.xa/share/classes/javax/transaction/xa/XAResource.java
+++ b/src/java.transaction.xa/share/classes/javax/transaction/xa/XAResource.java
@@ -249,58 +249,58 @@ public interface XAResource {
     /**
      * Ends a recovery scan.
      */
-    public final static int TMENDRSCAN =   0x00800000;
+    public static final int TMENDRSCAN =   0x00800000;
 
     /**
      * Disassociates the caller and marks the transaction branch
      * rollback-only.
      */
-    public final static int TMFAIL =       0x20000000;
+    public static final int TMFAIL =       0x20000000;
 
     /**
      * Caller is joining existing transaction branch.
      */
-    public final static int TMJOIN =       0x00200000;
+    public static final int TMJOIN =       0x00200000;
 
     /**
      * Use TMNOFLAGS to indicate no flags value is selected.
      */
-    public final static int TMNOFLAGS =     0x00000000;
+    public static final int TMNOFLAGS =     0x00000000;
 
     /**
      * Caller is using one-phase optimization.
      */
-    public final static int TMONEPHASE =   0x40000000;
+    public static final int TMONEPHASE =   0x40000000;
 
     /**
      * Caller is resuming association with a suspended
      * transaction branch.
      */
-    public final static int TMRESUME =     0x08000000;
+    public static final int TMRESUME =     0x08000000;
 
     /**
       * Starts a recovery scan.
       */
-    public final static int TMSTARTRSCAN = 0x01000000;
+    public static final int TMSTARTRSCAN = 0x01000000;
 
     /**
      * Disassociates caller from a transaction branch.
      */
-    public final static int TMSUCCESS =    0x04000000;
+    public static final int TMSUCCESS =    0x04000000;
 
     /**
      * Caller is suspending (not ending) its association with
      * a transaction branch.
      */
-    public final static int TMSUSPEND =    0x02000000;
+    public static final int TMSUSPEND =    0x02000000;
 
     /**
      * The transaction branch has been read-only and has been committed.
      */
-    public final static int XA_RDONLY = 0x00000003;
+    public static final int XA_RDONLY = 0x00000003;
 
     /**
      * The transaction work has been prepared normally.
      */
-    public final static int XA_OK = 0;
+    public static final int XA_OK = 0;
 }

--- a/src/java.transaction.xa/share/classes/javax/transaction/xa/Xid.java
+++ b/src/java.transaction.xa/share/classes/javax/transaction/xa/Xid.java
@@ -40,12 +40,12 @@ public interface Xid {
     /**
      * Maximum number of bytes returned by {@link #getGlobalTransactionId }.
      */
-    final static int MAXGTRIDSIZE = 64;
+    static final int MAXGTRIDSIZE = 64;
 
     /**
      * Maximum number of bytes returned by {@link #getBranchQualifier }.
      */
-    final static int MAXBQUALSIZE = 64;
+    static final int MAXBQUALSIZE = 64;
 
     /**
      * Obtain the format identifier part of the XID.


### PR DESCRIPTION
Fixes for the `java.sql`, `java.sql.rowset` and `java.transaction.xa` packages.

@cl4es would you mind creating a subtask of JDK-8263854 so I can update the PR title?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263885](https://bugs.openjdk.java.net/browse/JDK-8263885): Use the blessed modifier order in java.sql/rowset/transation.xa


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3090/head:pull/3090`
`$ git checkout pull/3090`

To update a local copy of the PR:
`$ git checkout pull/3090`
`$ git pull https://git.openjdk.java.net/jdk pull/3090/head`
