### PR TITLE
8263496: MetalHighContrastTheme.getControlHighlight cleanup

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalHighContrastTheme.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalHighContrastTheme.java
@@ -51,8 +51,6 @@ class MetalHighContrastTheme extends DefaultMetalTheme {
                               204, 204, 204);
     private static final ColorUIResource secondary3 = new ColorUIResource(
                               255, 255, 255);
-    private static final ColorUIResource controlHighlight = new
-                              ColorUIResource(102, 102, 102);
 
 
     // This does not override getSecondary1 (102,102,102)


### PR DESCRIPTION
SonarCloud reports the potential issue with MetalHighContrastTheme.getControlHighlight where `controlHighlight ` field is not used and the getControlHighlight() uses secondary field.
```
public ColorUIResource getControlHighlight() {
        // This was super.getSecondary3();
        return secondary2;
    } 
```
Removed the unused field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263496](https://bugs.openjdk.java.net/browse/JDK-8263496): MetalHighContrastTheme.getControlHighlight cleanup


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3149/head:pull/3149`
`$ git checkout pull/3149`

To update a local copy of the PR:
`$ git checkout pull/3149`
`$ git pull https://git.openjdk.java.net/jdk pull/3149/head`
