### PR TITLE
8264008: Incorrect metaspace statistics after JEP 387 when UseCompressedClassPointers is off

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -71,7 +71,7 @@ size_t MetaspaceUtils::used_words() {
 }
 
 size_t MetaspaceUtils::used_words(Metaspace::MetadataType mdtype) {
-  return Metaspace::is_class_space_allocation(mdtype) ? RunningCounters::used_words_class() : RunningCounters::used_words_nonclass();
+  return mdtype == Metaspace::ClassType ? RunningCounters::used_words_class() : RunningCounters::used_words_nonclass();
 }
 
 size_t MetaspaceUtils::reserved_words() {
@@ -79,7 +79,7 @@ size_t MetaspaceUtils::reserved_words() {
 }
 
 size_t MetaspaceUtils::reserved_words(Metaspace::MetadataType mdtype) {
-  return Metaspace::is_class_space_allocation(mdtype) ? RunningCounters::reserved_words_class() : RunningCounters::reserved_words_nonclass();
+  return mdtype == Metaspace::ClassType ? RunningCounters::reserved_words_class() : RunningCounters::reserved_words_nonclass();
 }
 
 size_t MetaspaceUtils::committed_words() {
@@ -87,7 +87,7 @@ size_t MetaspaceUtils::committed_words() {
 }
 
 size_t MetaspaceUtils::committed_words(Metaspace::MetadataType mdtype) {
-  return Metaspace::is_class_space_allocation(mdtype) ? RunningCounters::committed_words_class() : RunningCounters::committed_words_nonclass();
+  return mdtype == Metaspace::ClassType ? RunningCounters::committed_words_class() : RunningCounters::committed_words_nonclass();
 }
 
 void MetaspaceUtils::print_metaspace_change(const metaspace::MetaspaceSizesSnapshot& pre_meta_values) {

--- a/test/jdk/jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java
+++ b/test/jdk/jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java
@@ -39,10 +39,10 @@ import jdk.test.lib.jfr.GCHelper;
  * @test
  * @bug 8264008
  * @key jfr
- * @requires vm.hasJFR
+ * @requires vm.hasJFR & vm.bits == 64
  * @requires vm.gc == "Serial" | vm.gc == null
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSerialGC -XX:-UseCompressedClassPointers
+ * @run main/othervm -XX:+UseSerialGC -XX:-UseCompressedClassPointers
  *                   jdk.jfr.event.gc.heapsummary.TestHeapSummaryEventDefNewSerial
  */
 public class TestHeapSummaryEventDefNewSerial {

--- a/test/jdk/jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java
+++ b/test/jdk/jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,17 @@ import jdk.test.lib.jfr.GCHelper;
  * @requires vm.gc == "Serial" | vm.gc == null
  * @library /test/lib /test/jdk
  * @run main/othervm -XX:+UseSerialGC jdk.jfr.event.gc.heapsummary.TestHeapSummaryEventDefNewSerial
+ */
+
+/**
+ * @test
+ * @bug 8264008
+ * @key jfr
+ * @requires vm.hasJFR
+ * @requires vm.gc == "Serial" | vm.gc == null
+ * @library /test/lib /test/jdk
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSerialGC -XX:-UseCompressedClassPointers
+ *                   jdk.jfr.event.gc.heapsummary.TestHeapSummaryEventDefNewSerial
  */
 public class TestHeapSummaryEventDefNewSerial {
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

Metaspace statistics is incorrect after JEP 387 when UseCompressedClassPointers is off.

For example, here is the incorrect metaspace statistics before the fix:
```
Event:jdk.MetaspaceSummary {
  startTime = 10:35:24.762
  gcId = 3
  when = "Before GC"
  gcThreshold = 21.0 MB
  metaspace = {
    committed = 10.3 MB
    used = 10.2 MB
    reserved = 16.0 MB
  }
  dataSpace = {
    committed = 10.3 MB
    used = 10.2 MB
    reserved = 16.0 MB
  }
  classSpace = {
    committed = 10.3 MB
    used = 10.2 MB
    reserved = 16.0 MB
  }
}
```

This bug can be reproduced by running the following tests with `-XX:-UseCompressedClassPointers`, which would pass before JEP 387.
```
jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java
jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java
jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java
```

The failing reason is that `Metaspace::is_class_space_allocation(mdtype)` [1] will always return false when `UseCompressedClassPointers` is off.
So `RunningCounters::committed_words_nonclass()` will be returned even called with `Metaspace::is_class_space_allocation(Metaspace::ClassType)`, which is unreasonable.
And `MetaspaceUtils::reserved_words(Metaspace::MetadataType mdtype)`/`MetaspaceUtils::used_words(Metaspace::MetadataType mdtype)` also suffer from the same bug.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/memory/metaspace.cpp#L90


Metaspace statistics after the fix:
```
Event:jdk.MetaspaceSummary {
  startTime = 10:44:38.230
  gcId = 1
  when = "After GC"
  gcThreshold = 21.0 MB
  metaspace = {
    committed = 10.3 MB
    used = 10.2 MB
    reserved = 16.0 MB
  }
  dataSpace = {
    committed = 10.3 MB
    used = 10.2 MB
    reserved = 16.0 MB
  }
  classSpace = {
    committed = 0 bytes
    used = 0 bytes
    reserved = 0 bytes
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264008](https://bugs.openjdk.java.net/browse/JDK-8264008): Incorrect metaspace statistics after JEP 387 when UseCompressedClassPointers is off


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3142/head:pull/3142`
`$ git checkout pull/3142`

To update a local copy of the PR:
`$ git checkout pull/3142`
`$ git pull https://git.openjdk.java.net/jdk pull/3142/head`
