### PR TITLE
8264026: Remove dependency between free collection set and eagerly reclaim humongous object tasks

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3979,6 +3979,8 @@ void G1CollectedHeap::post_evacuate_collection_set(G1EvacuationInfo& evacuation_
 
   eagerly_reclaim_humongous_regions();
 
+  rebuild_free_region_list();
+
   record_obj_copy_mem_stats();
 
   evacuation_info.set_collectionset_used_before(collection_set()->bytes_used_before());
@@ -4029,7 +4031,6 @@ void G1CollectedHeap::free_region(HeapRegion* hr, FreeRegionList* free_list) {
 void G1CollectedHeap::free_humongous_region(HeapRegion* hr,
                                             FreeRegionList* free_list) {
   assert(hr->is_humongous(), "this is only for humongous regions");
-  assert(free_list != NULL, "pre-condition");
   hr->clear_humongous();
   free_region(hr, free_list);
 }
@@ -4181,6 +4182,7 @@ class G1FreeCollectionSetTask : public AbstractGangTask {
 
       // Free the region and and its remembered set.
       _g1h->free_region(r, NULL);
+      _g1h->hr_printer()->cleanup(r);
     }
 
     void handle_failed_region(HeapRegion* r) {
@@ -4330,21 +4332,17 @@ void G1CollectedHeap::free_collection_set(G1CollectionSet* collection_set, G1Eva
   Ticks free_cset_end_time = Ticks::now();
   phase_times()->record_total_free_cset_time_ms((free_cset_end_time - free_cset_start_time).seconds() * 1000.0);
 
-  // Now rebuild the free region list.
-  _hrm.rebuild_free_list(workers());
-  phase_times()->record_total_rebuild_freelist_time_ms((Ticks::now() - free_cset_end_time).seconds() * 1000.0);
-
   collection_set->clear();
 }
 
 class G1FreeHumongousRegionClosure : public HeapRegionClosure {
- private:
+private:
   FreeRegionList* _free_region_list;
   HeapRegionSet* _proxy_set;
   uint _humongous_objects_reclaimed;
   uint _humongous_regions_reclaimed;
   size_t _freed_bytes;
- public:
+public:
 
   G1FreeHumongousRegionClosure(FreeRegionList* free_region_list) :
     _free_region_list(free_region_list), _proxy_set(NULL), _humongous_objects_reclaimed(0), _humongous_regions_reclaimed(0), _freed_bytes(0) {
@@ -4479,11 +4477,17 @@ void G1CollectedHeap::eagerly_reclaim_humongous_regions() {
     }
   }
 
-  prepend_to_freelist(&local_cleanup_list);
   decrement_summary_bytes(cl.bytes_freed());
 
   phase_times()->record_fast_reclaim_humongous_time_ms((os::elapsedTime() - start_time) * 1000.0,
                                                        cl.humongous_objects_reclaimed());
+}
+
+void G1CollectedHeap::rebuild_free_region_list() {
+  Ticks start = Ticks::now();
+  // Now rebuild the free region list.
+  _hrm.rebuild_free_list(workers());
+  phase_times()->record_total_rebuild_freelist_time_ms((Ticks::now() - start).seconds() * 1000.0);
 }
 
 class G1AbandonCollectionSetClosure : public HeapRegionClosure {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -4031,6 +4031,7 @@ void G1CollectedHeap::free_region(HeapRegion* hr, FreeRegionList* free_list) {
 void G1CollectedHeap::free_humongous_region(HeapRegion* hr,
                                             FreeRegionList* free_list) {
   assert(hr->is_humongous(), "this is only for humongous regions");
+  assert(free_list != NULL, "pre-condition");
   hr->clear_humongous();
   free_region(hr, free_list);
 }
@@ -4182,7 +4183,6 @@ class G1FreeCollectionSetTask : public AbstractGangTask {
 
       // Free the region and and its remembered set.
       _g1h->free_region(r, NULL);
-      _g1h->hr_printer()->cleanup(r);
     }
 
     void handle_failed_region(HeapRegion* r) {
@@ -4485,7 +4485,6 @@ void G1CollectedHeap::eagerly_reclaim_humongous_regions() {
 
 void G1CollectedHeap::rebuild_free_region_list() {
   Ticks start = Ticks::now();
-  // Now rebuild the free region list.
   _hrm.rebuild_free_list(workers());
   phase_times()->record_total_rebuild_freelist_time_ms((Ticks::now() - start).seconds() * 1000.0);
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -172,6 +172,8 @@ private:
   HeapRegionSet _humongous_set;
 
   void eagerly_reclaim_humongous_regions();
+
+  void rebuild_free_region_list();
   // Start a new incremental collection set for the next pause.
   void start_new_collection_set();
 

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -114,11 +114,14 @@ G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1Fu
 void G1FullGCPrepareTask::G1CalculatePointersClosure::free_humongous_region(HeapRegion* hr) {
   assert(hr->is_humongous(), "must be but region %u is %s", hr->hrm_index(), hr->get_short_type_str());
 
+  FreeRegionList dummy_free_list("Humongous Dummy Free List for G1MarkSweep");
+
   hr->set_containing_set(NULL);
   _regions_freed = true;
 
-  _g1h->free_humongous_region(hr, NULL);
+  _g1h->free_humongous_region(hr, &dummy_free_list);
   prepare_for_compaction(hr);
+  dummy_free_list.remove_all();
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::free_open_archive_region(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -114,14 +114,11 @@ G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1Fu
 void G1FullGCPrepareTask::G1CalculatePointersClosure::free_humongous_region(HeapRegion* hr) {
   assert(hr->is_humongous(), "must be but region %u is %s", hr->hrm_index(), hr->get_short_type_str());
 
-  FreeRegionList dummy_free_list("Humongous Dummy Free List for G1MarkSweep");
-
   hr->set_containing_set(NULL);
   _regions_freed = true;
 
-  _g1h->free_humongous_region(hr, &dummy_free_list);
+  _g1h->free_humongous_region(hr, NULL);
   prepare_for_compaction(hr);
-  dummy_free_list.remove_all();
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::free_open_archive_region(HeapRegion* hr) {


### PR DESCRIPTION
Hi,

  I am currently working on [JDK-8214237](https://bugs.openjdk.java.net/browse/JDK-8214237) to merge some phases from `G1CollectedHeap::post_evacuate_collection_set()` into less parallel phases.

While investigating dependencies I found that `free_collection_set` and `eagerly_reclaim_humongous_regions` have a dependency: `free_collection_set` rebuilds the free list at the end (in another parallel phase :( ), and `eagerly_reclaim_humongous_regions` adds to those regions.

This dependency is unnecessary: just move the rebuilding of the free list after eagerly reclaiming humongous regions, and neither needs to care about updating the free regions list. 

Testing: hs-tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264026](https://bugs.openjdk.java.net/browse/JDK-8264026): Remove dependency between free collection set and eagerly reclaim humongous object tasks


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3154/head:pull/3154`
`$ git checkout pull/3154`

To update a local copy of the PR:
`$ git checkout pull/3154`
`$ git pull https://git.openjdk.java.net/jdk pull/3154/head`
