### PR TITLE
8264019: Use the blessed modifier order in java.xml

### DIFF
--- a/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
+++ b/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
@@ -161,7 +161,7 @@ public abstract class lr_parser {
   /** The default number of Symbols after an error we much match to consider
    *  it recovered from.
    */
-  protected final static int _error_sync_size = 3;
+  protected static final int _error_sync_size = 3;
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/XalanConstants.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/XalanConstants.java
@@ -177,9 +177,9 @@ public final class XalanConstants {
     public static final String JDK_EXTENSION_CLASSLOADER = "jdk.xml.transform.extensionClassLoader";
 
     //legacy System Properties
-    public final static String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
+    public static final String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
     public static final String ELEMENT_ATTRIBUTE_LIMIT = "elementAttributeLimit" ;
-    public final static String MAX_OCCUR_LIMIT = "maxOccurLimit";
+    public static final String MAX_OCCUR_LIMIT = "maxOccurLimit";
 
     /**
      * A string "yes" that can be used for properties such as getEntityCountInfo

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/DOM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/DOM.java
@@ -31,21 +31,21 @@ import org.w3c.dom.NodeList;
  * @author Santiago Pericas-Geertsen
  */
 public interface DOM {
-    public final static int  FIRST_TYPE             = 0;
+    public static final int  FIRST_TYPE             = 0;
 
-    public final static int  NO_TYPE                = -1;
+    public static final int  NO_TYPE                = -1;
 
     // 0 is reserved for NodeIterator.END
-    public final static int NULL     = 0;
+    public static final int NULL     = 0;
 
     // used by some node iterators to know which node to return
-    public final static int RETURN_CURRENT = 0;
-    public final static int RETURN_PARENT  = 1;
+    public static final int RETURN_CURRENT = 0;
+    public static final int RETURN_PARENT  = 1;
 
     // Constants used by getResultTreeFrag to indicate the types of the RTFs.
-    public final static int SIMPLE_RTF   = 0;
-    public final static int ADAPTIVE_RTF = 1;
-    public final static int TREE_RTF     = 2;
+    public static final int SIMPLE_RTF   = 0;
+    public static final int ADAPTIVE_RTF = 1;
+    public static final int TREE_RTF     = 2;
 
     /** returns singleton iterator containg the document root */
     public DTMAxisIterator getIterator();

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/AttributeValueTemplate.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/AttributeValueTemplate.java
@@ -46,11 +46,11 @@ import java.util.StringTokenizer;
  */
 final class AttributeValueTemplate extends AttributeValue {
 
-    final static int OUT_EXPR = 0;
-    final static int IN_EXPR  = 1;
-    final static int IN_EXPR_SQUOTES = 2;
-    final static int IN_EXPR_DQUOTES = 3;
-    final static String DELIMITER = "\uFFFE";      // A Unicode nonchar
+    static final int OUT_EXPR = 0;
+    static final int IN_EXPR  = 1;
+    static final int IN_EXPR_SQUOTES = 2;
+    static final int IN_EXPR_DQUOTES = 3;
+    static final String DELIMITER = "\uFFFE";      // A Unicode nonchar
 
     public AttributeValueTemplate(String value, Parser parser,
         SyntaxTreeNode parent)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/FunctionCall.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/FunctionCall.java
@@ -71,47 +71,47 @@ class FunctionCall extends Expression {
     // Arguments to this function call (might not be any)
     private final List<Expression> _arguments;
     // Empty argument list, used for certain functions
-    private final static List<Expression> EMPTY_ARG_LIST = new ArrayList<>(0);
+    private static final List<Expression> EMPTY_ARG_LIST = new ArrayList<>(0);
 
     // Valid namespaces for Java function-call extension
-    protected final static String EXT_XSLTC =
+    protected static final String EXT_XSLTC =
         TRANSLET_URI;
 
-    protected final static String JAVA_EXT_XSLTC =
+    protected static final String JAVA_EXT_XSLTC =
         EXT_XSLTC + "/java";
 
-    protected final static String EXT_XALAN =
+    protected static final String EXT_XALAN =
         "http://xml.apache.org/xalan";
 
-    protected final static String JAVA_EXT_XALAN =
+    protected static final String JAVA_EXT_XALAN =
         "http://xml.apache.org/xalan/java";
 
-    protected final static String JAVA_EXT_XALAN_OLD =
+    protected static final String JAVA_EXT_XALAN_OLD =
         "http://xml.apache.org/xslt/java";
 
-    protected final static String EXSLT_COMMON =
+    protected static final String EXSLT_COMMON =
         "http://exslt.org/common";
 
-    protected final static String EXSLT_MATH =
+    protected static final String EXSLT_MATH =
         "http://exslt.org/math";
 
-    protected final static String EXSLT_SETS =
+    protected static final String EXSLT_SETS =
         "http://exslt.org/sets";
 
-    protected final static String EXSLT_DATETIME =
+    protected static final String EXSLT_DATETIME =
         "http://exslt.org/dates-and-times";
 
-    protected final static String EXSLT_STRINGS =
+    protected static final String EXSLT_STRINGS =
         "http://exslt.org/strings";
 
-    protected final static String XALAN_CLASSPACKAGE_NAMESPACE =
+    protected static final String XALAN_CLASSPACKAGE_NAMESPACE =
         "xalan://";
 
     // Namespace format constants
-    protected final static int NAMESPACE_FORMAT_JAVA = 0;
-    protected final static int NAMESPACE_FORMAT_CLASS = 1;
-    protected final static int NAMESPACE_FORMAT_PACKAGE = 2;
-    protected final static int NAMESPACE_FORMAT_CLASS_OR_PACKAGE = 3;
+    protected static final int NAMESPACE_FORMAT_JAVA = 0;
+    protected static final int NAMESPACE_FORMAT_CLASS = 1;
+    protected static final int NAMESPACE_FORMAT_PACKAGE = 2;
+    protected static final int NAMESPACE_FORMAT_CLASS_OR_PACKAGE = 3;
 
     // Namespace format
     private int _namespace_format = NAMESPACE_FORMAT_JAVA;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Output.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Output.java
@@ -66,9 +66,9 @@ final class Output extends TopLevelElement {
     private boolean _disabled = false;
 
     // Some global constants
-    private final static String STRING_SIG = "Ljava/lang/String;";
-    private final static String XML_VERSION = "1.0";
-    private final static String HTML_VERSION = "4.0";
+    private static final String STRING_SIG = "Ljava/lang/String;";
+    private static final String XML_VERSION = "1.0";
+    private static final String HTML_VERSION = "4.0";
 
     /**
      * Displays the contents of this element (for debugging)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/UseAttributeSets.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/UseAttributeSets.java
@@ -41,7 +41,7 @@ import java.util.StringTokenizer;
 final class UseAttributeSets extends Instruction {
 
     // Only error that can occur:
-    private final static String ATTR_SET_NOT_FOUND =
+    private static final String ATTR_SET_NOT_FOUND =
         "";
 
     // Contains the names of all references attribute sets

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Whitespace.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Whitespace.java
@@ -63,7 +63,7 @@ final class Whitespace extends TopLevelElement {
     /**
      * Auxillary class for encapsulating a single strip/preserve rule
      */
-    final static class WhitespaceRule {
+    static final class WhitespaceRule {
         private final int _action;
         private String _namespace; // Should be replaced by NS type (int)
         private String _element;   // Should be replaced by node type (int)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ClassGenerator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ClassGenerator.java
@@ -46,7 +46,7 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.Stylesheet;
  * @author Santiago Pericas-Geertsen
  */
 public class ClassGenerator extends ClassGen {
-    protected final static int TRANSLET_INDEX = 0;
+    protected static final int TRANSLET_INDEX = 0;
     protected static int INVALID_INDEX  = -1;
 
     private Stylesheet _stylesheet;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
@@ -175,10 +175,10 @@ public final class ErrorMsg {
     // This array and the following 4 strings are read from that bundle.
     private static ResourceBundle _bundle;
 
-    public final static String ERROR_MESSAGES_KEY   = "ERROR_MESSAGES_KEY";
-    public final static String COMPILER_ERROR_KEY   = "COMPILER_ERROR_KEY";
-    public final static String COMPILER_WARNING_KEY = "COMPILER_WARNING_KEY";
-    public final static String RUNTIME_ERROR_KEY    = "RUNTIME_ERROR_KEY";
+    public static final String ERROR_MESSAGES_KEY   = "ERROR_MESSAGES_KEY";
+    public static final String COMPILER_ERROR_KEY   = "COMPILER_ERROR_KEY";
+    public static final String COMPILER_WARNING_KEY = "COMPILER_WARNING_KEY";
+    public static final String RUNTIME_ERROR_KEY    = "RUNTIME_ERROR_KEY";
 
     static {
         _bundle = SecuritySupport.getResourceBundle(

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MarkerInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MarkerInstruction.java
@@ -61,7 +61,7 @@ abstract class MarkerInstruction extends Instruction {
      * current {@link com.sun.org.apache.bcel.internal.generic.ClassGen}
      * @return <code>0</code> always
      */
-    final public int consumeStack(ConstantPoolGen cpg) {
+    public final int consumeStack(ConstantPoolGen cpg) {
         return 0;
     }
     /**
@@ -72,7 +72,7 @@ abstract class MarkerInstruction extends Instruction {
      * current {@link com.sun.org.apache.bcel.internal.generic.ClassGen}
      * @return <code>0</code> always
      */
-    final public int produceStack(ConstantPoolGen cpg) {
+    public final int produceStack(ConstantPoolGen cpg) {
         return 0;
     }
 
@@ -91,6 +91,6 @@ abstract class MarkerInstruction extends Instruction {
      * output stream.
      * @param out Output stream
      */
-    final public void dump(DataOutputStream out) throws IOException {
+    public final void dump(DataOutputStream out) throws IOException {
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/BitArray.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/BitArray.java
@@ -42,7 +42,7 @@ public class BitArray implements Externalizable {
 
     // This table is used to prevent expensive shift operations
     // (These operations are inexpensive on CPUs but very expensive on JVMs.)
-    private final static int[] _masks = {
+    private static final int[] _masks = {
         0x80000000, 0x40000000, 0x20000000, 0x10000000,
         0x08000000, 0x04000000, 0x02000000, 0x01000000,
         0x00800000, 0x00400000, 0x00200000, 0x00100000,
@@ -52,7 +52,7 @@ public class BitArray implements Externalizable {
         0x00000080, 0x00000040, 0x00000020, 0x00000010,
         0x00000008, 0x00000004, 0x00000002, 0x00000001 };
 
-    private final static boolean DEBUG_ASSERTIONS = false;
+    private static final boolean DEBUG_ASSERTIONS = false;
 
     /**
      * Constructor. Defines the initial size of the bit array (in bits).

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeCounter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeCounter.java
@@ -57,13 +57,13 @@ public abstract class NodeCounter {
     private int _nSepars  = 0;
     private int _nFormats = 0;
 
-    private final static String[] Thousands =
+    private static final String[] Thousands =
         {"", "m", "mm", "mmm" };
-    private final static String[] Hundreds =
+    private static final String[] Hundreds =
     {"", "c", "cc", "ccc", "cd", "d", "dc", "dcc", "dccc", "cm"};
-    private final static String[] Tens =
+    private static final String[] Tens =
     {"", "x", "xx", "xxx", "xl", "l", "lx", "lxx", "lxxx", "xc"};
-    private final static String[] Ones =
+    private static final String[] Ones =
     {"", "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix"};
 
     private StringBuilder _tempBuffer = new StringBuilder();

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SAXImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SAXImpl.java
@@ -104,10 +104,10 @@ public final class SAXImpl extends SAX2DTM2
     /* ------------------------------------------------------------------- */
 
     // empty String for null attribute values
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     // empty iterator to be returned when there are no children
-    private final static DTMAxisIterator EMPTYITERATOR = EmptyIterator.getInstance();
+    private static final DTMAxisIterator EMPTYITERATOR = EmptyIterator.getInstance();
     // The number of expanded names
     private int _namesSize = -1;
 
@@ -141,7 +141,7 @@ public final class SAXImpl extends SAX2DTM2
     // Support for access/navigation through org.w3c.dom API
     private Node[] _nodes;
     private NodeList[] _nodeLists;
-    // private final static String XML_LANG_ATTRIBUTE = "http://www.w3.org/XML/1998/namespace:@lang";
+    // private static final String XML_LANG_ATTRIBUTE = "http://www.w3.org/XML/1998/namespace:@lang";
 
     /**
      * Define the origin of the document from which the tree was built

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SimpleResultTreeImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SimpleResultTreeImpl.java
@@ -215,7 +215,7 @@ public class SimpleResultTreeImpl extends EmptySerializer implements DOM, DTM
     }  // END of SingletonIterator
 
     // empty iterator to be returned when there are no children
-    private final static DTMAxisIterator EMPTY_ITERATOR =
+    private static final DTMAxisIterator EMPTY_ITERATOR =
         new DTMAxisIteratorBase() {
             public DTMAxisIterator reset() { return this; }
             public DTMAxisIterator setStartNode(int node) { return this; }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SortingIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SortingIterator.java
@@ -31,7 +31,7 @@ import com.sun.org.apache.xml.internal.dtm.ref.DTMAxisIteratorBase;
  * @author Morten Jorgensen
  */
 public final class SortingIterator extends DTMAxisIteratorBase {
-    private final static int INIT_DATA_SIZE = 16;
+    private static final int INIT_DATA_SIZE = 16;
 
     private DTMAxisIterator _source;
     private NodeSortRecordFactory _factory;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
@@ -101,10 +101,10 @@ public abstract class AbstractTranslet implements Translet {
     protected StringValueHandler stringValueHandler = new StringValueHandler();
 
     // Use one empty string instead of constantly instanciating String("");
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     // This is the name of the index used for ID attributes
-    private final static String ID_INDEX_NAME = "##id";
+    private static final String ID_INDEX_NAME = "##id";
 
     private boolean _overrideDefaultParser;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/BasisLibrary.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/BasisLibrary.java
@@ -65,7 +65,7 @@ import org.xml.sax.SAXException;
  */
 public final class BasisLibrary {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     /**
      * Re-use a single instance of StringBuffer (per thread) in the basis library.
@@ -1602,7 +1602,7 @@ public final class BasisLibrary {
     // All error messages are localized and are stored in resource bundles.
     private static ResourceBundle m_bundle;
 
-    public final static String ERROR_MESSAGES_KEY = "error-messages";
+    public static final String ERROR_MESSAGES_KEY = "error-messages";
 
     static {
         String resource = "com.sun.org.apache.xalan.internal.xsltc.runtime.ErrorMessages";

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/Constants.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/Constants.java
@@ -31,13 +31,13 @@ import com.sun.org.apache.xml.internal.dtm.DTM;
  */
 public interface Constants {
 
-    final static int ANY       = -1;
-    final static int ATTRIBUTE = -2;
-    final static int ROOT      = DTM.ROOT_NODE;
-    final static int TEXT      = DTM.TEXT_NODE;
-    final static int ELEMENT   = DTM.ELEMENT_NODE;
-    final static int COMMENT   = DTM.COMMENT_NODE;
-    final static int PROCESSING_INSTRUCTION = DTM.PROCESSING_INSTRUCTION_NODE;
+    static final int ANY       = -1;
+    static final int ATTRIBUTE = -2;
+    static final int ROOT      = DTM.ROOT_NODE;
+    static final int TEXT      = DTM.TEXT_NODE;
+    static final int ELEMENT   = DTM.ELEMENT_NODE;
+    static final int COMMENT   = DTM.COMMENT_NODE;
+    static final int PROCESSING_INSTRUCTION = DTM.PROCESSING_INSTRUCTION_NODE;
 
     public static final String XSLT_URI = "http://www.w3.org/1999/XSL/Transform";
     public static final String NAMESPACE_FEATURE =

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2SAX.java
@@ -49,7 +49,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public class DOM2SAX implements XMLReader, Locator {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
     private static final String XMLNS_PREFIX = "xmlns";
 
     private Node _dom = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2TO.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2TO.java
@@ -45,7 +45,7 @@ import com.sun.org.apache.xml.internal.serializer.NamespaceMappings;
  */
 public class DOM2TO implements XMLReader, Locator2 {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
     private static final String XMLNS_PREFIX = "xmlns";
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXEvent2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXEvent2SAX.java
@@ -64,7 +64,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public class StAXEvent2SAX implements XMLReader, Locator {
 
-    //private final static String EMPTYSTRING = "";
+    //private static final String EMPTYSTRING = "";
     //private static final String XMLNS_PREFIX = "xmlns";
 
     // StAX event source

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
@@ -57,7 +57,7 @@ import javax.xml.stream.XMLStreamException;
  */
 public class StAXStream2SAX implements XMLReader, Locator {
 
-    //private final static String EMPTYSTRING = "";
+    //private static final String EMPTYSTRING = "";
     //private static final String XMLNS_PREFIX = "xmlns";
 
     // StAX Stream source

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TemplatesImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TemplatesImpl.java
@@ -72,7 +72,7 @@ import jdk.xml.internal.SecuritySupport;
  */
 public final class TemplatesImpl implements Templates, Serializable {
     static final long serialVersionUID = 673094361519270707L;
-    public final static String DESERIALIZE_TRANSLET = "jdk.xml.enableTemplatesImplDeserialization";
+    public static final String DESERIALIZE_TRANSLET = "jdk.xml.enableTemplatesImplDeserialization";
 
     /**
      * Name of the superclass of all translets. This is needed to

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -91,16 +91,16 @@ public class TransformerFactoryImpl
     extends SAXTransformerFactory implements SourceLoader
 {
     // Public constants for attributes supported by the XSLTC TransformerFactory.
-    public final static String TRANSLET_NAME = "translet-name";
-    public final static String DESTINATION_DIRECTORY = "destination-directory";
-    public final static String PACKAGE_NAME = "package-name";
-    public final static String JAR_NAME = "jar-name";
-    public final static String GENERATE_TRANSLET = "generate-translet";
-    public final static String AUTO_TRANSLET = "auto-translet";
-    public final static String USE_CLASSPATH = "use-classpath";
-    public final static String DEBUG = "debug";
-    public final static String ENABLE_INLINING = "enable-inlining";
-    public final static String INDENT_NUMBER = "indent-number";
+    public static final String TRANSLET_NAME = "translet-name";
+    public static final String DESTINATION_DIRECTORY = "destination-directory";
+    public static final String PACKAGE_NAME = "package-name";
+    public static final String JAR_NAME = "jar-name";
+    public static final String GENERATE_TRANSLET = "generate-translet";
+    public static final String AUTO_TRANSLET = "auto-translet";
+    public static final String USE_CLASSPATH = "use-classpath";
+    public static final String DEBUG = "debug";
+    public static final String ENABLE_INLINING = "enable-inlining";
+    public static final String INDENT_NUMBER = "indent-number";
 
     /**
      * Default error listener
@@ -131,7 +131,7 @@ public class TransformerFactoryImpl
      * compared to the rest of his bulk, waved helplessly before his eyes.
      * "What has happened to me?", he thought. It was no dream....
      */
-    protected final static String DEFAULT_TRANSLET_NAME = "GregorSamsa";
+    protected static final String DEFAULT_TRANSLET_NAME = "GregorSamsa";
 
     /**
      * The class name of the translet

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
@@ -101,7 +101,7 @@ public final class TransformerImpl extends Transformer
     implements DOMCache
 {
 
-    private final static String LEXICAL_HANDLER_PROPERTY =
+    private static final String LEXICAL_HANDLER_PROPERTY =
         "http://xml.org/sax/properties/lexical-handler";
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
@@ -344,7 +344,7 @@ public class CoreDocumentImpl
 
     // even though ownerDocument refers to this in this implementation
     // the DOM Level 2 spec says it must be null, so make it appear so
-    final public Document getOwnerDocument() {
+    public final Document getOwnerDocument() {
         return null;
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
@@ -146,7 +146,7 @@ public class CoreDocumentImpl
     transient Object fXPathEvaluator = null;
 
     /** Table for quick check of child insertion. */
-    private final static int[] kidOK;
+    private static final int[] kidOK;
 
     /**
      * Number of alterations made to this document since its creation.

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMConfigurationImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMConfigurationImpl.java
@@ -186,7 +186,7 @@ public class DOMConfigurationImpl extends ParserConfigurationSettings
         Constants.JAXP_PROPERTY_PREFIX + Constants.SCHEMA_SOURCE;
 
     /** Property identifier: DTD validator. */
-    protected final static String DTD_VALIDATOR_PROPERTY =
+    protected static final String DTD_VALIDATOR_PROPERTY =
         Constants.XERCES_PROPERTY_PREFIX + Constants.DTD_VALIDATOR_PROPERTY;
 
     /** Property identifier: datatype validator factory. */
@@ -223,20 +223,20 @@ public class DOMConfigurationImpl extends ParserConfigurationSettings
     /** Normalization features*/
     protected short features = 0;
 
-    protected final static short NAMESPACES          = 0x1<<0;
-    protected final static short DTNORMALIZATION     = 0x1<<1;
-    protected final static short ENTITIES            = 0x1<<2;
-    protected final static short CDATA               = 0x1<<3;
-    protected final static short SPLITCDATA          = 0x1<<4;
-    protected final static short COMMENTS            = 0x1<<5;
-    protected final static short VALIDATE            = 0x1<<6;
-    protected final static short PSVI                = 0x1<<7;
-    protected final static short WELLFORMED          = 0x1<<8;
-    protected final static short NSDECL              = 0x1<<9;
+    protected static final short NAMESPACES          = 0x1<<0;
+    protected static final short DTNORMALIZATION     = 0x1<<1;
+    protected static final short ENTITIES            = 0x1<<2;
+    protected static final short CDATA               = 0x1<<3;
+    protected static final short SPLITCDATA          = 0x1<<4;
+    protected static final short COMMENTS            = 0x1<<5;
+    protected static final short VALIDATE            = 0x1<<6;
+    protected static final short PSVI                = 0x1<<7;
+    protected static final short WELLFORMED          = 0x1<<8;
+    protected static final short NSDECL              = 0x1<<9;
 
-    protected final static short INFOSET_TRUE_PARAMS = NAMESPACES | COMMENTS | WELLFORMED | NSDECL;
-    protected final static short INFOSET_FALSE_PARAMS = ENTITIES | DTNORMALIZATION | CDATA;
-    protected final static short INFOSET_MASK = INFOSET_TRUE_PARAMS | INFOSET_FALSE_PARAMS;
+    protected static final short INFOSET_TRUE_PARAMS = NAMESPACES | COMMENTS | WELLFORMED | NSDECL;
+    protected static final short INFOSET_FALSE_PARAMS = ENTITIES | DTNORMALIZATION | CDATA;
+    protected static final short INFOSET_MASK = INFOSET_TRUE_PARAMS | INFOSET_FALSE_PARAMS;
 
     // components
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
@@ -97,14 +97,14 @@ public class DOMNormalizer implements XMLDocumentHandler {
     // constants
     //
     /** Debug normalize document*/
-    protected final static boolean DEBUG_ND = false;
+    protected static final boolean DEBUG_ND = false;
     /** Debug namespace fix up algorithm*/
-    protected final static boolean DEBUG = false;
+    protected static final boolean DEBUG = false;
     /** Debug document handler events */
-    protected final static boolean DEBUG_EVENTS = false;
+    protected static final boolean DEBUG_EVENTS = false;
 
     /** prefix added by namespace fixup algorithm should follow a pattern "NS" + index*/
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     //
     // Data

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
@@ -74,9 +74,9 @@ public class NamedNodeMapImpl
 
     protected short flags;
 
-    protected final static short READONLY     = 0x1<<0;
-    protected final static short CHANGED      = 0x1<<1;
-    protected final static short HASDEFAULTS  = 0x1<<2;
+    protected static final short READONLY     = 0x1<<0;
+    protected static final short CHANGED      = 0x1<<1;
+    protected static final short HASDEFAULTS  = 0x1<<2;
 
     /** Nodes. */
     protected List<Node> nodes;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NodeImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NodeImpl.java
@@ -144,16 +144,16 @@ public abstract class NodeImpl
 
     protected short flags;
 
-    protected final static short READONLY     = 0x1<<0;
-    protected final static short SYNCDATA     = 0x1<<1;
-    protected final static short SYNCCHILDREN = 0x1<<2;
-    protected final static short OWNED        = 0x1<<3;
-    protected final static short FIRSTCHILD   = 0x1<<4;
-    protected final static short SPECIFIED    = 0x1<<5;
-    protected final static short IGNORABLEWS  = 0x1<<6;
-    protected final static short HASSTRING    = 0x1<<7;
-    protected final static short NORMALIZED = 0x1<<8;
-    protected final static short ID           = 0x1<<9;
+    protected static final short READONLY     = 0x1<<0;
+    protected static final short SYNCDATA     = 0x1<<1;
+    protected static final short SYNCCHILDREN = 0x1<<2;
+    protected static final short OWNED        = 0x1<<3;
+    protected static final short FIRSTCHILD   = 0x1<<4;
+    protected static final short SPECIFIED    = 0x1<<5;
+    protected static final short IGNORABLEWS  = 0x1<<6;
+    protected static final short HASSTRING    = 0x1<<7;
+    protected static final short NORMALIZED = 0x1<<8;
+    protected static final short ID           = 0x1<<9;
 
     //
     // Constructors

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/Constants.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/Constants.java
@@ -322,9 +322,9 @@ public final class Constants {
     public static final String SP_MAX_ELEMENT_DEPTH = "jdk.xml.maxElementDepth";
 
     //legacy System Properties
-    public final static String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
+    public static final String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
     public static final String ELEMENT_ATTRIBUTE_LIMIT = "elementAttributeLimit" ;
-    public final static String MAX_OCCUR_LIMIT = "maxOccurLimit";
+    public static final String MAX_OCCUR_LIMIT = "maxOccurLimit";
 
     /**
      * A string "yes" that can be used for properties such as getEntityCountInfo
@@ -661,17 +661,17 @@ public final class Constants {
     // general constants
 
     /** Element PSVI is stored in augmentations using string "ELEMENT_PSVI" */
-    public final static String ELEMENT_PSVI = "ELEMENT_PSVI";
+    public static final String ELEMENT_PSVI = "ELEMENT_PSVI";
 
     /** Attribute PSVI is stored in augmentations using string "ATTRIBUTE_PSVI" */
-    public final static String ATTRIBUTE_PSVI = "ATTRIBUTE_PSVI";
+    public static final String ATTRIBUTE_PSVI = "ATTRIBUTE_PSVI";
 
     /**
      * Boolean indicating whether an attribute is declared in the DTD is stored
      * in augmentations using the string "ATTRIBUTE_DECLARED". The absence of this
      * augmentation indicates that the attribute was not declared in the DTD.
      */
-    public final static String ATTRIBUTE_DECLARED = "ATTRIBUTE_DECLARED";
+    public static final String ATTRIBUTE_DECLARED = "ATTRIBUTE_DECLARED";
 
 
     /**
@@ -683,7 +683,7 @@ public final class Constants {
      * {@link org.w3c.dom.Attr#getSchemaTypeInfo()} and
      * {@link org.w3c.dom.Element#getSchemaTypeInfo()} and
      */
-    public final static String TYPEINFO = "org.w3c.dom.TypeInfo";
+    public static final String TYPEINFO = "org.w3c.dom.TypeInfo";
 
     /**
      * Whether an attribute is an id or not is stored in augmentations
@@ -693,7 +693,7 @@ public final class Constants {
      * This will ultimately controls {@link com.sun.org.apache.xerces.internal.parsers.AbstractDOMParser}
      * about whether it will mark an attribute as ID or not.
      */
-    public final static String ID_ATTRIBUTE = "ID_ATTRIBUTE";
+    public static final String ID_ATTRIBUTE = "ID_ATTRIBUTE";
 
     // XML version constants
 
@@ -703,7 +703,7 @@ public final class Constants {
      * The absence of this augmentation indicates that the entity had a
      * declaration and was expanded.
      */
-    public final static String ENTITY_SKIPPED = "ENTITY_SKIPPED";
+    public static final String ENTITY_SKIPPED = "ENTITY_SKIPPED";
 
     /**
      * Boolean indicating whether a character is a probable white space
@@ -712,7 +712,7 @@ public final class Constants {
      * The absence of this augmentation indicates that the character is not
      * probable white space and/or was not included from a character reference.
      */
-    public final static String CHAR_REF_PROBABLE_WS = "CHAR_REF_PROBABLE_WS";
+    public static final String CHAR_REF_PROBABLE_WS = "CHAR_REF_PROBABLE_WS";
 
     /** Boolean indicating if this entity is the last opened entity.
      *
@@ -720,25 +720,25 @@ public final class Constants {
      *@see com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl#endEntity()
      *@see com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl#endEntity()
      */
-    public final static String LAST_ENTITY = "LAST_ENTITY";
+    public static final String LAST_ENTITY = "LAST_ENTITY";
 
     // XML version constants
-    public final static short XML_VERSION_ERROR = -1;
-    public final static short XML_VERSION_1_0 = 1;
-    public final static short XML_VERSION_1_1 = 2;
+    public static final short XML_VERSION_ERROR = -1;
+    public static final short XML_VERSION_1_0 = 1;
+    public static final short XML_VERSION_1_1 = 2;
 
 
 
     // DOM related constants
-    public final static String ANONYMOUS_TYPE_NAMESPACE =
+    public static final String ANONYMOUS_TYPE_NAMESPACE =
         "http://apache.org/xml/xmlschema/1.0/anonymousTypes";
 
 
 
     // Constant to enable Schema 1.1 support
-    public final static boolean SCHEMA_1_1_SUPPORT = false;
-    public final static short SCHEMA_VERSION_1_0          = 1;
-    public final static short SCHEMA_VERSION_1_0_EXTENDED = 2;
+    public static final boolean SCHEMA_1_1_SUPPORT = false;
+    public static final short SCHEMA_VERSION_1_0          = 1;
+    public static final short SCHEMA_VERSION_1_0_EXTENDED = 2;
 
     // private
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl.java
@@ -174,7 +174,7 @@ public class XMLDocumentFragmentScannerImpl
     /** access external dtd: file protocol
      *  For DOM/SAX, the secure feature is set to true by default
      */
-    final static String EXTERNAL_ACCESS_DEFAULT = Constants.EXTERNAL_ACCESS_DEFAULT;
+    static final String EXTERNAL_ACCESS_DEFAULT = Constants.EXTERNAL_ACCESS_DEFAULT;
 
     // recognized features and properties
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLScanner.java
@@ -215,28 +215,28 @@ public abstract class XMLScanner
     // symbols
 
     /** Symbol: "version". */
-    protected final static String fVersionSymbol = "version".intern();
+    protected static final String fVersionSymbol = "version".intern();
 
     /** Symbol: "encoding". */
-    protected final static String fEncodingSymbol = "encoding".intern();
+    protected static final String fEncodingSymbol = "encoding".intern();
 
     /** Symbol: "standalone". */
-    protected final static String fStandaloneSymbol = "standalone".intern();
+    protected static final String fStandaloneSymbol = "standalone".intern();
 
     /** Symbol: "amp". */
-    protected final static String fAmpSymbol = "amp".intern();
+    protected static final String fAmpSymbol = "amp".intern();
 
     /** Symbol: "lt". */
-    protected final static String fLtSymbol = "lt".intern();
+    protected static final String fLtSymbol = "lt".intern();
 
     /** Symbol: "gt". */
-    protected final static String fGtSymbol = "gt".intern();
+    protected static final String fGtSymbol = "gt".intern();
 
     /** Symbol: "quot". */
-    protected final static String fQuotSymbol = "quot".intern();
+    protected static final String fQuotSymbol = "quot".intern();
 
     /** Symbol: "apos". */
-    protected final static String fAposSymbol = "apos".intern();
+    protected static final String fAposSymbol = "apos".intern();
 
     // temporary variables
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLStreamReaderImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLStreamReaderImpl.java
@@ -674,7 +674,7 @@ public class XMLStreamReaderImpl implements javax.xml.stream.XMLStreamReader {
         fEventType = fScanner.next();
     }
 
-    final static String getEventTypeString(int eventType) {
+    static final String getEventTypeString(int eventType) {
         switch (eventType) {
             case XMLEvent.START_ELEMENT:
                 return "START_ELEMENT";

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java
@@ -49,7 +49,7 @@ public class XMLVersionDetector {
     // Constants
     //
 
-    private final static char[] XML11_VERSION = new char[]{'1', '.', '1'};
+    private static final char[] XML11_VERSION = new char[]{'1', '.', '1'};
 
 
     // property identifiers
@@ -71,7 +71,7 @@ public class XMLVersionDetector {
     //
 
     /** Symbol: "version". */
-    protected final static String fVersionSymbol = "version".intern();
+    protected static final String fVersionSymbol = "version".intern();
 
     // symbol:  [xml]:
     protected static final String fXMLSymbol = "[xml]".intern();

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dtd/XML11DTDValidator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dtd/XML11DTDValidator.java
@@ -38,7 +38,7 @@ public class XML11DTDValidator extends XMLDTDValidator {
     // Constants
     //
 
-    protected final static String DTD_VALIDATOR_PROPERTY =
+    protected static final String DTD_VALIDATOR_PROPERTY =
         Constants.XERCES_PROPERTY_PREFIX+Constants.DTD_VALIDATOR_PROPERTY;
 
     //

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/AbstractDateTimeDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/AbstractDateTimeDV.java
@@ -56,9 +56,9 @@ public abstract class AbstractDateTimeDV extends TypeValidator {
     //define shared variables for date/time
     //define constants to be used in assigning default values for
     //all date/time excluding duration
-    protected final static int YEAR = 2000;
-    protected final static int MONTH = 01;
-    protected final static int DAY = 01;
+    protected static final int YEAR = 2000;
+    protected static final int MONTH = 01;
+    protected static final int DAY = 01;
     protected static final DatatypeFactory datatypeFactory = new DatatypeFactoryImpl();
 
     @Override

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DayDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DayDV.java
@@ -38,7 +38,7 @@ import com.sun.org.apache.xerces.internal.impl.dv.ValidationContext;
 public class DayDV extends AbstractDateTimeDV {
 
     //size without time zone: ---09
-    private final static int DAY_SIZE=5;
+    private static final int DAY_SIZE=5;
 
     public Object getActualValue(String content, ValidationContext context) throws InvalidDatatypeValueException {
         try{

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DurationDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DurationDV.java
@@ -49,7 +49,7 @@ public class DurationDV extends AbstractDateTimeDV {
     // see 3.2.6 duration W3C schema datatype specs
     //
     // the dates are in format: {CCYY,MM,DD, H, S, M, MS, timezone}
-    private final static DateTimeData[] DATETIMES= {
+    private static final DateTimeData[] DATETIMES= {
         new DateTimeData(1696, 9, 1, 0, 0, 0, 'Z', null, true, null),
         new DateTimeData(1697, 2, 1, 0, 0, 0, 'Z', null, true, null),
         new DateTimeData(1903, 3, 1, 0, 0, 0, 'Z', null, true, null),

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/ListDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/ListDV.java
@@ -55,7 +55,7 @@ public class ListDV extends TypeValidator{
         return ((ListData)value).getLength();
     }
 
-    final static class ListData extends AbstractList<Object> implements ObjectList {
+    static final class ListData extends AbstractList<Object> implements ObjectList {
         final Object[] data;
         private String canonical;
         public ListData(Object[] data) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/MonthDayDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/MonthDayDV.java
@@ -40,7 +40,7 @@ import com.sun.org.apache.xerces.internal.impl.dv.ValidationContext;
 public class MonthDayDV extends AbstractDateTimeDV {
 
     //size without time zone: --MM-DD
-    private final static int MONTHDAY_SIZE = 7;
+    private static final int MONTHDAY_SIZE = 7;
 
     /**
      * Convert a string to a compiled form

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/SchemaGrammar.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/SchemaGrammar.java
@@ -1176,7 +1176,7 @@ public class SchemaGrammar implements XSGrammar, XSNamespaceItem {
 
     // anyType and anySimpleType: because there are so many places where
     // we need direct access to these two types
-    public final static XSComplexTypeDecl fAnyType = new XSAnyType();
+    public static final XSComplexTypeDecl fAnyType = new XSAnyType();
     private static class XSAnyType extends XSComplexTypeDecl {
         public XSAnyType () {
             fName = SchemaSymbols.ATTVAL_ANYTYPE;
@@ -1289,13 +1289,13 @@ public class SchemaGrammar implements XSGrammar, XSNamespaceItem {
     } // class BuiltinAttrDecl
 
     // the grammars to hold components of the schema namespace
-    public final static BuiltinSchemaGrammar SG_SchemaNS = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0);
-    private final static BuiltinSchemaGrammar SG_SchemaNSExtended = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0_EXTENDED);
+    public static final BuiltinSchemaGrammar SG_SchemaNS = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0);
+    private static final BuiltinSchemaGrammar SG_SchemaNSExtended = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0_EXTENDED);
 
-    public final static XSSimpleType fAnySimpleType = (XSSimpleType)SG_SchemaNS.getGlobalTypeDecl(SchemaSymbols.ATTVAL_ANYSIMPLETYPE);
+    public static final XSSimpleType fAnySimpleType = (XSSimpleType)SG_SchemaNS.getGlobalTypeDecl(SchemaSymbols.ATTVAL_ANYSIMPLETYPE);
 
     // the grammars to hold components of the schema-instance namespace
-    public final static BuiltinSchemaGrammar SG_XSI = new BuiltinSchemaGrammar(GRAMMAR_XSI, Constants.SCHEMA_VERSION_1_0);
+    public static final BuiltinSchemaGrammar SG_XSI = new BuiltinSchemaGrammar(GRAMMAR_XSI, Constants.SCHEMA_VERSION_1_0);
 
     public static SchemaGrammar getS4SGrammar(short schemaVersion) {
         if (schemaVersion == Constants.SCHEMA_VERSION_1_0) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSAttributeDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSAttributeDecl.java
@@ -46,9 +46,9 @@ import com.sun.org.apache.xerces.internal.xs.XSValue;
 public class XSAttributeDecl implements XSAttributeDeclaration {
 
     // scopes
-    public final static short     SCOPE_ABSENT        = 0;
-    public final static short     SCOPE_GLOBAL        = 1;
-    public final static short     SCOPE_LOCAL         = 2;
+    public static final short     SCOPE_ABSENT        = 0;
+    public static final short     SCOPE_GLOBAL        = 1;
+    public static final short     SCOPE_LOCAL         = 2;
 
     // the name of the attribute
     String fName = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSDDescription.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSDDescription.java
@@ -42,33 +42,33 @@ public class XSDDescription extends XMLResourceIdentifierImpl
     /**
      * Indicate that this description was just initialized.
      */
-    public final static short CONTEXT_INITIALIZE = -1;
+    public static final short CONTEXT_INITIALIZE = -1;
     /**
      * Indicate that the current schema document is <include>d by another
      * schema document.
      */
-    public final static short CONTEXT_INCLUDE   = 0;
+    public static final short CONTEXT_INCLUDE   = 0;
     /**
      * Indicate that the current schema document is <redefine>d by another
      * schema document.
      */
-    public final static short CONTEXT_REDEFINE  = 1;
+    public static final short CONTEXT_REDEFINE  = 1;
     /**
      * Indicate that the current schema document is <import>ed by another
      * schema document.
      */
-    public final static short CONTEXT_IMPORT    = 2;
+    public static final short CONTEXT_IMPORT    = 2;
     /**
      * Indicate that the current schema document is being preparsed.
      */
-    public final static short CONTEXT_PREPARSE  = 3;
+    public static final short CONTEXT_PREPARSE  = 3;
     /**
      * Indicate that the parse of the current schema document is triggered
      * by xsi:schemaLocation/noNamespaceSchemaLocation attribute(s) in the
      * instance document. This value is only used if we don't defer the loading
      * of schema documents.
      */
-    public final static short CONTEXT_INSTANCE  = 4;
+    public static final short CONTEXT_INSTANCE  = 4;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an element whose namespace is the target namespace
@@ -76,7 +76,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ELEMENT   = 5;
+    public static final short CONTEXT_ELEMENT   = 5;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an attribute whose namespace is the target namespace
@@ -84,7 +84,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ATTRIBUTE = 6;
+    public static final short CONTEXT_ATTRIBUTE = 6;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an "xsi:type" attribute, whose value (a QName) has
@@ -92,7 +92,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * This value is only used if we do defer the loading of schema documents
      * until a component from that namespace is referenced from the instance.
      */
-    public final static short CONTEXT_XSITYPE   = 7;
+    public static final short CONTEXT_XSITYPE   = 7;
 
     // REVISIT: write description of these fields
     protected short fContextType;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSElementDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSElementDecl.java
@@ -48,9 +48,9 @@ import com.sun.org.apache.xerces.internal.xs.XSValue;
 public class XSElementDecl implements XSElementDeclaration {
 
     // scopes
-    public final static short     SCOPE_ABSENT        = 0;
-    public final static short     SCOPE_GLOBAL        = 1;
-    public final static short     SCOPE_LOCAL         = 2;
+    public static final short     SCOPE_ABSENT        = 0;
+    public static final short     SCOPE_GLOBAL        = 1;
+    public static final short     SCOPE_LOCAL         = 2;
 
     // name of the element
     public String fName = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java
@@ -67,7 +67,7 @@ public class SchemaParsingConfig extends BasicParserConfiguration
     // Constants
     //
 
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
@@ -68,7 +68,7 @@ import org.w3c.dom.Element;
 class  XSDComplexTypeTraverser extends XSDAbstractParticleTraverser {
 
     // size of stack to hold globals:
-    private final static int GLOBAL_NUM = 11;
+    private static final int GLOBAL_NUM = 11;
 
     private static XSParticleDecl fErrorContent = null;
     private static XSWildcardDecl fErrorWildcard = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
@@ -233,17 +233,17 @@ public class XSDHandler {
 
     // different sorts of declarations; should make lookup and
     // traverser calling more efficient/less bulky.
-    final static int ATTRIBUTE_TYPE          = 1;
-    final static int ATTRIBUTEGROUP_TYPE     = 2;
-    final static int ELEMENT_TYPE            = 3;
-    final static int GROUP_TYPE              = 4;
-    final static int IDENTITYCONSTRAINT_TYPE = 5;
-    final static int NOTATION_TYPE           = 6;
-    final static int TYPEDECL_TYPE           = 7;
+    static final int ATTRIBUTE_TYPE          = 1;
+    static final int ATTRIBUTEGROUP_TYPE     = 2;
+    static final int ELEMENT_TYPE            = 3;
+    static final int GROUP_TYPE              = 4;
+    static final int IDENTITYCONSTRAINT_TYPE = 5;
+    static final int NOTATION_TYPE           = 6;
+    static final int TYPEDECL_TYPE           = 7;
 
     // this string gets appended to redefined names; it's purpose is to be
     // as unlikely as possible to cause collisions.
-    public final static String REDEF_IDENTIFIER = "_fn3dktizrknc9pi";
+    public static final String REDEF_IDENTIFIER = "_fn3dktizrknc9pi";
 
     //protected data that can be accessible by any traverser
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/validation/DOMResultBuilder.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/validation/DOMResultBuilder.java
@@ -70,7 +70,7 @@ import org.w3c.dom.Text;
 final class DOMResultBuilder implements DOMDocumentHandler {
 
     /** Table for quick check of child insertion. */
-    private final static int[] kidOK;
+    private static final int[] kidOK;
 
     static {
         kidOK = new int[13];

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParserImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParserImpl.java
@@ -150,7 +150,7 @@ extends AbstractDOMParser implements LSParser, DOMConfiguration {
 
     private Thread currentThread;
 
-    protected final static boolean DEBUG = false;
+    protected static final boolean DEBUG = false;
 
     private String fSchemaLocation = null;
         private DOMStringList fRecognizedParameters;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11Configuration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11Configuration.java
@@ -85,7 +85,7 @@ public class XML11Configuration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java
@@ -111,7 +111,7 @@ public class XML11DTDConfiguration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java
@@ -84,7 +84,7 @@ public class XML11NonValidatingConfiguration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLGrammarPreparser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLGrammarPreparser.java
@@ -58,7 +58,7 @@ public class XMLGrammarPreparser {
     //
 
     // feature:  continue-after-fatal-error
-    private final static String CONTINUE_AFTER_FATAL_ERROR =
+    private static final String CONTINUE_AFTER_FATAL_ERROR =
         Constants.XERCES_FEATURE_PREFIX + Constants.CONTINUE_AFTER_FATAL_ERROR_FEATURE;
 
     /** Property identifier: symbol table. */

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/AugmentationsImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/AugmentationsImpl.java
@@ -114,7 +114,7 @@ public class AugmentationsImpl implements Augmentations{
     }
 
     class SmallContainer extends AugmentationsItemsContainer {
-        final static int SIZE_LIMIT = 10;
+        static final int SIZE_LIMIT = 10;
         final Object[] fAugmentations = new Object[SIZE_LIMIT*2];
         int fNumEntries = 0;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/EncodingMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/EncodingMap.java
@@ -479,10 +479,10 @@ public class EncodingMap {
     //
 
     /** fIANA2JavaMap */
-    protected final static Map<String, String> fIANA2JavaMap;
+    protected static final Map<String, String> fIANA2JavaMap;
 
     /** fJava2IANAMap */
-    protected final static Map<String, String> fJava2IANAMap;
+    protected static final Map<String, String> fJava2IANAMap;
 
     //
     // Static initialization

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/SecurityManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/SecurityManager.java
@@ -45,16 +45,16 @@ public final class SecurityManager {
     //
 
     // default value for entity expansion limit
-    private final static int DEFAULT_ENTITY_EXPANSION_LIMIT = 64000;
+    private static final int DEFAULT_ENTITY_EXPANSION_LIMIT = 64000;
 
     /** Default value of number of nodes created. **/
-    private final static int DEFAULT_MAX_OCCUR_NODE_LIMIT = 5000;
+    private static final int DEFAULT_MAX_OCCUR_NODE_LIMIT = 5000;
 
     //
     // Data
     //
 
-        private final static int DEFAULT_ELEMENT_ATTRIBUTE_LIMIT = 10000;
+        private static final int DEFAULT_ELEMENT_ATTRIBUTE_LIMIT = 10000;
 
     /** Entity expansion limit. **/
     private int entityExpansionLimit;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/XMLSymbols.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/XMLSymbols.java
@@ -38,7 +38,7 @@ public class XMLSymbols {
     /**
      * The empty string.
      */
-    public final static String EMPTY_STRING = "".intern();
+    public static final String EMPTY_STRING = "".intern();
 
     //==========================
     // Namespace prefixes/uris
@@ -47,12 +47,12 @@ public class XMLSymbols {
     /**
      * The internalized "xml" prefix.
      */
-    public final static String PREFIX_XML = "xml".intern();
+    public static final String PREFIX_XML = "xml".intern();
 
     /**
      * The internalized "xmlns" prefix.
      */
-    public final static String PREFIX_XMLNS = "xmlns".intern();
+    public static final String PREFIX_XMLNS = "xmlns".intern();
 
     //==========================
     // DTD symbols

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xinclude/XIncludeHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xinclude/XIncludeHandler.java
@@ -132,33 +132,33 @@ import org.xml.sax.InputSource;
 public class XIncludeHandler
     implements XMLComponent, XMLDocumentFilter, XMLDTDFilter {
 
-    public final static String HTTP_ACCEPT = "Accept";
-    public final static String HTTP_ACCEPT_LANGUAGE = "Accept-Language";
-    public final static String XPOINTER = "xpointer";
+    public static final String HTTP_ACCEPT = "Accept";
+    public static final String HTTP_ACCEPT_LANGUAGE = "Accept-Language";
+    public static final String XPOINTER = "xpointer";
 
-    public final static String XINCLUDE_NS_URI =
+    public static final String XINCLUDE_NS_URI =
         "http://www.w3.org/2001/XInclude".intern();
-    public final static String XINCLUDE_INCLUDE = "include".intern();
-    public final static String XINCLUDE_FALLBACK = "fallback".intern();
+    public static final String XINCLUDE_INCLUDE = "include".intern();
+    public static final String XINCLUDE_FALLBACK = "fallback".intern();
 
-    public final static String XINCLUDE_PARSE_XML = "xml".intern();
-    public final static String XINCLUDE_PARSE_TEXT = "text".intern();
+    public static final String XINCLUDE_PARSE_XML = "xml".intern();
+    public static final String XINCLUDE_PARSE_TEXT = "text".intern();
 
-    public final static String XINCLUDE_ATTR_HREF = "href".intern();
-    public final static String XINCLUDE_ATTR_PARSE = "parse".intern();
-    public final static String XINCLUDE_ATTR_ENCODING = "encoding".intern();
-    public final static String XINCLUDE_ATTR_ACCEPT = "accept".intern();
-    public final static String XINCLUDE_ATTR_ACCEPT_LANGUAGE = "accept-language".intern();
+    public static final String XINCLUDE_ATTR_HREF = "href".intern();
+    public static final String XINCLUDE_ATTR_PARSE = "parse".intern();
+    public static final String XINCLUDE_ATTR_ENCODING = "encoding".intern();
+    public static final String XINCLUDE_ATTR_ACCEPT = "accept".intern();
+    public static final String XINCLUDE_ATTR_ACCEPT_LANGUAGE = "accept-language".intern();
 
     // Top Level Information Items have [included] property in infoset
-    public final static String XINCLUDE_INCLUDED = "[included]".intern();
+    public static final String XINCLUDE_INCLUDED = "[included]".intern();
 
     /** The identifier for the Augmentation that contains the current base URI */
-    public final static String CURRENT_BASE_URI = "currentBaseURI";
+    public static final String CURRENT_BASE_URI = "currentBaseURI";
 
     // used for adding [base URI] attributes
-    private final static String XINCLUDE_BASE = "base".intern();
-    private final static QName XML_BASE_QNAME =
+    private static final String XINCLUDE_BASE = "base".intern();
+    private static final QName XML_BASE_QNAME =
         new QName(
             XMLSymbols.PREFIX_XML,
             XINCLUDE_BASE,
@@ -166,15 +166,15 @@ public class XIncludeHandler
             NamespaceContext.XML_URI);
 
     // used for adding [language] attributes
-    private final static String XINCLUDE_LANG = "lang".intern();
-    private final static QName XML_LANG_QNAME =
+    private static final String XINCLUDE_LANG = "lang".intern();
+    private static final QName XML_LANG_QNAME =
         new QName(
             XMLSymbols.PREFIX_XML,
             XINCLUDE_LANG,
             (XMLSymbols.PREFIX_XML + ":" + XINCLUDE_LANG).intern(),
             NamespaceContext.XML_URI);
 
-    private final static QName NEW_NS_ATTR_QNAME =
+    private static final QName NEW_NS_ATTR_QNAME =
         new QName(
             XMLSymbols.PREFIX_XMLNS,
             "",
@@ -182,13 +182,13 @@ public class XIncludeHandler
             NamespaceContext.XMLNS_URI);
 
     // Processing States
-    private final static int STATE_NORMAL_PROCESSING = 1;
+    private static final int STATE_NORMAL_PROCESSING = 1;
     // we go into this state after a successful include (thus we ignore the children
     // of the include) or after a fallback
-    private final static int STATE_IGNORE = 2;
+    private static final int STATE_IGNORE = 2;
     // we go into this state after a failed include.  If we don't encounter a fallback
     // before we reach the end include tag, it's a fatal error
-    private final static int STATE_EXPECT_FALLBACK = 3;
+    private static final int STATE_EXPECT_FALLBACK = 3;
 
     // recognized features and properties
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/NamespaceContext.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/NamespaceContext.java
@@ -46,14 +46,14 @@ public interface NamespaceContext {
      * The XML Namespace ("http://www.w3.org/XML/1998/namespace"). This is
      * the Namespace URI that is automatically mapped to the "xml" prefix.
      */
-    public final static String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
+    public static final String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
 
     /**
      * XML Information Set REC
      * all namespace attributes (including those named xmlns,
      * whose [prefix] property has no value) have a namespace URI of http://www.w3.org/2000/xmlns/
      */
-    public final static String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
+    public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
 
     //
     // NamespaceContext methods

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/grammars/XMLSchemaDescription.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/grammars/XMLSchemaDescription.java
@@ -37,28 +37,28 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * Indicate that the current schema document is &lt;include&gt;d by another
      * schema document.
      */
-    public final static short CONTEXT_INCLUDE   = 0;
+    public static final short CONTEXT_INCLUDE   = 0;
     /**
      * Indicate that the current schema document is &lt;redefine&gt;d by another
      * schema document.
      */
-    public final static short CONTEXT_REDEFINE  = 1;
+    public static final short CONTEXT_REDEFINE  = 1;
     /**
      * Indicate that the current schema document is &lt;import&gt;ed by another
      * schema document.
      */
-    public final static short CONTEXT_IMPORT    = 2;
+    public static final short CONTEXT_IMPORT    = 2;
     /**
      * Indicate that the current schema document is being preparsed.
      */
-    public final static short CONTEXT_PREPARSE  = 3;
+    public static final short CONTEXT_PREPARSE  = 3;
     /**
      * Indicate that the parse of the current schema document is triggered
      * by xsi:schemaLocation/noNamespaceSchemaLocation attribute(s) in the
      * instance document. This value is only used if we don't defer the loading
      * of schema documents.
      */
-    public final static short CONTEXT_INSTANCE  = 4;
+    public static final short CONTEXT_INSTANCE  = 4;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an element whose namespace is the target namespace
@@ -66,7 +66,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ELEMENT   = 5;
+    public static final short CONTEXT_ELEMENT   = 5;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an attribute whose namespace is the target namespace
@@ -74,7 +74,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ATTRIBUTE = 6;
+    public static final short CONTEXT_ATTRIBUTE = 6;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an "xsi:type" attribute, whose value (a QName) has
@@ -82,7 +82,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * This value is only used if we do defer the loading of schema documents
      * until a component from that namespace is referenced from the instance.
      */
-    public final static short CONTEXT_XSITYPE   = 7;
+    public static final short CONTEXT_XSITYPE   = 7;
 
     /**
      * Get the context. The returned value is one of the pre-defined

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/CoroutineManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/CoroutineManager.java
@@ -150,8 +150,8 @@ public class CoroutineManager
   Object m_yield=null;
 
   // Expose???
-  final static int NOBODY=-1;
-  final static int ANYBODY=-1;
+  static final int NOBODY=-1;
+  static final int ANYBODY=-1;
 
   /** Internal field used to confirm that the coroutine now waking up is
    * in fact the one we intended to resume. Some such selection mechanism

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
@@ -121,7 +121,7 @@ public abstract class DTMDefaultBase implements DTM
   /** The mask for the identity.
       %REVIEW% Should this really be set to the _DEFAULT? What if
       a particular DTM wanted to use another value? */
-  //protected final static int m_mask = DTMManager.IDENT_NODE_DEFAULT;
+  //protected static final int m_mask = DTMManager.IDENT_NODE_DEFAULT;
 
   /** The base URI for this document. */
   protected String m_documentBaseURI;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
@@ -894,7 +894,7 @@ public abstract class DTMDefaultBase implements DTM
    * @param nodeIdentity Internal offset to this node's records.
    * @return NodeHandle (external representation of node)
    * */
-  final public int makeNodeHandle(int nodeIdentity)
+  public final int makeNodeHandle(int nodeIdentity)
   {
     if(NULL==nodeIdentity) return NULL;
 
@@ -921,7 +921,7 @@ public abstract class DTMDefaultBase implements DTM
    * @param nodeHandle (external representation of node)
    * @return nodeIdentity Internal offset to this node's records.
    * */
-  final public int makeNodeIdentity(int nodeHandle)
+  public final int makeNodeIdentity(int nodeHandle)
   {
     if(NULL==nodeHandle) return NULL;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
@@ -1774,16 +1774,16 @@ public class SAX2DTM2 extends SAX2DTM
    * doing this.
    */
   // The number of bits for the length of a Text node.
-  protected final static int TEXT_LENGTH_BITS = 10;
+  protected static final int TEXT_LENGTH_BITS = 10;
 
   // The number of bits for the offset of a Text node.
-  protected final static int TEXT_OFFSET_BITS = 21;
+  protected static final int TEXT_OFFSET_BITS = 21;
 
   // The maximum length value
-  protected final static int TEXT_LENGTH_MAX = (1<<TEXT_LENGTH_BITS) - 1;
+  protected static final int TEXT_LENGTH_MAX = (1<<TEXT_LENGTH_BITS) - 1;
 
   // The maximum offset value
-  protected final static int TEXT_OFFSET_MAX = (1<<TEXT_OFFSET_BITS) - 1;
+  protected static final int TEXT_OFFSET_MAX = (1<<TEXT_OFFSET_BITS) - 1;
 
   // True if we want to build the ID index table.
   protected boolean m_buildIdIndex = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
@@ -100,18 +100,18 @@ public class DOMSerializerImpl implements LSSerializer, DOMConfiguration {
      */
     protected short features = 0;
 
-    protected final static short NAMESPACES = 0x1 << 0;
-    protected final static short WELLFORMED = 0x1 << 1;
-    protected final static short ENTITIES = 0x1 << 2;
-    protected final static short CDATA = 0x1 << 3;
-    protected final static short SPLITCDATA = 0x1 << 4;
-    protected final static short COMMENTS = 0x1 << 5;
-    protected final static short DISCARDDEFAULT = 0x1 << 6;
-    protected final static short INFOSET = 0x1 << 7;
-    protected final static short XMLDECL = 0x1 << 8;
-    protected final static short NSDECL = 0x1 << 9;
-    protected final static short DOM_ELEMENT_CONTENT_WHITESPACE = 0x1 << 10;
-    protected final static short PRETTY_PRINT = 0x1 << 11;
+    protected static final short NAMESPACES = 0x1 << 0;
+    protected static final short WELLFORMED = 0x1 << 1;
+    protected static final short ENTITIES = 0x1 << 2;
+    protected static final short CDATA = 0x1 << 3;
+    protected static final short SPLITCDATA = 0x1 << 4;
+    protected static final short COMMENTS = 0x1 << 5;
+    protected static final short DISCARDDEFAULT = 0x1 << 6;
+    protected static final short INFOSET = 0x1 << 7;
+    protected static final short XMLDECL = 0x1 << 8;
+    protected static final short NSDECL = 0x1 << 9;
+    protected static final short DOM_ELEMENT_CONTENT_WHITESPACE = 0x1 << 10;
+    protected static final short PRETTY_PRINT = 0x1 << 11;
 
     // well-formness checking
     private DOMErrorHandler fErrorHandler = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
@@ -114,7 +114,7 @@ extends XMLSerializer {
     protected boolean fDOML1 = false;
     // counter for new prefix names
     protected int fNamespaceCounter = 1;
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     /**
      * Controls whether namespace fixup should be performed during

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
@@ -121,7 +121,7 @@ extends BaseMarkupSerializer {
     /** symbol table for serialization */
     protected SymbolTable fSymbolTable;
 
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     /**
      * Controls whether namespace fixup should be performed during

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/Encodings.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/Encodings.java
@@ -308,7 +308,7 @@ public final class Encodings extends Object
     // Using an inner static class here prevent initialization races
     // where the hash maps could be used before they were populated.
     //
-    private final static class EncodingInfos {
+    private static final class EncodingInfos {
         // These maps are final and not modified after initialization.
         private final Map<String, EncodingInfo> _encodingTableKeyJava = new HashMap<>();
         private final Map<String, EncodingInfo> _encodingTableKeyMime = new HashMap<>();
@@ -576,6 +576,6 @@ public final class Encodings extends Object
         return codePoint;
     }
 
-    private final static EncodingInfos _encodingInfos = new EncodingInfos();
+    private static final EncodingInfos _encodingInfos = new EncodingInfos();
 
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
@@ -138,63 +138,63 @@ final class DOM3TreeWalker {
     // DOMConfiguration paramter settings
     // ***********************************************************************
     // Parameter canonical-form, true [optional] - NOT SUPPORTED
-    private final static int CANONICAL = 0x1 << 0;
+    private static final int CANONICAL = 0x1 << 0;
 
     // Parameter cdata-sections, true [required] (default)
-    private final static int CDATA = 0x1 << 1;
+    private static final int CDATA = 0x1 << 1;
 
     // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
-    private final static int CHARNORMALIZE = 0x1 << 2;
+    private static final int CHARNORMALIZE = 0x1 << 2;
 
     // Parameter comments, true [required] (default)
-    private final static int COMMENTS = 0x1 << 3;
+    private static final int COMMENTS = 0x1 << 3;
 
     // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
-    private final static int DTNORMALIZE = 0x1 << 4;
+    private static final int DTNORMALIZE = 0x1 << 4;
 
     // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
-    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+    private static final int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
 
     // Parameter entities, true [required] (default)
-    private final static int ENTITIES = 0x1 << 6;
+    private static final int ENTITIES = 0x1 << 6;
 
     // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
-    private final static int INFOSET = 0x1 << 7;
+    private static final int INFOSET = 0x1 << 7;
 
     // Parameter namespaces, true [required] (default)
-    private final static int NAMESPACES = 0x1 << 8;
+    private static final int NAMESPACES = 0x1 << 8;
 
     // Parameter namespace-declarations, true [required] (default)
-    private final static int NAMESPACEDECLS = 0x1 << 9;
+    private static final int NAMESPACEDECLS = 0x1 << 9;
 
     // Parameter normalize-characters, true [optional] - NOT SUPPORTED
-    private final static int NORMALIZECHARS = 0x1 << 10;
+    private static final int NORMALIZECHARS = 0x1 << 10;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int SPLITCDATA = 0x1 << 11;
+    private static final int SPLITCDATA = 0x1 << 11;
 
     // Parameter validate, true [optional] - NOT SUPPORTED
-    private final static int VALIDATE = 0x1 << 12;
+    private static final int VALIDATE = 0x1 << 12;
 
     // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
-    private final static int SCHEMAVALIDATE = 0x1 << 13;
+    private static final int SCHEMAVALIDATE = 0x1 << 13;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int WELLFORMED = 0x1 << 14;
+    private static final int WELLFORMED = 0x1 << 14;
 
     // Parameter discard-default-content, true [required] (default)
     // Not sure how this will be used in level 2 Documents
-    private final static int DISCARDDEFAULT = 0x1 << 15;
+    private static final int DISCARDDEFAULT = 0x1 << 15;
 
     // Parameter format-pretty-print, true [optional]
-    private final static int PRETTY_PRINT = 0x1 << 16;
+    private static final int PRETTY_PRINT = 0x1 << 16;
 
     // Parameter ignore-unknown-character-denormalizations, true [required] (default)
     // We currently do not support XML 1.1 character normalization
-    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+    private static final int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
 
     // Parameter discard-default-content, true [required] (default)
-    private final static int XMLDECL = 0x1 << 18;
+    private static final int XMLDECL = 0x1 << 18;
 
     /**
      * Constructor.

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
@@ -103,66 +103,66 @@ final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
     // DOM Level 3 DOM Configuration parameter names
     // ************************************************************************
     // Parameter canonical-form, true [optional] - NOT SUPPORTED
-    private final static int CANONICAL = 0x1 << 0;
+    private static final int CANONICAL = 0x1 << 0;
 
     // Parameter cdata-sections, true [required] (default)
-    private final static int CDATA = 0x1 << 1;
+    private static final int CDATA = 0x1 << 1;
 
     // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
-    private final static int CHARNORMALIZE = 0x1 << 2;
+    private static final int CHARNORMALIZE = 0x1 << 2;
 
     // Parameter comments, true [required] (default)
-    private final static int COMMENTS = 0x1 << 3;
+    private static final int COMMENTS = 0x1 << 3;
 
     // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
-    private final static int DTNORMALIZE = 0x1 << 4;
+    private static final int DTNORMALIZE = 0x1 << 4;
 
     // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
-    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+    private static final int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
 
     // Parameter entities, true [required] (default)
-    private final static int ENTITIES = 0x1 << 6;
+    private static final int ENTITIES = 0x1 << 6;
 
     // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
-    private final static int INFOSET = 0x1 << 7;
+    private static final int INFOSET = 0x1 << 7;
 
     // Parameter namespaces, true [required] (default)
-    private final static int NAMESPACES = 0x1 << 8;
+    private static final int NAMESPACES = 0x1 << 8;
 
     // Parameter namespace-declarations, true [required] (default)
-    private final static int NAMESPACEDECLS = 0x1 << 9;
+    private static final int NAMESPACEDECLS = 0x1 << 9;
 
     // Parameter normalize-characters, true [optional] - NOT SUPPORTED
-    private final static int NORMALIZECHARS = 0x1 << 10;
+    private static final int NORMALIZECHARS = 0x1 << 10;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int SPLITCDATA = 0x1 << 11;
+    private static final int SPLITCDATA = 0x1 << 11;
 
     // Parameter validate, true [optional] - NOT SUPPORTED
-    private final static int VALIDATE = 0x1 << 12;
+    private static final int VALIDATE = 0x1 << 12;
 
     // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
-    private final static int SCHEMAVALIDATE = 0x1 << 13;
+    private static final int SCHEMAVALIDATE = 0x1 << 13;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int WELLFORMED = 0x1 << 14;
+    private static final int WELLFORMED = 0x1 << 14;
 
     // Parameter discard-default-content, true [required] (default)
     // Not sure how this will be used in level 2 Documents
-    private final static int DISCARDDEFAULT = 0x1 << 15;
+    private static final int DISCARDDEFAULT = 0x1 << 15;
 
     // Parameter format-pretty-print, true [optional]
-    private final static int PRETTY_PRINT = 0x1 << 16;
+    private static final int PRETTY_PRINT = 0x1 << 16;
 
     // Parameter ignore-unknown-character-denormalizations, true [required] (default)
     // We currently do not support XML 1.1 character normalization
-    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+    private static final int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
 
     // Parameter discard-default-content, true [required] (default)
-    private final static int XMLDECL = 0x1 << 18;
+    private static final int XMLDECL = 0x1 << 18;
 
     // Parameter is-standalone, jdk specific, not required
-    private final static int IS_STANDALONE = 0x1 << 19;
+    private static final int IS_STANDALONE = 0x1 << 19;
 
     // ************************************************************************
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
@@ -70,7 +70,7 @@ import org.w3c.dom.ls.LSSerializerFilter;
  * @xsl.usage internal
  * @LastModified: Jan 2021
  */
-final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
+public final class LSSerializerImpl implements DOMConfiguration, LSSerializer {
 
     /** private data members */
     private Serializer fXMLSerializer = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
@@ -47,14 +47,14 @@ public class NamespaceSupport {
      * The XML Namespace ("http://www.w3.org/XML/1998/namespace"). This is
      * the Namespace URI that is automatically mapped to the "xml" prefix.
      */
-    public final static String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
+    public static final String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
 
     /**
      * XML Information Set REC
      * all namespace attributes (including those named xmlns,
      * whose [prefix] property has no value) have a namespace URI of http://www.w3.org/2000/xmlns/
      */
-    public final static String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
+    public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
 
         //
     // Data

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/LocaleUtility.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/LocaleUtility.java
@@ -32,8 +32,8 @@ public class LocaleUtility {
     /**
      * IETF RFC 1766 tag separator
      */
-    public final static char IETF_SEPARATOR = '-';
-    public final static String EMPTY_STRING = "";
+    public static final char IETF_SEPARATOR = '-';
+    public static final String EMPTY_STRING = "";
 
 
  public static Locale langToLocale(String lang) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringComparable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringComparable.java
@@ -33,9 +33,9 @@ import java.util.Locale;
 */
 public class StringComparable implements Comparable<StringComparable>  {
 
-     public final static int UNKNOWN_CASE = -1;
-     public final static int UPPER_CASE = 1;
-     public final static int LOWER_CASE = 2;
+     public static final int UNKNOWN_CASE = -1;
+     public static final int UPPER_CASE = 1;
+     public static final int LOWER_CASE = 2;
 
      private  String m_text;
      private  Locale m_locale;
@@ -53,7 +53,7 @@ public class StringComparable implements Comparable<StringComparable>  {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public final static Comparable getComparator( final String text, final Locale locale,
+    public static final Comparable getComparator( final String text, final Locale locale,
             final Collator collator, final String caseOrder){
         if((caseOrder == null) ||(caseOrder.length() == 0)){// no case-order specified
             return  ((RuleBasedCollator)collator).getCollationKey(text);

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
@@ -840,7 +840,7 @@ public class NodeSequence extends XObject
     * <p>
     * Its use-count is the number of NodeSequence objects that use it.
     */
-   private final static class IteratorCache {
+   private static final class IteratorCache {
        /**
         * A list of nodes already obtained from the iterator.
         * As the iterator is walked the nodes obtained from

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
@@ -68,9 +68,9 @@ public class XPathParser
   /**
    * Results from checking FilterExpr syntax
    */
-  protected final static int FILTER_MATCH_FAILED     = 0;
-  protected final static int FILTER_MATCH_PRIMARY    = 1;
-  protected final static int FILTER_MATCH_PREDICATES = 2;
+  protected static final int FILTER_MATCH_FAILED     = 0;
+  protected static final int FILTER_MATCH_PRIMARY    = 1;
+  protected static final int FILTER_MATCH_PREDICATES = 2;
 
   // counts open predicates
   private int countPredicate;

--- a/src/java.xml/share/classes/javax/xml/catalog/Util.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/Util.java
@@ -47,12 +47,12 @@ import jdk.xml.internal.SecuritySupport;
  */
 class Util {
 
-    final static String URN = "urn:publicid:";
-    final static String PUBLICID_PREFIX = "-//";
-    final static String PUBLICID_PREFIX_ALT = "+//";
-    final static String SCHEME_FILE = "file";
-    final static String SCHEME_JAR = "jar";
-    final static String SCHEME_JARFILE = "jar:file:";
+    static final String URN = "urn:publicid:";
+    static final String PUBLICID_PREFIX = "-//";
+    static final String PUBLICID_PREFIX_ALT = "+//";
+    static final String SCHEME_FILE = "file";
+    static final String SCHEME_JAR = "jar";
+    static final String SCHEME_JARFILE = "jar:file:";
 
     /**
      * Finds an entry in the catalog that matches with the publicId or systemId.

--- a/src/java.xml/share/classes/javax/xml/datatype/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/datatype/FactoryFinder.java
@@ -54,7 +54,7 @@ class FactoryFinder {
     /**
      * Cache for properties in java.home/conf/jaxp.properties
      */
-    private final static Properties cacheProps = new Properties();
+    private static final Properties cacheProps = new Properties();
 
     /**
      * Flag indicating if properties from java.home/conf/jaxp.properties

--- a/src/java.xml/share/classes/javax/xml/transform/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/transform/FactoryFinder.java
@@ -56,7 +56,7 @@ class FactoryFinder {
     /**
      * Cache for properties in java.home/conf/jaxp.properties
      */
-    private final static Properties cacheProps = new Properties();
+    private static final Properties cacheProps = new Properties();
 
     /**
      * Flag indicating if properties from java.home/conf/jaxp.properties

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
@@ -56,7 +56,7 @@ public class JdkXmlFeatures {
             "jdk.xml.enableExtensionFunctions";
     public static final String CATALOG_FEATURES = "javax.xml.catalog.catalogFeatures";
 
-    public final static String PROPERTY_USE_CATALOG = XMLConstants.USE_CATALOG;
+    public static final String PROPERTY_USE_CATALOG = XMLConstants.USE_CATALOG;
 
     public static enum XmlFeature {
         /**

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
@@ -66,18 +66,18 @@ public class JdkXmlUtils {
     /**
      * Catalog features
      */
-    public final static String USE_CATALOG = XMLConstants.USE_CATALOG;
-    public final static String SP_USE_CATALOG = "javax.xml.useCatalog";
-    public final static String CATALOG_FILES = CatalogFeatures.Feature.FILES.getPropertyName();
-    public final static String CATALOG_DEFER = CatalogFeatures.Feature.DEFER.getPropertyName();
-    public final static String CATALOG_PREFER = CatalogFeatures.Feature.PREFER.getPropertyName();
-    public final static String CATALOG_RESOLVE = CatalogFeatures.Feature.RESOLVE.getPropertyName();
+    public static final String USE_CATALOG = XMLConstants.USE_CATALOG;
+    public static final String SP_USE_CATALOG = "javax.xml.useCatalog";
+    public static final String CATALOG_FILES = CatalogFeatures.Feature.FILES.getPropertyName();
+    public static final String CATALOG_DEFER = CatalogFeatures.Feature.DEFER.getPropertyName();
+    public static final String CATALOG_PREFER = CatalogFeatures.Feature.PREFER.getPropertyName();
+    public static final String CATALOG_RESOLVE = CatalogFeatures.Feature.RESOLVE.getPropertyName();
 
     /**
      * Reset SymbolTable feature System property name is identical to feature
      * name
      */
-    public final static String RESET_SYMBOL_TABLE = "jdk.xml.resetSymbolTable";
+    public static final String RESET_SYMBOL_TABLE = "jdk.xml.resetSymbolTable";
 
     /**
      * jdk.xml.overrideDefaultParser: enables the use of a 3rd party's parser
@@ -108,7 +108,7 @@ public class JdkXmlUtils {
     /**
      * JDK features (will be consolidated in the next major feature revamp
      */
-    public final static String CDATA_CHUNK_SIZE = "jdk.xml.cdataChunkSize";
+    public static final String CDATA_CHUNK_SIZE = "jdk.xml.cdataChunkSize";
     public static final int CDATA_CHUNK_SIZE_DEFAULT
             = SecuritySupport.getJAXPSystemProperty(Integer.class, CDATA_CHUNK_SIZE, "0");
 

--- a/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
@@ -45,7 +45,7 @@ import java.util.ResourceBundle;
  * This class contains utility methods for reading resources in the JAXP packages
  */
 public class SecuritySupport {
-    public final static String NEWLINE = System.lineSeparator();
+    public static final String NEWLINE = System.lineSeparator();
 
     /**
      * Cache for properties in java.home/conf/jaxp.properties

--- a/src/java.xml/share/classes/org/xml/sax/helpers/NamespaceSupport.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/NamespaceSupport.java
@@ -100,7 +100,7 @@ public class NamespaceSupport
      * <p>This is the Namespace URI that is automatically mapped
      * to the "xml" prefix.</p>
      */
-    public final static String XMLNS =
+    public static final String XMLNS =
         "http://www.w3.org/XML/1998/namespace";
 
 
@@ -120,14 +120,14 @@ public class NamespaceSupport
      * @see #setNamespaceDeclUris
      * @see #isNamespaceDeclUris
      */
-    public final static String NSDECL =
+    public static final String NSDECL =
         "http://www.w3.org/xmlns/2000/";
 
 
     /**
      * An empty enumeration.
      */
-    private final static Enumeration<String> EMPTY_ENUMERATION =
+    private static final Enumeration<String> EMPTY_ENUMERATION =
             Collections.enumeration(new ArrayList<String>());
 
 

--- a/src/java.xml/share/classes/org/xml/sax/helpers/ParserAdapter.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/ParserAdapter.java
@@ -167,10 +167,10 @@ public class ParserAdapter implements XMLReader, DocumentHandler
     //
     // Internal constants for the sake of convenience.
     //
-    private final static String FEATURES = "http://xml.org/sax/features/";
-    private final static String NAMESPACES = FEATURES + "namespaces";
-    private final static String NAMESPACE_PREFIXES = FEATURES + "namespace-prefixes";
-    private final static String XMLNS_URIs = FEATURES + "xmlns-uris";
+    private static final String FEATURES = "http://xml.org/sax/features/";
+    private static final String NAMESPACES = FEATURES + "namespaces";
+    private static final String NAMESPACE_PREFIXES = FEATURES + "namespace-prefixes";
+    private static final String XMLNS_URIs = FEATURES + "xmlns-uris";
 
 
     /**

--- a/src/java.xml/share/classes/org/xml/sax/helpers/XMLReaderFactory.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/XMLReaderFactory.java
@@ -70,7 +70,7 @@ import org.xml.sax.XMLReader;
  * instead.
  */
 @Deprecated(since="9")
-final public class XMLReaderFactory
+public final class XMLReaderFactory
 {
     /**
      * Private constructor.


### PR DESCRIPTION
As a subtask of JDK-8263854 this cleans up the `java.xml` module to used the blessed modifier order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264019](https://bugs.openjdk.java.net/browse/JDK-8264019): Use the blessed modifier order in java.xml


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3091/head:pull/3091`
`$ git checkout pull/3091`

To update a local copy of the PR:
`$ git checkout pull/3091`
`$ git pull https://git.openjdk.java.net/jdk pull/3091/head`
