### PR TITLE
8263890: Broken links to Unicode.org

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,14 +174,14 @@ import java.util.TreeMap;
  * href="http://www.ietf.org/rfc/rfc2279.txt"><i>RFC&nbsp;2279</i></a>; the
  * transformation format upon which it is based is specified in
  * Amendment&nbsp;2 of ISO&nbsp;10646-1 and is also described in the <a
- * href="http://www.unicode.org/unicode/standard/standard.html"><i>Unicode
+ * href="http://www.unicode.org/standard/standard.html"><i>Unicode
  * Standard</i></a>.
  *
  * <p> The {@code UTF-16} charsets are specified by <a
  * href="http://www.ietf.org/rfc/rfc2781.txt"><i>RFC&nbsp;2781</i></a>; the
  * transformation formats upon which they are based are specified in
  * Amendment&nbsp;1 of ISO&nbsp;10646-1 and are also described in the <a
- * href="http://www.unicode.org/unicode/standard/standard.html"><i>Unicode
+ * href="http://www.unicode.org/standard/standard.html"><i>Unicode
  * Standard</i></a>.
  *
  * <p> The {@code UTF-16} charsets use sixteen-bit quantities and are

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ public abstract class Collator
      * <p>
      * CANONICAL_DECOMPOSITION corresponds to Normalization Form D as
      * described in
-     * <a href="http://www.unicode.org/unicode/reports/tr15/tr15-23.html">Unicode
+     * <a href="http://www.unicode.org/reports/tr15/tr15-23.html">Unicode
      * Technical Report #15</a>.
      * @see java.text.Collator#getDecomposition
      * @see java.text.Collator#setDecomposition
@@ -208,7 +208,7 @@ public abstract class Collator
      * <p>
      * FULL_DECOMPOSITION corresponds to Normalization Form KD as
      * described in
-     * <a href="http://www.unicode.org/unicode/reports/tr15/tr15-23.html">Unicode
+     * <a href="http://www.unicode.org/reports/tr15/tr15-23.html">Unicode
      * Technical Report #15</a>.
      * @see java.text.Collator#getDecomposition
      * @see java.text.Collator#setDecomposition

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -189,8 +189,8 @@ public abstract class Collator
      * <p>
      * CANONICAL_DECOMPOSITION corresponds to Normalization Form D as
      * described in
-     * <a href="http://www.unicode.org/reports/tr15/tr15-23.html">Unicode
-     * Technical Report #15</a>.
+     * <a href="http://www.unicode.org/reports/tr15/">Unicode
+     * Standard Annex #15: Unicode Normalization Forms</a>.
      * @see java.text.Collator#getDecomposition
      * @see java.text.Collator#setDecomposition
      */
@@ -208,8 +208,8 @@ public abstract class Collator
      * <p>
      * FULL_DECOMPOSITION corresponds to Normalization Form KD as
      * described in
-     * <a href="http://www.unicode.org/reports/tr15/tr15-23.html">Unicode
-     * Technical Report #15</a>.
+     * <a href="http://www.unicode.org/reports/tr15/">Unicode
+     * Standard Annex #15: Unicode Normalization Forms</a>.
      * @see java.text.Collator#getDecomposition
      * @see java.text.Collator#setDecomposition
      */

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -602,7 +602,7 @@ import jdk.internal.util.ArraysSupport;
  * {@code gc}) as in {@code general_category=Lu} or {@code gc=Lu}.
  * <p>
  * The supported categories are those of
- * <a href="http://www.unicode.org/unicode/standard/standard.html">
+ * <a href="http://www.unicode.org/standard/standard.html">
  * <i>The Unicode Standard</i></a> in the version specified by the
  * {@link java.lang.Character Character} class. The category names are those
  * defined in the Standard, both normative and informative.
@@ -906,7 +906,7 @@ public final class Pattern
      * <i>Predefined character classes</i> and <i>POSIX character classes</i>
      * are in conformance with
      * <a href="http://www.unicode.org/reports/tr18/"><i>Unicode Technical
-     * Standard #18: Unicode Regular Expression</i></a>
+     * Standard #18: Unicode Regular Expressions</i></a>
      * <i>Annex C: Compatibility Properties</i>.
      * <p>
      * The UNICODE_CHARACTER_CLASS mode can also be enabled via the embedded

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -539,7 +539,7 @@ import jdk.internal.util.ArraysSupport;
  *
  * <p> This class is in conformance with Level 1 of <a
  * href="http://www.unicode.org/reports/tr18/"><i>Unicode Technical
