### PR TITLE
8263894: Convert defaultPrinter and printers fields to local variables

### DIFF
--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -43,10 +43,8 @@ import javax.print.attribute.standard.PrinterName;
 
 public class PrintServiceLookupProvider extends PrintServiceLookup {
 
-    private String defaultPrinter;
     private PrintService defaultPrintService;
-    private String[] printers; /* excludes the default printer */
-    private PrintService[] printServices; /* includes the default printer */
+    private PrintService[] printServices;
 
     static {
         java.security.AccessController.doPrivileged(
@@ -114,7 +112,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
     }
 
     private synchronized void refreshServices() {
-        printers = getAllPrinterNames();
+        String[] printers = getAllPrinterNames();
         if (printers == null) {
             // In Windows it is safe to assume no default if printers == null so we
             // don't get the default.
@@ -279,7 +277,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
 
         // Windows does not have notification for a change in default
         // so we always get the latest.
-        defaultPrinter = getDefaultPrinterName();
+        String defaultPrinter = getDefaultPrinterName();
         if (defaultPrinter == null) {
             return null;
         }

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -44,7 +44,7 @@ import javax.print.attribute.standard.PrinterName;
 public class PrintServiceLookupProvider extends PrintServiceLookup {
 
     private PrintService defaultPrintService;
-    private PrintService[] printServices;
+    private PrintService[] printServices; /* includes the default printer */
 
     static {
         java.security.AccessController.doPrivileged(


### PR DESCRIPTION
`PrintServiceLookupProvider` has `defaultPrinter` and `printers` fields but they are used only in `getDefaultPrintService()` and `refreshServices()` correspondingly. Thus these two fields can be converted to local variables in the corresponding methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263894](https://bugs.openjdk.java.net/browse/JDK-8263894): Convert defaultPrinter and printers fields to local variables


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3095/head:pull/3095`
`$ git checkout pull/3095`

To update a local copy of the PR:
`$ git checkout pull/3095`
`$ git pull https://git.openjdk.java.net/jdk pull/3095/head`
