### PR TITLE
8263979: Cleanup duplicate check in Unicode.contains

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/Unicode.java
+++ b/src/java.base/share/classes/sun/nio/cs/Unicode.java
@@ -86,7 +86,6 @@ abstract class Unicode extends Charset
                 || (cs.name().equals("ISO-2022-KR"))
                 || (cs.name().equals("x-ISO-2022-CN-CNS"))
                 || (cs.name().equals("x-ISO-2022-CN-GB"))
-                || (cs.name().equals("Big5-HKSCS"))
                 || (cs.name().equals("x-Johab"))
                 || (cs.name().equals("Shift_JIS")));
     }


### PR DESCRIPTION
SonarCloud reports an easy problem in Unicode.contains:
 Correct one of the identical sub-expressions on both sides of operator "||"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263979](https://bugs.openjdk.java.net/browse/JDK-8263979): Cleanup duplicate check in Unicode.contains


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3122/head:pull/3122`
`$ git checkout pull/3122`

To update a local copy of the PR:
`$ git checkout pull/3122`
`$ git pull https://git.openjdk.java.net/jdk pull/3122/head`
