### PR TITLE
8263928: Add JAWT test files for mac

### DIFF
--- a/test/jdk/java/awt/JAWT/MyMacCanvas.java
+++ b/test/jdk/java/awt/JAWT/MyMacCanvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/JAWT/MyMacCanvas.java
+++ b/test/jdk/java/awt/JAWT/MyMacCanvas.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.*;
+import java.awt.event.*;
+import javax.swing.*;
+
+public class MyMacCanvas extends Canvas {
+
+    static {
+        try {
+            System.loadLibrary("mylib");
+        } catch (Throwable t) {
+            System.out.println("Test failed!!");
+            t.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    public void addNotify() {
+        super.addNotify();
+        addNativeCoreAnimationLayer();
+    }
+
+    public native void addNativeCoreAnimationLayer();
+
+    static JAWTFrame f;
+    public static void main(String[] args) {
+        try {
+            Robot robot = new Robot();
+            EventQueue.invokeLater(new Runnable() {
+                public void run() {
+                    f = new JAWTFrame("JAWTExample");
+                    f.setBackground(Color.white);
+                    f.setLayout(new BorderLayout(10, 20));
+                    f.setLocation(50, 50);
+                    ((JComponent) f.getContentPane()).setBorder(BorderFactory.createMatteBorder(10, 10, 10, 10, Color.cyan));
+                    f.addNotify();
+                    f.pack();
+                    f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    f.setVisible(true);
+                }
+            });
+            robot.delay(5000);
+            Color col1 = new Color(0, 0, 0);
+            Color col2 = robot.getPixelColor(f.getX()+50, f.getY()+50);
+            if (col1.equals(col2)) {
+                System.out.println("Test passed!");
+            } else {
+                System.out.println("col1 " + col1 + " col2 " + col2);
+                throw new RuntimeException("Color of JAWT canvas is wrong or " +
+                        "it was not rendered. " + "Check that other windows " +
+                        "do not block the test frame.");
+            }
+            System.exit(0);
+        } catch (Throwable t) {
+            System.out.println("Test failed!");
+            t.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static class JAWTFrame extends JFrame {
+        public JAWTFrame(final String title) {
+            super(title);
+        }
+
+        public void addNotify() {
+            super.addNotify(); // ensures native component hierarchy is setup
+
+            final Component layerBackedCanvas = new MyMacCanvas();
+            layerBackedCanvas.setPreferredSize(new Dimension(400, 200));
+            add(layerBackedCanvas, BorderLayout.CENTER);
+
+            invalidate();
+        }
+    }
+}

--- a/test/jdk/java/awt/JAWT/jawt-mac-buildrun.sh
+++ b/test/jdk/java/awt/JAWT/jawt-mac-buildrun.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+JAVA_HOME='/export/lanai/build/macosx-x64-debug/jdk'
+
+$JAVA_HOME/bin/javac MyMacCanvas.java
+
+gcc -v myfile.m -I"$JAVA_HOME/include" -c -o myfile.o
+
+gcc -v myfile.o -L$JAVA_HOME/lib -ljawt -framework AppKit -framework OpenGL -framework Metal -framework Quartz -shared -o libmylib.jnilib
+
+$JAVA_HOME/bin/java -Djava.library.path=. -Dsun.java2d.metal=True MyMacCanvas

--- a/test/jdk/java/awt/JAWT/myfile.m
+++ b/test/jdk/java/awt/JAWT/myfile.m
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JAVAVM/jawt_md.h"
+#import <Quartz/Quartz.h>
+
+/*
+ * Pass the block to a selector of a class that extends NSObject
+ * There is no need to copy the block since this class always waits.
+ */
+@interface BlockRunner : NSObject { }
+
++ (void)invokeBlock:(void (^)())block;
+@end
+
+@implementation BlockRunner
+
++ (void)invokeBlock:(void (^)())block{
+  block();
+}
+
++ (void)performBlock:(void (^)())block {
+  [self performSelectorOnMainThread:@selector(invokeBlock:) withObject:block waitUntilDone:YES];
+}
+
+@end
+
+
+/*
+ * Class:	MyMacCanvas
+ * Method:	paint
+ * SIgnature:	(Ljava/awt/Graphics;)V
+ */
+JNIEXPORT void JNICALL Java_MyMacCanvas_addNativeCoreAnimationLayer
+(JNIEnv* env, jobject canvas, jobject graphics)
+{
+    printf("paint called\n");
+
+    JAWT awt;
+    awt.version = JAWT_VERSION_1_4 | JAWT_MACOSX_USE_CALAYER;
+    if (JAWT_GetAWT(env, &awt) == JNI_FALSE) {
+        printf("AWT Not found\n");
+        return;
+    }
+
+    printf("JAWT found\n");
+
+    /* Get the drawing surface */
+    JAWT_DrawingSurface* ds = awt.GetDrawingSurface(env, canvas);
+    if (ds == NULL) {
+        printf("NULL drawing surface\n");
+        return;
+    }
+
+    /* Lock the drawing surface */
+    jint lock = ds->Lock(ds);
+    printf("Lock value %d\n", (int)lock);
+    if((lock & JAWT_LOCK_ERROR) != 0) {
+        printf("Error locking surface");
+        return;
+    }
+
+    /* Get the drawing surface info */
+    JAWT_DrawingSurfaceInfo *dsi = ds->GetDrawingSurfaceInfo(ds);
+    if (dsi == NULL) {
+        printf("Error getting surface info\n");
+        ds->Unlock(ds);
+        return;
+    }
+
+    // create and attach the layer on the AppKit thread
+    void (^block)() = ^(){
+        // attach the "root layer" to the AWT Canvas surface layers
+        CALayer *layer = [[CALayer new] autorelease];
+        id <JAWT_SurfaceLayers> surfaceLayers = (id <JAWT_SurfaceLayers>)dsi->platformInfo;
+        CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB ();
+        CGFloat rgba[4] = {0.0, 0.0, 0.0, 1.0};
+        CGColorRef color = CGColorCreate (colorspace, rgba);
+        layer.backgroundColor = color;
+        surfaceLayers.layer = layer;
+    };
+
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        [BlockRunner performBlock:block];
+    }
+
+    /* Free the drawing surface info */
+    ds->FreeDrawingSurfaceInfo(dsi);
+
+    /* Unlock the drawing surface */
+    ds->Unlock(ds);
+
+    /* Free the drawing surface */
+    awt.FreeDrawingSurface(ds);
+}

--- a/test/jdk/java/awt/JAWT/myfile.m
+++ b/test/jdk/java/awt/JAWT/myfile.m
@@ -47,9 +47,9 @@
 
 
 /*
- * Class:	MyMacCanvas
- * Method:	paint
- * SIgnature:	(Ljava/awt/Graphics;)V
+ * Class:        MyMacCanvas
+ * Method:       paint
+ * SIgnature:    (Ljava/awt/Graphics;)V
  */
 JNIEXPORT void JNICALL Java_MyMacCanvas_addNativeCoreAnimationLayer
 (JNIEnv* env, jobject canvas, jobject graphics)

--- a/test/jdk/java/awt/JAWT/myfile.m
+++ b/test/jdk/java/awt/JAWT/myfile.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
JAWT has testcase for windows and linux but no testcase is provided for mac.
We need to have a JAWT based testcase for mac, in similar lines to windows and linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263928](https://bugs.openjdk.java.net/browse/JDK-8263928): Add JAWT test files for mac


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3112/head:pull/3112`
`$ git checkout pull/3112`

To update a local copy of the PR:
`$ git checkout pull/3112`
`$ git pull https://git.openjdk.java.net/jdk pull/3112/head`
