### PR TITLE
8263454: com.apple.laf.AquaFileChooserUI ignores the result of String.trim()

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2038,7 +2038,6 @@ public class AquaFileChooserUI extends FileChooserUI {
         String getApproveButtonText(final JFileChooser fc, final String fallbackText) {
             final String buttonText = fc.getApproveButtonText();
             if (buttonText != null) {
-                buttonText.trim();
                 if (!buttonText.isEmpty()) return buttonText;
             }
             return fallbackText;
@@ -2057,7 +2056,6 @@ public class AquaFileChooserUI extends FileChooserUI {
         String getApproveButtonToolTipText(final JFileChooser fc, final String fallbackText) {
             final String tooltipText = fc.getApproveButtonToolTipText();
             if (tooltipText != null) {
-                tooltipText.trim();
                 if (!tooltipText.isEmpty()) return tooltipText;
             }
             return fallbackText;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -2037,10 +2037,9 @@ public class AquaFileChooserUI extends FileChooserUI {
         // Try to get the custom text.  If none, use the fallback
         String getApproveButtonText(final JFileChooser fc, final String fallbackText) {
             final String buttonText = fc.getApproveButtonText();
-            if (buttonText != null) {
-                if (!buttonText.isEmpty()) return buttonText;
-            }
-            return fallbackText;
+            return buttonText != null
+                    ? buttonText
+                    : fallbackText;
         }
 
         int getApproveButtonMnemonic(final JFileChooser fc) {
@@ -2055,10 +2054,9 @@ public class AquaFileChooserUI extends FileChooserUI {
 
         String getApproveButtonToolTipText(final JFileChooser fc, final String fallbackText) {
             final String tooltipText = fc.getApproveButtonToolTipText();
-            if (tooltipText != null) {
-                if (!tooltipText.isEmpty()) return tooltipText;
-            }
-            return fallbackText;
+            return tooltipText != null
+                    ? tooltipText
+                    : fallbackText;
         }
 
         String getCancelButtonToolTipText(final JFileChooser fc) {


### PR DESCRIPTION
Looks like the original idea was to set `fallbacktext` on strings containing only spaces.

I decided to remove the `trim()` call to keep the same behavior and to allows to set such meaningless space only titles/tooltips(same as on other platforms, maybe someone want empty label for some reason).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263454](https://bugs.openjdk.java.net/browse/JDK-8263454): com.apple.laf.AquaFileChooserUI ignores the result of String.trim()


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to 06c5322d44926f39b0609fd6df0bf2b5e86b9138
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 06c5322d44926f39b0609fd6df0bf2b5e86b9138
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3136/head:pull/3136`
`$ git checkout pull/3136`

To update a local copy of the PR:
`$ git checkout pull/3136`
`$ git pull https://git.openjdk.java.net/jdk pull/3136/head`
