### PR TITLE
8263904: compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.simpleArch == "x64" & vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails on x86_32.
The reason is that currently the bzhiq instruction is only generated on x86_64.
So it shouldn't be run on x86_32.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263904](https://bugs.openjdk.java.net/browse/JDK-8263904): compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails on x86_32


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * @mgkwill (no known github.com user name / role)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3104/head:pull/3104`
`$ git checkout pull/3104`

To update a local copy of the PR:
`$ git checkout pull/3104`
`$ git pull https://git.openjdk.java.net/jdk pull/3104/head`
