### PR TITLE
8262465: Very long compilation times and high memory consumption in C2 debug builds

### DIFF
--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -1278,15 +1278,17 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
       IndexSet *liveout = _live->live(b);
       if( !liveout->member(defidx) ) {
 #ifdef ASSERT
-        // The index defidx is not live.  Check the liveout array to ensure that
-        // it contains no members which compress to defidx.  Finding such an
-        // instance may be a case to add liveout adjustment in compress_uf_map().
-        // See 5063219.
-        if (!liveout->is_empty()) {
-          uint member;
-          IndexSetIterator isi(liveout);
-          while ((member = isi.next()) != 0) {
-            assert(defidx != _lrg_map.find_const(member), "Live out member has not been compressed");
+        if (VerifyRegisterAllocator) {
+          // The index defidx is not live.  Check the liveout array to ensure that
+          // it contains no members which compress to defidx.  Finding such an
+          // instance may be a case to add liveout adjustment in compress_uf_map().
+          // See 5063219.
+          if (!liveout->is_empty()) {
+            uint member;
+            IndexSetIterator isi(liveout);
+            while ((member = isi.next()) != 0) {
+              assert(defidx != _lrg_map.find_const(member), "Live out member has not been compressed");
+            }
           }
         }
 #endif


### PR DESCRIPTION
I tracked down the cause of the compilation times to a assert guarded block in reg_split.cpp.

The test method that causes this behaviour is a main method with an outer iteration loop, and inner loops that iterates over a value array. The inner loops is filled with about 40 calls to a verify() method but with different tests of rotate. Every call to verify is also accompanied by a string concatenation that expands with indy-string-concat.

The result IR has a huge number of live ranges and the index set are very large.

In reg_split there is some code that validate that any liveout isn't compressible to defidx. For all spills - all liveouts a searched for the def. But the lrgs are not compressed yet - so they will scan a chain of renames. To add insult to injury the indexset is huge. Fortunately this is only in debug builds.

I have posted some compile time numbers and IndexSet statistics in the bug.

I propose to guard the assert code with VerifyRegisterAllocation. This isn't optimal since we don't test with that flag regularly, but I think it might be an ok trade off. Bugs in split would still be caught - but later, and then VerifyRegisterAllocation can be turned on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262465](https://bugs.openjdk.java.net/browse/JDK-8262465): Very long compilation times and high memory consumption in C2 debug builds


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 00c8928e7ffef0041ff356d70dcc745fe6c98679
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3119/head:pull/3119`
`$ git checkout pull/3119`

To update a local copy of the PR:
`$ git checkout pull/3119`
`$ git pull https://git.openjdk.java.net/jdk pull/3119/head`
