### PR TITLE
8263985: BCEscapeAnalyzer::invoke checks target->is_loaded() twice

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -302,8 +302,7 @@ void BCEscapeAnalyzer::invoke(StateInfo &state, Bytecodes::Code code, ciMethod* 
   // determine actual method (use CHA if necessary)
   ciMethod* inline_target = NULL;
   if (target->is_loaded() && klass->is_loaded()
-      && (klass->is_initialized() || (klass->is_interface() && target->holder()->is_initialized()))
-      && target->is_loaded()) {
+      && (klass->is_initialized() || (klass->is_interface() && target->holder()->is_initialized()))) {
     if (code == Bytecodes::_invokestatic
         || code == Bytecodes::_invokespecial
         || (code == Bytecodes::_invokevirtual && target->is_final_method())) {


### PR DESCRIPTION
SonarCloud reports: Identical sub-expressions on both sides of operator "&&".

```
  if (target->is_loaded() && klass->is_loaded()
      && (klass->is_initialized() || (klass->is_interface() && target->holder()->is_initialized()))
      && target->is_loaded()) { // <--- here
```

This code was last touched a long time ago: https://hg.openjdk.java.net/hsx/hsx25/hotspot/rev/bb33c6fdcf0d#l2.5 ...and it would seem it went unnoticed that there is already `target->is_loaded()` check in the same condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263985](https://bugs.openjdk.java.net/browse/JDK-8263985): BCEscapeAnalyzer::invoke checks target->is_loaded() twice


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3127/head:pull/3127`
`$ git checkout pull/3127`

To update a local copy of the PR:
`$ git checkout pull/3127`
`$ git pull https://git.openjdk.java.net/jdk pull/3127/head`
