### PR TITLE
JDK-8263884: Clean up os::is_allocatable() across Posix platforms

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -556,7 +556,7 @@ static bool is_allocatable(size_t s) {
   // of our reservation layers. We will unmap right away.
   void* p = ::mmap(NULL, s, PROT_NONE,
                    MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS, -1, 0);
-  if (p == (void*)MAP_FAILED) {
+  if (p == MAP_FAILED) {
     return false;
   } else {
     ::munmap(p, s);

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -641,26 +641,6 @@ bool os::supports_sse() {
   return true;
 }
 
-bool os::is_allocatable(size_t bytes) {
-#ifdef AMD64
-  // unused on amd64?
-  return true;
-#else
-
-  if (bytes < 2 * G) {
-    return true;
-  }
-
-  char* addr = reserve_memory(bytes);
-
-  if (addr != NULL) {
-    release_memory(addr, bytes);
-  }
-
-  return addr != NULL;
-#endif // AMD64
-}
-
 juint os::cpu_microcode_revision() {
   juint result = 0;
   char data[8];

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.hpp
@@ -37,8 +37,6 @@
 
   static jlong rdtsc();
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -158,24 +158,6 @@ void os::Bsd::init_thread_fpu_state(void) {
   // Nothing to do
 }
 
-bool os::is_allocatable(size_t bytes) {
-#ifdef _LP64
-  return true;
-#else
-  if (bytes < 2 * G) {
-    return true;
-  }
-
-  char* addr = reserve_memory(bytes);
-
-  if (addr != NULL) {
-    release_memory(addr, bytes);
-  }
-
-  return addr != NULL;
-#endif // _LP64
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // thread stack
 

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.hpp
@@ -28,8 +28,6 @@
 
   static void setup_fpu() {}
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -304,10 +304,6 @@ int os::Linux::get_fpu_control_word(void) {
 void os::Linux::set_fpu_control_word(int fpu_control) {
 }
 
-bool os::is_allocatable(size_t bytes) {
-  return true;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // thread stack
 

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.hpp
@@ -32,8 +32,6 @@
 
   static void setup_fpu();
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -413,10 +413,6 @@ void os::setup_fpu() {
 #endif
 }
 
-bool os::is_allocatable(size_t bytes) {
-  return true;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // thread stack
 

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.hpp
@@ -34,8 +34,6 @@
 
   static void setup_fpu();
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -478,26 +478,6 @@ juint os::cpu_microcode_revision() {
   return result;
 }
 
-bool os::is_allocatable(size_t bytes) {
-#ifdef AMD64
-  // unused on amd64?
-  return true;
-#else
-
-  if (bytes < 2 * G) {
-    return true;
-  }
-
-  char* addr = reserve_memory(bytes);
-
-  if (addr != NULL) {
-    release_memory(addr, bytes);
-  }
-
-  return addr != NULL;
-#endif // AMD64
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // thread stack
 

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.hpp
@@ -31,8 +31,6 @@
 
   static jlong rdtsc();
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -182,24 +182,6 @@ void os::Linux::set_fpu_control_word(int fpu) {
   ShouldNotCallThis();
 }
 
-bool os::is_allocatable(size_t bytes) {
-#ifdef _LP64
-  return true;
-#else
-  if (bytes < 2 * G) {
-    return true;
-  }
-
-  char* addr = reserve_memory(bytes);
-
-  if (addr != NULL) {
-    release_memory(addr, bytes);
-  }
-
-  return addr != NULL;
-#endif // _LP64
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // thread stack
 

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
@@ -28,8 +28,6 @@
 
   static void setup_fpu() {}
 
-  static bool is_allocatable(size_t bytes);
-
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }


### PR DESCRIPTION
There exists a function `os::is_allocatable()` which is really only used on 32bit platforms if AggressiveHeap is set. That function tests if a given memory size can be mapped. A variant of this function exists for every os_cpu variant. They don't really differ much. Some of the 64bit only variants (eg ppc) never bothered to implement this.

I am not sure how much worth this function has, but it could at least be unified across POSIX platforms, and it should not use os::reserve_memory but plain raw mmap. There is no need for it to go through our whole reservation layer (eg NMT) if it just immediately releases the memory again.

I also would like NMT to be kept out of this since I work on NMT late stage initialization (JDK-8256844) and would like to avoid calling any of our reservation APIs before NMT initialization ran.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263884](https://bugs.openjdk.java.net/browse/JDK-8263884): Clean up os::is_allocatable() across Posix platforms


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to ffeb9bd6b0089eb98a9595cad404e35a7374e6f0
 * @mgkwill (no known github.com user name / role) ⚠️ Review applies to ffeb9bd6b0089eb98a9595cad404e35a7374e6f0


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3092/head:pull/3092`
`$ git checkout pull/3092`

To update a local copy of the PR:
`$ git checkout pull/3092`
`$ git pull https://git.openjdk.java.net/jdk pull/3092/head`
