### PR TITLE
8263976: Remove block allocation from BasicHashtable

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -69,11 +69,10 @@ Dictionary::~Dictionary() {
     }
   }
   assert(number_of_entries() == 0, "should have removed all entries");
-  assert(new_entry_free_list() == NULL, "entry present on Dictionary's free list");
 }
 
 DictionaryEntry* Dictionary::new_entry(unsigned int hash, InstanceKlass* klass) {
-  DictionaryEntry* entry = (DictionaryEntry*)Hashtable<InstanceKlass*, mtClass>::allocate_new_entry(hash, klass);
+  DictionaryEntry* entry = (DictionaryEntry*)Hashtable<InstanceKlass*, mtClass>::new_entry(hash, klass);
   entry->set_pd_set(NULL);
   assert(klass->is_instance_klass(), "Must be");
   return entry;
@@ -90,9 +89,7 @@ void Dictionary::free_entry(DictionaryEntry* entry) {
     entry->set_pd_set(to_delete->next());
     delete to_delete;
   }
-  // Unlink from the Hashtable prior to freeing
-  unlink_entry(entry);
-  FREE_C_HEAP_ARRAY(char, entry);
+  BasicHashtable<mtClass>::free_entry(entry);
 }
 
 const int _resize_load_trigger = 5;       // load factor that will trigger the resize
@@ -479,7 +476,7 @@ void SymbolPropertyTable::methods_do(void f(Method*)) {
 
 void SymbolPropertyTable::free_entry(SymbolPropertyEntry* entry) {
   entry->free_entry();
-  Hashtable<Symbol*, mtSymbol>::free_entry(entry);
+  BasicHashtable<mtSymbol>::free_entry(entry);
 }
 
 void DictionaryEntry::verify_protection_domain_set() {

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -93,14 +93,6 @@ public:
     return (DictionaryEntry**)Hashtable<InstanceKlass*, mtClass>::bucket_addr(i);
   }
 
-  void add_entry(int index, DictionaryEntry* new_entry) {
-    Hashtable<InstanceKlass*, mtClass>::add_entry(index, (HashtableEntry<InstanceKlass*, mtClass>*)new_entry);
-  }
-
-  void unlink_entry(DictionaryEntry* entry) {
-    Hashtable<InstanceKlass*, mtClass>::unlink_entry((HashtableEntry<InstanceKlass*, mtClass>*)entry);
-  }
-
   void free_entry(DictionaryEntry* entry);
 };
 

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -58,7 +58,7 @@ LoaderConstraintEntry* LoaderConstraintTable::new_entry(
 void LoaderConstraintTable::free_entry(LoaderConstraintEntry *entry) {
   // decrement name refcount before freeing
   entry->name()->decrement_refcount();
-  Hashtable<InstanceKlass*, mtClass>::free_entry(entry);
+  BasicHashtable<mtClass>::free_entry(entry);
 }
 
 // The loaderConstraintTable must always be accessed with the

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -357,14 +357,10 @@ ModuleEntryTable::~ModuleEntryTable() {
       if (to_remove->location() != NULL) {
         to_remove->location()->decrement_refcount();
       }
-
-      // Unlink from the Hashtable prior to freeing
-      unlink_entry(to_remove);
-      FREE_C_HEAP_ARRAY(char, to_remove);
+      BasicHashtable<mtModule>::free_entry(to_remove);
     }
   }
   assert(number_of_entries() == 0, "should have removed all entries");
-  assert(new_entry_free_list() == NULL, "entry present on ModuleEntryTable's free list");
 }
 
 void ModuleEntry::set_loader_data(ClassLoaderData* cld) {
@@ -579,7 +575,7 @@ ModuleEntry* ModuleEntryTable::new_entry(unsigned int hash, Handle module_handle
                                          Symbol* version, Symbol* location,
                                          ClassLoaderData* loader_data) {
   assert(Module_lock->owned_by_self(), "should have the Module_lock");
-  ModuleEntry* entry = (ModuleEntry*)Hashtable<Symbol*, mtModule>::allocate_new_entry(hash, name);
+  ModuleEntry* entry = (ModuleEntry*)Hashtable<Symbol*, mtModule>::new_entry(hash, name);
 
   // Initialize fields specific to a ModuleEntry
   entry->init();

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -187,13 +187,10 @@ PackageEntryTable::~PackageEntryTable() {
       to_remove->delete_qualified_exports();
       to_remove->name()->decrement_refcount();
 
-      // Unlink from the Hashtable prior to freeing
-      unlink_entry(to_remove);
-      FREE_C_HEAP_ARRAY(char, to_remove);
+      BasicHashtable<mtModule>::free_entry(to_remove);
     }
   }
   assert(number_of_entries() == 0, "should have removed all entries");
-  assert(new_entry_free_list() == NULL, "entry present on PackageEntryTable's free list");
 }
 
 #if INCLUDE_CDS_JAVA_HEAP
