### PR TITLE
8263905: Remove finalize methods for SocketInput/OutputStream

### DIFF
--- a/src/java.base/share/classes/java/net/SocketInputStream.java
+++ b/src/java.base/share/classes/java/net/SocketInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,12 +242,6 @@ class SocketInputStream extends FileInputStream {
         // InputStream which calls Socket.close directly
         assert false;
     }
-
-    /**
-     * Overrides finalize, the fd is closed by the Socket.
-     */
-    @SuppressWarnings({"deprecation", "removal"})
-    protected void finalize() {}
 
     /**
      * Perform class load-time initializations.

--- a/src/java.base/share/classes/java/net/SocketOutputStream.java
+++ b/src/java.base/share/classes/java/net/SocketOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,12 +152,6 @@ class SocketOutputStream extends FileOutputStream {
         // OutputStream which calls Socket.close directly
         assert false;
     }
-
-    /**
-     * Overrides finalize, the fd is closed by the Socket.
-     */
-    @SuppressWarnings({"deprecation", "removal"})
-    protected void finalize() {}
 
     /**
      * Perform class load-time initializations.


### PR DESCRIPTION
Please review this change to java.net.SocketInputStream and
java.net.SocketOutputStream, removing their "finalize" methods.  These
methods are empty.  Their purpose is to override and suppress the finalize
methods of their superclasses (FileInputStream and FileOutputStream,
respectively).  But those classes had their finalize methods removed by
JDK-8192939 in JDK 12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263905](https://bugs.openjdk.java.net/browse/JDK-8263905): Remove finalize methods for SocketInput/OutputStream


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to e2db6df27d6c0b5a42a84656bff1122e0486daef
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to e2db6df27d6c0b5a42a84656bff1122e0486daef
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to e2db6df27d6c0b5a42a84656bff1122e0486daef
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to e2db6df27d6c0b5a42a84656bff1122e0486daef


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3111/head:pull/3111`
`$ git checkout pull/3111`

To update a local copy of the PR:
`$ git checkout pull/3111`
`$ git pull https://git.openjdk.java.net/jdk pull/3111/head`
