### PR TITLE
8263978: Clarify why 0 argument is ignored in SecureRandom::setSeed

### DIFF
--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -733,7 +733,7 @@ public class SecureRandom extends java.util.Random {
          * Ignore call from super constructor (as well as any other calls
          * unfortunate enough to be passing 0).  It's critical that we
          * ignore call from superclass constructor. All SecureRandom
-         * constructors calls `super(0)` but we do not want  `setSeed(0)`
+         * constructors call `super(0)` but we do not want `setSeed(0)`
          * to actually do any seeding. We either keep the object unseeded
          * (in `new SecureRandom()`) or we seed the object explicitly
          * (in `new SecureRandom(byte[])`).

--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -732,8 +732,11 @@ public class SecureRandom extends java.util.Random {
         /*
          * Ignore call from super constructor (as well as any other calls
          * unfortunate enough to be passing 0).  It's critical that we
-         * ignore call from superclass constructor, as digest has not
-         * yet been initialized at that point.
+         * ignore call from superclass constructor. All SecureRandom
+         * constructors calls `super(0)` but we do not want  `setSeed(0)`
+         * to actually do any seeding. We either keep the object unseeded
+         * (in `new SecureRandom()`) or we seed the object explicitly
+         * (in `new SecureRandom(byte[])`).
          */
         if (seed != 0) {
             setSeed(longToByteArray(seed));

--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -730,13 +730,11 @@ public class SecureRandom extends java.util.Random {
     @Override
     public void setSeed(long seed) {
         /*
-         * Ignore call from super constructor (as well as any other calls
-         * unfortunate enough to be passing 0).  It's critical that we
-         * ignore call from superclass constructor. All SecureRandom
-         * constructors call `super(0)` but we do not want `setSeed(0)`
-         * to actually do any seeding. We either keep the object unseeded
-         * (in `new SecureRandom()`) or we seed the object explicitly
-         * (in `new SecureRandom(byte[])`).
+         * Ignore call from super constructor as well as any other calls
+         * unfortunate enough to be passing 0. All SecureRandom
+         * constructors call `super(0)` which leads to `setSeed(0)`.
+         * We either keep the object unseeded (in `new SecureRandom()`)
+         * or we seed the object explicitly (in `new SecureRandom(byte[])`).
          */
         if (seed != 0) {
             setSeed(longToByteArray(seed));


### PR DESCRIPTION
We don't use `digest` anymore but still need to ignore the 0 argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263978](https://bugs.openjdk.java.net/browse/JDK-8263978): Clarify why 0 argument is ignored in SecureRandom::setSeed


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to 6bd8b1001273ea9b5aaa23ed6f8a7e09dd77c5a1


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3124/head:pull/3124`
`$ git checkout pull/3124`

To update a local copy of the PR:
`$ git checkout pull/3124`
`$ git pull https://git.openjdk.java.net/jdk pull/3124/head`
