### PR TITLE
8263992: Remove dead code NativeLookup::base_library_lookup

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -37,7 +37,6 @@
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -45,7 +45,6 @@
 #include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/handles.inline.hpp"
 #include "utilities/bitMap.inline.hpp"

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -32,7 +32,6 @@
 #include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.hpp"

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1432,8 +1432,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   // Note: A native method implies non-osr compilation which is
   //       checked with an assertion at the entry of this method.
   if (method->is_native() && !method->is_method_handle_intrinsic()) {
-    bool in_base_library;
-    address adr = NativeLookup::lookup(method, in_base_library, THREAD);
+    address adr = NativeLookup::lookup(method, THREAD);
     if (HAS_PENDING_EXCEPTION) {
       // In case of an exception looking up the method, we just forget
       // about it. The interpreter will kick-in and throw the exception.

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1450,9 +1450,8 @@ JRT_ENTRY(void, InterpreterRuntime::prepare_native_call(JavaThread* thread, Meth
   methodHandle m(thread, method);
   assert(m->is_native(), "sanity check");
   // lookup native function entry point if it doesn't exist
-  bool in_base_library;
   if (!m->has_native_function()) {
-    NativeLookup::lookup(m, in_base_library, CHECK);
+    NativeLookup::lookup(m, CHECK);
   }
   // make sure signature handler is installed
   SignatureHandlerLibrary::add(m);

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -51,7 +51,6 @@
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -59,7 +59,6 @@
 #include "oops/symbol.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/frame.inline.hpp"

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@
 #include "opto/runtime.hpp"
 #include "opto/subnode.hpp"
 #include "prims/methodHandles.hpp"
-#include "prims/nativeLookup.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 void trace_type_profile(Compile* C, ciMethod *method, int depth, int bci, ciMethod *prof_method, ciKlass *prof_klass, int site_count, int receiver_count) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -50,7 +50,6 @@
 #include "opto/runtime.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
-#include "prims/nativeLookup.hpp"
 #include "prims/unsafe.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/sharedRuntime.hpp"

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -65,7 +65,6 @@
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
-#include "prims/nativeLookup.hpp"
 #include "prims/stackwalk.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -560,23 +560,3 @@ address NativeLookup::lookup(const methodHandle& method, bool& in_base_library, 
   }
   return method->native_function();
 }
-
-address NativeLookup::base_library_lookup(const char* class_name, const char* method_name, const char* signature) {
-  EXCEPTION_MARK;
-  bool in_base_library = true;  // SharedRuntime inits some math methods.
-  TempNewSymbol c_name = SymbolTable::new_symbol(class_name);
-  TempNewSymbol m_name = SymbolTable::new_symbol(method_name);
-  TempNewSymbol s_name = SymbolTable::new_symbol(signature);
-
-  // Find the class
-  Klass* k = SystemDictionary::resolve_or_fail(c_name, true, CATCH);
-  InstanceKlass* klass  = InstanceKlass::cast(k);
-
-  // Find method and invoke standard lookup
-  methodHandle method (THREAD,
-                       klass->uncached_lookup_method(m_name, s_name, Klass::OverpassLookupMode::find));
-  address result = lookup(method, in_base_library, CATCH);
-  assert(in_base_library, "must be in basic library");
-  guarantee(result != NULL, "must be non NULL");
-  return result;
-}

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -266,7 +266,7 @@ static address lookup_special_native(const char* jni_name) {
   return NULL;
 }
 
-address NativeLookup::lookup_style(const methodHandle& method, char* pure_name, const char* long_name, int args_size, bool os_style, bool& in_base_library, TRAPS) {
+address NativeLookup::lookup_style(const methodHandle& method, char* pure_name, const char* long_name, int args_size, bool os_style, TRAPS) {
   address entry;
   const char* jni_name = compute_complete_jni_name(pure_name, long_name, args_size, os_style);
 
@@ -283,7 +283,6 @@ address NativeLookup::lookup_style(const methodHandle& method, char* pure_name, 
        entry = (address) os::dll_lookup(os::native_java_library(), jni_name);
     }
     if (entry != NULL) {
-      in_base_library = true;
       return entry;
     }
   }
@@ -340,9 +339,8 @@ address NativeLookup::lookup_critical_style(void* dll, const char* pure_name, co
 
 // Check all the formats of native implementation name to see if there is one
 // for the specified method.
-address NativeLookup::lookup_entry(const methodHandle& method, bool& in_base_library, TRAPS) {
+address NativeLookup::lookup_entry(const methodHandle& method, TRAPS) {
   address entry = NULL;
-  in_base_library = false;
   // Compute pure name
   char* pure_name = pure_jni_name(method);
   if (pure_name == NULL) {
@@ -357,7 +355,7 @@ address NativeLookup::lookup_entry(const methodHandle& method, bool& in_base_lib
                 + method->size_of_parameters(); // actual parameters
 
   // 1) Try JNI short style
-  entry = lookup_style(method, pure_name, "",        args_size, true,  in_base_library, CHECK_NULL);
+  entry = lookup_style(method, pure_name, "",        args_size, true,  CHECK_NULL);
   if (entry != NULL) return entry;
 
   // Compute long name
@@ -369,15 +367,15 @@ address NativeLookup::lookup_entry(const methodHandle& method, bool& in_base_lib
   }
 
   // 2) Try JNI long style
-  entry = lookup_style(method, pure_name, long_name, args_size, true,  in_base_library, CHECK_NULL);
+  entry = lookup_style(method, pure_name, long_name, args_size, true,  CHECK_NULL);
   if (entry != NULL) return entry;
 
   // 3) Try JNI short style without os prefix/suffix
-  entry = lookup_style(method, pure_name, "",        args_size, false, in_base_library, CHECK_NULL);
+  entry = lookup_style(method, pure_name, "",        args_size, false, CHECK_NULL);
   if (entry != NULL) return entry;
 
   // 4) Try JNI long style without os prefix/suffix
-  entry = lookup_style(method, pure_name, long_name, args_size, false, in_base_library, CHECK_NULL);
+  entry = lookup_style(method, pure_name, long_name, args_size, false, CHECK_NULL);
 
   return entry; // NULL indicates not found
 }
@@ -489,7 +487,7 @@ address NativeLookup::lookup_critical_style(void* dll, const methodHandle& metho
 // If any are found, remove them before attemping the look up of the
 // native implementation again.
 // See SetNativeMethodPrefix in the JVM TI Spec for more details.
-address NativeLookup::lookup_entry_prefixed(const methodHandle& method, bool& in_base_library, TRAPS) {
+address NativeLookup::lookup_entry_prefixed(const methodHandle& method, TRAPS) {
 #if INCLUDE_JVMTI
   ResourceMark rm(THREAD);
 
@@ -516,7 +514,7 @@ address NativeLookup::lookup_entry_prefixed(const methodHandle& method, bool& in
       if (wrapper_method != NULL && !wrapper_method->is_native()) {
         // we found a wrapper method, use its native entry
         method->set_is_prefixed_native();
-        return lookup_entry(methodHandle(THREAD, wrapper_method), in_base_library, THREAD);
+        return lookup_entry(methodHandle(THREAD, wrapper_method), THREAD);
       }
     }
   }
@@ -524,16 +522,16 @@ address NativeLookup::lookup_entry_prefixed(const methodHandle& method, bool& in
   return NULL;
 }
 
-address NativeLookup::lookup_base(const methodHandle& method, bool& in_base_library, TRAPS) {
+address NativeLookup::lookup_base(const methodHandle& method, TRAPS) {
   address entry = NULL;
   ResourceMark rm(THREAD);
 
-  entry = lookup_entry(method, in_base_library, THREAD);
+  entry = lookup_entry(method, THREAD);
   if (entry != NULL) return entry;
 
   // standard native method resolution has failed.  Check if there are any
   // JVM TI prefixes which have been applied to the native method name.
-  entry = lookup_entry_prefixed(method, in_base_library, THREAD);
+  entry = lookup_entry_prefixed(method, THREAD);
   if (entry != NULL) return entry;
 
   // Native function not found, throw UnsatisfiedLinkError
@@ -545,9 +543,9 @@ address NativeLookup::lookup_base(const methodHandle& method, bool& in_base_libr
 }
 
 
-address NativeLookup::lookup(const methodHandle& method, bool& in_base_library, TRAPS) {
+address NativeLookup::lookup(const methodHandle& method, TRAPS) {
   if (!method->has_native_function()) {
-    address entry = lookup_base(method, in_base_library, CHECK_NULL);
+    address entry = lookup_base(method, CHECK_NULL);
     method->set_native_function(entry,
       Method::native_bind_event_is_interesting);
     // -verbose:jni printing

--- a/src/hotspot/share/prims/nativeLookup.hpp
+++ b/src/hotspot/share/prims/nativeLookup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,6 @@ class NativeLookup : AllStatic {
   // Lookup native function. May throw UnsatisfiedLinkError.
   static address lookup(const methodHandle& method, bool& in_base_library, TRAPS);
   static address lookup_critical_entry(const methodHandle& method);
-
-  // Lookup native functions in base library.
-  static address base_library_lookup(const char* class_name, const char* method_name, const char* signature);
 };
 
 #endif // SHARE_PRIMS_NATIVELOOKUP_HPP

--- a/src/hotspot/share/prims/nativeLookup.hpp
+++ b/src/hotspot/share/prims/nativeLookup.hpp
@@ -34,12 +34,12 @@
 class NativeLookup : AllStatic {
  private:
   // Style specific lookup
-  static address lookup_style(const methodHandle& method, char* pure_name, const char* long_name, int args_size, bool os_style, bool& in_base_library, TRAPS);
+  static address lookup_style(const methodHandle& method, char* pure_name, const char* long_name, int args_size, bool os_style, TRAPS);
   static address lookup_critical_style(void* dll, const char* pure_name, const char* long_name, int args_size, bool os_style);
   static address lookup_critical_style(void* dll, const methodHandle& method, int args_size);
-  static address lookup_base (const methodHandle& method, bool& in_base_library, TRAPS);
-  static address lookup_entry(const methodHandle& method, bool& in_base_library, TRAPS);
-  static address lookup_entry_prefixed(const methodHandle& method, bool& in_base_library, TRAPS);
+  static address lookup_base (const methodHandle& method, TRAPS);
+  static address lookup_entry(const methodHandle& method, TRAPS);
+  static address lookup_entry_prefixed(const methodHandle& method, TRAPS);
 
   static void* dll_load(const methodHandle& method);
   static const char* compute_complete_jni_name(const char* pure_name, const char* long_name, int args_size, bool os_style);
@@ -50,7 +50,7 @@ class NativeLookup : AllStatic {
   static char* critical_jni_name(const methodHandle& method);
 
   // Lookup native function. May throw UnsatisfiedLinkError.
-  static address lookup(const methodHandle& method, bool& in_base_library, TRAPS);
+  static address lookup(const methodHandle& method, TRAPS);
   static address lookup_critical_entry(const methodHandle& method);
 };
 


### PR DESCRIPTION
Please review this removal of dead code, and unused parameter of `in_base_library` for the functions that remain. The word `base_library_lookup` does not exist in any C source code in the entire JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263992](https://bugs.openjdk.java.net/browse/JDK-8263992): Remove dead code NativeLookup::base_library_lookup


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 039ca6866e1ccc53c8458ad0202e9266cb80aae6
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3139/head:pull/3139`
`$ git checkout pull/3139`

To update a local copy of the PR:
`$ git checkout pull/3139`
`$ git pull https://git.openjdk.java.net/jdk pull/3139/head`
