### PR TITLE
8263968: CDS: java/lang/ModuleLayer.EMPTY_LAYER should be singleton

### DIFF
--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -93,6 +93,7 @@ static ArchivableStaticFieldInfo closed_archive_subgraph_entry_fields[] = {
 static ArchivableStaticFieldInfo open_archive_subgraph_entry_fields[] = {
   {"jdk/internal/module/ArchivedModuleGraph",     "archivedModuleGraph"},
   {"java/util/ImmutableCollections",              "archivedObjects"},
+  {"java/lang/ModuleLayer",                       "EMPTY_LAYER"},
   {"java/lang/module/Configuration",              "EMPTY_CONFIGURATION"},
   {"jdk/internal/math/FDBigInteger",              "archivedCaches"},
 };

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -48,6 +48,8 @@ import jdk.internal.loader.ClassLoaderValue;
 import jdk.internal.loader.Loader;
 import jdk.internal.loader.LoaderPool;
 import jdk.internal.module.ServicesCatalog;
+import jdk.internal.misc.CDS;
+import jdk.internal.vm.annotation.Stable;
 import sun.security.util.SecurityConstants;
 
 
@@ -147,9 +149,17 @@ import sun.security.util.SecurityConstants;
 
 public final class ModuleLayer {
 
-    // the empty layer
-    private static final ModuleLayer EMPTY_LAYER
-        = new ModuleLayer(Configuration.empty(), List.of(), null);
+    // the empty layer (may be initialized from the CDS archive)
+    private static @Stable ModuleLayer EMPTY_LAYER;
+
+    static {
+	// Initialize EMPTY_LAYER from the archive.
+        CDS.initializeFromArchive(ModuleLayer.class);
+        if (EMPTY_LAYER == null) {
+            // create a new empty layer if there is no archived version.
+            EMPTY_LAYER = new ModuleLayer(Configuration.empty(), List.of(), null);
+        }
+    }
 
     // the configuration from which this layer was created
     private final Configuration cf;

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -151,9 +151,7 @@ public final class ModuleLayer {
 
     // the empty layer (may be initialized from the CDS archive)
     private static @Stable ModuleLayer EMPTY_LAYER;
-
     static {
-        // Initialize EMPTY_LAYER from the archive.
         CDS.initializeFromArchive(ModuleLayer.class);
         if (EMPTY_LAYER == null) {
             // create a new empty layer if there is no archived version.

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -153,7 +153,7 @@ public final class ModuleLayer {
     private static @Stable ModuleLayer EMPTY_LAYER;
 
     static {
-	// Initialize EMPTY_LAYER from the archive.
+        // Initialize EMPTY_LAYER from the archive.
         CDS.initializeFromArchive(ModuleLayer.class);
         if (EMPTY_LAYER == null) {
             // create a new empty layer if there is no archived version.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckArchivedModuleApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckArchivedModuleApp.java
@@ -61,6 +61,7 @@ public class CheckArchivedModuleApp {
         checkModuleDescriptors(expectArchivedDescriptors);
         checkConfiguration(expectArchivedConfiguration);
         checkEmptyConfiguration(expectArchivedConfiguration);
+        checkEmptyLayer();
     }
 
     private static void checkModuleDescriptors(boolean expectArchivedDescriptors) {
@@ -137,6 +138,15 @@ public class CheckArchivedModuleApp {
                 throw new RuntimeException(
                     "FAILED. Boot layer configuration is archived.");
             }
+        }
+    }
+
+    private static void checkEmptyLayer() {
+        // ModuleLayer.EMPTY_FIELD returned by empty() method is singleton.
+        // Check that with CDS there is still a single instance of EMPTY_LAYER
+        // and boot() layer parent is THE empty layer.
+        if (ModuleLayer.empty() != ModuleLayer.boot().parents().get(0)) {
+            throw new RuntimeException("FAILED. Empty module layer is not singleton");
         }
     }
 }


### PR DESCRIPTION
With CDS and G1, test api/java_lang/ModuleLayer/Boot.html fails in JDK 16. 

After JDK-8253081 with CDS enabled two instances of empty layer appear in the runtime. One comes from default initialization of java/lang/ModuleLayer.EMPTY_LAYER, another one comes from CDS archive and is returned by ModuleLayer.boot().parents().get(0). The fix makes java/lang/ModuleLayer.EMPTY_LAYER a singleton with both CDS on and off, similar to java/lang/module/Configuration.EMPTY_CONFIGURATION.

Testing: JCK 16, jtreg (including newly added test), pre-submit GitHub actions tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263968](https://bugs.openjdk.java.net/browse/JDK-8263968): CDS: java/lang/ModuleLayer.EMPTY_LAYER should be singleton


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 3a69084aee36ef1a2dc2b6b78e043609350a71dd
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 3a69084aee36ef1a2dc2b6b78e043609350a71dd
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3131/head:pull/3131`
`$ git checkout pull/3131`

To update a local copy of the PR:
`$ git checkout pull/3131`
`$ git pull https://git.openjdk.java.net/jdk pull/3131/head`
