### PR TITLE
8225438: javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java failed with Read timed out

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018,2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 /*
  * @test
- * @bug 8206355
+ * @bug 8206355 8225438
  * @summary Test principal that was sent to the peer during handshake.
  * @run main/othervm TestSessionLocalPrincipal
  */
@@ -131,7 +131,6 @@ public class TestSessionLocalPrincipal {
             latch.countDown();
             try (SSLSocket sslSocket = (SSLSocket) sslServerSocket.accept()) {
                 sslSocket.setNeedClientAuth(this.clientAuth);
-                sslSocket.setSoTimeout(5000);
                 try (InputStream sslIS = sslSocket.getInputStream();
                         OutputStream sslOS = sslSocket.getOutputStream();) {
                     sslIS.read();


### PR DESCRIPTION
The Test getting timeout intermittently because the SO_TIMEOUT of 5 seconds set on sslServerSocket. This time interval could be inadequate when the machine is too busy. Also it looks setting SO_TIMEOUT is unnecessary here. So the statement has been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225438](https://bugs.openjdk.java.net/browse/JDK-8225438): javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java failed with Read timed out


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3116/head:pull/3116`
`$ git checkout pull/3116`

To update a local copy of the PR:
`$ git checkout pull/3116`
`$ git pull https://git.openjdk.java.net/jdk pull/3116/head`
