### PR TITLE
8263896: Remove not_suspended parameter from ObjectMonitor::exit()

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -303,7 +303,7 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
   bool      check_owner(TRAPS);
 
   bool      enter(JavaThread* current);
-  void      exit(bool not_suspended, JavaThread* current);
+  void      exit(JavaThread* current);
   void      wait(jlong millis, bool interruptible, TRAPS);
   void      notify(TRAPS);
   void      notifyAll(TRAPS);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -518,7 +518,7 @@ void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* current) 
   // The ObjectMonitor* can't be async deflated until ownership is
   // dropped inside exit() and the ObjectMonitor* must be !is_busy().
   ObjectMonitor* monitor = inflate(current, object, inflate_cause_vm_internal);
-  monitor->exit(true, current);
+  monitor->exit(current);
 }
 
 // -----------------------------------------------------------------------------
@@ -608,7 +608,7 @@ void ObjectSynchronizer::jni_exit(oop obj, TRAPS) {
   // intentionally do not use CHECK on check_owner because we must exit the
   // monitor even if an exception was already pending.
   if (monitor->check_owner(THREAD)) {
-    monitor->exit(true, current);
+    monitor->exit(current);
   }
 }
 


### PR DESCRIPTION
Hi,

Please review the following small patch. The boolean parameter not_suspended is used to detect if we need to set the current JavaThread exiting the monitor as the previous owner (_previous_owner_tid). If not_suspended is true then we set _previous_owner_tid, otherwise we skip the write (modulo the JFR checks). This parameter is always true except when we call exit() from inside enter(). This happens when the JavaThread acquires the monitor but notices that it was suspended while being in the _thread_blocked state. Since in that case the JT was never really "the owner" we skip setting _previous_owner_tid.

This behaviour of releasing the monitor is just an implementation detail of ObjectMonitor::enter() which doesn't need to be exposed in the exit() API. We can identify the same scenario just by checking _current_pending_monitor instead.

Thanks,
Patricio