### PR TITLE
8263964: Redundant check in ObjectStartArray::object_starts_in_range

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -129,9 +129,6 @@ bool ObjectStartArray::object_starts_in_range(HeapWord* start_addr,
   assert(start_addr <= end_addr,
          "Range is wrong. start_addr (" PTR_FORMAT ") is after end_addr (" PTR_FORMAT ")",
          p2i(start_addr), p2i(end_addr));
-  if (start_addr > end_addr) {
-    return false;
-  }
 
   jbyte* start_block = block_for_addr(start_addr);
   jbyte* end_block = block_for_addr(end_addr);

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -84,7 +84,7 @@ class ObjectStartArray : public CHeapObj<mtGC> {
   // Mapping that includes the derived offset.
   // If the block is clean, returns the last address in the covered region.
   // If the block is < index 0, returns the start of the covered region.
-  HeapWord* offset_addr_for_block (jbyte* p) const {
+  HeapWord* offset_addr_for_block(jbyte* p) const {
     // We have to do this before the assert
     if (p < _raw_base) {
       return _covered_region.start();
@@ -144,10 +144,7 @@ class ObjectStartArray : public CHeapObj<mtGC> {
   bool is_block_allocated(HeapWord* addr) {
     assert_covered_region_contains(addr);
     jbyte* block = block_for_addr(addr);
-    if (*block == clean_block)
-      return false;
-
-    return true;
+    return *block != clean_block;
   }
 
   // Return true if an object starts in the range of heap addresses.


### PR DESCRIPTION
Trivial change of removing a redundant check and some general cleanup in the surrounding code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263964](https://bugs.openjdk.java.net/browse/JDK-8263964): Redundant check in ObjectStartArray::object_starts_in_range


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3117/head:pull/3117`
`$ git checkout pull/3117`

To update a local copy of the PR:
`$ git checkout pull/3117`
`$ git pull https://git.openjdk.java.net/jdk pull/3117/head`
