### PR TITLE
8264002: Delete outdated assumptions about ColorSpace initialization

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/ImageUtil.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/ImageUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package com.sun.imageio.plugins.common;
 
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Transparency;
 import java.awt.color.ColorSpace;
@@ -47,10 +46,9 @@ import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import java.awt.image.SinglePixelPackedSampleModel;
 import java.awt.image.WritableRaster;
-import java.util.Arrays;
 import java.util.Iterator;
+
 import javax.imageio.IIOException;
-import javax.imageio.IIOImage;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriter;
@@ -1162,30 +1160,17 @@ public class ImageUtil {
     }
 
     /**
-     * Returns <code>true</code> if the given <code>ColorSpace</code> object is
-     * an instance of <code>ICC_ColorSpace</code> but is not one of the standard
-     * <code>ColorSpace</code>s returned by <code>ColorSpace.getInstance()</code>.
+     * Returns {@code true} if the given {@code ColorSpace} object is an
+     * instance of {@code ICC_ColorSpace} but is not one of the standard
+     * {@code ColorSpace}s returned by {@code ColorSpace.getInstance()}.
      *
-     * @param cs The <code>ColorSpace</code> to test.
+     * @param  cs the {@code ColorSpace} to test
      */
     public static boolean isNonStandardICCColorSpace(ColorSpace cs) {
-        boolean retval = false;
-
-        try {
-            // Check the standard ColorSpaces in decreasing order of
-            // likelihood except check CS_PYCC last as in some JREs
-            // PYCC.pf used not to be installed.
-            retval =
-                (cs instanceof ICC_ColorSpace) &&
-                !(cs.isCS_sRGB() ||
-                  cs.equals(ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB)) ||
-                  cs.equals(ColorSpace.getInstance(ColorSpace.CS_GRAY)) ||
-                  cs.equals(ColorSpace.getInstance(ColorSpace.CS_CIEXYZ)) ||
-                  cs.equals(ColorSpace.getInstance(ColorSpace.CS_PYCC)));
-        } catch(IllegalArgumentException e) {
-            // PYCC.pf not installed: ignore it - 'retval' is still 'false'.
-        }
-
-        return retval;
+        return cs instanceof ICC_ColorSpace && !cs.isCS_sRGB()
+                && !cs.equals(ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB))
+                && !cs.equals(ColorSpace.getInstance(ColorSpace.CS_GRAY))
+                && !cs.equals(ColorSpace.getInstance(ColorSpace.CS_CIEXYZ))
+                && !cs.equals(ColorSpace.getInstance(ColorSpace.CS_PYCC));
     }
 }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1001,7 +1001,7 @@ class JFIFMarkerSegment extends MarkerSegment {
                                                3,
                                                new int [] {0, 1, 2},
                                                null);
