### PR TITLE
8263903: Use Cleaner instead of finalize to auto stop Timer thread

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -112,7 +112,7 @@ public class Timer {
         private final TaskQueue queue;
         private final TimerThread thread;
 
-        public ThreadReaper(TaskQueue queue, TimerThread thread) {
+        ThreadReaper(TaskQueue queue, TimerThread thread) {
             this.queue = queue;
             this.thread = thread;
         }

--- a/test/jdk/java/util/Timer/AutoStop.java
+++ b/test/jdk/java/util/Timer/AutoStop.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @requires !vm.gc.Epsilon
+ * @bug 8263903
+ * @requires vm.gc != "Epsilon"
  * @summary Discarding a Timer causes the Timer thread to stop.
  */
 
@@ -33,7 +34,7 @@ import java.lang.ref.Reference;
 
 public class AutoStop {
     static final Object wakeup = new Object();
-    static volatile Thread tdThread = null;
+    static Thread tdThread = null;
     static volatile int counter = 0;
     static final int COUNTER_LIMIT = 10;
 
@@ -43,8 +44,8 @@ public class AutoStop {
         // Run an event that records the timer thread.
         t.schedule(new TimerTask() {
                 public void run() {
-                    tdThread = Thread.currentThread();
                     synchronized(wakeup) {
+                        tdThread = Thread.currentThread();
                         wakeup.notify();
                     }
                 }

--- a/test/jdk/java/util/Timer/AutoStop.java
+++ b/test/jdk/java/util/Timer/AutoStop.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires !vm.gc.Epsilon
+ * @summary Discarding a Timer causes the Timer thread to stop.
+ */
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.lang.ref.Reference;
+
+public class AutoStop {
+    static final Object wakeup = new Object();
+    static volatile Thread tdThread = null;
+    static volatile int counter = 0;
+    static final int COUNTER_LIMIT = 10;
+
+    public static void main(String[] args) throws Exception {
+        Timer t = new Timer();
+
+        // Run an event that records the timer thread.
+        t.schedule(new TimerTask() {
+                public void run() {
+                    tdThread = Thread.currentThread();
+                    synchronized(wakeup) {
+                        wakeup.notify();
+                    }
+                }
+            }, 0);
+
+        // Wait for the thread to be accessible.
+        try {
+            synchronized(wakeup) {
+                while (tdThread == null) {
+                    wakeup.wait();
+                }
+            }
+        } catch (InterruptedException e) {
+        }
+
+        // Schedule some events that increment the counter.
+        for (int i = 0; i < COUNTER_LIMIT; ++i) {
+            t.schedule(new TimerTask() {
+                    public void run() {
+                        ++counter;
+                    }
+                }, 100);
+        }
+
+        // Ensure the timer is accessible at least until here.
+        Reference.reachabilityFence(t);
+        t = null;               // Remove the reference to the timer.
+        System.gc();            // Run GC to trigger cleanup.
+        tdThread.join();        // Wait for thread to stop.
+        int finalCounter = counter;
+        if (finalCounter != COUNTER_LIMIT) {
+            throw new RuntimeException("Unrun events: counter = " + finalCounter);
+        }
+    }
+}
+


### PR DESCRIPTION
Please review this change to java.util.Timer, replacing the use of deprecated finalization-based cleanup with use of java.lang.ref.Cleaner.

In addition, Timer.cancel now cancels any later execution of the the no longer relevant cleanup.

Testing:
mach5 tier1
New AutoStop test verifies the specified cleanup behavior.
(There are existing tests involving Timer.cancel.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263903](https://bugs.openjdk.java.net/browse/JDK-8263903): Use Cleaner instead of finalize to auto stop Timer thread


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 57500464c5d83354b44f20f93ecce5d52e1d9a79
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 57500464c5d83354b44f20f93ecce5d52e1d9a79
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**) ⚠️ Review applies to 57500464c5d83354b44f20f93ecce5d52e1d9a79
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 57500464c5d83354b44f20f93ecce5d52e1d9a79
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 57500464c5d83354b44f20f93ecce5d52e1d9a79


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3106/head:pull/3106`
`$ git checkout pull/3106`

To update a local copy of the PR:
`$ git checkout pull/3106`
`$ git pull https://git.openjdk.java.net/jdk pull/3106/head`
