### PR TITLE
8263974: Move SystemDictionary::verify_protection_domain

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -30,7 +30,6 @@
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoadInfo.hpp"
 #include "classfile/defaultMethods.hpp"
-#include "classfile/dictionary.hpp"
 #include "classfile/fieldLayoutBuilder.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/moduleEntry.hpp"

--- a/src/hotspot/share/classfile/classFileStream.cpp
+++ b/src/hotspot/share/classfile/classFileStream.cpp
@@ -25,7 +25,6 @@
 #include "precompiled.hpp"
 #include "classfile/classFileStream.hpp"
 #include "classfile/classLoader.hpp"
-#include "classfile/dictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "memory/resourceArea.hpp"
 

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -290,7 +290,7 @@ DictionaryEntry* Dictionary::get_entry(int index, unsigned int hash,
   for (DictionaryEntry* entry = bucket(index);
                         entry != NULL;
                         entry = entry->next()) {
-    if (entry->hash() == hash && entry->equals(class_name)) {
+    if (entry->hash() == hash && entry->instance_klass()->name() == class_name) {
       return entry;
     }
   }

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -25,18 +25,23 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/dictionary.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/protectionDomainCache.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
 #include "memory/iterator.hpp"
 #include "memory/metaspaceClosure.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "oops/klass.inline.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/handles.inline.hpp"
+#include "runtime/javaCalls.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "utilities/hashtable.inline.hpp"
@@ -320,8 +325,7 @@ InstanceKlass* Dictionary::find_class(unsigned int hash,
 
 void Dictionary::add_protection_domain(int index, unsigned int hash,
                                        InstanceKlass* klass,
-                                       Handle protection_domain,
-                                       TRAPS) {
+                                       Handle protection_domain) {
   assert(java_lang_System::allow_security_manager(), "only needed if security manager allowed");
   Symbol*  klass_name = klass->name();
   DictionaryEntry* entry = get_entry(index, hash, klass_name);
@@ -341,12 +345,80 @@ void Dictionary::add_protection_domain(int index, unsigned int hash,
 }
 
 
-bool Dictionary::is_valid_protection_domain(unsigned int hash,
+inline bool Dictionary::is_valid_protection_domain(unsigned int hash,
                                             Symbol* name,
                                             Handle protection_domain) {
   int index = hash_to_index(hash);
   DictionaryEntry* entry = get_entry(index, hash, name);
   return entry->is_valid_protection_domain(protection_domain);
+}
+
+void Dictionary::validate_protection_domain(unsigned int name_hash,
+                                            InstanceKlass* klass,
+                                            Handle class_loader,
+                                            Handle protection_domain,
+                                            TRAPS) {
+
+  // Now we have to call back to java to check if the initating class has access
+  assert(class_loader() != NULL, "Should not call this");
+  assert(protection_domain() != NULL, "Should not call this");
+
+  if (!java_lang_System::allow_security_manager() ||
+      is_valid_protection_domain(name_hash, klass->name(), protection_domain)) {
+    return;
+  }
+
+  // We only have to call checkPackageAccess if there's a security manager installed.
+  if (java_lang_System::has_security_manager()) {
+
+    // This handle and the class_loader handle passed in keeps this class from
+    // being unloaded through several GC points.
+    // The class_loader handle passed in is the initiating loader.
+    Handle mirror(THREAD, klass->java_mirror());
+
+    InstanceKlass* system_loader = vmClasses::ClassLoader_klass();
+    JavaValue result(T_VOID);
+    JavaCalls::call_special(&result,
+                           class_loader,
+                           system_loader,
+                           vmSymbols::checkPackageAccess_name(),
+                           vmSymbols::class_protectiondomain_signature(),
+                           mirror,
+                           protection_domain,
+                           THREAD);
+
+    LogTarget(Debug, protectiondomain) lt;
+    if (lt.is_enabled()) {
+      ResourceMark rm(THREAD);
+      // Print out trace information
+      LogStream ls(lt);
+      ls.print_cr("Checking package access");
+      ls.print("class loader: ");
+      class_loader()->print_value_on(&ls);
+      ls.print(" protection domain: ");
+      protection_domain()->print_value_on(&ls);
+      ls.print(" loading: "); klass->print_value_on(&ls);
+      if (HAS_PENDING_EXCEPTION) {
+        ls.print_cr(" DENIED !!!!!!!!!!!!!!!!!!!!!");
+      } else {
+        ls.print_cr(" granted");
+      }
+    }
+
+    if (HAS_PENDING_EXCEPTION) return;
+  }
+
+  // If no exception has been thrown, we have validated the protection domain
+  // Insert the protection domain of the initiating class into the set.
+  // We still have to add the protection_domain to the dictionary in case a new
+  // security manager is installed later. Calls to load the same class with class loader
+  // and protection domain are expected to succeed.
+  {
+    MutexLocker mu(THREAD, SystemDictionary_lock);
+    int d_index = hash_to_index(name_hash);
+    add_protection_domain(d_index, name_hash, klass,
+                          protection_domain);
+  }
 }
 
 // During class loading we may have cached a protection domain that has

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -359,7 +359,6 @@ void Dictionary::validate_protection_domain(unsigned int name_hash,
                                             Handle protection_domain,
                                             TRAPS) {
 
-  // Now we have to call back to java to check if the initating class has access
   assert(class_loader() != NULL, "Should not call this");
   assert(protection_domain() != NULL, "Should not call this");
 
@@ -376,6 +375,7 @@ void Dictionary::validate_protection_domain(unsigned int name_hash,
     // The class_loader handle passed in is the initiating loader.
     Handle mirror(THREAD, klass->java_mirror());
 
+    // Now we have to call back to java to check if the initating class has access
     InstanceKlass* system_loader = vmClasses::ClassLoader_klass();
     JavaValue result(T_VOID);
     JavaCalls::call_special(&result,

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -144,10 +144,6 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
   // Adds a protection domain to the approved set.
   void add_protection_domain(Dictionary* dict, Handle protection_domain);
 
-  // Tells whether the initiating class' protection domain can access the klass in this entry
-  inline bool is_valid_protection_domain(Handle protection_domain);
-  void verify_protection_domain_set();
-
   InstanceKlass* instance_klass() const { return literal(); }
   InstanceKlass** klass_addr() { return (InstanceKlass**)literal_addr(); }
 
@@ -162,10 +158,9 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
   ProtectionDomainEntry* pd_set() const            { return _pd_set; }
   void set_pd_set(ProtectionDomainEntry* new_head) {  _pd_set = new_head; }
 
-  bool equals(const Symbol* class_name) const {
-    InstanceKlass* klass = (InstanceKlass*)literal();
-    return (klass->name() == class_name);
-  }
+  // Tells whether the initiating class' protection domain can access the klass in this entry
+  inline bool is_valid_protection_domain(Handle protection_domain);
+  void verify_protection_domain_set();
 
   void print_count(outputStream *st);
   void verify();

--- a/src/hotspot/share/classfile/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.cpp
@@ -25,7 +25,6 @@
 #include "precompiled.hpp"
 #include "classfile/classLoadInfo.hpp"
 #include "classfile/classFileStream.hpp"
-#include "classfile/dictionary.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/klassFactory.hpp"
 #include "classfile/lambdaFormInvokers.hpp"

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -315,10 +315,6 @@ private:
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;
 
-  static void validate_protection_domain(InstanceKlass* klass,
-                                         Handle class_loader,
-                                         Handle protection_domain, TRAPS);
-
   friend class VM_PopulateDumpSharedSpace;
   static LoaderConstraintTable* constraints() { return _loader_constraints; }
   static ResolutionErrorTable* resolution_errors() { return _resolution_errors; }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -26,7 +26,6 @@
 #include "jvm_io.h"
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoaderDataGraph.inline.hpp"
-#include "classfile/dictionary.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/systemDictionary.hpp"


### PR DESCRIPTION
Please review this mostly trivial fix to move SystemDictionary::validate_protection_domain into Dictionary and hide the functions in Dictionary that it calls.  This change also removes some #include dictionary.hpp and a TRAPS parameter where not needed.

See CR for more details.  This function was in the middle of others that I want to keep together in systemDictionary.cpp.

Tested with tier1 on 4 Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263974](https://bugs.openjdk.java.net/browse/JDK-8263974): Move SystemDictionary::verify_protection_domain


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to 33283cbf297f37f7c4ef163ede9bc5535e2d12bd
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3120/head:pull/3120`
`$ git checkout pull/3120`

To update a local copy of the PR:
`$ git checkout pull/3120`
`$ git pull https://git.openjdk.java.net/jdk pull/3120/head`
