### PR TITLE
8263904: compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
@@ -44,7 +44,7 @@ public class TestBzhiI2L {
 
     public static void main(String args[]) throws Throwable {
         if (Platform.isX86()) {
-            System.out.println("INFO: Bzhiq not implimented for x86_32, test SKIPPED" );
+            System.out.println("INFO: Bzhiq not implemented for x86_32, test SKIPPED" );
             return;
         }
         if (!CPUInfo.hasFeature("bmi2")) {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBzhiI2L.java
@@ -37,11 +37,16 @@
 
 package compiler.intrinsics.bmi;
 
+import jdk.test.lib.Platform;
 import sun.hotspot.cpuinfo.CPUInfo;
 
 public class TestBzhiI2L {
 
     public static void main(String args[]) throws Throwable {
+        if (Platform.isX86()) {
+            System.out.println("INFO: Bzhiq not implimented for x86_32, test SKIPPED" );
+            return;
+        }
         if (!CPUInfo.hasFeature("bmi2")) {
             System.out.println("INFO: CPU does not support bmi2 feature, test SKIPPED" );
             return;

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -110,7 +110,7 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
 
     protected void checkEmittedCode(Executable executable) {
         final byte[] nativeCode = NMethod.get(executable, false).insts;
-        final byte[] matchInstrPattern = (((BmiTestCase) testCase).getTestCaseX64()) ? ((BmiTestCase_x64) testCase).getInstrPattern_x64() : ((BmiTestCase) testCase).getInstrPattern();
+        final byte[] matchInstrPattern = (((BmiTestCase) testCase).getTestCaseX64() && Platform.isX64()) ? ((BmiTestCase_x64) testCase).getInstrPattern_x64() : ((BmiTestCase) testCase).getInstrPattern();
         if (!((BmiTestCase) testCase).verifyPositive(nativeCode)) {
             throw new AssertionError(testCase.name() + " " + "CPU instructions expected not found in nativeCode: " + Utils.toHexString(nativeCode) + " ---- Expected instrPattern: " +
             Utils.toHexString(matchInstrPattern));


### PR DESCRIPTION
Further fixes (in addition to https://github.com/openjdk/jdk/pull/3104) for issue where BzhiTestI2L.java fails on x86_32.  bzhiq instructions are only generated on x86_64.

This adds a skip to the test if `Platform.isX86()` and uses `((BmiTestCase) testCase).getTestCaseX64() && Platform.isX64()` to decide when to use `((BmiTestCase_x64) testCase).getInstrPattern_x64()` versus `((BmiTestCase) testCase).getInstrPattern()` (x86_32 version of instruction)

Signed-off-by: Marcus G K Williams <marcus.williams@intel.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263904](https://bugs.openjdk.java.net/browse/JDK-8263904): compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails on x86_32 ⚠️ Issue is not open.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3128/head:pull/3128`
`$ git checkout pull/3128`

To update a local copy of the PR:
`$ git checkout pull/3128`
`$ git pull https://git.openjdk.java.net/jdk pull/3128/head`
