### PR TITLE
8263977: GTK L&F: Cleanup duplicate checks in GTKStyle and GTKLookAndFeel

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -249,7 +249,6 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
                 region == Region.SPINNER ||
                 region == Region.TABLE ||
                 region == Region.TEXT_AREA ||
-                region == Region.TEXT_FIELD ||
                 region == Region.TEXT_PANE ||
                 region == Region.TREE);
     }

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -166,8 +166,7 @@ class GTKStyle extends SynthStyle implements GTKConstants {
                 id == Region.TABBED_PANE_TAB ||
                 id == Region.TOGGLE_BUTTON ||
                 id == Region.TOOL_TIP ||
-                id == Region.MENU_ITEM_ACCELERATOR ||
-                id == Region.TABBED_PANE_TAB)) {
+                id == Region.MENU_ITEM_ACCELERATOR)) {
             type = ColorType.FOREGROUND;
         } else if (id == Region.TABLE ||
                    id == Region.LIST ||

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
SonarCloud reports a few minor problems in GTKStyle and GTKLookAndFeel: Correct one of the identical sub-expressions on both sides of operator "||".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263977](https://bugs.openjdk.java.net/browse/JDK-8263977): GTK L&F: Cleanup duplicate checks in GTKStyle and GTKLookAndFeel


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 285cefc516ed50c161a0f375e4dc2354b962dc2f
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 285cefc516ed50c161a0f375e4dc2354b962dc2f


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3121/head:pull/3121`
`$ git checkout pull/3121`

To update a local copy of the PR:
`$ git checkout pull/3121`
`$ git pull https://git.openjdk.java.net/jdk pull/3121/head`
