### PR TITLE
8264040: Simplify the partial obj size calculation in ParallelCompactData::add_obj

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -534,6 +534,7 @@ void ParallelCompactData::add_obj(HeapWord* addr, size_t len)
 {
   const size_t obj_ofs = pointer_delta(addr, _region_start);
   const size_t beg_region = obj_ofs >> Log2RegionSize;
+  // end_region is inclusive
   const size_t end_region = (obj_ofs + len - 1) >> Log2RegionSize;
 
   DEBUG_ONLY(Atomic::inc(&add_obj_count);)
@@ -557,8 +558,8 @@ void ParallelCompactData::add_obj(HeapWord* addr, size_t len)
   }
 
   // Last region.
-  const size_t end_ofs = region_offset(addr + len - 1);
-  _region_data[end_region].set_partial_obj_size(end_ofs + 1);
+  const size_t end_ofs = region_offset(addr + len);
+  _region_data[end_region].set_partial_obj_size(end_ofs);
   _region_data[end_region].set_partial_obj_addr(addr);
 }
 


### PR DESCRIPTION
Remove unnecessary "off by one" adjustment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264040](https://bugs.openjdk.java.net/browse/JDK-8264040): Simplify the partial obj size calculation in ParallelCompactData::add_obj


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3160/head:pull/3160`
`$ git checkout pull/3160`

To update a local copy of the PR:
`$ git checkout pull/3160`
`$ git pull https://git.openjdk.java.net/jdk pull/3160/head`
