### PR TITLE
8263995: Incorrect double-checked locking in Types.arraySuperType()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4076,22 +4076,15 @@ public class Types {
             return buf.toList();
         }
 
-        private volatile Type arraySuperType;
+        private Type arraySuperType;
         private Type arraySuperType() {
             // initialized lazily to avoid problems during compiler startup
-            Type ast = arraySuperType;
-            if (ast == null) {
-                synchronized (this) {
-                    ast = arraySuperType;
-                    if (ast == null) {
-                        // JLS 10.8: all arrays implement Cloneable and Serializable.
-                        ast = makeIntersectionType(List.of(syms.serializableType,
-                                syms.cloneableType), true);
-                        arraySuperType = ast;
-                    }
-                }
+            if (arraySuperType == null) {
+                // JLS 10.8: all arrays implement Cloneable and Serializable.
+                arraySuperType = makeIntersectionType(List.of(syms.serializableType,
+                        syms.cloneableType), true);
             }
-            return ast;
+            return arraySuperType;
         }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4076,19 +4076,22 @@ public class Types {
             return buf.toList();
         }
 
-        private Type arraySuperType = null;
+        private volatile Type arraySuperType;
         private Type arraySuperType() {
             // initialized lazily to avoid problems during compiler startup
-            if (arraySuperType == null) {
+            Type ast = arraySuperType;
+            if (ast == null) {
                 synchronized (this) {
-                    if (arraySuperType == null) {
+                    ast = arraySuperType;
+                    if (ast == null) {
                         // JLS 10.8: all arrays implement Cloneable and Serializable.
-                        arraySuperType = makeIntersectionType(List.of(syms.serializableType,
+                        ast = makeIntersectionType(List.of(syms.serializableType,
                                 syms.cloneableType), true);
+                        arraySuperType = ast;
                     }
                 }
             }
-            return arraySuperType;
+            return ast;
         }
     // </editor-fold>
 


### PR DESCRIPTION
In Types.arraySuperType(), SonarCloud reports:
 Remove this dangerous instance of double-checked locking.

Indeed, the `arraySuperType` is not `volatile`, while `IntersectionClassType` has non-`final` fields (both in itself and in superclasses). This is an incorrect DCL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263995](https://bugs.openjdk.java.net/browse/JDK-8263995): Incorrect double-checked locking in Types.arraySuperType()


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3129/head:pull/3129`
`$ git checkout pull/3129`

To update a local copy of the PR:
`$ git checkout pull/3129`
`$ git pull https://git.openjdk.java.net/jdk pull/3129/head`
