### PR TITLE
8263892: More modifier order fixes in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -301,7 +301,7 @@ abstract class BoundMethodHandle extends MethodHandle {
     static final class SpeciesData
             extends ClassSpecializer<BoundMethodHandle, String, SpeciesData>.SpeciesData {
         // This array is filled in lazily, as new species come into being over time.
-        @Stable final private SpeciesData[] extensions = new SpeciesData[ARG_TYPE_LIMIT];
+        @Stable private final SpeciesData[] extensions = new SpeciesData[ARG_TYPE_LIMIT];
 
         public SpeciesData(Specializer outer, String key) {
             outer.super(key);

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
  * blocking mode of this channel as well as its current set of selection keys.
  * It performs all of the synchronization required to implement the {@link
  * java.nio.channels.SelectableChannel} specification.  Implementations of the
- * abstract protected methods defined in this class need not synchronize
+ * protected abstract methods defined in this class need not synchronize
  * against other threads that might be engaged in the same operations.  </p>
  *
  *

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -942,13 +942,13 @@ public final class Currency implements Serializable {
      */
     private static class SpecialCaseEntry {
 
-        final private long cutOverTime;
-        final private String oldCurrency;
-        final private String newCurrency;
-        final private int oldCurrencyFraction;
-        final private int newCurrencyFraction;
-        final private int oldCurrencyNumericCode;
-        final private int newCurrencyNumericCode;
+        private final long cutOverTime;
+        private final String oldCurrency;
+        private final String newCurrency;
+        private final int oldCurrencyFraction;
+        private final int newCurrencyFraction;
+        private final int oldCurrencyNumericCode;
+        private final int newCurrencyNumericCode;
 
         private SpecialCaseEntry(long cutOverTime, String oldCurrency, String newCurrency,
                 int oldCurrencyFraction, int newCurrencyFraction,
@@ -1041,9 +1041,9 @@ public final class Currency implements Serializable {
      */
     private static class OtherCurrencyEntry {
 
-        final private String currencyCode;
-        final private int fraction;
-        final private int numericCode;
+        private final String currencyCode;
+        private final int fraction;
+        private final int numericCode;
 
         private OtherCurrencyEntry(String currencyCode, int fraction,
                 int numericCode) {
@@ -1078,11 +1078,11 @@ public final class Currency implements Serializable {
      * - date: cutover date
      */
     private static class CurrencyProperty {
-        final private String country;
-        final private String currencyCode;
-        final private int fraction;
-        final private int numericCode;
-        final private String date;
+        private final String country;
+        private final String currencyCode;
+        private final int fraction;
+        private final int numericCode;
+        private final String date;
 
         private CurrencyProperty(String country, String currencyCode,
                 int fraction, int numericCode, String date) {

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/TraceSignatureVisitor.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/TraceSignatureVisitor.java
@@ -256,7 +256,7 @@ public final class TraceSignatureVisitor extends SignatureVisitor {
     @Override
     public void visitClassType(final String name) {
         if ("java/lang/Object".equals(name)) {
-            // 'Map<java.lang.Object,java.util.List>' or 'abstract public V get(Object key);' should have
+            // 'Map<java.lang.Object,java.util.List>' or 'public abstract V get(Object key);' should have
             // Object 'but java.lang.String extends java.lang.Object' is unnecessary.
             boolean needObjectClass = argumentStack % 2 != 0 || parameterTypeVisited;
             if (needObjectClass) {

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -170,7 +170,7 @@ public class DerValue {
     private final boolean allowBER;
 
     // Unsafe. Legacy. Never null.
-    final public DerInputStream data;
+    public final DerInputStream data;
 
     /*
      * These values are the high order bits for the other kinds of tags.


### PR DESCRIPTION
Additional changes found in `java.base` of `final private` -> `private final`. Filed with existing bug because it's the same module; can change to a different bug number if required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263892](https://bugs.openjdk.java.net/browse/JDK-8263892): More modifier order fixes in java.base


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3094/head:pull/3094`
`$ git checkout pull/3094`

To update a local copy of the PR:
`$ git checkout pull/3094`
`$ git pull https://git.openjdk.java.net/jdk pull/3094/head`
