### PR TITLE
8264062: Use the blessed modifier order in jdk.jfr

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Enabled.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Enabled.java
@@ -47,7 +47,7 @@ public @interface Enabled {
      * Setting name {@code "enabled"}, signifies that the event should be
      * recorded.
      */
-    public final static String NAME = "enabled";
+    public static final String NAME = "enabled";
 
     /**
      * Returns {@code true} if by default the event should be enabled, {@code false} otherwise.

--- a/src/jdk.jfr/share/classes/jdk/jfr/Event.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Event.java
@@ -86,7 +86,7 @@ package jdk.jfr;
 @Enabled(true)
 @StackTrace(true)
 @Registered(true)
-abstract public class Event extends jdk.internal.event.Event {
+public abstract class Event extends jdk.internal.event.Event {
     /**
      * Sole constructor, for invocation by subclass constructors, typically
      * implicit.
@@ -98,7 +98,7 @@ abstract public class Event extends jdk.internal.event.Event {
      * Starts the timing of this event.
      */
     @Override
-    final public void begin() {
+    public final void begin() {
     }
 
     /**
@@ -107,7 +107,7 @@ abstract public class Event extends jdk.internal.event.Event {
      * The {@code end} method must be invoked after the {@code begin} method.
      */
     @Override
-    final public void end() {
+    public final void end() {
     }
 
     /**
@@ -119,7 +119,7 @@ abstract public class Event extends jdk.internal.event.Event {
      * ends when the {@code commit} method is invoked.
      */
     @Override
-    final public void commit() {
+    public final void commit() {
     }
 
     /**
@@ -130,7 +130,7 @@ abstract public class Event extends jdk.internal.event.Event {
      * @return {@code true} if event is enabled, {@code false} otherwise
      */
     @Override
-    final public boolean isEnabled() {
+    public final boolean isEnabled() {
         return false;
     }
 
@@ -144,7 +144,7 @@ abstract public class Event extends jdk.internal.event.Event {
      *         system, {@code false} otherwise
      */
     @Override
-    final public boolean shouldCommit() {
+    public final boolean shouldCommit() {
         return false;
     }
 
@@ -170,6 +170,6 @@ abstract public class Event extends jdk.internal.event.Event {
      * @see EventFactory
      */
     @Override
-    final public void set(int index, Object value) {
+    public final void set(int index, Object value) {
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/EventSettings.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventSettings.java
@@ -88,7 +88,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    final public EventSettings withStackTrace() {
+    public final EventSettings withStackTrace() {
         return with(StackTrace.NAME, "true");
     }
 
@@ -99,7 +99,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    final public EventSettings withoutStackTrace() {
+    public final EventSettings withoutStackTrace() {
         return with(StackTrace.NAME, "false");
     }
 
@@ -111,7 +111,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    final public EventSettings withoutThreshold() {
+    public final EventSettings withoutThreshold() {
         return with(Threshold.NAME, "0 s");
     }
 
@@ -122,7 +122,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    final public EventSettings withPeriod(Duration duration) {
+    public final EventSettings withPeriod(Duration duration) {
         return with(Period.NAME, duration.toNanos() + " ns");
     }
 
@@ -133,7 +133,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    final public EventSettings withThreshold(Duration duration) {
+    public final EventSettings withThreshold(Duration duration) {
         if (duration == null) {
             return with(Threshold.NAME, "0 ns");
         } else {
@@ -151,7 +151,7 @@ public abstract class EventSettings {
      *
      * @return event settings object for further configuration, not {@code null}
      */
-    abstract public EventSettings with(String name, String value);
+    public abstract EventSettings with(String name, String value);
 
     /**
      * Creates a settings {@code Map} for the event that is associated with this

--- a/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorderPermission.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorderPermission.java
@@ -104,7 +104,7 @@ public final class FlightRecorderPermission extends java.security.BasicPermissio
         PrivateAccess.setPrivateAccess(new InternalAccess());
     }
 
-    private final static class InternalAccess extends PrivateAccess {
+    private static final class InternalAccess extends PrivateAccess {
 
         @Override
         public Type getType(Object o) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/Period.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Period.java
@@ -44,7 +44,7 @@ public @interface Period {
     /**
      * Settings name {@code "period"} for configuring periodic events
      */
-    public final static String NAME = "period";
+    public static final String NAME = "period";
 
     /**
      * Returns the default setting value for a periodic setting.

--- a/src/jdk.jfr/share/classes/jdk/jfr/StackTrace.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/StackTrace.java
@@ -45,7 +45,7 @@ public @interface StackTrace {
     /**
      * Settings name {@code "stackTrace"} to be used for enabling event stack traces.
      */
-    public final static String NAME = "stackTrace";
+    public static final String NAME = "stackTrace";
 
     /**
      * Returns if the stack trace from the {@code Event#commit()} method should be recorded.

--- a/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
@@ -45,7 +45,7 @@ public @interface Threshold {
     /**
      * Setting name {@code "threshold"} for configuring event thresholds.
      */
-    public final static String NAME = "threshold";
+    public static final String NAME = "threshold";
 
     /**
      * The threshold (for example, {@code "20 ms"}).

--- a/src/jdk.jfr/share/classes/jdk/jfr/Timestamp.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Timestamp.java
@@ -46,13 +46,13 @@ public @interface Timestamp {
      * The unit for the difference, measured in milliseconds, between the current
      * time and midnight, January 1, 1970 UTC.
      */
-    public final static String MILLISECONDS_SINCE_EPOCH = "MILLISECONDS_SINCE_EPOCH";
+    public static final String MILLISECONDS_SINCE_EPOCH = "MILLISECONDS_SINCE_EPOCH";
 
     /**
      * The unit for the number of ticks that have transpired since some arbitrary
      * starting date.
      */
-    public final static String TICKS = "TICKS";
+    public static final String TICKS = "TICKS";
 
     /**
      * Unit for the time stamp.

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -150,7 +150,7 @@ public class RecordedObject {
         JdkJfrConsumer.setAccess(access);
     }
 
-    private final static class UnsignedValue {
+    private static final class UnsignedValue {
         private final Object o;
 
         UnsignedValue(Object o) {
@@ -261,7 +261,7 @@ public class RecordedObject {
      * @see #hasField(String)
      *
      */
-    final public <T> T getValue(String name) {
+    public final <T> T getValue(String name) {
         @SuppressWarnings("unchecked")
         T t = (T) getValue(name, false);
         return t;
@@ -978,7 +978,7 @@ public class RecordedObject {
      * @return textual description of this object
      */
     @Override
-    final public String toString() {
+    public final String toString() {
         StringWriter s = new StringWriter();
         PrettyWriter p = new PrettyWriter(new PrintWriter(s));
         p.setStackDepth(5);

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -67,7 +67,7 @@ import jdk.jfr.internal.consumer.EventDirectoryStream;
  */
 public final class RecordingStream implements AutoCloseable, EventStream {
 
-    final static class ChunkConsumer implements Consumer<Long> {
+    static final class ChunkConsumer implements Consumer<Long> {
 
         private final Recording recording;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/Handlers.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/Handlers.java
@@ -28,11 +28,11 @@ import jdk.jfr.internal.handlers.EventHandler;
 import jdk.jfr.internal.Utils;
 
 public final class Handlers {
-    public final static EventHandler SOCKET_READ = Utils.getHandler(SocketReadEvent.class);
-    public final static EventHandler SOCKET_WRITE = Utils.getHandler(SocketWriteEvent.class);
-    public final static EventHandler FILE_READ = Utils.getHandler(FileReadEvent.class);
-    public final static EventHandler FILE_WRITE = Utils.getHandler(FileWriteEvent.class);
-    public final static EventHandler FILE_FORCE = Utils.getHandler(FileForceEvent.class);
-    public final static EventHandler ERROR_THROWN = Utils.getHandler(ErrorThrownEvent.class);
-    public final static EventHandler EXCEPTION_THROWN = Utils.getHandler(ExceptionThrownEvent.class);
+    public static final EventHandler SOCKET_READ = Utils.getHandler(SocketReadEvent.class);
+    public static final EventHandler SOCKET_WRITE = Utils.getHandler(SocketWriteEvent.class);
+    public static final EventHandler FILE_READ = Utils.getHandler(FileReadEvent.class);
+    public static final EventHandler FILE_WRITE = Utils.getHandler(FileWriteEvent.class);
+    public static final EventHandler FILE_FORCE = Utils.getHandler(FileForceEvent.class);
+    public static final EventHandler ERROR_THROWN = Utils.getHandler(ErrorThrownEvent.class);
+    public static final EventHandler EXCEPTION_THROWN = Utils.getHandler(ExceptionThrownEvent.class);
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
@@ -38,7 +38,7 @@ import jdk.jfr.internal.settings.JDKSettingControl;
 
 public final class Control {
     private final AccessControlContext context;
-    private final static int CACHE_SIZE = 5;
+    private static final int CACHE_SIZE = 5;
     private final Set<?>[] cachedUnions = new HashSet<?>[CACHE_SIZE];
     private final String[] cachedValues = new String[CACHE_SIZE];
     private final SettingControl delegate;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Cutoff.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Cutoff.java
@@ -49,8 +49,8 @@ public @interface Cutoff {
     /**
      * Settings name {@code "cutoff"} for configuring event cutoffs.
      */
-    public final static String NAME = "cutoff";
-    public final static String INFINITY = "infinity";
+    public static final String NAME = "cutoff";
+    public static final String INFINITY = "infinity";
 
     /**
      * Cutoff, for example {@code "20 ms"}.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -56,7 +56,7 @@ import jdk.jfr.internal.settings.ThrottleSetting;
 // holds SettingControl instances that need to be released
 // when a class is unloaded (to avoid memory leaks).
 public final class EventControl {
-    final static class NamedControl {
+    static final class NamedControl {
         public final String name;
         public final Control control;
         NamedControl(String name, Control control) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventHandlerCreator.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventHandlerCreator.java
@@ -63,17 +63,17 @@ final class EventHandlerCreator {
     private static final String FIELD_EVENT_TYPE = "platformEventType";
     private static final String FIELD_PREFIX_STRING_POOL = "stringPool";
 
-    private final static Type TYPE_STRING_POOL = Type.getType(StringPool.class);
-    private final static Type TYPE_EVENT_WRITER = Type.getType(EventWriter.class);
-    private final static Type TYPE_PLATFORM_EVENT_TYPE = Type.getType(PlatformEventType.class);
-    private final static Type TYPE_EVENT_HANDLER = Type.getType(EventHandler.class);
-    private final static Type TYPE_SETTING_CONTROL = Type.getType(SettingControl.class);
-    private final static Type TYPE_EVENT_TYPE = Type.getType(EventType.class);
-    private final static Type TYPE_EVENT_CONTROL = Type.getType(EventControl.class);
-    private final static String DESCRIPTOR_EVENT_HANDLER = "(" + Type.BOOLEAN_TYPE.getDescriptor() + TYPE_EVENT_TYPE.getDescriptor() + TYPE_EVENT_CONTROL.getDescriptor() + ")V";
-    private final static Method METHOD_GET_EVENT_WRITER = new Method("getEventWriter", "()" + TYPE_EVENT_WRITER.getDescriptor());
-    private final static Method METHOD_EVENT_HANDLER_CONSTRUCTOR = new Method("<init>", DESCRIPTOR_EVENT_HANDLER);
-    private final static Method METHOD_RESET = new Method("reset", "()V");
+    private static final Type TYPE_STRING_POOL = Type.getType(StringPool.class);
+    private static final Type TYPE_EVENT_WRITER = Type.getType(EventWriter.class);
+    private static final Type TYPE_PLATFORM_EVENT_TYPE = Type.getType(PlatformEventType.class);
+    private static final Type TYPE_EVENT_HANDLER = Type.getType(EventHandler.class);
+    private static final Type TYPE_SETTING_CONTROL = Type.getType(SettingControl.class);
+    private static final Type TYPE_EVENT_TYPE = Type.getType(EventType.class);
+    private static final Type TYPE_EVENT_CONTROL = Type.getType(EventControl.class);
+    private static final String DESCRIPTOR_EVENT_HANDLER = "(" + Type.BOOLEAN_TYPE.getDescriptor() + TYPE_EVENT_TYPE.getDescriptor() + TYPE_EVENT_CONTROL.getDescriptor() + ")V";
+    private static final Method METHOD_GET_EVENT_WRITER = new Method("getEventWriter", "()" + TYPE_EVENT_WRITER.getDescriptor());
+    private static final Method METHOD_EVENT_HANDLER_CONSTRUCTOR = new Method("<init>", DESCRIPTOR_EVENT_HANDLER);
+    private static final Method METHOD_RESET = new Method("reset", "()V");
 
     private final ClassWriter classWriter;
     private final String className;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -78,7 +78,7 @@ public final class EventInstrumentation {
     }
 
     static final class FieldInfo {
-        private final static Type STRING = Type.getType(String.class);
+        private static final Type STRING = Type.getType(String.class);
         final String fieldName;
         final String fieldDescriptor;
         final String internalClassName;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -39,7 +39,7 @@ public final class EventWriter {
     // Event may not exceed size for a padded integer
     private static final long MAX_EVENT_SIZE = (1 << 28) -1;
     private static final Unsafe unsafe = Unsafe.getUnsafe();
-    private final static JVM jvm = JVM.getJVM();
+    private static final JVM jvm = JVM.getJVM();
 
     // The JVM needs access to these values. Don't remove
     private final long threadID;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/FilePurger.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/FilePurger.java
@@ -36,7 +36,7 @@ import jdk.jfr.internal.SecuritySupport.SafePath;
 // so they can a later staged be removed.
 final class FilePurger {
 
-    private final static Set<SafePath> paths = new LinkedHashSet<>();
+    private static final Set<SafePath> paths = new LinkedHashSet<>();
 
     public synchronized static void add(SafePath p) {
         paths.add(p);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Logger.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Logger.java
@@ -32,7 +32,7 @@ package jdk.jfr.internal;
 
 public final class Logger {
 
-    private final static int MAX_SIZE = 10000;
+    private static final int MAX_SIZE = 10000;
     static {
         // This will try to initialize the JVM logging system
         JVMSupport.tryToInitializeJVM();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataLoader.java
@@ -67,7 +67,7 @@ public final class MetadataLoader {
     private final Type PERIOD_TYPE = TypeLibrary.createAnnotationType(Period.class);
 
     // <Event>, <Type> and <Relation>
-    private final static class TypeElement {
+    private static final class TypeElement {
         private final List<FieldElement> fields;
         private final String name;
         private final String label;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
@@ -36,10 +36,10 @@ import jdk.internal.misc.Unsafe;
  */
 public final class Options {
 
-    private final static JVM jvm = JVM.getJVM();
-    private final static long WAIT_INTERVAL = 1000; // ms;
+    private static final JVM jvm = JVM.getJVM();
+    private static final long WAIT_INTERVAL = 1000; // ms;
 
-    private final static long MIN_MAX_CHUNKSIZE = 1024 * 1024;
+    private static final long MIN_MAX_CHUNKSIZE = 1024 * 1024;
 
     private static final long DEFAULT_GLOBAL_BUFFER_COUNT = 20;
     private static final long DEFAULT_GLOBAL_BUFFER_SIZE = 524288;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -63,9 +63,9 @@ public final class PlatformRecorder {
 
 
     private final List<PlatformRecording> recordings = new ArrayList<>();
-    private final static List<SecureRecorderListener> changeListeners = new ArrayList<>();
+    private static final List<SecureRecorderListener> changeListeners = new ArrayList<>();
     private final Repository repository;
-    private final static JVM jvm = JVM.getJVM();
+    private static final JVM jvm = JVM.getJVM();
     private final EventType activeRecordingEvent;
     private final EventType activeSettingEvent;
     private final Thread shutdownHook;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
@@ -40,9 +40,9 @@ import jdk.jfr.EventType;
 
 public final class RequestEngine {
 
-    private final static JVM jvm = JVM.getJVM();
+    private static final JVM jvm = JVM.getJVM();
 
-    final static class RequestHook {
+    static final class RequestHook {
         private final Runnable hook;
         private final PlatformEventType type;
         private final AccessControlContext accessControllerContext;
@@ -99,7 +99,7 @@ public final class RequestEngine {
         }
     }
 
-    private final static List<RequestHook> entries = new CopyOnWriteArrayList<>();
+    private static final List<RequestHook> entries = new CopyOnWriteArrayList<>();
     private static long lastTimeMillis;
     private static long flushInterval = Long.MAX_VALUE;
     private static long streamDelta;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -72,10 +72,10 @@ import jdk.jfr.internal.consumer.FileAccess;
  * {@link AccessController#doPrivileged(PrivilegedAction)}
  */
 public final class SecuritySupport {
-    private final static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-    private final static Module JFR_MODULE = Event.class.getModule();
-    public  final static SafePath JFC_DIRECTORY = getPathInProperty("java.home", "lib/jfr");
-    public final static FileAccess PRIVILEGED = new Privileged();
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final Module JFR_MODULE = Event.class.getModule();
+    public  static final SafePath JFC_DIRECTORY = getPathInProperty("java.home", "lib/jfr");
+    public static final FileAccess PRIVILEGED = new Privileged();
     static final SafePath USER_HOME = getPathInProperty("user.home", null);
     static final SafePath JAVA_IO_TMPDIR = getPathInProperty("java.io.tmpdir", null);
 
@@ -87,7 +87,7 @@ public final class SecuritySupport {
         addInstrumentExport(Object.class);
     }
 
-    final static class SecureRecorderListener implements FlightRecorderListener {
+    static final class SecureRecorderListener implements FlightRecorderListener {
 
         private final AccessControlContext context;
         private final FlightRecorderListener changeListener;
@@ -477,7 +477,7 @@ public final class SecuritySupport {
         return new SafePath(doPrivilegedIOWithReturn((()-> path.toPath().toAbsolutePath())));
     }
 
-    private final static class Privileged extends FileAccess {
+    private static final class Privileged extends FileAccess {
         @Override
         public RandomAccessFile openRAF(File f, String mode) throws IOException {
             return doPrivilegedIOWithReturn( () -> new RandomAccessFile(f, mode));

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Throttle.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Throttle.java
@@ -49,8 +49,8 @@ public @interface Throttle {
     /**
      * Settings name {@code "throttle"} for configuring an event emission rate in events per time unit.
      */
-    public final static String NAME = "throttle";
-    public final static String DEFAULT = "off";
+    public static final String NAME = "throttle";
+    public static final String DEFAULT = "off";
 
     /**
      * Throttle, for example {@code "100/s"}.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
@@ -56,7 +56,7 @@ public class Type implements Comparable<Type> {
     // To bootstrap the type system, the supported Java types
     // are available here as statics. When metadata.xml is parsed
     // fields are added to THREAD and STACK_TRACE.
-    private final static Map<Type, Class<?>> knownTypes = new LinkedHashMap<>();
+    private static final Map<Type, Class<?>> knownTypes = new LinkedHashMap<>();
     static final Type BOOLEAN = createKnownType(boolean.class);
     static final Type CHAR = createKnownType(char.class);
     static final Type FLOAT = createKnownType(float.class);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -75,7 +75,7 @@ public final class Utils {
     public static final String HANDLERS_PACKAGE_NAME = "jdk.jfr.internal.handlers";
     public static final String REGISTER_EVENT = "registerEvent";
     public static final String ACCESS_FLIGHT_RECORDER = "accessFlightRecorder";
-    private final static String LEGACY_EVENT_NAME_PREFIX = "com.oracle.jdk.";
+    private static final String LEGACY_EVENT_NAME_PREFIX = "com.oracle.jdk.";
 
     private static Boolean SAVE_GENERATED;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -52,7 +52,7 @@ import jdk.jfr.internal.SecuritySupport;
  * an event stream.
  */
 public abstract class AbstractEventStream implements EventStream {
-    private final static AtomicLong counter = new AtomicLong();
+    private static final AtomicLong counter = new AtomicLong();
 
     private final Object terminated = new Object();
     private final Runnable flushOperation = () -> dispatcher().runFlushActions();
@@ -73,13 +73,13 @@ public abstract class AbstractEventStream implements EventStream {
     }
 
     @Override
-    abstract public void start();
+    public abstract void start();
 
     @Override
-    abstract public void startAsync();
+    public abstract void startAsync();
 
     @Override
-    abstract public void close();
+    public abstract void close();
 
     protected final Dispatcher dispatcher() {
         if (streamConfiguration.hasChanged()) { // quick check
@@ -233,7 +233,7 @@ public abstract class AbstractEventStream implements EventStream {
     }
 
 
-    final protected void onFlush() {
+    protected final void onFlush() {
        Runnable r = getFlushOperation();
        if (r != null) {
            r.run();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -91,7 +91,7 @@ public final class ChunkParser {
             return (mask & flags) != 0;
         }
     }
-    public final static RecordedEvent FLUSH_MARKER = JdkJfrConsumer.instance().newRecordedEvent(null, null, 0L, 0L);
+    public static final RecordedEvent FLUSH_MARKER = JdkJfrConsumer.instance().newRecordedEvent(null, null, 0L, 0L);
 
     private static final long CONSTANT_POOL_TYPE_ID = 1;
     private final RecordingInput input;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
@@ -47,7 +47,7 @@ final class ConstantMap {
     // reference themselves (directly, or indirectly),
     // when making a transition from numeric id references
     // to normal Java references.
-    private final static class Reference {
+    private static final class Reference {
         private final long key;
         private final ConstantMap pool;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
@@ -38,8 +38,8 @@ import jdk.jfr.internal.consumer.ChunkParser.ParserConfiguration;
 
 final class Dispatcher {
 
-    final static class EventDispatcher {
-        private final static EventDispatcher[] NO_DISPATCHERS = new EventDispatcher[0];
+    static final class EventDispatcher {
+        private static final EventDispatcher[] NO_DISPATCHERS = new EventDispatcher[0];
 
         private final String eventName;
         private final Consumer<RecordedEvent> action;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -50,7 +50,7 @@ import jdk.jfr.internal.consumer.ChunkParser.ParserConfiguration;
  */
 public class EventDirectoryStream extends AbstractEventStream {
 
-    private final static Comparator<? super RecordedEvent> EVENT_COMPARATOR = JdkJfrConsumer.instance().eventComparator();
+    private static final Comparator<? super RecordedEvent> EVENT_COMPARATOR = JdkJfrConsumer.instance().eventComparator();
 
     private final RepositoryFiles repositoryFiles;
     private final FileAccess fileAccess;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -39,7 +39,7 @@ import jdk.jfr.consumer.RecordedEvent;
  *
  */
 public final class EventFileStream extends AbstractEventStream {
-    private final static Comparator<? super RecordedEvent> EVENT_COMPARATOR = JdkJfrConsumer.instance().eventComparator();
+    private static final Comparator<? super RecordedEvent> EVENT_COMPARATOR = JdkJfrConsumer.instance().eventComparator();
 
     private final RecordingInput input;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/FileAccess.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 
 // Protected by modular boundaries.
 public abstract class FileAccess {
-    public final static FileAccess UNPRIVILEGED = new UnPrivileged();
+    public static final FileAccess UNPRIVILEGED = new UnPrivileged();
 
     public abstract RandomAccessFile openRAF(File f, String mode) throws IOException;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ObjectFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ObjectFactory.java
@@ -40,10 +40,10 @@ import jdk.jfr.internal.Type;
 public abstract class ObjectFactory<T> {
     private static final JdkJfrConsumer PRIVATE_ACCESS = JdkJfrConsumer.instance();
 
-    private final static String TYPE_PREFIX_VERSION_1 = "com.oracle.jfr.types.";
-    private final static String TYPE_PREFIX_VERSION_2 = Type.TYPES_PREFIX;
-    public final static String STACK_FRAME_VERSION_1 = TYPE_PREFIX_VERSION_1 + "StackFrame";
-    public final static String STACK_FRAME_VERSION_2 = TYPE_PREFIX_VERSION_2 + "StackFrame";
+    private static final String TYPE_PREFIX_VERSION_1 = "com.oracle.jfr.types.";
+    private static final String TYPE_PREFIX_VERSION_2 = Type.TYPES_PREFIX;
+    public static final String STACK_FRAME_VERSION_1 = TYPE_PREFIX_VERSION_1 + "StackFrame";
+    public static final String STACK_FRAME_VERSION_2 = TYPE_PREFIX_VERSION_2 + "StackFrame";
 
     static ObjectFactory<?> create(Type type, TimeConverter timeConverter) {
         switch (type.getName()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
@@ -286,7 +286,7 @@ final class ParserFactory {
         }
     }
 
-    private final static class ArrayParser extends Parser {
+    private static final class ArrayParser extends Parser {
         private final Parser elementParser;
 
         public ArrayParser(Parser elementParser) {
@@ -312,7 +312,7 @@ final class ParserFactory {
         }
     }
 
-    private final static class CompositeParser extends Parser {
+    private static final class CompositeParser extends Parser {
         private final Parser[] parsers;
 
         public CompositeParser(Parser[] valueParsers) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 
 public final class RecordingInput implements DataInput, AutoCloseable {
 
-    private final static int DEFAULT_BLOCK_SIZE = 64_000;
+    private static final int DEFAULT_BLOCK_SIZE = 64_000;
 
     private static final class Block {
         private byte[] bytes = new byte[0];

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/StringParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/StringParser.java
@@ -53,10 +53,10 @@ public final class StringParser extends Parser {
         }
 
     }
-    private final static Charset UTF8 = Charset.forName("UTF-8");
-    private final static Charset LATIN1 = Charset.forName("ISO-8859-1");
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final Charset LATIN1 = Charset.forName("ISO-8859-1");
 
-    private final static class CharsetParser extends Parser {
+    private static final class CharsetParser extends Parser {
         private final Charset charset;
         private int lastSize;
         private byte[] buffer = new byte[16];
@@ -106,7 +106,7 @@ public final class StringParser extends Parser {
         }
     }
 
-    private final static class CharArrayParser extends Parser {
+    private static final class CharArrayParser extends Parser {
         private char[] buffer = new char[16];
         private int lastSize = -1;
         private String lastString = null;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/handlers/EventHandler.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/handlers/EventHandler.java
@@ -52,7 +52,7 @@ public abstract class EventHandler {
         platformEventType.setRegistered(registered);
     }
 
-    final protected StringPool createStringFieldWriter() {
+    protected final StringPool createStringFieldWriter() {
         return new StringPool();
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/EventByteStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/EventByteStream.java
@@ -55,17 +55,17 @@ public abstract class EventByteStream implements Closeable {
         return new FinishedStream(is, blockSize);
     }
 
-    final protected void touch() {
+    protected final void touch() {
         time = System.currentTimeMillis();
     }
 
-    final public long getLastTouched() {
+    public final long getLastTouched() {
         return time;
     }
 
-    abstract public byte[] read() throws IOException;
+    public abstract byte[] read() throws IOException;
 
-    final public long getId() {
+    public final long getId() {
         return identifier;
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/CutoffSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/CutoffSetting.java
@@ -43,7 +43,7 @@ import jdk.jfr.internal.Utils;
 @Name(Type.SETTINGS_PREFIX + "Cutoff")
 @Timespan
 public final class CutoffSetting extends JDKSettingControl {
-    private final static long typeId = Type.getTypeId(CutoffSetting.class);
+    private static final long typeId = Type.getTypeId(CutoffSetting.class);
 
     private String value = "0 ns";
     private final PlatformEventType eventType;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/StackTraceSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/StackTraceSetting.java
@@ -42,7 +42,7 @@ import jdk.jfr.internal.Type;
 @Description("Record stack traces")
 @BooleanFlag
 public final class StackTraceSetting extends JDKSettingControl {
-    private final static long typeId =  Type.getTypeId(StackTraceSetting.class);
+    private static final long typeId =  Type.getTypeId(StackTraceSetting.class);
     private final BooleanValue booleanValue;
     private final PlatformEventType eventType;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThresholdSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThresholdSetting.java
@@ -42,7 +42,7 @@ import jdk.jfr.internal.Utils;
 @Description("Record event with duration above or equal to threshold")
 @Timespan
 public final class ThresholdSetting extends JDKSettingControl {
-    private final static long typeId = Type.getTypeId(ThresholdSetting.class);
+    private static final long typeId = Type.getTypeId(ThresholdSetting.class);
     private String value = "0 ns";
     private final PlatformEventType eventType;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -42,8 +42,8 @@ import jdk.jfr.internal.Utils;
 @Description("Throttles the emission rate for an event")
 @Name(Type.SETTINGS_PREFIX + "Throttle")
 public final class ThrottleSetting extends JDKSettingControl {
-    private final static long typeId = Type.getTypeId(ThrottleSetting.class);
-    private final static long OFF = -2;
+    private static final long typeId = Type.getTypeId(ThrottleSetting.class);
+    private static final long OFF = -2;
     private String value = "0/s";
     private final PlatformEventType eventType;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
@@ -47,9 +47,9 @@ import java.util.function.Predicate;
 import jdk.jfr.EventType;
 
 abstract class Command {
-    public final static String title = "Tool for working with Flight Recorder files";
-    private final static Command HELP = new Help();
-    private final static List<Command> COMMANDS = createCommands();
+    public static final String title = "Tool for working with Flight Recorder files";
+    private static final Command HELP = new Help();
+    private static final List<Command> COMMANDS = createCommands();
 
     private static List<Command> createCommands() {
         List<Command> commands = new ArrayList<>();
@@ -70,11 +70,11 @@ abstract class Command {
         displayAvailableCommands(System.out);
     }
 
-    abstract public String getName();
+    public abstract String getName();
 
-    abstract public String getDescription();
+    public abstract String getDescription();
 
-    abstract public void execute(Deque<String> argList) throws UserSyntaxException, UserDataException;
+    public abstract void execute(Deque<String> argList) throws UserSyntaxException, UserDataException;
 
     protected String getTitle() {
         return getDescription();
@@ -204,19 +204,19 @@ abstract class Command {
         return true;
     }
 
-    final protected void ensureMaxArgumentCount(Deque<String> options, int maxCount) throws UserSyntaxException {
+    protected final void ensureMaxArgumentCount(Deque<String> options, int maxCount) throws UserSyntaxException {
         if (options.size() > maxCount) {
             throw new UserSyntaxException("too many arguments");
         }
     }
 
-    final protected void ensureMinArgumentCount(Deque<String> options, int minCount) throws UserSyntaxException {
+    protected final void ensureMinArgumentCount(Deque<String> options, int minCount) throws UserSyntaxException {
         if (options.size() < minCount) {
             throw new UserSyntaxException("too few arguments");
         }
     }
 
-    final protected Path getDirectory(String pathText) throws UserDataException {
+    protected final Path getDirectory(String pathText) throws UserDataException {
         try {
             Path path = Paths.get(pathText).toAbsolutePath();
             if (!Files.exists((path))) {
@@ -231,7 +231,7 @@ abstract class Command {
         }
     }
 
-    final protected Path getJFRInputFile(Deque<String> options) throws UserSyntaxException, UserDataException {
+    protected final Path getJFRInputFile(Deque<String> options) throws UserSyntaxException, UserDataException {
         if (options.isEmpty()) {
             throw new UserSyntaxException("missing file");
         }
@@ -251,7 +251,7 @@ abstract class Command {
         }
     }
 
-    final protected void ensureAccess(Path path) throws UserDataException {
+    protected final void ensureAccess(Path path) throws UserDataException {
         try (RandomAccessFile rad = new RandomAccessFile(path.toFile(), "r")) {
             if (rad.length() == 0) {
                 throw new UserDataException("file is empty '" + path + "'");
@@ -264,18 +264,18 @@ abstract class Command {
         }
     }
 
-    final protected void couldNotReadError(Path p, IOException e) throws UserDataException {
+    protected final void couldNotReadError(Path p, IOException e) throws UserDataException {
         throw new UserDataException("could not read recording at " + p.toAbsolutePath() + ". " + e.getMessage());
     }
 
-    final protected Path ensureFileDoesNotExist(Path file) throws UserDataException {
+    protected final Path ensureFileDoesNotExist(Path file) throws UserDataException {
         if (Files.exists(file)) {
             throw new UserDataException("file '" + file + "' already exists");
         }
         return file;
     }
 
-    final protected void ensureFileExtension(Path path, String extension) throws UserDataException {
+    protected final void ensureFileExtension(Path path, String extension) throws UserDataException {
         if (!path.toString().endsWith(extension)) {
             throw new UserDataException("filename must end with '" + extension + "'");
         }
@@ -287,19 +287,19 @@ abstract class Command {
         displayOptionUsage(stream);
     }
 
-    final protected void println() {
+    protected final void println() {
         System.out.println();
     }
 
-    final protected void print(String text) {
+    protected final void print(String text) {
         System.out.print(text);
     }
 
-    final protected void println(String text) {
+    protected final void println(String text) {
         System.out.println(text);
     }
 
-    final protected boolean matches(String command) {
+    protected final boolean matches(String command) {
         for (String s : getNames()) {
             if (s.equals(command)) {
                 return true;
@@ -325,7 +325,7 @@ abstract class Command {
         }
     }
 
-    final protected static char quoteCharacter() {
+    protected final static char quoteCharacter() {
         return File.pathSeparatorChar == ';' ? '"' : '\'';
     }
 
@@ -382,7 +382,7 @@ abstract class Command {
         return list;
     }
 
-    final protected static Predicate<EventType> addCategoryFilter(String filterText, Predicate<EventType> eventFilter) throws UserSyntaxException {
+    protected final static Predicate<EventType> addCategoryFilter(String filterText, Predicate<EventType> eventFilter) throws UserSyntaxException {
         List<String> filters = explodeFilter(filterText);
         Predicate<EventType> newFilter = recurseIfPossible(eventType -> {
             for (String category : eventType.getCategoryNames()) {
@@ -400,7 +400,7 @@ abstract class Command {
         return eventFilter == null ? newFilter : eventFilter.or(newFilter);
     }
 
-    final protected static Predicate<EventType> addEventFilter(String filterText, final Predicate<EventType> eventFilter) throws UserSyntaxException {
+    protected final static Predicate<EventType> addEventFilter(String filterText, final Predicate<EventType> eventFilter) throws UserSyntaxException {
         List<String> filters = explodeFilter(filterText);
         Predicate<EventType> newFilter = recurseIfPossible(eventType -> {
             for (String filter : filters) {
@@ -418,7 +418,7 @@ abstract class Command {
         return eventFilter == null ? newFilter : eventFilter.or(newFilter);
     }
 
-    final protected static <T, X> Predicate<T> addCache(final Predicate<T> filter, Function<T, X> cacheFunction) {
+    protected final static <T, X> Predicate<T> addCache(final Predicate<T> filter, Function<T, X> cacheFunction) {
         Map<X, Boolean> cache = new HashMap<>();
         return t -> cache.computeIfAbsent(cacheFunction.apply(t), x -> filter.test(t));
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
@@ -325,7 +325,7 @@ abstract class Command {
         }
     }
 
-    protected final static char quoteCharacter() {
+    protected static final char quoteCharacter() {
         return File.pathSeparatorChar == ';' ? '"' : '\'';
     }
 
@@ -382,7 +382,7 @@ abstract class Command {
         return list;
     }
 
-    protected final static Predicate<EventType> addCategoryFilter(String filterText, Predicate<EventType> eventFilter) throws UserSyntaxException {
+    protected static final Predicate<EventType> addCategoryFilter(String filterText, Predicate<EventType> eventFilter) throws UserSyntaxException {
         List<String> filters = explodeFilter(filterText);
         Predicate<EventType> newFilter = recurseIfPossible(eventType -> {
             for (String category : eventType.getCategoryNames()) {
@@ -400,7 +400,7 @@ abstract class Command {
         return eventFilter == null ? newFilter : eventFilter.or(newFilter);
     }
 
-    protected final static Predicate<EventType> addEventFilter(String filterText, final Predicate<EventType> eventFilter) throws UserSyntaxException {
+    protected static final Predicate<EventType> addEventFilter(String filterText, final Predicate<EventType> eventFilter) throws UserSyntaxException {
         List<String> filters = explodeFilter(filterText);
         Predicate<EventType> newFilter = recurseIfPossible(eventType -> {
             for (String filter : filters) {
@@ -418,7 +418,7 @@ abstract class Command {
         return eventFilter == null ? newFilter : eventFilter.or(newFilter);
     }
 
-    protected final static <T, X> Predicate<T> addCache(final Predicate<T> filter, Function<T, X> cacheFunction) {
+    protected static final <T, X> Predicate<T> addCache(final Predicate<T> filter, Function<T, X> cacheFunction) {
         Map<X, Boolean> cache = new HashMap<>();
         return t -> cache.computeIfAbsent(cacheFunction.apply(t), x -> filter.test(t));
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
@@ -65,7 +65,7 @@ abstract class EventPrintWriter extends StructuredWriter {
         super(p);
     }
 
-    abstract protected void print(List<RecordedEvent> events);
+    protected abstract void print(List<RecordedEvent> events);
 
     void print(Path source) throws FileNotFoundException, IOException {
         List<RecordedEvent> events = new ArrayList<>(500_000);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
@@ -49,7 +49,7 @@ import jdk.jfr.internal.consumer.JdkJfrConsumer;
 
 final class Metadata extends Command {
 
-    private final static JdkJfrConsumer PRIVATE_ACCESS = JdkJfrConsumer.instance();
+    private static final JdkJfrConsumer PRIVATE_ACCESS = JdkJfrConsumer.instance();
 
     private static class TypeComparator implements Comparator<Type> {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -59,8 +59,8 @@ import jdk.jfr.internal.Utils;
  */
 public final class PrettyWriter extends EventPrintWriter {
     private static final String TYPE_OLD_OBJECT = Type.TYPES_PREFIX + "OldObject";
-    private final static DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
-    private final static Long ZERO = 0L;
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+    private static final Long ZERO = 0L;
     private boolean showIds;
     private RecordedEvent currentEvent;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
@@ -28,7 +28,7 @@ package jdk.jfr.internal.tool;
 import java.io.PrintWriter;
 
 abstract class StructuredWriter {
-    private final static String LINE_SEPARATOR = String.format("%n");
+    private static final String LINE_SEPARATOR = String.format("%n");
 
     private final PrintWriter out;
     private final StringBuilder builder = new StringBuilder(4000);
@@ -43,7 +43,7 @@ abstract class StructuredWriter {
         out = p;
     }
 
-    final protected int getColumn() {
+    protected final int getColumn() {
         return column;
     }
 
@@ -61,51 +61,51 @@ abstract class StructuredWriter {
         }
     }
 
-    final public void printIndent() {
+    public final void printIndent() {
         builder.append(indentionArray, 0, indent);
         column += indent;
     }
 
-    final public void println() {
+    public final void println() {
         builder.append(LINE_SEPARATOR);
         column = 0;
     }
 
-    final public void print(String... texts) {
+    public final void print(String... texts) {
         for (String text : texts) {
             print(text);
         }
     }
 
-    final public void printAsString(Object o) {
+    public final void printAsString(Object o) {
         print(String.valueOf(o));
     }
 
-    final public void print(String text) {
+    public final void print(String text) {
         builder.append(text);
         column += text.length();
     }
 
-    final public void print(char c) {
+    public final void print(char c) {
         builder.append(c);
         column++;
     }
 
-    final public void print(int value) {
+    public final void print(int value) {
         print(String.valueOf(value));
     }
 
-    final public void indent() {
+    public final void indent() {
         indent += 2;
         updateIndent();
     }
 
-    final public void retract() {
+    public final void retract() {
         indent -= 2;
         updateIndent();
     }
 
-    final public void println(String text) {
+    public final void println(String text) {
         print(text);
         println();
     }

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -46,7 +46,7 @@ import jdk.jfr.internal.management.ManagementSupport;
 
 final class DiskRepository implements Closeable {
 
-    final static class DiskChunk {
+    static final class DiskChunk {
         final Path path;
         final long startTimeNanos;
         Instant endTime;

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -123,7 +123,7 @@ public final class RemoteRecordingStream implements EventStream {
     }
 
     // Reference to stream is released when EventStream::close is called
-    final static class ChunkConsumer implements Consumer<Long> {
+    static final class ChunkConsumer implements Consumer<Long> {
 
         private final DiskRepository repository;
 

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/internal/FlightRecorderMXBeanProvider.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/internal/FlightRecorderMXBeanProvider.java
@@ -38,7 +38,7 @@ import sun.management.spi.PlatformMBeanProvider;
 
 public final class FlightRecorderMXBeanProvider extends PlatformMBeanProvider {
 
-    private final static class SingleMBeanComponent
+    private static final class SingleMBeanComponent
             implements PlatformComponent<FlightRecorderMXBean> {
         private final String objectName;
         private final Class<FlightRecorderMXBean> mbeanInterface;


### PR DESCRIPTION
This replaces patterns such as "final public" with "public final" to bring the modifiers in the standard order for the jdk.jfr module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264062](https://bugs.openjdk.java.net/browse/JDK-8264062): Use the blessed modifier order in jdk.jfr


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to ec31fbd390671c8903b8dd502895634a26f95614


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3161/head:pull/3161`
`$ git checkout pull/3161`

To update a local copy of the PR:
`$ git checkout pull/3161`
`$ git pull https://git.openjdk.java.net/jdk pull/3161/head`
