### PR TITLE
8263915: runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java fails when UseCompressedClassPointers is off

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
@@ -31,16 +31,13 @@
  * @run main MismatchedPathTriggerMemoryRelease
  */
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class MismatchedPathTriggerMemoryRelease {
     private static String ERR_MSGS[] = {
         "UseSharedSpaces: shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)",
         "UseSharedSpaces: Unable to map shared spaces"};
-    private static String RELEASE_SPACE_MATCH = Platform.is64bit() ?
-        "Released shared space\\s(\\(archive\\s*\\+\\s*class\\) | ?)0(x|X)[0-9a-fA-F]+$" :
-        "Released shared space\\s(\\(archive\\s*\\) | ?)0(x|X)[0-9a-fA-F]+$";
+    private static String RELEASE_SPACE_MATCH = "Released shared space .* 0(x|X)[0-9a-fA-F]+$";
     private static String OS_RELEASE_MSG = "os::release_memory failed";
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,16 @@
  * @run main MismatchedPathTriggerMemoryRelease
  */
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class MismatchedPathTriggerMemoryRelease {
     private static String ERR_MSGS[] = {
         "UseSharedSpaces: shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)",
         "UseSharedSpaces: Unable to map shared spaces"};
-    private static String RELEASE_SPACE_MATCH =
-        "Released shared space\\s(\\(archive\\s*\\+\\s*class\\) | ?)0(x|X)[0-9a-fA-F]+$";
+    private static String RELEASE_SPACE_MATCH = Platform.is64bit() ?
+        "Released shared space\\s(\\(archive\\s*\\+\\s*class\\) | ?)0(x|X)[0-9a-fA-F]+$" :
+        "Released shared space\\s(\\(archive\\s*\\) | ?)0(x|X)[0-9a-fA-F]+$";
     private static String OS_RELEASE_MSG = "os::release_memory failed";
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java fails on x86_32 due to failure of this check [1].
However, this check will always fail if UseCompressedClassPointers=0 [2] (e.g., on x86_32) since the class_space_rs remains unreserved.
It would be better to fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java#L66
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/memory/metaspaceShared.cpp#L1141

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263915](https://bugs.openjdk.java.net/browse/JDK-8263915): runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java fails when UseCompressedClassPointers is off


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3110/head:pull/3110`
`$ git checkout pull/3110`

To update a local copy of the PR:
`$ git checkout pull/3110`
`$ git pull https://git.openjdk.java.net/jdk pull/3110/head`
