### PR TITLE
8263897: compiler/c2/aarch64/TestVolatilesSerial.java failed with "java.lang.RuntimeException: Wrong method"

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatiles.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatiles.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,28 +75,28 @@ public class TestVolatiles {
         // i.e. GC type plus GC conifg
         switch(testType) {
         case "G1":
-            argcount = 8;
+            argcount = 9;
             procArgs = new String[argcount];
             procArgs[argcount - 2] = "-XX:+UseG1GC";
             break;
         case "Parallel":
-            argcount = 8;
+            argcount = 9;
             procArgs = new String[argcount];
             procArgs[argcount - 2] = "-XX:+UseParallelGC";
             break;
         case "Serial":
-            argcount = 8;
+            argcount = 9;
             procArgs = new String[argcount];
             procArgs[argcount - 2] = "-XX:+UseSerialGC";
             break;
         case "Shenandoah":
-            argcount = 9;
+            argcount = 10;
             procArgs = new String[argcount];
             procArgs[argcount - 3] = "-XX:+UnlockExperimentalVMOptions";
             procArgs[argcount - 2] = "-XX:+UseShenandoahGC";
             break;
         case "ShenandoahIU":
-            argcount = 10;
+            argcount = 11;
             procArgs = new String[argcount];
             procArgs[argcount - 4] = "-XX:+UnlockExperimentalVMOptions";
             procArgs[argcount - 3] = "-XX:+UseShenandoahGC";
@@ -113,11 +114,12 @@ public class TestVolatiles {
         // disable the transform.
 
         procArgs[0] = "-XX:+UseCompressedOops";
-        procArgs[1] = "-XX:-TieredCompilation";
-        procArgs[2] = "-XX:+PrintOptoAssembly";
-        procArgs[3] = "-XX:CompileCommand=compileonly," + fullclassname + "::" + "test*";
-        procArgs[4] = "--add-exports";
-        procArgs[5] = "java.base/jdk.internal.misc=ALL-UNNAMED";
+        procArgs[1] = "-XX:-BackgroundCompilation";
+        procArgs[2] = "-XX:-TieredCompilation";
+        procArgs[3] = "-XX:+PrintOptoAssembly";
+        procArgs[4] = "-XX:CompileCommand=compileonly," + fullclassname + "::" + "test*";
+        procArgs[5] = "--add-exports";
+        procArgs[6] = "java.base/jdk.internal.misc=ALL-UNNAMED";
         procArgs[argcount - 1] = fullclassname;
 
         runtest(classname, testType, true, procArgs);


### PR DESCRIPTION
The test assumes that testInt() method's compilation information will be first in output. 
But these tests did not run with -Xbatch or -XX:CICompilerCount=1 flag. They only use `-XX:-TieredCompilation` which does not guarantee which method is compiled first.

Added `-XX:-BackgroundCompilation` flag to make sure all test methods compiled in expected order.

Tested tier1-3 and 50x test run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263897](https://bugs.openjdk.java.net/browse/JDK-8263897): compiler/c2/aarch64/TestVolatilesSerial.java failed with "java.lang.RuntimeException: Wrong method"


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3103/head:pull/3103`
`$ git checkout pull/3103`

To update a local copy of the PR:
`$ git checkout pull/3103`
`$ git pull https://git.openjdk.java.net/jdk pull/3103/head`
