### PR TITLE
8264047: Duplicate global variable 'jvm' in libjavajpeg and libawt

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -85,7 +85,7 @@ static jfieldID JPEGHuffmanTable_valuesID;
 /*
  * Defined in jpegdecoder.c.  Copy code from there if and
  * when that disappears. */
-extern JavaVM *jvm;
+extern JavaVM *the_jvm;
 
 /*
  * The following sets of defines must match the warning messages in the
@@ -557,7 +557,7 @@ sun_jpeg_output_message (j_common_ptr cinfo)
     char buffer[JMSG_LENGTH_MAX];
     jstring string;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     jobject theObject;
 
     /* Create the message */
@@ -928,7 +928,7 @@ imageio_fill_input_buffer(j_decompress_ptr cinfo)
     struct jpeg_source_mgr *src = cinfo->src;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     int ret;
     jobject input = NULL;
 
@@ -1021,7 +1021,7 @@ imageio_fill_suspended_buffer(j_decompress_ptr cinfo)
     struct jpeg_source_mgr *src = cinfo->src;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     jint ret;
     size_t offset, buflen;
     jobject input = NULL;
@@ -1122,7 +1122,7 @@ imageio_skip_input_data(j_decompress_ptr cinfo, long num_bytes)
     struct jpeg_source_mgr *src = cinfo->src;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     jlong ret;
     jobject reader;
     jobject input = NULL;
@@ -1207,7 +1207,7 @@ imageio_term_source(j_decompress_ptr cinfo)
     // To pushback, just seek back by src->bytes_in_buffer
     struct jpeg_source_mgr *src = cinfo->src;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     jobject reader = data->imageIOobj;
     if (src->bytes_in_buffer > 0) {
          RELEASE_ARRAYS(env, data, src->next_input_byte);
@@ -2369,7 +2369,7 @@ imageio_init_destination (j_compress_ptr cinfo)
     struct jpeg_destination_mgr *dest = cinfo->dest;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
 
     if (sb->buf == NULL) {
         // We forgot to pin the array
@@ -2395,7 +2395,7 @@ imageio_empty_output_buffer (j_compress_ptr cinfo)
     struct jpeg_destination_mgr *dest = cinfo->dest;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     jobject output = NULL;
 
     RELEASE_ARRAYS(env, data, (const JOCTET *)(dest->next_output_byte));
@@ -2431,7 +2431,7 @@ imageio_term_destination (j_compress_ptr cinfo)
     struct jpeg_destination_mgr *dest = cinfo->dest;
     imageIODataPtr data = (imageIODataPtr) cinfo->client_data;
     streamBufferPtr sb = &data->streamBuf;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
 
     /* find out how much needs to be written */
     /* this conversion from size_t to jint is safe, because the lenght of the buffer is limited by jint */

--- a/src/java.desktop/share/native/libjavajpeg/jpegdecoder.c
+++ b/src/java.desktop/share/native/libjavajpeg/jpegdecoder.c
@@ -64,12 +64,12 @@ static jmethodID InputStream_availableID;
 
 /* Initialize the Java VM instance variable when the library is
    first loaded */
-JavaVM *jvm;
+JavaVM *the_jvm;
 
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 {
-    jvm = vm;
+    the_jvm = vm;
     return JNI_VERSION_1_2;
 }
 
@@ -284,7 +284,7 @@ GLOBAL(boolean)
 sun_jpeg_fill_input_buffer(j_decompress_ptr cinfo)
 {
     sun_jpeg_source_ptr src = (sun_jpeg_source_ptr) cinfo->src;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     int ret, buflen;
 
     if (src->suspendable) {
@@ -327,7 +327,7 @@ GLOBAL(void)
 sun_jpeg_fill_suspended_buffer(j_decompress_ptr cinfo)
 {
     sun_jpeg_source_ptr src = (sun_jpeg_source_ptr) cinfo->src;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     size_t offset, buflen;
     int ret;
 
@@ -397,7 +397,7 @@ GLOBAL(void)
 sun_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes)
 {
     sun_jpeg_source_ptr src = (sun_jpeg_source_ptr) cinfo->src;
-    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
     int ret;
     int buflen;
 


### PR DESCRIPTION
The suggestion is to rename 'jvm' variable in `libjavajpeg` to `the_jvm` so this conflict no longer occurs when `libjavajpeg.a` and `libawt.a` are being linked into one native image.

Testing: test/jdk/javax/imageio jtreg tests. GHA pre-integration tests running too.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264047](https://bugs.openjdk.java.net/browse/JDK-8264047): Duplicate global variable 'jvm' in libjavajpeg and libawt


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3155/head:pull/3155` \
`$ git checkout pull/3155`

Update a local copy of the PR: \
`$ git checkout pull/3155` \
`$ git pull https://git.openjdk.java.net/jdk pull/3155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3155`

View PR using the GUI difftool: \
`$ git pr show -t 3155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3155.diff">https://git.openjdk.java.net/jdk/pull/3155.diff</a>

</details>
