### PR TITLE
8264004: Don't use TRAPS if no exceptions are thrown

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1298,8 +1298,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = klass_index_at(index1);
     int recur2 = cp2->klass_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2);
-    if (match) {
+    if (compare_entry_to(recur1, cp2, recur2)) {
       return true;
     }
   } break;
@@ -1323,8 +1322,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
     if (match) {
       recur1 = uncached_name_and_type_ref_index_at(index1);
       recur2 = cp2->uncached_name_and_type_ref_index_at(index2);
-      match = compare_entry_to(recur1, cp2, recur2);
-      if (match) {
+      if (compare_entry_to(recur1, cp2, recur2)) {
         return true;
       }
     }
@@ -1361,12 +1359,10 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = name_ref_index_at(index1);
     int recur2 = cp2->name_ref_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2);
-    if (match) {
+    if (compare_entry_to(recur1, cp2, recur2)) {
       recur1 = signature_ref_index_at(index1);
       recur2 = cp2->signature_ref_index_at(index2);
-      match = compare_entry_to(recur1, cp2, recur2);
-      if (match) {
+      if (compare_entry_to(recur1, cp2, recur2)) {
         return true;
       }
     }
@@ -1376,8 +1372,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = string_index_at(index1);
     int recur2 = cp2->string_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2);
-    if (match) {
+    if (compare_entry_to(recur1, cp2, recur2)) {
       return true;
     }
   } break;
@@ -1395,8 +1390,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int k1 = method_type_index_at(index1);
     int k2 = cp2->method_type_index_at(index2);
-    bool match = compare_entry_to(k1, cp2, k2);
-    if (match) {
+    if (compare_entry_to(k1, cp2, k2)) {
       return true;
     }
   } break;
@@ -1408,8 +1402,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
     if (k1 == k2) {
       int i1 = method_handle_index_at(index1);
       int i2 = cp2->method_handle_index_at(index2);
-      bool match = compare_entry_to(i1, cp2, i2);
-      if (match) {
+      if (compare_entry_to(i1, cp2, i2)) {
         return true;
       }
     }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1268,7 +1268,7 @@ void ConstantPool::unreference_symbols() {
 // Compare this constant pool's entry at index1 to the constant pool
 // cp2's entry at index2.
 bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
-       int index2, TRAPS) {
+       int index2) {
 
   // The error tags are equivalent to non-error tags when comparing
   jbyte t1 = tag_at(index1).non_error_value();
@@ -1287,8 +1287,8 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   switch (t1) {
   case JVM_CONSTANT_Class:
   {
-    Klass* k1 = klass_at(index1, CHECK_false);
-    Klass* k2 = cp2->klass_at(index2, CHECK_false);
+    Klass* k1 = resolved_klass_at(index1);
+    Klass* k2 = cp2->resolved_klass_at(index2);
     if (k1 == k2) {
       return true;
     }
@@ -1298,7 +1298,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = klass_index_at(index1);
     int recur2 = cp2->klass_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+    bool match = compare_entry_to(recur1, cp2, recur2);
     if (match) {
       return true;
     }
@@ -1319,11 +1319,11 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = uncached_klass_ref_index_at(index1);
     int recur2 = cp2->uncached_klass_ref_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+    bool match = compare_entry_to(recur1, cp2, recur2);
     if (match) {
       recur1 = uncached_name_and_type_ref_index_at(index1);
       recur2 = cp2->uncached_name_and_type_ref_index_at(index2);
-      match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+      match = compare_entry_to(recur1, cp2, recur2);
       if (match) {
         return true;
       }
@@ -1361,11 +1361,11 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = name_ref_index_at(index1);
     int recur2 = cp2->name_ref_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+    bool match = compare_entry_to(recur1, cp2, recur2);
     if (match) {
       recur1 = signature_ref_index_at(index1);
       recur2 = cp2->signature_ref_index_at(index2);
-      match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+      match = compare_entry_to(recur1, cp2, recur2);
       if (match) {
         return true;
       }
@@ -1376,7 +1376,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int recur1 = string_index_at(index1);
     int recur2 = cp2->string_index_at(index2);
-    bool match = compare_entry_to(recur1, cp2, recur2, CHECK_false);
+    bool match = compare_entry_to(recur1, cp2, recur2);
     if (match) {
       return true;
     }
@@ -1395,7 +1395,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int k1 = method_type_index_at(index1);
     int k2 = cp2->method_type_index_at(index2);
-    bool match = compare_entry_to(k1, cp2, k2, CHECK_false);
+    bool match = compare_entry_to(k1, cp2, k2);
     if (match) {
       return true;
     }
@@ -1408,7 +1408,7 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
     if (k1 == k2) {
       int i1 = method_handle_index_at(index1);
       int i2 = cp2->method_handle_index_at(index2);
-      bool match = compare_entry_to(i1, cp2, i2, CHECK_false);
+      bool match = compare_entry_to(i1, cp2, i2);
       if (match) {
         return true;
       }
@@ -1421,9 +1421,8 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
     int k2 = cp2->bootstrap_name_and_type_ref_index_at(index2);
     int i1 = bootstrap_methods_attribute_index(index1);
     int i2 = cp2->bootstrap_methods_attribute_index(index2);
-    // separate statements and variables because CHECK_false is used
-    bool match_entry = compare_entry_to(k1, cp2, k2, CHECK_false);
-    bool match_operand = compare_operand_to(i1, cp2, i2, CHECK_false);
+    bool match_entry = compare_entry_to(k1, cp2, k2);
+    bool match_operand = compare_operand_to(i1, cp2, i2);
     return (match_entry && match_operand);
   } break;
 
@@ -1433,9 +1432,8 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
     int k2 = cp2->bootstrap_name_and_type_ref_index_at(index2);
     int i1 = bootstrap_methods_attribute_index(index1);
     int i2 = cp2->bootstrap_methods_attribute_index(index2);
-    // separate statements and variables because CHECK_false is used
-    bool match_entry = compare_entry_to(k1, cp2, k2, CHECK_false);
-    bool match_operand = compare_operand_to(i1, cp2, i2, CHECK_false);
+    bool match_entry = compare_entry_to(k1, cp2, k2);
+    bool match_operand = compare_operand_to(i1, cp2, i2);
     return (match_entry && match_operand);
   } break;
 
@@ -1616,7 +1614,7 @@ void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_
   int dest_i = to_i;  // leave original alone for debug purposes
 
   for (int src_i = start_i; src_i <= end_i; /* see loop bottom */ ) {
-    copy_entry_to(from_cp, src_i, to_cp, dest_i, CHECK);
+    copy_entry_to(from_cp, src_i, to_cp, dest_i);
 
     switch (from_cp->tag_at(src_i).value()) {
     case JVM_CONSTANT_Double:
@@ -1641,8 +1639,7 @@ void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_
 // Copy this constant pool's entry at from_i to the constant pool
 // to_cp's entry at to_i.
 void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
-                                        const constantPoolHandle& to_cp, int to_i,
-                                        TRAPS) {
+                                        const constantPoolHandle& to_cp, int to_i) {
 
   int tag = from_cp->tag_at(from_i).value();
   switch (tag) {
@@ -1786,11 +1783,11 @@ void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
 // constant pool's entry at pattern_i. Returns the index of a
 // matching entry or zero (0) if there is no matching entry.
 int ConstantPool::find_matching_entry(int pattern_i,
-      const constantPoolHandle& search_cp, TRAPS) {
+      const constantPoolHandle& search_cp) {
 
   // index zero (0) is not used
   for (int i = 1; i < search_cp->length(); i++) {
-    bool found = compare_entry_to(pattern_i, search_cp, i, CHECK_0);
+    bool found = compare_entry_to(pattern_i, search_cp, i);
     if (found) {
       return i;
     }
@@ -1802,10 +1799,10 @@ int ConstantPool::find_matching_entry(int pattern_i,
 
 // Compare this constant pool's bootstrap specifier at idx1 to the constant pool
 // cp2's bootstrap specifier at idx2.
-bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, int idx2, TRAPS) {
+bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, int idx2) {
   int k1 = operand_bootstrap_method_ref_index_at(idx1);
   int k2 = cp2->operand_bootstrap_method_ref_index_at(idx2);
-  bool match = compare_entry_to(k1, cp2, k2, CHECK_false);
+  bool match = compare_entry_to(k1, cp2, k2);
 
   if (!match) {
     return false;
@@ -1815,7 +1812,7 @@ bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, i
     for (int j = 0; j < argc; j++) {
       k1 = operand_argument_index_at(idx1, j);
       k2 = cp2->operand_argument_index_at(idx2, j);
-      match = compare_entry_to(k1, cp2, k2, CHECK_false);
+      match = compare_entry_to(k1, cp2, k2);
       if (!match) {
         return false;
       }
@@ -1829,9 +1826,9 @@ bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, i
 // this constant pool's bootstrap specifier data at pattern_i index.
 // Return the index of a matching bootstrap attribute record or (-1) if there is no match.
 int ConstantPool::find_matching_operand(int pattern_i,
-                    const constantPoolHandle& search_cp, int search_len, TRAPS) {
+                    const constantPoolHandle& search_cp, int search_len) {
   for (int i = 0; i < search_len; i++) {
-    bool found = compare_operand_to(pattern_i, search_cp, i, CHECK_(-1));
+    bool found = compare_operand_to(pattern_i, search_cp, i);
     if (found) {
       return i;
     }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -660,10 +660,10 @@ class ConstantPool : public Metadata {
   }
   // Compare a bootstrap specifier data in the operands arrays
   bool compare_operand_to(int bsms_attribute_index1, const constantPoolHandle& cp2,
-                          int bsms_attribute_index2, TRAPS);
+                          int bsms_attribute_index2);
   // Find a bootstrap specifier data in the operands array
   int find_matching_operand(int bsms_attribute_index, const constantPoolHandle& search_cp,
-                            int operands_cur_len, TRAPS);
+                            int operands_cur_len);
   // Resize the operands array with delta_len and delta_size
   void resize_operands(int delta_len, int delta_size, TRAPS);
   // Extend the operands array with the length and size of the ext_cp operands
@@ -903,15 +903,15 @@ class ConstantPool : public Metadata {
   static void throw_resolution_error(const constantPoolHandle& this_cp, int which, TRAPS);
 
   // Merging ConstantPool* support:
-  bool compare_entry_to(int index1, const constantPoolHandle& cp2, int index2, TRAPS);
+  bool compare_entry_to(int index1, const constantPoolHandle& cp2, int index2);
   void copy_cp_to(int start_i, int end_i, const constantPoolHandle& to_cp, int to_i, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
     copy_cp_to_impl(h_this, start_i, end_i, to_cp, to_i, THREAD);
   }
   static void copy_cp_to_impl(const constantPoolHandle& from_cp, int start_i, int end_i, const constantPoolHandle& to_cp, int to_i, TRAPS);
-  static void copy_entry_to(const constantPoolHandle& from_cp, int from_i, const constantPoolHandle& to_cp, int to_i, TRAPS);
+  static void copy_entry_to(const constantPoolHandle& from_cp, int from_i, const constantPoolHandle& to_cp, int to_i);
   static void copy_operands(const constantPoolHandle& from_cp, const constantPoolHandle& to_cp, TRAPS);
-  int  find_matching_entry(int pattern_i, const constantPoolHandle& search_cp, TRAPS);
+  int  find_matching_entry(int pattern_i, const constantPoolHandle& search_cp);
   int  version() const                    { return _saved._version; }
   void set_version(int version)           { _saved._version = version; }
   void increment_and_save_version(int version) {

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1387,6 +1387,7 @@ jvmtiError VM_RedefineClasses::load_new_class_versions() {
     state->set_class_being_redefined(the_class, _class_load_kind);
 
     Thread* THREAD = current;  // for exception processing
+    ExceptionMark em(THREAD);
     ClassLoadInfo cl_info(protection_domain);
     InstanceKlass* scratch_class = SystemDictionary::parse_stream(
                                                       the_class_sym,
@@ -2110,12 +2111,13 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods(InstanceKlass* scratch_class
     return true;
   }
 
-  JavaThread* current = JavaThread::current();
+  Thread* THREAD = Thread::current();  // For exception processing
+  ExceptionMark em(THREAD);
+
   // rewrite constant pool references in the methods:
   for (int i = methods->length() - 1; i >= 0; i--) {
-    methodHandle method(current, methods->at(i));
+    methodHandle method(THREAD, methods->at(i));
     methodHandle new_method;
-    Thread* THREAD = current; // For exception handling
     rewrite_cp_refs_in_method(method, &new_method, THREAD);
     if (!new_method.is_null()) {
       // the method has been replaced so save the new method version

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -354,8 +354,7 @@ bool VM_RedefineClasses::is_modifiable_class(oop klass_mirror) {
 // there is nothing extra to append and only the current entry is
 // appended.
 void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
-       int scratch_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p,
-       TRAPS) {
+       int scratch_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   // append is different depending on entry tag type
   switch (scratch_cp->tag_at(scratch_i).value()) {
@@ -377,7 +376,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     {
       int name_i = scratch_cp->klass_name_index_at(scratch_i);
       int new_name_i = find_or_append_indirect_entry(scratch_cp, name_i, merge_cp_p,
-                                                     merge_cp_length_p, THREAD);
+                                                     merge_cp_length_p);
 
       if (new_name_i != name_i) {
         log_trace(redefine, class, constantpool)
@@ -399,8 +398,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Double:  // fall through
     case JVM_CONSTANT_Long:
     {
-      ConstantPool::copy_entry_to(scratch_cp, scratch_i, *merge_cp_p, *merge_cp_length_p,
-        THREAD);
+      ConstantPool::copy_entry_to(scratch_cp, scratch_i, *merge_cp_p, *merge_cp_length_p);
 
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
@@ -419,8 +417,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // Symbol*s so this entry can be directly appended.
     case JVM_CONSTANT_String:      // fall through
     {
-      ConstantPool::copy_entry_to(scratch_cp, scratch_i, *merge_cp_p, *merge_cp_length_p,
-        THREAD);
+      ConstantPool::copy_entry_to(scratch_cp, scratch_i, *merge_cp_p, *merge_cp_length_p);
 
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
@@ -435,12 +432,11 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     {
       int name_ref_i = scratch_cp->name_ref_index_at(scratch_i);
       int new_name_ref_i = find_or_append_indirect_entry(scratch_cp, name_ref_i, merge_cp_p,
-                                                         merge_cp_length_p, THREAD);
+                                                         merge_cp_length_p);
 
       int signature_ref_i = scratch_cp->signature_ref_index_at(scratch_i);
       int new_signature_ref_i = find_or_append_indirect_entry(scratch_cp, signature_ref_i,
-                                                              merge_cp_p, merge_cp_length_p,
-                                                              THREAD);
+                                                              merge_cp_p, merge_cp_length_p);
 
       // If the referenced entries already exist in *merge_cp_p, then
       // both new_name_ref_i and new_signature_ref_i will both be 0.
@@ -473,11 +469,11 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     {
       int klass_ref_i = scratch_cp->uncached_klass_ref_index_at(scratch_i);
       int new_klass_ref_i = find_or_append_indirect_entry(scratch_cp, klass_ref_i,
-                                                          merge_cp_p, merge_cp_length_p, THREAD);
+                                                          merge_cp_p, merge_cp_length_p);
 
       int name_and_type_ref_i = scratch_cp->uncached_name_and_type_ref_index_at(scratch_i);
       int new_name_and_type_ref_i = find_or_append_indirect_entry(scratch_cp, name_and_type_ref_i,
-                                                          merge_cp_p, merge_cp_length_p, THREAD);
+                                                          merge_cp_p, merge_cp_length_p);
 
       const char *entry_name = NULL;
       switch (scratch_cp->tag_at(scratch_i).value()) {
@@ -524,7 +520,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     {
       int ref_i = scratch_cp->method_type_index_at(scratch_i);
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
-                                                    merge_cp_length_p, THREAD);
+                                                    merge_cp_length_p);
       if (new_ref_i != ref_i) {
         log_trace(redefine, class, constantpool)
           ("MethodType entry@%d ref_index change: %d to %d", *merge_cp_length_p, ref_i, new_ref_i);
@@ -544,7 +540,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       int ref_kind = scratch_cp->method_handle_ref_kind_at(scratch_i);
       int ref_i = scratch_cp->method_handle_index_at(scratch_i);
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
-                                                    merge_cp_length_p, THREAD);
+                                                    merge_cp_length_p);
       if (new_ref_i != ref_i) {
         log_trace(redefine, class, constantpool)
           ("MethodHandle entry@%d ref_index change: %d to %d", *merge_cp_length_p, ref_i, new_ref_i);
@@ -565,11 +561,11 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       // Index of the bootstrap specifier in the operands array
       int old_bs_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
       int new_bs_i = find_or_append_operand(scratch_cp, old_bs_i, merge_cp_p,
-                                            merge_cp_length_p, THREAD);
+                                            merge_cp_length_p);
       // The bootstrap method NameAndType_info index
       int old_ref_i = scratch_cp->bootstrap_name_and_type_ref_index_at(scratch_i);
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
-                                                    merge_cp_length_p, THREAD);
+                                                    merge_cp_length_p);
       if (new_bs_i != old_bs_i) {
         log_trace(redefine, class, constantpool)
           ("Dynamic entry@%d bootstrap_method_attr_index change: %d to %d",
@@ -619,15 +615,15 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
 
 
 int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& scratch_cp,
-      int ref_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS) {
+      int ref_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   int new_ref_i = ref_i;
   bool match = (ref_i < *merge_cp_length_p) &&
-               scratch_cp->compare_entry_to(ref_i, *merge_cp_p, ref_i, THREAD);
+               scratch_cp->compare_entry_to(ref_i, *merge_cp_p, ref_i);
 
   if (!match) {
     // forward reference in *merge_cp_p or not a direct match
-    int found_i = scratch_cp->find_matching_entry(ref_i, *merge_cp_p, THREAD);
+    int found_i = scratch_cp->find_matching_entry(ref_i, *merge_cp_p);
     if (found_i != 0) {
       guarantee(found_i != ref_i, "compare_entry_to() and find_matching_entry() do not agree");
       // Found a matching entry somewhere else in *merge_cp_p so just need a mapping entry.
@@ -635,7 +631,7 @@ int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& 
       map_index(scratch_cp, ref_i, found_i);
     } else {
       // no match found so we have to append this entry to *merge_cp_p
-      append_entry(scratch_cp, ref_i, merge_cp_p, merge_cp_length_p, THREAD);
+      append_entry(scratch_cp, ref_i, merge_cp_p, merge_cp_length_p);
       // The above call to append_entry() can only append one entry
       // so the post call query of *merge_cp_length_p is only for
       // the sake of consistency.
@@ -651,11 +647,11 @@ int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& 
 // to the scratch_cp operands bootstrap specifier passed by the old_bs_i index.
 // Recursively append new merge_cp entries referenced by the new bootstrap specifier.
 void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, int old_bs_i,
-       constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS) {
+       constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   int old_ref_i = scratch_cp->operand_bootstrap_method_ref_index_at(old_bs_i);
   int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
-                                                merge_cp_length_p, THREAD);
+                                                merge_cp_length_p);
   if (new_ref_i != old_ref_i) {
     log_trace(redefine, class, constantpool)
       ("operands entry@%d bootstrap method ref_index change: %d to %d", _operands_cur_length, old_ref_i, new_ref_i);
@@ -676,7 +672,7 @@ void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, in
   for (int i = 0; i < argc; i++) {
     int old_arg_ref_i = scratch_cp->operand_argument_index_at(old_bs_i, i);
     int new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
-                                                      merge_cp_length_p, THREAD);
+                                                      merge_cp_length_p);
     merge_ops->at_put(new_base++, new_arg_ref_i);
     if (new_arg_ref_i != old_arg_ref_i) {
       log_trace(redefine, class, constantpool)
@@ -694,16 +690,16 @@ void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, in
 
 
 int VM_RedefineClasses::find_or_append_operand(const constantPoolHandle& scratch_cp,
-      int old_bs_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS) {
+      int old_bs_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   int new_bs_i = old_bs_i; // bootstrap specifier index
   bool match = (old_bs_i < _operands_cur_length) &&
-               scratch_cp->compare_operand_to(old_bs_i, *merge_cp_p, old_bs_i, THREAD);
+               scratch_cp->compare_operand_to(old_bs_i, *merge_cp_p, old_bs_i);
 
   if (!match) {
     // forward reference in *merge_cp_p or not a direct match
     int found_i = scratch_cp->find_matching_operand(old_bs_i, *merge_cp_p,
-                                                    _operands_cur_length, THREAD);
+                                                    _operands_cur_length);
     if (found_i != -1) {
       guarantee(found_i != old_bs_i, "compare_operand_to() and find_matching_operand() disagree");
       // found a matching operand somewhere else in *merge_cp_p so just need a mapping
@@ -711,7 +707,7 @@ int VM_RedefineClasses::find_or_append_operand(const constantPoolHandle& scratch
       map_operand_index(old_bs_i, found_i);
     } else {
       // no match found so we have to append this bootstrap specifier to *merge_cp_p
-      append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p, THREAD);
+      append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p);
       new_bs_i = _operands_cur_length - 1;
     }
   }
@@ -1645,13 +1641,13 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       case JVM_CONSTANT_Long:
         // just copy the entry to *merge_cp_p, but double and long take
         // two constant pool entries
-        ConstantPool::copy_entry_to(old_cp, old_i, *merge_cp_p, old_i, CHECK_false);
+        ConstantPool::copy_entry_to(old_cp, old_i, *merge_cp_p, old_i);
         old_i++;
         break;
 
       default:
         // just copy the entry to *merge_cp_p
-        ConstantPool::copy_entry_to(old_cp, old_i, *merge_cp_p, old_i, CHECK_false);
+        ConstantPool::copy_entry_to(old_cp, old_i, *merge_cp_p, old_i);
         break;
       }
     } // end for each old_cp entry
@@ -1690,8 +1686,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
         break;
       }
 
-      bool match = scratch_cp->compare_entry_to(scratch_i, *merge_cp_p,
-        scratch_i, CHECK_false);
+      bool match = scratch_cp->compare_entry_to(scratch_i, *merge_cp_p, scratch_i);
       if (match) {
         // found a match at the same index so nothing more to do
         continue;
@@ -1705,8 +1700,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
         continue;
       }
 
-      int found_i = scratch_cp->find_matching_entry(scratch_i, *merge_cp_p,
-        CHECK_false);
+      int found_i = scratch_cp->find_matching_entry(scratch_i, *merge_cp_p);
       if (found_i != 0) {
         guarantee(found_i != scratch_i,
           "compare_entry_to() and find_matching_entry() do not agree");
@@ -1726,8 +1720,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
 
       // No match found so we have to append this entry and any unique
       // referenced entries to *merge_cp_p.
-      append_entry(scratch_cp, scratch_i, merge_cp_p, merge_cp_length_p,
-        CHECK_false);
+      append_entry(scratch_cp, scratch_i, merge_cp_p, merge_cp_length_p);
     }
   }
 
@@ -1755,7 +1748,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       }
 
       int found_i =
-        scratch_cp->find_matching_entry(scratch_i, *merge_cp_p, CHECK_false);
+        scratch_cp->find_matching_entry(scratch_i, *merge_cp_p);
       if (found_i != 0) {
         // Found a matching entry somewhere else in *merge_cp_p so
         // just need a mapping entry.
@@ -1765,8 +1758,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
 
       // No match found so we have to append this entry and any unique
       // referenced entries to *merge_cp_p.
-      append_entry(scratch_cp, scratch_i, merge_cp_p, merge_cp_length_p,
-        CHECK_false);
+      append_entry(scratch_cp, scratch_i, merge_cp_p, merge_cp_length_p);
     }
 
     log_debug(redefine, class, constantpool)
@@ -1948,7 +1940,7 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class,
   }
 
   // rewrite constant pool references in the Record attribute:
-  if (!rewrite_cp_refs_in_record_attribute(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_record_attribute(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
@@ -1966,51 +1958,49 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class,
   }
 
   // rewrite constant pool references in the class_annotations:
-  if (!rewrite_cp_refs_in_class_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_class_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the fields_annotations:
-  if (!rewrite_cp_refs_in_fields_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_fields_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the methods_annotations:
-  if (!rewrite_cp_refs_in_methods_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_methods_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the methods_parameter_annotations:
-  if (!rewrite_cp_refs_in_methods_parameter_annotations(scratch_class,
-         THREAD)) {
+  if (!rewrite_cp_refs_in_methods_parameter_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the methods_default_annotations:
-  if (!rewrite_cp_refs_in_methods_default_annotations(scratch_class,
-         THREAD)) {
+  if (!rewrite_cp_refs_in_methods_default_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the class_type_annotations:
-  if (!rewrite_cp_refs_in_class_type_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_class_type_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the fields_type_annotations:
-  if (!rewrite_cp_refs_in_fields_type_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_fields_type_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
 
   // rewrite constant pool references in the methods_type_annotations:
-  if (!rewrite_cp_refs_in_methods_type_annotations(scratch_class, THREAD)) {
+  if (!rewrite_cp_refs_in_methods_type_annotations(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
@@ -2058,8 +2048,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_nest_attributes(
 }
 
 // Rewrite constant pool references in the Record attribute.
-bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(
-       InstanceKlass* scratch_class, TRAPS) {
+bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(InstanceKlass* scratch_class) {
   Array<RecordComponent*>* components = scratch_class->record_components();
   if (components != NULL) {
     for (int i = 0; i < components->length(); i++) {
@@ -2076,7 +2065,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(
       AnnotationArray* annotations = component->annotations();
       if (annotations != NULL && annotations->length() != 0) {
         int byte_i = 0;  // byte index into annotations
-        if (!rewrite_cp_refs_in_annotations_typeArray(annotations, byte_i, THREAD)) {
+        if (!rewrite_cp_refs_in_annotations_typeArray(annotations, byte_i)) {
           log_debug(redefine, class, annotation)("bad record_component_annotations at %d", i);
           // propagate failure back to caller
           return false;
@@ -2086,7 +2075,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(
       AnnotationArray* type_annotations = component->type_annotations();
       if (type_annotations != NULL && type_annotations->length() != 0) {
         int byte_i = 0;  // byte index into annotations
-        if (!rewrite_cp_refs_in_annotations_typeArray(type_annotations, byte_i, THREAD)) {
+        if (!rewrite_cp_refs_in_annotations_typeArray(type_annotations, byte_i)) {
           log_debug(redefine, class, annotation)("bad record_component_type_annotations at %d", i);
           // propagate failure back to caller
           return false;
@@ -2292,8 +2281,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
 
 
 // Rewrite constant pool references in the class_annotations field.
-bool VM_RedefineClasses::rewrite_cp_refs_in_class_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+bool VM_RedefineClasses::rewrite_cp_refs_in_class_annotations(InstanceKlass* scratch_class) {
 
   AnnotationArray* class_annotations = scratch_class->class_annotations();
   if (class_annotations == NULL || class_annotations->length() == 0) {
@@ -2304,8 +2292,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_class_annotations(
   log_debug(redefine, class, annotation)("class_annotations length=%d", class_annotations->length());
 
   int byte_i = 0;  // byte index into class_annotations
-  return rewrite_cp_refs_in_annotations_typeArray(class_annotations, byte_i,
-           THREAD);
+  return rewrite_cp_refs_in_annotations_typeArray(class_annotations, byte_i);
 }
 
 
@@ -2319,7 +2306,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_class_annotations(
 // }
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_annotations_typeArray(
-       AnnotationArray* annotations_typeArray, int &byte_i_ref, TRAPS) {
+       AnnotationArray* annotations_typeArray, int &byte_i_ref) {
 
   if ((byte_i_ref + 2) > annotations_typeArray->length()) {
     // not enough room for num_annotations field
@@ -2335,8 +2322,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_annotations_typeArray(
 
   int calc_num_annotations = 0;
   for (; calc_num_annotations < num_annotations; calc_num_annotations++) {
-    if (!rewrite_cp_refs_in_annotation_struct(annotations_typeArray,
-           byte_i_ref, THREAD)) {
+    if (!rewrite_cp_refs_in_annotation_struct(annotations_typeArray, byte_i_ref)) {
       log_debug(redefine, class, annotation)("bad annotation_struct at %d", calc_num_annotations);
       // propagate failure back to caller
       return false;
@@ -2362,7 +2348,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_annotations_typeArray(
 // }
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_annotation_struct(
-       AnnotationArray* annotations_typeArray, int &byte_i_ref, TRAPS) {
+       AnnotationArray* annotations_typeArray, int &byte_i_ref) {
   if ((byte_i_ref + 2 + 2) > annotations_typeArray->length()) {
     // not enough room for smallest annotation_struct
     log_debug(redefine, class, annotation)("length() is too small for annotation_struct");
@@ -2370,7 +2356,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_annotation_struct(
   }
 
   u2 type_index = rewrite_cp_ref_in_annotation_data(annotations_typeArray,
-                    byte_i_ref, "type_index", THREAD);
+                    byte_i_ref, "type_index");
 
   u2 num_element_value_pairs = Bytes::get_Java_u2((address)
                                  annotations_typeArray->adr_at(byte_i_ref));
@@ -2391,12 +2377,11 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_annotation_struct(
 
     u2 element_name_index = rewrite_cp_ref_in_annotation_data(
                               annotations_typeArray, byte_i_ref,
-                              "element_name_index", THREAD);
+                              "element_name_index");
 
     log_debug(redefine, class, annotation)("element_name_index=%d", element_name_index);
 
-    if (!rewrite_cp_refs_in_element_value(annotations_typeArray,
-           byte_i_ref, THREAD)) {
+    if (!rewrite_cp_refs_in_element_value(annotations_typeArray, byte_i_ref)) {
       log_debug(redefine, class, annotation)("bad element_value at %d", calc_num_element_value_pairs);
       // propagate failure back to caller
       return false;
@@ -2415,7 +2400,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_annotation_struct(
 // pool reference if a rewrite was needed.
 u2 VM_RedefineClasses::rewrite_cp_ref_in_annotation_data(
      AnnotationArray* annotations_typeArray, int &byte_i_ref,
-     const char * trace_mesg, TRAPS) {
+     const char * trace_mesg) {
 
   address cp_index_addr = (address)
     annotations_typeArray->adr_at(byte_i_ref);
@@ -2453,7 +2438,7 @@ u2 VM_RedefineClasses::rewrite_cp_ref_in_annotation_data(
 // }
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
-       AnnotationArray* annotations_typeArray, int &byte_i_ref, TRAPS) {
+       AnnotationArray* annotations_typeArray, int &byte_i_ref) {
 
   if ((byte_i_ref + 1) > annotations_typeArray->length()) {
     // not enough room for a tag let alone the rest of an element_value
@@ -2491,7 +2476,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
 
       u2 const_value_index = rewrite_cp_ref_in_annotation_data(
                                annotations_typeArray, byte_i_ref,
-                               "const_value_index", THREAD);
+                               "const_value_index");
 
       log_debug(redefine, class, annotation)("const_value_index=%d", const_value_index);
     } break;
@@ -2508,11 +2493,11 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
 
       u2 type_name_index = rewrite_cp_ref_in_annotation_data(
                              annotations_typeArray, byte_i_ref,
-                             "type_name_index", THREAD);
+                             "type_name_index");
 
       u2 const_name_index = rewrite_cp_ref_in_annotation_data(
                               annotations_typeArray, byte_i_ref,
-                              "const_name_index", THREAD);
+                              "const_name_index");
 
       log_debug(redefine, class, annotation)
         ("type_name_index=%d  const_name_index=%d", type_name_index, const_name_index);
@@ -2530,7 +2515,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
 
       u2 class_info_index = rewrite_cp_ref_in_annotation_data(
                               annotations_typeArray, byte_i_ref,
-                              "class_info_index", THREAD);
+                              "class_info_index");
 
       log_debug(redefine, class, annotation)("class_info_index=%d", class_info_index);
     } break;
@@ -2538,8 +2523,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
     case '@':
       // For the above tag value, value.attr_value is the right union
       // field. This is a nested annotation.
-      if (!rewrite_cp_refs_in_annotation_struct(annotations_typeArray,
-             byte_i_ref, THREAD)) {
+      if (!rewrite_cp_refs_in_annotation_struct(annotations_typeArray, byte_i_ref)) {
         // propagate failure back to caller
         return false;
       }
@@ -2562,8 +2546,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
 
       int calc_num_values = 0;
       for (; calc_num_values < num_values; calc_num_values++) {
-        if (!rewrite_cp_refs_in_element_value(
-               annotations_typeArray, byte_i_ref, THREAD)) {
+        if (!rewrite_cp_refs_in_element_value(annotations_typeArray, byte_i_ref)) {
           log_debug(redefine, class, annotation)("bad nested element_value at %d", calc_num_values);
           // propagate failure back to caller
           return false;
@@ -2583,7 +2566,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_element_value(
 
 // Rewrite constant pool references in a fields_annotations field.
 bool VM_RedefineClasses::rewrite_cp_refs_in_fields_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   Array<AnnotationArray*>* fields_annotations = scratch_class->fields_annotations();
 
@@ -2602,8 +2585,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_fields_annotations(
     }
 
     int byte_i = 0;  // byte index into field_annotations
-    if (!rewrite_cp_refs_in_annotations_typeArray(field_annotations, byte_i,
-           THREAD)) {
+    if (!rewrite_cp_refs_in_annotations_typeArray(field_annotations, byte_i)) {
       log_debug(redefine, class, annotation)("bad field_annotations at %d", i);
       // propagate failure back to caller
       return false;
@@ -2616,7 +2598,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_fields_annotations(
 
 // Rewrite constant pool references in a methods_annotations field.
 bool VM_RedefineClasses::rewrite_cp_refs_in_methods_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   for (int i = 0; i < scratch_class->methods()->length(); i++) {
     Method* m = scratch_class->methods()->at(i);
@@ -2628,8 +2610,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_annotations(
     }
 
     int byte_i = 0;  // byte index into method_annotations
-    if (!rewrite_cp_refs_in_annotations_typeArray(method_annotations, byte_i,
-           THREAD)) {
+    if (!rewrite_cp_refs_in_annotations_typeArray(method_annotations, byte_i)) {
       log_debug(redefine, class, annotation)("bad method_annotations at %d", i);
       // propagate failure back to caller
       return false;
@@ -2654,7 +2635,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_annotations(
 // }
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_methods_parameter_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   for (int i = 0; i < scratch_class->methods()->length(); i++) {
     Method* m = scratch_class->methods()->at(i);
@@ -2680,8 +2661,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_parameter_annotations(
 
     int calc_num_parameters = 0;
     for (; calc_num_parameters < num_parameters; calc_num_parameters++) {
-      if (!rewrite_cp_refs_in_annotations_typeArray(
-             method_parameter_annotations, byte_i, THREAD)) {
+      if (!rewrite_cp_refs_in_annotations_typeArray(method_parameter_annotations, byte_i)) {
         log_debug(redefine, class, annotation)("bad method_parameter_annotations at %d", calc_num_parameters);
         // propagate failure back to caller
         return false;
@@ -2703,7 +2683,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_parameter_annotations(
 // }
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_methods_default_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   for (int i = 0; i < scratch_class->methods()->length(); i++) {
     Method* m = scratch_class->methods()->at(i);
@@ -2717,7 +2697,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_default_annotations(
     int byte_i = 0;  // byte index into method_default_annotations
 
     if (!rewrite_cp_refs_in_element_value(
-           method_default_annotations, byte_i, THREAD)) {
+           method_default_annotations, byte_i)) {
       log_debug(redefine, class, annotation)("bad default element_value at %d", i);
       // propagate failure back to caller
       return false;
@@ -2730,7 +2710,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_default_annotations(
 
 // Rewrite constant pool references in a class_type_annotations field.
 bool VM_RedefineClasses::rewrite_cp_refs_in_class_type_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   AnnotationArray* class_type_annotations = scratch_class->class_type_annotations();
   if (class_type_annotations == NULL || class_type_annotations->length() == 0) {
@@ -2742,13 +2722,12 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_class_type_annotations(
 
   int byte_i = 0;  // byte index into class_type_annotations
   return rewrite_cp_refs_in_type_annotations_typeArray(class_type_annotations,
-      byte_i, "ClassFile", THREAD);
+      byte_i, "ClassFile");
 } // end rewrite_cp_refs_in_class_type_annotations()
 
 
 // Rewrite constant pool references in a fields_type_annotations field.
-bool VM_RedefineClasses::rewrite_cp_refs_in_fields_type_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+bool VM_RedefineClasses::rewrite_cp_refs_in_fields_type_annotations(InstanceKlass* scratch_class) {
 
   Array<AnnotationArray*>* fields_type_annotations = scratch_class->fields_type_annotations();
   if (fields_type_annotations == NULL || fields_type_annotations->length() == 0) {
@@ -2767,7 +2746,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_fields_type_annotations(
 
     int byte_i = 0;  // byte index into field_type_annotations
     if (!rewrite_cp_refs_in_type_annotations_typeArray(field_type_annotations,
-           byte_i, "field_info", THREAD)) {
+           byte_i, "field_info")) {
       log_debug(redefine, class, annotation)("bad field_type_annotations at %d", i);
       // propagate failure back to caller
       return false;
@@ -2780,7 +2759,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_fields_type_annotations(
 
 // Rewrite constant pool references in a methods_type_annotations field.
 bool VM_RedefineClasses::rewrite_cp_refs_in_methods_type_annotations(
-       InstanceKlass* scratch_class, TRAPS) {
+       InstanceKlass* scratch_class) {
 
   for (int i = 0; i < scratch_class->methods()->length(); i++) {
     Method* m = scratch_class->methods()->at(i);
@@ -2795,7 +2774,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_type_annotations(
 
     int byte_i = 0;  // byte index into method_type_annotations
     if (!rewrite_cp_refs_in_type_annotations_typeArray(method_type_annotations,
-           byte_i, "method_info", THREAD)) {
+           byte_i, "method_info")) {
       log_debug(redefine, class, annotation)("bad method_type_annotations at %d", i);
       // propagate failure back to caller
       return false;
@@ -2818,7 +2797,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_methods_type_annotations(
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_type_annotations_typeArray(
        AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-       const char * location_mesg, TRAPS) {
+       const char * location_mesg) {
 
   if ((byte_i_ref + 2) > type_annotations_typeArray->length()) {
     // not enough room for num_annotations field
@@ -2835,7 +2814,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_type_annotations_typeArray(
   int calc_num_annotations = 0;
   for (; calc_num_annotations < num_annotations; calc_num_annotations++) {
     if (!rewrite_cp_refs_in_type_annotation_struct(type_annotations_typeArray,
-           byte_i_ref, location_mesg, THREAD)) {
+           byte_i_ref, location_mesg)) {
       log_debug(redefine, class, annotation)("bad type_annotation_struct at %d", calc_num_annotations);
       // propagate failure back to caller
       return false;
@@ -2879,20 +2858,18 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_type_annotations_typeArray(
 //
 bool VM_RedefineClasses::rewrite_cp_refs_in_type_annotation_struct(
        AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-       const char * location_mesg, TRAPS) {
+       const char * location_mesg) {
 
   if (!skip_type_annotation_target(type_annotations_typeArray,
-         byte_i_ref, location_mesg, THREAD)) {
+         byte_i_ref, location_mesg)) {
     return false;
   }
 
-  if (!skip_type_annotation_type_path(type_annotations_typeArray,
-         byte_i_ref, THREAD)) {
+  if (!skip_type_annotation_type_path(type_annotations_typeArray, byte_i_ref)) {
     return false;
   }
 
-  if (!rewrite_cp_refs_in_annotation_struct(type_annotations_typeArray,
-         byte_i_ref, THREAD)) {
+  if (!rewrite_cp_refs_in_annotation_struct(type_annotations_typeArray, byte_i_ref)) {
     return false;
   }
 
@@ -2919,7 +2896,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_type_annotation_struct(
 //
 bool VM_RedefineClasses::skip_type_annotation_target(
        AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-       const char * location_mesg, TRAPS) {
+       const char * location_mesg) {
 
   if ((byte_i_ref + 1) > type_annotations_typeArray->length()) {
     // not enough room for a target_type let alone the rest of a type_annotation
@@ -3231,7 +3208,7 @@ bool VM_RedefineClasses::skip_type_annotation_target(
 // }
 //
 bool VM_RedefineClasses::skip_type_annotation_type_path(
-       AnnotationArray* type_annotations_typeArray, int &byte_i_ref, TRAPS) {
+       AnnotationArray* type_annotations_typeArray, int &byte_i_ref) {
 
   if ((byte_i_ref + 1) > type_annotations_typeArray->length()) {
     // not enough room for a path_length let alone the rest of the type_path
@@ -3286,7 +3263,7 @@ bool VM_RedefineClasses::skip_type_annotation_type_path(
 // }
 //
 void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
-       const methodHandle& method, TRAPS) {
+       const methodHandle& method) {
 
   if (!method->has_stackmap_table()) {
     return;
@@ -3335,7 +3312,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
     // }
     else if (frame_type >= 64 && frame_type <= 127) {
       rewrite_cp_refs_in_verification_type_info(stackmap_p, stackmap_end,
-        calc_number_of_entries, frame_type, THREAD);
+        calc_number_of_entries, frame_type);
     }
 
     // reserved for future use
@@ -3351,7 +3328,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
     else if (frame_type == 247) {
       stackmap_p += 2;
       rewrite_cp_refs_in_verification_type_info(stackmap_p, stackmap_end,
-        calc_number_of_entries, frame_type, THREAD);
+        calc_number_of_entries, frame_type);
     }
 
     // chop_frame {
@@ -3382,7 +3359,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
       u1 len = frame_type - 251;
       for (u1 i = 0; i < len; i++) {
         rewrite_cp_refs_in_verification_type_info(stackmap_p, stackmap_end,
-          calc_number_of_entries, frame_type, THREAD);
+          calc_number_of_entries, frame_type);
       }
     }
 
@@ -3404,7 +3381,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
 
       for (u2 locals_i = 0; locals_i < number_of_locals; locals_i++) {
         rewrite_cp_refs_in_verification_type_info(stackmap_p, stackmap_end,
-          calc_number_of_entries, frame_type, THREAD);
+          calc_number_of_entries, frame_type);
       }
 
       // Use the largest size for the number_of_stack_items, but only get
@@ -3414,7 +3391,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
 
       for (u2 stack_i = 0; stack_i < number_of_stack_items; stack_i++) {
         rewrite_cp_refs_in_verification_type_info(stackmap_p, stackmap_end,
-          calc_number_of_entries, frame_type, THREAD);
+          calc_number_of_entries, frame_type);
       }
     }
   } // end while there is a stack_map_frame
@@ -3445,7 +3422,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_stack_map_table(
 //
 void VM_RedefineClasses::rewrite_cp_refs_in_verification_type_info(
        address& stackmap_p_ref, address stackmap_end, u2 frame_i,
-       u1 frame_type, TRAPS) {
+       u1 frame_type) {
 
   assert(stackmap_p_ref + 1 <= stackmap_end, "no room for tag");
   u1 tag = *stackmap_p_ref;
@@ -3714,7 +3691,7 @@ void VM_RedefineClasses::set_new_constant_pool(
       } // end for each local variable table entry
     } // end if there are local variable table entries
 
-    rewrite_cp_refs_in_stack_map_table(method, THREAD);
+    rewrite_cp_refs_in_stack_map_table(method);
   } // end for each method
 } // end set_new_constant_pool()
 
@@ -4454,7 +4431,7 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
     the_class->oop_map_cache()->flush_obsolete_entries();
   }
 
-  increment_class_counter((InstanceKlass *)the_class, THREAD);
+  increment_class_counter((InstanceKlass *)the_class);
 
   if (EventClassRedefinition::is_enabled()) {
     EventClassRedefinition event;
@@ -4483,7 +4460,7 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
 
 // Increment the classRedefinedCount field in the specific InstanceKlass
 // and in all direct and indirect subclasses.
-void VM_RedefineClasses::increment_class_counter(InstanceKlass *ik, TRAPS) {
+void VM_RedefineClasses::increment_class_counter(InstanceKlass *ik) {
   oop class_mirror = ik->java_mirror();
   Klass* class_oop = java_lang_Class::as_Klass(class_mirror);
   int new_count = java_lang_Class::classRedefinedCount(class_mirror) + 1;
@@ -4500,7 +4477,7 @@ void VM_RedefineClasses::increment_class_counter(InstanceKlass *ik, TRAPS) {
       // Only update instanceKlasses
       InstanceKlass *subik = InstanceKlass::cast(subk);
       // recursively do subclasses of the current subclass
-      increment_class_counter(subik, THREAD);
+      increment_class_counter(subik);
     }
   }
 }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1765,7 +1765,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       ("after pass 1b: merge_cp_len=%d, scratch_i=%d, index_map_len=%d",
        *merge_cp_length_p, scratch_i, _index_map_count);
   }
-  finalize_operands_merge(*merge_cp_p, THREAD);
+  finalize_operands_merge(*merge_cp_p, CHECK_false);
 
   return true;
 } // end merge_constant_pools()

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -429,18 +429,18 @@ class VM_RedefineClasses: public VM_Operation {
 
   // Increment the classRedefinedCount field in the specific InstanceKlass
   // and in all direct and indirect subclasses.
-  void increment_class_counter(InstanceKlass *ik, TRAPS);
+  void increment_class_counter(InstanceKlass *ik);
 
   // Support for constant pool merging (these routines are in alpha order):
   void append_entry(const constantPoolHandle& scratch_cp, int scratch_i,
-    constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS);
+    constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   void append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
-    constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS);
+    constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   void finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS);
   int find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
-    constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS);
+    constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   int find_or_append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
-    constantPoolHandle *merge_cp_p, int *merge_cp_length_p, TRAPS);
+    constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   int find_new_index(int old_index);
   int find_new_operand_index(int old_bootstrap_spec_index);
   bool is_unresolved_class_mismatch(const constantPoolHandle& cp1, int index1,
@@ -454,51 +454,46 @@ class VM_RedefineClasses: public VM_Operation {
     InstanceKlass* scratch_class, TRAPS);
   u2 rewrite_cp_ref_in_annotation_data(
     AnnotationArray* annotations_typeArray, int &byte_i_ref,
-    const char * trace_mesg, TRAPS);
+    const char * trace_mesg);
   bool rewrite_cp_refs(InstanceKlass* scratch_class, TRAPS);
   bool rewrite_cp_refs_in_annotation_struct(
-    AnnotationArray* class_annotations, int &byte_i_ref, TRAPS);
+    AnnotationArray* class_annotations, int &byte_i_ref);
   bool rewrite_cp_refs_in_annotations_typeArray(
-    AnnotationArray* annotations_typeArray, int &byte_i_ref, TRAPS);
-  bool rewrite_cp_refs_in_class_annotations(
-    InstanceKlass* scratch_class, TRAPS);
+    AnnotationArray* annotations_typeArray, int &byte_i_ref);
+  bool rewrite_cp_refs_in_class_annotations(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_element_value(
-    AnnotationArray* class_annotations, int &byte_i_ref, TRAPS);
+    AnnotationArray* class_annotations, int &byte_i_ref);
   bool rewrite_cp_refs_in_type_annotations_typeArray(
     AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-    const char * location_mesg, TRAPS);
+    const char * location_mesg);
   bool rewrite_cp_refs_in_type_annotation_struct(
     AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-    const char * location_mesg, TRAPS);
+    const char * location_mesg);
   bool skip_type_annotation_target(
     AnnotationArray* type_annotations_typeArray, int &byte_i_ref,
-    const char * location_mesg, TRAPS);
+    const char * location_mesg);
   bool skip_type_annotation_type_path(
-    AnnotationArray* type_annotations_typeArray, int &byte_i_ref, TRAPS);
-  bool rewrite_cp_refs_in_fields_annotations(
-    InstanceKlass* scratch_class, TRAPS);
+    AnnotationArray* type_annotations_typeArray, int &byte_i_ref);
+  bool rewrite_cp_refs_in_fields_annotations(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_nest_attributes(InstanceKlass* scratch_class);
-  bool rewrite_cp_refs_in_record_attribute(InstanceKlass* scratch_class, TRAPS);
+  bool rewrite_cp_refs_in_record_attribute(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_permitted_subclasses_attribute(InstanceKlass* scratch_class);
+
   void rewrite_cp_refs_in_method(methodHandle method,
     methodHandle * new_method_p, TRAPS);
   bool rewrite_cp_refs_in_methods(InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_methods_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_methods_default_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_methods_parameter_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_class_type_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_fields_type_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  bool rewrite_cp_refs_in_methods_type_annotations(
-    InstanceKlass* scratch_class, TRAPS);
-  void rewrite_cp_refs_in_stack_map_table(const methodHandle& method, TRAPS);
+
+  bool rewrite_cp_refs_in_methods_annotations(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_methods_default_annotations(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_methods_parameter_annotations(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_class_type_annotations(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_fields_type_annotations(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_methods_type_annotations(InstanceKlass* scratch_class);
+
+  void rewrite_cp_refs_in_stack_map_table(const methodHandle& method);
   void rewrite_cp_refs_in_verification_type_info(
          address& stackmap_addr_ref, address stackmap_end, u2 frame_i,
-         u1 frame_size, TRAPS);
+         u1 frame_size);
   void set_new_constant_pool(ClassLoaderData* loader_data,
          InstanceKlass* scratch_class,
          constantPoolHandle scratch_cp, int scratch_cp_length, TRAPS);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -400,7 +400,7 @@ class VM_RedefineClasses: public VM_Operation {
   // Constant pool merging work is done here as needed. Also calls
   // compare_and_normalize_class_versions() to verify the class
   // definition(s).
-  jvmtiError load_new_class_versions(TRAPS);
+  jvmtiError load_new_class_versions();
 
   // Verify that the caller provided class definition(s) that meet
   // the restrictions of RedefineClasses. Normalize the order of
@@ -455,7 +455,7 @@ class VM_RedefineClasses: public VM_Operation {
   u2 rewrite_cp_ref_in_annotation_data(
     AnnotationArray* annotations_typeArray, int &byte_i_ref,
     const char * trace_mesg);
-  bool rewrite_cp_refs(InstanceKlass* scratch_class, TRAPS);
+  bool rewrite_cp_refs(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_annotation_struct(
     AnnotationArray* class_annotations, int &byte_i_ref);
   bool rewrite_cp_refs_in_annotations_typeArray(
@@ -481,7 +481,7 @@ class VM_RedefineClasses: public VM_Operation {
 
   void rewrite_cp_refs_in_method(methodHandle method,
     methodHandle * new_method_p, TRAPS);
-  bool rewrite_cp_refs_in_methods(InstanceKlass* scratch_class, TRAPS);
+  bool rewrite_cp_refs_in_methods(InstanceKlass* scratch_class);
 
   bool rewrite_cp_refs_in_methods_annotations(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_methods_default_annotations(InstanceKlass* scratch_class);


### PR DESCRIPTION
Removed the TRAPS in function declarations in jvmtiRedefineClasses and in ConstantPool merging functions.
Tested with vmTestbase/nsk/jvmti and tier1 (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264004](https://bugs.openjdk.java.net/browse/JDK-8264004): Don't use TRAPS if no exceptions are thrown


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to 36006162854f8fa68976502c1acc135bc5ec8255
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 9134ce0b5dec738c94386b17e3fc702d1e26d15c


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3141/head:pull/3141`
`$ git checkout pull/3141`

To update a local copy of the PR:
`$ git checkout pull/3141`
`$ git pull https://git.openjdk.java.net/jdk pull/3141/head`
