### PR TITLE
8254196: jshell infinite loops when startup script contains System.exit call

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1165,7 +1165,11 @@ public class JShellTool implements MessageHandler {
     //where
     private void startUpRun(String start) {
         try (IOContext suin = new ScannerIOContext(new StringReader(start))) {
-            run(suin);
+            while (run(suin)) {
+                if (!live) {
+                    resetState();
+                }
+            }
         } catch (Exception ex) {
             errormsg("jshell.err.startup.unexpected.exception", ex);
             ex.printStackTrace(cmderr);
@@ -1187,8 +1191,10 @@ public class JShellTool implements MessageHandler {
      * Main loop
      *
      * @param in the line input/editing context
+     * @return true iff something remains in the input after this method finishes
+     *              (e.g. due to live == false).
      */
-    private void run(IOContext in) {
+    private boolean run(IOContext in) {
         IOContext oldInput = input;
         input = in;
         try {
@@ -1202,11 +1208,13 @@ public class JShellTool implements MessageHandler {
             }
         } catch (EOFException ex) {
             // Just exit loop
+            return false;
         } catch (IOException ex) {
             errormsg("jshell.err.unexpected.exception", ex);
         } finally {
             input = oldInput;
         }
+        return true;
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/StreamingExecutionControl.java
@@ -24,6 +24,7 @@
  */
 package jdk.jshell.execution;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -341,6 +342,8 @@ public class StreamingExecutionControl implements ExecutionControl {
                     throw new EngineTerminationException("Bad remote result code: " + status);
                 }
             }
+        } catch (EOFException ex) {
+            throw new EngineTerminationException("Terminated.");
         } catch (IOException | ClassNotFoundException ex) {
             ex.printStackTrace();
             throw new EngineTerminationException(ex.toString());

--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8143037 8142447 8144095 8140265 8144906 8146138 8147887 8147886 8148316 8148317 8143955 8157953 8080347 8154714 8166649 8167643 8170162 8172102 8165405 8174796 8174797 8175304 8167554 8180508 8166232 8196133 8199912 8211694 8223688
+ * @bug 8143037 8142447 8144095 8140265 8144906 8146138 8147887 8147886 8148316 8148317 8143955 8157953 8080347 8154714 8166649 8167643 8170162 8172102 8165405 8174796 8174797 8175304 8167554 8180508 8166232 8196133 8199912 8211694 8223688 8254196
  * @summary Tests for Basic tests for REPL tool
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -48,6 +48,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Scanner;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -889,4 +890,16 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    public void testSystemExitStartUp() {
+        Compiler compiler = new Compiler();
+        Path startup = compiler.getPath("SystemExitStartUp/startup.txt");
+        compiler.writeToFile(startup, "int i1 = 0;\n" +
+                                      "System.exit(0);\n" +
+                                      "int i2 = 0;\n");
+        test(Locale.ROOT, true, new String[]{"--startup", startup.toString()},
+                "State engine terminated.",
+                (a) -> assertCommand(a, "i2", "i2 ==> 0"),
+                (a) -> assertCommandOutputContains(a, "i1", "Error:", "variable i1")
+        );
+    }
 }


### PR DESCRIPTION
If the startup script contains `System.exit(0);`, JShell will end up in an infinite loop of remote agent crashing, restarting, startup script running on the new instance, crashing, etc.

The proposal here is to avoid re-running the script from the beginning after the remote stops during startup. This should be fairly consistent with behavior of options like "/reload". Behavior in other cases should be unmodified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254196](https://bugs.openjdk.java.net/browse/JDK-8254196): jshell infinite loops when startup script contains System.exit call


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3150/head:pull/3150`
`$ git checkout pull/3150`

To update a local copy of the PR:
`$ git checkout pull/3150`
`$ git pull https://git.openjdk.java.net/jdk pull/3150/head`
