### PR TITLE
8263984: Invalidate printServices when there are no printers

### DIFF
--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -156,7 +156,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
         if (printServices != null) {
             for (int j=0; j < printServices.length; j++) {
                 if ((printServices[j] instanceof Win32PrintService) &&
-                            (!printServices[j].equals(defaultPrintService))) {
+                    (!printServices[j].equals(defaultPrintService))) {
                     ((Win32PrintService)printServices[j]).invalidateService();
                 }
             }

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -157,6 +157,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
             for (int j=0; j < printServices.length; j++) {
                 if ((printServices[j] instanceof Win32PrintService) &&
                     (!printServices[j].equals(defaultPrintService))) {
+
                     ((Win32PrintService)printServices[j]).invalidateService();
                 }
             }

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -116,6 +116,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
         if (printers == null) {
             // In Windows it is safe to assume no default if printers == null so we
             // don't get the default.
+            invalidateServices();
             printServices = new PrintService[0];
             return;
         }
@@ -146,16 +147,20 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
             }
         }
 
+        invalidateServices();
+        printServices = newServices;
+    }
+
+    private void invalidateServices() {
         // Look for deleted services and invalidate these
         if (printServices != null) {
             for (int j=0; j < printServices.length; j++) {
                 if ((printServices[j] instanceof Win32PrintService) &&
-                    (!printServices[j].equals(defaultPrintService))) {
+                            (!printServices[j].equals(defaultPrintService))) {
                     ((Win32PrintService)printServices[j]).invalidateService();
                 }
             }
         }
-        printServices = newServices;
     }
 
 


### PR DESCRIPTION
When `getAllPrinterNames()` returns null, the list of `printServices` is assigned a new empty array without invalidating old services which were in the array before.

The old print services should be invalidated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263984](https://bugs.openjdk.java.net/browse/JDK-8263984): Invalidate printServices when there are no printers


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3151/head:pull/3151` \
`$ git checkout pull/3151`

Update a local copy of the PR: \
`$ git checkout pull/3151` \
`$ git pull https://git.openjdk.java.net/jdk pull/3151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3151`

View PR using the GUI difftool: \
`$ git pr show -t 3151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3151.diff">https://git.openjdk.java.net/jdk/pull/3151.diff</a>

</details>
