### PR TITLE
8263891: Changes for 8076985 missed the fix.

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1648,7 +1648,7 @@ bool Matcher::const_oop_prefer_decode() {
 
 bool Matcher::const_klass_prefer_decode() {
   // Prefer ConP over ConNKlass+DecodeNKlass.
-  return true;
+  return false;
 }
 
 // Is it better to copy float constants, or load them directly from


### PR DESCRIPTION
The fix for JDK-8076985 was supposed to be this: 
https://cr.openjdk.java.net/~kvn/8076985/webrev.00/src/hotspot/cpu/x86/x86_64.ad.udiff.html

But the final push had only comment change: 
https://hg.openjdk.java.net/jdk/jdk/rev/4d1c4400c75d

Here is explanation of the fix from 8076985 RFR:

```
First, this is about how C2 generates code for *constant* class pointers.

A little history here. When we implemented compressed oops and class pointers we had PermGen and classes were Java objects. We used the same decoding/encoding code for oops and classes - we used the same register containing Heap Base address. It was profitable to decode constant class and reuse it [1]. Also we greatly benefited on SPARC since decoding 32-bit constant required 4 instructions instead of up to 7 instructions to load 64-bit constant.

Now compressed class decoding is different and always takes 2 instructions on x86 [2] if either base or shift is not 0.

As result we generated 3 instructions to get full class pointer from compressed 32-bit constant (example for base = 0, shift = 3):

movl $0x200001d5,%r11d
movabs $0x0,%r10
lea (%r10,%r11,8),%r10

Also when we store compressed class pointer into new object header we don't use register anymore on x86 - keeping it in register does not help now:

movl $0x200001d5,0x8(%rax)

Aleksey suggested to have only one instruction to load full 64-bit class pointer:

movq $0x100000EA8,%r10

It frees one register and uses 10 bytes instead of up to 20 bytes of code on x86.

In JDK 9 SAP contributed nice change [3] to have choice when to use 'compressed class pointer + decoding' or full '64-bit constant class pointer'. It significantly simplified changes for this RFE.


I ran performance testing but did not see difference - we don't use biased locking now and as result we don't need to load prototype header from class. But there are other places where we need load from class. 
```

Tested tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263891](https://bugs.openjdk.java.net/browse/JDK-8263891): Changes for 8076985 missed the fix.


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3102/head:pull/3102`
`$ git checkout pull/3102`

To update a local copy of the PR:
`$ git checkout pull/3102`
`$ git pull https://git.openjdk.java.net/jdk pull/3102/head`
