### PR TITLE
8263907: Specification of CellRendererPane::paintComponent(..Rectangle) should clearly mention which method it delegates the call to

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -200,7 +200,7 @@ public class CellRendererPane extends Container implements Accessible
 
 
     /**
-     * Calls this.paintComponent(g, c, p, r.x, r.y, r.w, r.h) where
+     * Calls this.paintComponent(g, c, p, r.x, r.y, r.width, r.height) where
      * {@code r} is the input {@code Rectangle} parameter.
      *
      * @param g  the {@code Graphics} object to draw on

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -200,8 +200,8 @@ public class CellRendererPane extends Container implements Accessible
 
 
     /**
-     * Calls this.paintComponent(g, c, p, x, y, w, h) with the input parameter
-     * {@code Rectangle} x,y,width,height fields.
+     * Calls this.paintComponent(g, c, p, r.x, r.y, r.w, r.h) where
+     * {@code r} is the input {@code Rectangle} parameter.
      *
      * @param g  the {@code Graphics} object to draw on
      * @param c  the {@code Component} to draw

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -200,7 +200,8 @@ public class CellRendererPane extends Container implements Accessible
 
 
     /**
-     * Calls this.paintComponent() with the rectangles x,y,width,height fields.
+     * Calls this.paintComponent(g, c, p, x, y, w, h) with the input parameter
+     * {@code Rectangle} x,y,width,height fields.
      *
      * @param g  the {@code Graphics} object to draw on
      * @param c  the {@code Component} to draw


### PR DESCRIPTION
Specification for method
javax/swing/CellRendererPane.html#paintComponent(java.awt.Graphics,java.awt.Component,java.awt.Container,java.awt.Rectangle)
is not perfectly clear which method the call is delegated to. 

Updated spec to clarify.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263907](https://bugs.openjdk.java.net/browse/JDK-8263907): Specification of CellRendererPane::paintComponent(..Rectangle) should clearly mention which method it delegates the call to


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to c74fbd1be743aa09c33967224d3f8252cd95b44f
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to c74fbd1be743aa09c33967224d3f8252cd95b44f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3146/head:pull/3146` \
`$ git checkout pull/3146`

Update a local copy of the PR: \
`$ git checkout pull/3146` \
`$ git pull https://git.openjdk.java.net/jdk pull/3146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3146`

View PR using the GUI difftool: \
`$ git pr show -t 3146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3146.diff">https://git.openjdk.java.net/jdk/pull/3146.diff</a>

</details>
