### PR TITLE
8247895: SHA1PRNGReseed.java is calling setSeed(0)

### DIFF
--- a/test/jdk/sun/security/provider/SecureRandom/SHA1PRNGReseed.java
+++ b/test/jdk/sun/security/provider/SecureRandom/SHA1PRNGReseed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,14 +28,14 @@ import java.security.SecureRandom;
 
 /**
  * @test
- * @bug 8154523
+ * @bug 8154523 8247895
  * @summary SHA1PRNG output should change after setSeed
  */
 public class SHA1PRNGReseed {
 
     public static void main(String[] args) throws Exception {
         SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
-        sr.setSeed(0);
+        sr.setSeed(1);
         sr.nextInt();
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -45,7 +45,7 @@ public class SHA1PRNGReseed {
                 new ByteArrayInputStream(bout.toByteArray())).readObject();
 
         int i1 = sr.nextInt();
-        sr2.setSeed(1);
+        sr2.setSeed(2);
         int i2 = sr2.nextInt();
 
         if (i1 == i2) {


### PR DESCRIPTION
The Test is updated to use positive integer as seed for SecureRandom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247895](https://bugs.openjdk.java.net/browse/JDK-8247895): SHA1PRNGReseed.java is calling setSeed(0)


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3114/head:pull/3114`
`$ git checkout pull/3114`

To update a local copy of the PR:
`$ git checkout pull/3114`
`$ git pull https://git.openjdk.java.net/jdk pull/3114/head`