- * Standard #18: Unicode Regular Expression</i></a>, plus RL2.1
+ * Standard #18: Unicode Regular Expressions</i></a>, plus RL2.1
  * Canonical Equivalents and RL2.2 Extended Grapheme Clusters.
  * <p>
  * <b>Unicode escape sequences</b> such as <code>&#92;u2014</code> in Java source code
@@ -630,8 +630,8 @@ import jdk.internal.util.ArraysSupport;
  * <p>
  * The following <b>Predefined Character classes</b> and <b>POSIX character classes</b>
  * are in conformance with the recommendation of <i>Annex C: Compatibility Properties</i>
- * of <a href="http://www.unicode.org/reports/tr18/"><i>Unicode Regular Expression
- * </i></a>, when {@link #UNICODE_CHARACTER_CLASS} flag is specified.
+ * of <a href="http://www.unicode.org/reports/tr18/"><i>Unicode Technical Standard #18:
+ * Unicode Regular Expressions</i></a>, when {@link #UNICODE_CHARACTER_CLASS} flag is specified.
  *
  * <table class="striped">
  * <caption style="display:none">predefined and posix character classes in Unicode mode</caption>

--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ import jdk.internal.icu.impl.UBiDiProps;
  *
  * This is an implementation of the Unicode Bidirectional Algorithm. The
  * algorithm is defined in the <a
- * href="http://www.unicode.org/unicode/reports/tr9/">Unicode Standard Annex #9</a>.
+ * href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>.
  * <p>
  *
  * Note: Libraries that perform a bidirectional algorithm and reorder strings
@@ -3363,7 +3363,7 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm. It is defined in the
-     * <a href="http://www.unicode.org/unicode/reports/tr9/">Unicode Standard Annex #9</a>,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
      * version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *
@@ -3448,7 +3448,7 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm. It is defined in the
-     * <a href="http://www.unicode.org/unicode/reports/tr9/">Unicode Standard Annex #9</a>,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
      * version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *
@@ -3784,7 +3784,7 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm on a given paragraph, as defined in the
-     * <a href="http://www.unicode.org/unicode/reports/tr9/">Unicode Standard Annex #9</a>,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
      * version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *

--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
@@ -62,8 +62,9 @@ import jdk.internal.icu.impl.UBiDiProps;
  * <h2>Bidi algorithm for ICU</h2>
  *
  * This is an implementation of the Unicode Bidirectional Algorithm. The
- * algorithm is defined in the <a
- * href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>.
+ * algorithm is defined in the
+ * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+ * Unicode Bidirectional Algorithm</a>.
  * <p>
  *
  * Note: Libraries that perform a bidirectional algorithm and reorder strings
@@ -983,8 +984,9 @@ public class BidiBase {
 
     /**
      * Enumerated property Bidi_Paired_Bracket_Type (new in Unicode 6.3).
-     * Used in UAX #9: Unicode Bidirectional Algorithm
-     * (http://www.unicode.org/reports/tr9/)
+     * Used in
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+     * Unicode Bidirectional Algorithm</a>.
      * Returns UCharacter.BidiPairedBracketType values.
      * @stable ICU 52
      */
@@ -3363,8 +3365,8 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm. It is defined in the
-     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
-     * version 13,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+     * Unicode Bidirectional Algorithm</a>, version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *
      * This method takes a piece of plain text containing one or more paragraphs,
@@ -3448,8 +3450,8 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm. It is defined in the
-     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
-     * version 13,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+     * Unicode Bidirectional Algorithm</a>, version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *
      * This method takes a piece of plain text containing one or more paragraphs,
@@ -3784,8 +3786,8 @@ public class BidiBase {
 
     /**
      * Perform the Unicode Bidi algorithm on a given paragraph, as defined in the
-     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9</a>,
-     * version 13,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+     * Unicode Bidirectional Algorithm</a>, version 13,
      * also described in The Unicode Standard, Version 4.0 .<p>
      *
      * This method takes a paragraph of text and computes the

--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiLine.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ final class BidiLine {
      * text in a single paragraph or in a line of a single paragraph
      * which has already been processed according to
      * the Unicode 3.0 Bidi algorithm as defined in
-     * http://www.unicode.org/unicode/reports/tr9/ , version 13,
+     * http://www.unicode.org/reports/tr9/ , version 13,
      * also described in The Unicode Standard, Version 4.0.1 .
      *
      * This means that there is a Bidi object with a levels

--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiLine.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiLine.java
@@ -47,7 +47,8 @@ final class BidiLine {
      * text in a single paragraph or in a line of a single paragraph
      * which has already been processed according to
      * the Unicode 3.0 Bidi algorithm as defined in
-     * http://www.unicode.org/reports/tr9/ , version 13,
+     * <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9:
+     * Unicode Bidirectional Algorithm</a>, version 13,
      * also described in The Unicode Standard, Version 4.0.1 .
      *
      * This means that there is a Bidi object with a levels

--- a/src/java.base/share/classes/jdk/internal/icu/text/Normalizer2.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/Normalizer2.java
@@ -43,7 +43,8 @@ import jdk.internal.icu.impl.Norm2AllModes;
  * The primary functions are to produce a normalized string and to detect whether
  * a string is already normalized.
  * The most commonly used normalization forms are those defined in
- * http://www.unicode.org/reports/tr15/
+ * <a href="http://www.unicode.org/reports/tr15/">Unicode Standard Annex #15:
+ * Unicode Normalization Forms</a>.
  * However, this API supports additional normalization forms for specialized purposes.
  * For example, NFKC_Casefold is provided via getInstance("nfkc_cf", COMPOSE)
  * and can be used in implementations of UTS #46.

--- a/src/java.base/share/classes/jdk/internal/icu/text/Normalizer2.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/Normalizer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import jdk.internal.icu.impl.Norm2AllModes;
  * The primary functions are to produce a normalized string and to detect whether
  * a string is already normalized.
  * The most commonly used normalization forms are those defined in
- * http://www.unicode.org/unicode/reports/tr15/
+ * http://www.unicode.org/reports/tr15/
  * However, this API supports additional normalization forms for specialized purposes.
  * For example, NFKC_Casefold is provided via getInstance("nfkc_cf", COMPOSE)
  * and can be used in implementations of UTS #46.

--- a/src/java.base/share/classes/jdk/internal/icu/text/NormalizerBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/NormalizerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.text.Normalizer;
  * <code>normalize</code> transforms Unicode text into an equivalent composed or
  * decomposed form, allowing for easier sorting and searching of text.
  * <code>normalize</code> supports the standard normalization forms described in
- * <a href="http://www.unicode.org/unicode/reports/tr15/" target="unicode">
+ * <a href="http://www.unicode.org/reports/tr15/" target="unicode">
  * Unicode Standard Annex #15 &mdash; Unicode Normalization Forms</a>.
  *
  * Characters with accents or other adornments can be encoded in

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -473,7 +473,7 @@ import com.sun.org.apache.xerces.internal.util.IntStack;
  * <hr width="50%">
  * <h3>TODO</h3>
  * <ul>
- *   <li><a href="http://www.unicode.org/reports/tr18/">Unicode Regular Expression Guidelines</a>
+ *   <li><a href="http://www.unicode.org/reports/tr18/">Unicode Technical Standard #18: Unicode Regular Expressions</a>
  *     <ul>
  *       <li>2.4 Canonical Equivalents
  *       <li>Level 3

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -473,7 +473,7 @@ import com.sun.org.apache.xerces.internal.util.IntStack;
  * <hr width="50%">
  * <h3>TODO</h3>
  * <ul>
- *   <li><a href="http://www.unicode.org/unicode/reports/tr18/">Unicode Regular Expression Guidelines</a>
+ *   <li><a href="http://www.unicode.org/reports/tr18/">Unicode Regular Expression Guidelines</a>
  *     <ul>
  *       <li>2.4 Canonical Equivalents
  *       <li>Level 3


### PR DESCRIPTION
Fixed several broken links to Unicode.org.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263890](https://bugs.openjdk.java.net/browse/JDK-8263890): Broken links to Unicode.org


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 2b32b86ad5638095496dada622730522d346e85b
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 2b32b86ad5638095496dada622730522d346e85b


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3093/head:pull/3093`
`$ git checkout pull/3093`

To update a local copy of the PR:
`$ git checkout pull/3093`
`$ git pull https://git.openjdk.java.net/jdk pull/3093/head`
