### PR TITLE
8264050: Remove unused field VM_HeapWalkOperation::_collecting_heap_roots

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2376,7 +2376,6 @@ class VM_HeapWalkOperation: public VM_Operation {
   Handle _initial_object;
   GrowableArray<oop>* _visit_stack;                 // the visit stack
 
-  bool _collecting_heap_roots;                      // are we collecting roots
   bool _following_object_refs;                      // are we following object references
 
   bool _reporting_primitive_fields;                 // optional reporting


### PR DESCRIPTION
SonarCloud reports field `_collecting_heap_roots` is not initialized after constructor ends. In fact, that field is not used anywhere. It was like that since the initial load. We can trivially remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264050](https://bugs.openjdk.java.net/browse/JDK-8264050): Remove unused field VM_HeapWalkOperation::_collecting_heap_roots


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3153/head:pull/3153`
`$ git checkout pull/3153`

To update a local copy of the PR:
`$ git checkout pull/3153`
`$ git pull https://git.openjdk.java.net/jdk pull/3153/head`
