### PR TITLE
8263895: Test nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp uses incorrect indices

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
@@ -351,16 +351,16 @@ static jthreadGroup findThreadGroupByName(jvmtiEnv* jvmti, JNIEnv* jni, const ch
             for (j = 0; j < groupsCount; j++) {
                 jvmtiThreadGroupInfo info;
 
-                if (groups[i] != NULL) {
+                if (groups[j] != NULL) {
 
                     if (!NSK_JVMTI_VERIFY(
-                            jvmti->GetThreadGroupInfo(groups[i], &info))) {
+                            jvmti->GetThreadGroupInfo(groups[j], &info))) {
                         nsk_jvmti_setFailStatus();
                         continue;
                     }
 
                     if (info.name != 0 && strcmp(info.name, name) == 0) {
-                        foundGroup = groups[i];
+                        foundGroup = groups[j];
                         break;
                     }
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263895](https://bugs.openjdk.java.net/browse/JDK-8263895): Test nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp uses incorrect indices


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to aebc0d3d4b2870edef0845c09f989369213ab231
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3098/head:pull/3098`
`$ git checkout pull/3098`

To update a local copy of the PR:
`$ git checkout pull/3098`
`$ git pull https://git.openjdk.java.net/jdk pull/3098/head`
