### PR TITLE
8263893: getPrinterNames() leaks nameArray if Java String allocation fails

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
@@ -175,6 +175,10 @@ static jobjectArray getPrinterNames(JNIEnv *env, DWORD flags) {
         }
     } catch (std::bad_alloc&) {
         delete [] pPrinterEnum;
+        if (nameArray != NULL) {
+            env->DeleteLocalRef(nameArray);
+            nameArray = NULL;
+        }
         throw;
     }
 


### PR DESCRIPTION
If `JNU_NewStringPlatform` fails to allocate new Java String object for printer name, `std::bad_alloc` is thrown. The handler for the exception does not release the local reference to the `nameArray`, thus it will be leaked.