### PR TITLE
8264052: Shenandoah: Backout 8263832

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -96,19 +96,23 @@ class ShenandoahSATBAndRemarkThreadsClosure : public ThreadClosure {
 private:
   SATBMarkQueueSet& _satb_qset;
   OopClosure* const _cl;
+  uintx _claim_token;
 
 public:
   ShenandoahSATBAndRemarkThreadsClosure(SATBMarkQueueSet& satb_qset, OopClosure* cl) :
     _satb_qset(satb_qset),
-    _cl(cl) {}
+    _cl(cl),
+    _claim_token(Threads::thread_claim_token()) {}
 
   void do_thread(Thread* thread) {
-    // Transfer any partial buffer to the qset for completed buffer processing.
-    _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
-    if (thread->is_Java_thread()) {
-      if (_cl != NULL) {
-        ResourceMark rm;
-        thread->oops_do(_cl, NULL);
+    if (thread->claim_threads_do(true, _claim_token)) {
+      // Transfer any partial buffer to the qset for completed buffer processing.
+      _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
+      if (thread->is_Java_thread()) {
+        if (_cl != NULL) {
+          ResourceMark rm;
+          thread->oops_do(_cl, NULL);
+        }
       }
     }
   }
@@ -143,7 +147,7 @@ public:
       ShenandoahMarkRefsClosure mark_cl(q, rp);
       ShenandoahSATBAndRemarkThreadsClosure tc(satb_mq_set,
                                                ShenandoahIUBarrier ? &mark_cl : NULL);
-      Threads::possibly_parallel_threads_do(true /*par*/, &tc);
+      Threads::threads_do(&tc);
     }
 
     _cm->mark_loop(worker_id, _terminator, rp,


### PR DESCRIPTION
TestStringDedupStress started to fail after JDK-8263832. 

JDK-8263832 is incorrect, because Threads::possibly_parallel_threads_do() only iterates over Java and VM threads, it should be backed out. The original works correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264052](https://bugs.openjdk.java.net/browse/JDK-8264052): Shenandoah: Backout 8263832


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3158/head:pull/3158`
`$ git checkout pull/3158`

To update a local copy of the PR:
`$ git checkout pull/3158`
`$ git pull https://git.openjdk.java.net/jdk pull/3158/head`
