### PR TITLE
8262081: vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001/TestDescription.java failed with "ERROR: eventSet1.size() != 3 :: 2"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,7 @@ public class addthreadfilter001 extends JDIBase {
         vm.resume();
 
         log2("......waiting for ThreadDeathEvent");
-        getEventSet();
+        getEventSetForThreadStartDeath(testThread.name());
         EventSet eventSet1 = eventSet;
         if ( !(eventIterator.nextEvent() instanceof ThreadDeathEvent) ) {
             testExitCode = FAILED;


### PR DESCRIPTION
The fix updates the test to use special method to wait for ThreadDeathEvent for the specific thread, ignoring event from other threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262081](https://bugs.openjdk.java.net/browse/JDK-8262081): vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001/TestDescription.java failed with "ERROR: eventSet1.size() != 3  :: 2"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3133/head:pull/3133`
`$ git checkout pull/3133`

To update a local copy of the PR:
`$ git checkout pull/3133`
`$ git pull https://git.openjdk.java.net/jdk pull/3133/head`
