### PR TITLE
8263981: java.awt.image.ComponentSampleModel equals/hashcode use numBands twice

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -1199,7 +1199,6 @@ public class ComponentSampleModel extends SampleModel
             this.dataType == that.dataType &&
             Arrays.equals(this.bandOffsets, that.bandOffsets) &&
             Arrays.equals(this.bankIndices, that.bankIndices) &&
-            this.numBands == that.numBands &&
             this.numBanks == that.numBanks &&
             this.scanlineStride == that.scanlineStride &&
             this.pixelStride == that.pixelStride;
@@ -1224,8 +1223,6 @@ public class ComponentSampleModel extends SampleModel
             hash ^= bankIndices[i];
             hash <<= 8;
         }
-        hash ^= numBands;
-        hash <<= 8;
         hash ^= numBanks;
         hash <<= 8;
         hash ^= scanlineStride;


### PR DESCRIPTION
SonarCloud reports the problem in ComponentSampleModel.equals:
  Correct one of the identical sub-expressions on both sides of operator "&&"

...near "this.numBands == that.numBands". It is checked twice. hashCode also processes it twice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263981](https://bugs.openjdk.java.net/browse/JDK-8263981): java.awt.image.ComponentSampleModel equals/hashcode use numBands twice


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3125/head:pull/3125`
`$ git checkout pull/3125`

To update a local copy of the PR:
`$ git checkout pull/3125`
`$ git pull https://git.openjdk.java.net/jdk pull/3125/head`
