### PR TITLE
8263766: Confusing specification of JEditorPaneAccessibleHypertextSupport constructor

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -2061,7 +2061,7 @@ public class JEditorPane extends JTextComponent {
         }
 
         /**
-         * Make one of these puppies
+         * Constructs a {@code JEditorPaneAccessibleHypertextSupport}.
          */
         public JEditorPaneAccessibleHypertextSupport() {
             hyperlinks = new LinkVector();


### PR DESCRIPTION
The constructor JEditorPaneAccessibleHypertextSupport  javadoc wording is wrong. Rectified the anomaly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263766](https://bugs.openjdk.java.net/browse/JDK-8263766): Confusing specification of JEditorPaneAccessibleHypertextSupport constructor


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3145/head:pull/3145`
`$ git checkout pull/3145`

To update a local copy of the PR:
`$ git checkout pull/3145`
`$ git pull https://git.openjdk.java.net/jdk pull/3145/head`
