### PR TITLE
JDK-8262899: TestRedirectLinks fails

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
@@ -385,7 +385,7 @@ public class Extern {
         private static final long serialVersionUID = 0;
 
         Fault(String msg, Exception cause) {
-            super(msg, cause);
+            super(msg + (cause == null ? "" : " (" + cause + ")"), cause);
         }
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -88,7 +88,7 @@ public class TestRedirectLinks extends JavadocTester {
     @Test
     public void testRedirects() throws Exception {
         // This test relies on access to an external resource, which may or may not be
-        // reliably available, depending on the shost system configuration and other
+        // reliably available, depending on the host system configuration and other
         // networking issues. Therefore, it is disabled by default, unless the system
         // property "javadoc.dev" is set "true".
         String property = "javadoc.dev";

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -87,7 +87,18 @@ public class TestRedirectLinks extends JavadocTester {
      */
     @Test
     public void testRedirects() throws Exception {
-        // first, test to see if access to external URLs is available
+        // This test relies on access to an external resource, which may or may not be
+        // reliably available, depending on the shost system configuration and other
+        // networking issues. Therefore, it is disabled by default, unless the system
+        // property "javadoc.dev" is set "true".
+        String property = "javadoc.dev";
+        if (!Boolean.getBoolean(property)) {
+            out.println("Test case disabled by default; "
+                    + "set system property \"" + property + "\" to true to enable it.");
+            return;
+        }
+
+        // test to see if access to external URLs is available, and that the URL uses a redirect
 
         URL testURL = new URL("http://docs.oracle.com/en/java/javase/11/docs/api/element-list");
         String testURLHost = testURL.getHost();

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -43,9 +43,12 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.time.Duration;
+import java.time.Instant;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -85,8 +88,19 @@ public class TestRedirectLinks extends JavadocTester {
     @Test
     public void testRedirects() throws Exception {
         // first, test to see if access to external URLs is available
+
         URL testURL = new URL("http://docs.oracle.com/en/java/javase/11/docs/api/element-list");
+        String testURLHost = testURL.getHost();
+        try {
+            InetAddress testAddr = InetAddress.getByName(testURLHost);
+            out.println("Found " + testURLHost + ": " + testAddr);
+        } catch (UnknownHostException e) {
+            out.println("Setup failed (" + testURLHost + " not found); this test skipped");
+            return;
+        }
+
         boolean haveRedirectURL = false;
+        Instant start = Instant.now();
         try {
             URLConnection conn = testURL.openConnection();
             conn.connect();
@@ -107,10 +121,12 @@ public class TestRedirectLinks extends JavadocTester {
             }
         } catch (Exception e) {
             out.println("Exception occurred: " + e);
+            Instant now = Instant.now();
+            out.println("Attempt took " + Duration.between(start, now).toSeconds() + " seconds");
         }
 
         if (!haveRedirectURL) {
-            out.println("Setup failed; this test skipped");
+            out.println("Setup failed (no redirect URL); this test skipped");
             return;
         }
 
@@ -119,6 +135,7 @@ public class TestRedirectLinks extends JavadocTester {
         javadoc("-d", outRedirect,
                 "-sourcepath", testSrc,
                 "-link", apiURL,
+                "-Xdoclint:none",
                 "pkg");
         checkExit(Exit.OK);
         checkOutput("pkg/B.html", true,
@@ -157,17 +174,19 @@ public class TestRedirectLinks extends JavadocTester {
         new JavacTask(tb)
                 .outdir(libModules)
                 .options("--module-source-path", libSrc.toString(),
-                        "--module", "mA,mB")
+                        "--module", "mA,mB",
+                        "-Xdoclint:none")
                 .run()
                 .writeAll();
 
         javadoc("-d", libApi.toString(),
                 "--module-source-path", libSrc.toString(),
-                "--module", "mA,mB" );
+                "--module", "mA,mB",
+                "-Xdoclint:none" );
 
         // start web servers
-        // use explicit 127.0.0.1 to avoid any issues if proxy is in use
-        InetAddress localHost = InetAddress.getByAddress("localhost", new byte[] { 127, 0, 0, 1});
+        // use loopback address to avoid any issues if proxy is in use
+        InetAddress localHost = InetAddress.getLoopbackAddress();
         try {
             oldServer = HttpServer.create(new InetSocketAddress(localHost, 0), 0);
             String oldURL = "http:/" + oldServer.getAddress();
@@ -202,7 +221,8 @@ public class TestRedirectLinks extends JavadocTester {
                         "--module-source-path", src.toString(),
                         "--module-path", libModules.toString(),
                         "-link", "http:/" + oldServer.getAddress(),
-                        "--module", "mC" );
+                        "--module", "mC",
+                        "-Xdoclint:none");
 
             } finally {
                 HttpsURLConnection.setDefaultHostnameVerifier(prevHostNameVerifier);

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,8 @@ public class TestRedirectLinks extends JavadocTester {
                 "--module", "mA,mB" );
 
         // start web servers
-        InetAddress localHost = InetAddress.getLocalHost();
+        // use explicit 127.0.0.1 to avoid any issues if proxy is in use
+        InetAddress localHost = InetAddress.getByAddress("localhost", new byte[] { 127, 0, 0, 1});
         try {
             oldServer = HttpServer.create(new InetSocketAddress(localHost, 0), 0);
             String oldURL = "http:/" + oldServer.getAddress();


### PR DESCRIPTION
Please review a trivial change to fix this test when run behind a firewall with a proxy set.

Previously, the test used `InetAddress.getLocalHost` which returns an IP address for the current host.  It runs a temporary local web server on that address, but since the address is typically not on the `nonProxyHosts` list, the attempted access to the web server goes to the proxy, and fails.

The fix is to explicitly use `127.0.0.1`, which should never go to a proxy, if one is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262899](https://bugs.openjdk.java.net/browse/JDK-8262899): TestRedirectLinks fails


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 6901c1c4fc3b15f2878e31a26511a6fe15c054b1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3137/head:pull/3137` \
`$ git checkout pull/3137`

Update a local copy of the PR: \
`$ git checkout pull/3137` \
`$ git pull https://git.openjdk.java.net/jdk pull/3137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3137`

View PR using the GUI difftool: \
`$ git pr show -t 3137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3137.diff">https://git.openjdk.java.net/jdk/pull/3137.diff</a>

</details>