@@ -322,7 +319,7 @@ void PackageEntryTable::load_archived_entries(Array<PackageEntry*>* archived_pac
 
 PackageEntry* PackageEntryTable::new_entry(unsigned int hash, Symbol* name, ModuleEntry* module) {
   assert(Module_lock->owned_by_self(), "should have the Module_lock");
-  PackageEntry* entry = (PackageEntry*)Hashtable<Symbol*, mtModule>::allocate_new_entry(hash, name);
+  PackageEntry* entry = (PackageEntry*)Hashtable<Symbol*, mtModule>::new_entry(hash, name);
 
   JFR_ONLY(INIT_ID(entry);)
 

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -193,7 +193,7 @@ void PlaceholderTable::free_entry(PlaceholderEntry* entry) {
   // decrement Symbol refcount here because Hashtable doesn't.
   entry->literal()->decrement_refcount();
   if (entry->supername() != NULL) entry->supername()->decrement_refcount();
-  Hashtable<Symbol*, mtClass>::free_entry(entry);
+  BasicHashtable<mtClass>::free_entry(entry);
 }
 
 

--- a/src/hotspot/share/classfile/resolutionErrors.cpp
+++ b/src/hotspot/share/classfile/resolutionErrors.cpp
@@ -137,7 +137,7 @@ void ResolutionErrorTable::free_entry(ResolutionErrorEntry *entry) {
   if (entry->nest_host_error() != NULL) {
     FREE_C_HEAP_ARRAY(char, entry->nest_host_error());
   }
-  Hashtable<ConstantPool*, mtClass>::free_entry(entry);
+  BasicHashtable<mtClass>::free_entry(entry);
 }
 
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1646,13 +1646,14 @@ InstanceKlass* SystemDictionary::find_or_define_helper(Symbol* class_name, Handl
     // Other cases fall through, and may run into duplicate defines
     // caught by finding an entry in the SystemDictionary
     if (is_parallelDefine(class_loader) && (probe->instance_klass() != NULL)) {
+      InstanceKlass* ik = probe->instance_klass();
       placeholders()->find_and_remove(name_hash, name_h, loader_data, PlaceholderTable::DEFINE_CLASS, THREAD);
       SystemDictionary_lock->notify_all();
 #ifdef ASSERT
       InstanceKlass* check = dictionary->find_class(name_hash, name_h);
       assert(check != NULL, "definer missed recording success");
 #endif
-      return probe->instance_klass();
+      return ik;
     } else {
       // This thread will define the class (even if earlier thread tried and had an error)
       probe->set_definer(THREAD);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -94,6 +94,7 @@
 #include "services/threadService.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/defaultStream.hpp"
+#include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/utf8.hpp"

--- a/src/hotspot/share/prims/jvmtiTagMapTable.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.cpp
@@ -64,7 +64,6 @@ void JvmtiTagMapTable::clear() {
     *p = NULL; // clear out buckets.
   }
   assert(number_of_entries() == 0, "should have removed all entries");
-  assert(new_entry_free_list() == NULL, "entry present on JvmtiTagMapTable's free list");
 }
 
 JvmtiTagMapTable::~JvmtiTagMapTable() {
@@ -74,15 +73,14 @@ JvmtiTagMapTable::~JvmtiTagMapTable() {
 
 // Entries are C_Heap allocated
 JvmtiTagMapEntry* JvmtiTagMapTable::new_entry(unsigned int hash, WeakHandle w, jlong tag) {
-  JvmtiTagMapEntry* entry = (JvmtiTagMapEntry*)Hashtable<WeakHandle, mtServiceability>::allocate_new_entry(hash, w);
+  JvmtiTagMapEntry* entry = (JvmtiTagMapEntry*)Hashtable<WeakHandle, mtServiceability>::new_entry(hash, w);
   entry->set_tag(tag);
   return entry;
 }
 
 void JvmtiTagMapTable::free_entry(JvmtiTagMapEntry* entry) {
-  unlink_entry(entry);
   entry->literal().release(JvmtiExport::weak_tag_storage()); // release to OopStorage
-  FREE_C_HEAP_ARRAY(char, entry);
+  BasicHashtable<mtServiceability>::free_entry(entry);
 }
 
 unsigned int JvmtiTagMapTable::compute_hash(oop obj) {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -491,10 +491,6 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
                                                                                                                                      \
   nonstatic_field(BasicHashtable<mtInternal>,  _table_size,                                   int)                                   \
   nonstatic_field(BasicHashtable<mtInternal>,  _buckets,                                      HashtableBucket<mtInternal>*)          \
-  volatile_nonstatic_field(BasicHashtable<mtInternal>,  _free_list,                           BasicHashtableEntry<mtInternal>*)      \
-  nonstatic_field(BasicHashtable<mtInternal>,  _first_free_entry,                             char*)                                 \
-  nonstatic_field(BasicHashtable<mtInternal>,  _end_block,                                    char*)                                 \
-  nonstatic_field(BasicHashtable<mtInternal>,  _entry_size,                                   int)                                   \
                                                                                                                                      \
   /*******************/                                                                                                              \
   /* ClassLoaderData */                                                                                                              \

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -23,20 +23,19 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/altHashing.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/packageEntry.hpp"
 #include "classfile/placeholders.hpp"
 #include "classfile/protectionDomainCache.hpp"
-#include "classfile/stringTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "code/nmethod.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/symbol.hpp"
 #include "oops/weakHandle.inline.hpp"
 #include "prims/jvmtiTagMapTable.hpp"
 #include "runtime/safepoint.hpp"
@@ -45,56 +44,21 @@
 #include "utilities/hashtable.inline.hpp"
 #include "utilities/numberSeq.hpp"
 
-
 // This hashtable is implemented as an open hash table with a fixed number of buckets.
 
-template <MEMFLAGS F> BasicHashtableEntry<F>* BasicHashtable<F>::new_entry_free_list() {
-  BasicHashtableEntry<F>* entry = NULL;
-  if (_free_list != NULL) {
-    entry = _free_list;
-    _free_list = _free_list->next();
-  }
-  return entry;
-}
+// Hashtable entry allocates in the C heap directly.
 
-// HashtableEntrys are allocated in blocks to reduce the space overhead.
 template <MEMFLAGS F> BasicHashtableEntry<F>* BasicHashtable<F>::new_entry(unsigned int hashValue) {
-  BasicHashtableEntry<F>* entry = new_entry_free_list();
-
-  if (entry == NULL) {
-    if (_first_free_entry + _entry_size >= _end_block) {
-      int block_size = MAX2((int)_table_size / 2, (int)_number_of_entries); // pick a reasonable value
-      block_size = clamp(block_size, 2, 512); // but never go out of this range
-      int len = round_down_power_of_2(_entry_size * block_size);
-      assert(len >= _entry_size, "");
-      _first_free_entry = NEW_C_HEAP_ARRAY2(char, len, F, CURRENT_PC);
-      _entry_blocks.append(_first_free_entry);
-      _end_block = _first_free_entry + len;
-    }
-    entry = (BasicHashtableEntry<F>*)_first_free_entry;
-    _first_free_entry += _entry_size;
-  }
-
+  BasicHashtableEntry<F>* entry = ::new (NEW_C_HEAP_ARRAY(char, this->entry_size(), F))
+                                        BasicHashtableEntry<F>(hashValue);
   assert(_entry_size % HeapWordSize == 0, "");
-  entry->set_hash(hashValue);
   return entry;
 }
 
 
 template <class T, MEMFLAGS F> HashtableEntry<T, F>* Hashtable<T, F>::new_entry(unsigned int hashValue, T obj) {
-  HashtableEntry<T, F>* entry;
-
-  entry = (HashtableEntry<T, F>*)BasicHashtable<F>::new_entry(hashValue);
-  entry->set_literal(obj);
-  return entry;
-}
-
-// Version of hashtable entry allocation that allocates in the C heap directly.
-// The block allocator in BasicHashtable has less fragmentation, but the memory is not freed until
-// the whole table is freed. Use allocate_new_entry() if you want to individually free the memory
-// used by each entry
-template <class T, MEMFLAGS F> HashtableEntry<T, F>* Hashtable<T, F>::allocate_new_entry(unsigned int hashValue, T obj) {
-  HashtableEntry<T, F>* entry = (HashtableEntry<T, F>*) NEW_C_HEAP_ARRAY(char, this->entry_size(), F);
+  HashtableEntry<T, F>* entry = ::new (NEW_C_HEAP_ARRAY(char, this->entry_size(), F))
+                                      HashtableEntry<T, F>(hashValue);
 
   if (DumpSharedSpaces) {
     // Avoid random bits in structure padding so we can have deterministic content in CDS archive
@@ -105,6 +69,14 @@ template <class T, MEMFLAGS F> HashtableEntry<T, F>* Hashtable<T, F>::allocate_n
   entry->set_next(NULL);
   return entry;
 }
+
+template <MEMFLAGS F> inline void BasicHashtable<F>::free_entry(BasicHashtableEntry<F>* entry) {
+  // Unlink from the Hashtable prior to freeing
+  unlink_entry(entry);
+  FREE_C_HEAP_ARRAY(char, entry);
+  JFR_ONLY(_stats_rate.remove();)
+}
+
 
 template <MEMFLAGS F> void BasicHashtable<F>::free_buckets() {
   FREE_C_HEAP_ARRAY(HashtableBucket, _buckets);

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -51,22 +51,13 @@
 template <MEMFLAGS F> BasicHashtableEntry<F>* BasicHashtable<F>::new_entry(unsigned int hashValue) {
   BasicHashtableEntry<F>* entry = ::new (NEW_C_HEAP_ARRAY(char, this->entry_size(), F))
                                         BasicHashtableEntry<F>(hashValue);
-  assert(_entry_size % HeapWordSize == 0, "");
   return entry;
 }
 
 
 template <class T, MEMFLAGS F> HashtableEntry<T, F>* Hashtable<T, F>::new_entry(unsigned int hashValue, T obj) {
   HashtableEntry<T, F>* entry = ::new (NEW_C_HEAP_ARRAY(char, this->entry_size(), F))
-                                      HashtableEntry<T, F>(hashValue);
-
-  if (DumpSharedSpaces) {
-    // Avoid random bits in structure padding so we can have deterministic content in CDS archive
-    memset((void*)entry, 0, this->entry_size());
-  }
-  entry->set_hash(hashValue);
-  entry->set_literal(obj);
-  entry->set_next(NULL);
+                                      HashtableEntry<T, F>(hashValue, obj);
   return entry;
 }
 

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -26,10 +26,8 @@
 #define SHARE_UTILITIES_HASHTABLE_HPP
 
 #include "memory/allocation.hpp"
-#include "oops/oop.hpp"
 #include "oops/symbol.hpp"
 #include "runtime/handles.hpp"
-#include "utilities/growableArray.hpp"
 #include "utilities/tableStatistics.hpp"
 
 // This is a generic hashtable, designed to be used for the symbol
@@ -50,16 +48,11 @@ private:
   // Link to next element in the linked list for this bucket.
   BasicHashtableEntry<F>* _next;
 
-  // Windows IA64 compiler requires subclasses to be able to access these
-protected:
-  // Entry objects should not be created, they should be taken from the
-  // free list with BasicHashtable.new_entry().
-  BasicHashtableEntry() { ShouldNotReachHere(); }
-  // Entry objects should not be destroyed.  They should be placed on
-  // the free list instead with BasicHashtable.free_entry().
-  ~BasicHashtableEntry() { ShouldNotReachHere(); }
-
 public:
+  BasicHashtableEntry(unsigned int hashValue) : _hash(hashValue), _next(nullptr) {}
+  // Still should not call this. Entries are placement new allocated, so are
+  // deleted with free_entry.
+  ~BasicHashtableEntry() { ShouldNotReachHere(); }
 
   unsigned int hash() const             { return _hash; }
   void set_hash(unsigned int hash)      { _hash = hash; }
@@ -86,6 +79,8 @@ private:
   T               _literal;          // ref to item in table.
 
 public:
+  HashtableEntry(unsigned int hashValue) : BasicHashtableEntry<F>(hashValue) {}
+
   // Literal
   T literal() const                   { return _literal; }
   T* literal_addr()                   { return &_literal; }
@@ -142,12 +137,8 @@ private:
   // Instance variables
   int                              _table_size;
   HashtableBucket<F>*              _buckets;
-  BasicHashtableEntry<F>* volatile _free_list;
-  char*                            _first_free_entry;
-  char*                            _end_block;
   int                              _entry_size;
   volatile int                     _number_of_entries;
-  GrowableArrayCHeap<char*, F>     _entry_blocks;
 
 protected:
 
@@ -164,27 +155,14 @@ protected:
   // The following method is not MT-safe and must be done under lock.
   BasicHashtableEntry<F>** bucket_addr(int i) { return _buckets[i].entry_addr(); }
 
-  // Attempt to get an entry from the free list
-  BasicHashtableEntry<F>* new_entry_free_list();
-
   // Table entry management
   BasicHashtableEntry<F>* new_entry(unsigned int hashValue);
 
-  // Used when moving the entry to another table
-  // Clean up links, but do not add to free_list
+  // Used when moving the entry to another table or deleting entry.
+  // Clean up links.
   void unlink_entry(BasicHashtableEntry<F>* entry) {
     entry->set_next(NULL);
     --_number_of_entries;
-  }
-
-  // Move over freelist and free block for allocation
-  void copy_freelist(BasicHashtable* src) {
-    _free_list = src->_free_list;
-    src->_free_list = NULL;
-    _first_free_entry = src->_first_free_entry;
-    src->_first_free_entry = NULL;
-    _end_block = src->_end_block;
-    src->_end_block = NULL;
   }
 
   // Free the buckets in this hashtable
@@ -236,10 +214,7 @@ public:
 
  protected:
 
-  // Table entry management
   HashtableEntry<T, F>* new_entry(unsigned int hashValue, T obj);
-  // Don't create and use freelist of HashtableEntry.
-  HashtableEntry<T, F>* allocate_new_entry(unsigned int hashValue, T obj);
 
   // The following method is MT-safe and may be used with caution.
   HashtableEntry<T, F>* bucket(int i) const {

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -30,15 +30,8 @@
 #include "runtime/handles.hpp"
 #include "utilities/tableStatistics.hpp"
 
-// This is a generic hashtable, designed to be used for the symbol
-// and string tables.
-//
-// It is implemented as an open hash table with a fixed number of buckets.
-//
-// %note:
-//  - TableEntrys are allocated in blocks to reduce the space overhead.
-
-
+// This is a generic hashtable which is implemented as an open hash table with
+// a fixed number of buckets.
 
 template <MEMFLAGS F> class BasicHashtableEntry {
   friend class VMStructs;
@@ -79,7 +72,7 @@ private:
   T               _literal;          // ref to item in table.
 
 public:
-  HashtableEntry(unsigned int hashValue) : BasicHashtableEntry<F>(hashValue) {}
+  HashtableEntry(unsigned int hashValue, T value) : BasicHashtableEntry<F>(hashValue), _literal(value) {}
 
   // Literal
   T literal() const                   { return _literal; }

--- a/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
+++ b/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class CheckForProperDetailStackTrace {
        to make sure it matches even if the symbol is not unmangled.
     */
     private static String stackTraceDefault =
-        ".*Hashtable.*allocate_new_entry.*\n" +
+        ".*Hashtable.*new_entry.*\n" +
         ".*ModuleEntryTable.*new_entry.*\n" +
         ".*ModuleEntryTable.*locked_create_entry.*\n" +
         ".*Modules.*define_module.*\n";
@@ -71,7 +71,7 @@ public class CheckForProperDetailStackTrace {
        new_entry may be inlined.
     */
     private static String stackTraceAlternate =
-        ".*Hashtable.*allocate_new_entry.*\n" +
+        ".*Hashtable.*new_entry.*\n" +
         ".*ModuleEntryTable.*locked_create_entry.*\n" +
         ".*Modules.*define_module.*\n" +
         ".*JVM_DefineModule.*\n";


### PR DESCRIPTION
From CR:
The useful/general BasicHashtable uses a block allocation scheme to reportedly reduce fragmentation. When the StringTable and SymbolTable used to use this hashtable, performance benefits were reportedly observed because of the block allocation scheme. Since these tables were moved to the concurrent hashtables, the tables left that use the block allocation scheme are:

AdapterHandlerLibrary, ResolutionError, LoaderConstraints, Leak profiler bitset table and Placeholders. 3 of these tables are very small and never needed block allocation to prevent fragmentation at least. Also there are 3 KVHashtables, which are built from BasicHashtable. 2 are used during dumping and 1 is ID2KlassTable which appears small.

ModuleEntry, PackageEntry, Dictionary, G1RootSet for nmethods, and JvmtiTagMap tables didn't use the block allocation scheme.

Removing this removes 7 pointers per table, and for each ClassLoaderData, which has 3 tables, removes 21 pointers.

This change was performance tested on linux and windows.

It was also tested with tier1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263976](https://bugs.openjdk.java.net/browse/JDK-8263976): Remove block allocation from BasicHashtable


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 328f72c53096534fcbe582b26fd34d124e68fc8b
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3123/head:pull/3123`
`$ git checkout pull/3123`

To update a local copy of the PR:
`$ git checkout pull/3123`
`$ git pull https://git.openjdk.java.net/jdk pull/3123/head`
