### PR TITLE
8263908: Build fails due to initialize_static_field_for_dump defined but not used after JDK-8263771

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -841,6 +841,7 @@ static void initialize_static_string_field(fieldDescriptor* fd, Handle mirror, T
   mirror()->obj_field_put(fd->offset(), string);
 }
 
+#if INCLUDE_CDS_JAVA_HEAP
 static void initialize_static_string_field_for_dump(fieldDescriptor* fd, Handle mirror) {
   DEBUG_ONLY(assert_valid_static_string_field(fd);)
   assert(DumpSharedSpaces, "must be");
@@ -853,6 +854,7 @@ static void initialize_static_string_field_for_dump(fieldDescriptor* fd, Handle 
     guarantee(false, "Unexpected");
   }
 }
+#endif
 
 static void initialize_static_primitive_field(fieldDescriptor* fd, Handle mirror) {
   assert(fd->has_initial_value(), "caller should have checked this");
@@ -900,6 +902,7 @@ static void initialize_static_field(fieldDescriptor* fd, Handle mirror, TRAPS) {
   }
 }
 
+#if INCLUDE_CDS_JAVA_HEAP
 static void initialize_static_field_for_dump(fieldDescriptor* fd, Handle mirror) {
   assert(mirror.not_null() && fd->is_static(), "just checking");
   if (fd->has_initial_value()) {
@@ -910,6 +913,7 @@ static void initialize_static_field_for_dump(fieldDescriptor* fd, Handle mirror)
     }
   }
 }
+#endif
 
 void java_lang_Class::fixup_mirror(Klass* k, TRAPS) {
   assert(InstanceMirrorKlass::offset_of_static_fields() != 0, "must have been computed already");


### PR DESCRIPTION
Hi all,

Build failures were observed when cds or g1gc was disabled due to initialize_static_field_for_dump/initialize_static_string_field_for_dump defined but not used.

This can be reproduced by:
  - build without cds,  or
  - build without g1gc, or
  - build on x86_32

This is because INCLUDE_CDS_JAVA_HEAP will be false for these cases [1].
Let's fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/macros.hpp#L612

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263908](https://bugs.openjdk.java.net/browse/JDK-8263908): Build fails due to initialize_static_field_for_dump defined but not used after JDK-8263771


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3108/head:pull/3108`
`$ git checkout pull/3108`

To update a local copy of the PR:
`$ git checkout pull/3108`
`$ git pull https://git.openjdk.java.net/jdk pull/3108/head`
