### PR TITLE
8263914: CDS fails to find the default shared archive on x86_32

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -121,10 +121,6 @@ ifeq ($(BUILD_CDS_ARCHIVE), true)
   else
     CDS_ARCHIVE := lib/server/classes.jsa
     CDS_NOCOOPS_ARCHIVE := lib/server/classes_nocoops.jsa
-  endif
-
-  ifeq ($(call isTargetCpuBits, 32), true)
-    CDS_ARCHIVE := $(CDS_NOCOOPS_ARCHIVE)
   endif
 
   $(eval $(call SetupExecute, gen_cds_archive_jdk, \

--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -121,6 +121,10 @@ ifeq ($(BUILD_CDS_ARCHIVE), true)
   else
     CDS_ARCHIVE := lib/server/classes.jsa
     CDS_NOCOOPS_ARCHIVE := lib/server/classes_nocoops.jsa
+  endif
+
+  ifeq ($(call isTargetCpuBits, 32), true)
+    CDS_ARCHIVE := $(CDS_NOCOOPS_ARCHIVE)
   endif
 
   $(eval $(call SetupExecute, gen_cds_archive_jdk, \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3438,7 +3438,7 @@ char* Arguments::get_default_shared_archive_path() {
   const size_t len = jvm_path_len + file_sep_len + 20;
   default_archive_path = NEW_C_HEAP_ARRAY(char, len, mtArguments);
   jio_snprintf(default_archive_path, len,
-               UseCompressedOops ? "%s%sclasses.jsa": "%s%sclasses_nocoops.jsa",
+               LP64_ONLY(!UseCompressedOops ? "%s%sclasses_nocoops.jsa":) "%s%sclasses.jsa",
                jvm_path, os::file_separator());
   return default_archive_path;
 }


### PR DESCRIPTION
Hi all,

The VM fails to get initialized when running with `java -Xshare:on -version` on x86_32.
The reason is that the default shared archive (classes_nocoops.jsa) doesn't exist.
So the build system should generate classes_nocoops.jsa instead of classes.jsa on x86_32.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263914](https://bugs.openjdk.java.net/browse/JDK-8263914): CDS fails to find the default shared archive on x86_32


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3109/head:pull/3109`
`$ git checkout pull/3109`

To update a local copy of the PR:
`$ git checkout pull/3109`
`$ git pull https://git.openjdk.java.net/jdk pull/3109/head`