-            ColorModel cm = new ComponentColorModel(JPEG.JCS.sRGB,
+            ColorModel cm = new ComponentColorModel(JPEG.sRGB,
                                                     false,
                                                     false,
                                                     ColorModel.OPAQUE,

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEG.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEG.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,12 @@
 
 package com.sun.imageio.plugins.jpeg;
 
-import javax.imageio.ImageTypeSpecifier;
-import javax.imageio.plugins.jpeg.JPEGQTable;
-import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
-
-import java.awt.image.ColorModel;
 import java.awt.color.ColorSpace;
-import java.awt.color.ICC_ColorSpace;
+import java.awt.image.ColorModel;
+
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
+import javax.imageio.plugins.jpeg.JPEGQTable;
 
 /**
  * A class containing JPEG-related constants, definitions, and
@@ -199,38 +198,10 @@ public class JPEG {
 
     static final int [] bOffsRGB = { 2, 1, 0 };
 
-    /* These are kept in the inner class to avoid static initialization
-     * of the CMM class until someone actually needs it.
-     * (e.g. do not init CMM on the request for jpeg mime types)
-     */
-    public static class JCS {
-        public static final ColorSpace sRGB =
-            ColorSpace.getInstance(ColorSpace.CS_sRGB);
-    }
+    static final ColorSpace sRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB);
 
     // Default value for ImageWriteParam
     public static final float DEFAULT_QUALITY = 0.75F;
-
-    /**
-     * Returns {@code true} if the given {@code ColorSpace}
-     * object is an instance of ICC_ColorSpace but is not one of the
-     * standard {@code ColorSpaces} returned by
-     * {@code ColorSpace.getInstance()}.
-     */
-    static boolean isNonStandardICC(ColorSpace cs) {
-        boolean retval = false;
-        if ((cs instanceof ICC_ColorSpace)
-            && (!cs.isCS_sRGB())
-            && (!cs.equals(ColorSpace.getInstance(ColorSpace.CS_CIEXYZ)))
-            && (!cs.equals(ColorSpace.getInstance(ColorSpace.CS_GRAY)))
-            && (!cs.equals(ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB)))
-            && (!cs.equals(ColorSpace.getInstance(ColorSpace.CS_PYCC)))
-            ) {
-            retval = true;
-        }
-        return retval;
-    }
-
 
     /**
      * Returns {@code true} if the given imageType can be used
@@ -342,5 +313,4 @@ public class JPEG {
         }
         return tables;
     }
-
 }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1047,7 +1047,7 @@ public class JPEGImageReader extends ImageReader {
                        (!cs.isCS_sRGB()) &&
                        (cm.getNumComponents() == numComponents)) {
                 // Target isn't sRGB, so convert from sRGB to the target
-                convert = new ColorConvertOp(JPEG.JCS.sRGB, cs, null);
+                convert = new ColorConvertOp(JPEG.sRGB, cs, null);
             } else if (csType != ColorSpace.TYPE_RGB) {
                 throw new IIOException("Incompatible color conversion");
             }
@@ -1898,7 +1898,7 @@ class ImageTypeProducer {
             case JPEG.JCS_YCbCr:
             //there is no YCbCr raw type so by default we assume it as RGB
             case JPEG.JCS_RGB:
-                return ImageTypeSpecifier.createInterleaved(JPEG.JCS.sRGB,
+                return ImageTypeSpecifier.createInterleaved(JPEG.sRGB,
                         JPEG.bOffsRGB,
                         DataBuffer.TYPE_BYTE,
                         false,

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,43 +25,41 @@
 
 package com.sun.imageio.plugins.jpeg;
 
-import javax.imageio.IIOException;
-import javax.imageio.ImageWriter;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.IIOImage;
-import javax.imageio.ImageTypeSpecifier;
-import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataFormatImpl;
-import javax.imageio.metadata.IIOInvalidTreeException;
-import javax.imageio.spi.ImageWriterSpi;
-import javax.imageio.stream.ImageOutputStream;
-import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
-import javax.imageio.plugins.jpeg.JPEGQTable;
-import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
-
-import org.w3c.dom.Node;
-
-import java.awt.image.Raster;
-import java.awt.image.WritableRaster;
-import java.awt.image.DataBufferByte;
-import java.awt.image.ColorModel;
-import java.awt.image.IndexColorModel;
-import java.awt.image.ColorConvertOp;
-import java.awt.image.RenderedImage;
-import java.awt.image.BufferedImage;
-import java.awt.color.ColorSpace;
-import java.awt.color.ICC_ColorSpace;
-import java.awt.color.ICC_Profile;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Transparency;
-
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.awt.image.ColorModel;
+import java.awt.image.DataBufferByte;
+import java.awt.image.IndexColorModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
 import java.io.IOException;
-
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
+import javax.imageio.IIOException;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.metadata.IIOInvalidTreeException;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.metadata.IIOMetadataFormatImpl;
+import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
+import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
+import javax.imageio.plugins.jpeg.JPEGQTable;
+import javax.imageio.spi.ImageWriterSpi;
+import javax.imageio.stream.ImageOutputStream;
+
+import com.sun.imageio.plugins.common.ImageUtil;
+import org.w3c.dom.Node;
 import sun.java2d.Disposer;
 import sun.java2d.DisposerRecord;
 
@@ -687,7 +685,7 @@ public class JPEGImageWriter extends ImageWriter {
                 checkJFIF(jfif, destType, false);
                 // Do we want to write an ICC profile?
                 if ((jfif != null) && (ignoreJFIF == false)) {
-                    if (JPEG.isNonStandardICC(cs)) {
+                    if (ImageUtil.isNonStandardICCColorSpace(cs)) {
                         iccProfile = ((ICC_ColorSpace) cs).getProfile();
                     }
                 }
@@ -698,7 +696,7 @@ public class JPEGImageWriter extends ImageWriter {
                 if (JPEG.isJFIFcompliant(destType, false)) {
                     writeDefaultJFIF = true;
                     // Do we want to write an ICC profile?
-                    if (JPEG.isNonStandardICC(cs)) {
+                    if (ImageUtil.isNonStandardICCColorSpace(cs)) {
                         iccProfile = ((ICC_ColorSpace) cs).getProfile();
                     }
                 } else {
@@ -722,7 +720,7 @@ public class JPEGImageWriter extends ImageWriter {
                     if (metadata.findMarkerSegment
                         (JFIFMarkerSegment.class, true) != null) {
                         cs = rimage.getColorModel().getColorSpace();
-                        if (JPEG.isNonStandardICC(cs)) {
+                        if (ImageUtil.isNonStandardICCColorSpace(cs)) {
                             iccProfile = ((ICC_ColorSpace) cs).getProfile();
                         }
                     }
@@ -766,7 +764,7 @@ public class JPEGImageWriter extends ImageWriter {
                         case ColorSpace.TYPE_RGB:
                             if (jfif != null) {
                                 outCsType = JPEG.JCS_YCbCr;
-                                if (JPEG.isNonStandardICC(cs)
+                                if (ImageUtil.isNonStandardICCColorSpace(cs)
                                     || ((cs instanceof ICC_ColorSpace)
                                         && (jfif.iccSegment != null))) {
                                     iccProfile =

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,36 +25,34 @@
 
 package com.sun.imageio.plugins.jpeg;
 
-import javax.imageio.ImageTypeSpecifier;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.IIOException;
-import javax.imageio.stream.ImageInputStream;
-import javax.imageio.stream.ImageOutputStream;
-import javax.imageio.metadata.IIOMetadata;
-import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.metadata.IIOMetadataFormat;
-import javax.imageio.metadata.IIOMetadataFormatImpl;
-import javax.imageio.metadata.IIOInvalidTreeException;
-import javax.imageio.plugins.jpeg.JPEGQTable;
-import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
-import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.NamedNodeMap;
-
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.ListIterator;
-import java.io.IOException;
-import java.awt.color.ICC_Profile;
-import java.awt.color.ICC_ColorSpace;
+import java.awt.Point;
 import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
-import java.awt.Point;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.imageio.IIOException;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.metadata.IIOInvalidTreeException;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.metadata.IIOMetadataFormatImpl;
+import javax.imageio.metadata.IIOMetadataNode;
+import javax.imageio.plugins.jpeg.JPEGHuffmanTable;
+import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
+
+import com.sun.imageio.plugins.common.ImageUtil;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Metadata for the JPEG plug-in.
@@ -576,7 +574,7 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
         }
 
         // do we want an ICC profile?
-        if (wantJFIF && JPEG.isNonStandardICC(cs)) {
+        if (wantJFIF && ImageUtil.isNonStandardICCColorSpace(cs)) {
             wantICC = true;
         }
 


### PR DESCRIPTION
Some codes have outdated assumptions about the initialization of ColorSpace class.
 - The ColorSpace.getInstance() will never throw an IllegalArgumentException for the builtin profiles
 - The ColorSpace.getInstance() will not trigger initialisation of the CMM classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264002](https://bugs.openjdk.java.net/browse/JDK-8264002): Delete outdated assumptions about ColorSpace initialization


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3140/head:pull/3140`
`$ git checkout pull/3140`

To update a local copy of the PR:
`$ git checkout pull/3140`
`$ git pull https://git.openjdk.java.net/jdk pull/3140/head`
