### PR TITLE
8264096: slowdebug jvm crashes when StrInflatedCopy match rule is not supported

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -179,11 +179,11 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   switch (id) {
   case vmIntrinsics::_compressStringC:
   case vmIntrinsics::_compressStringB:
-    if (!Matcher::has_match_rule(Op_StrCompressedCopy)) return false;
+    if (!Matcher::match_rule_supported(Op_StrCompressedCopy)) return false;
     break;
   case vmIntrinsics::_inflateStringC:
   case vmIntrinsics::_inflateStringB:
-    if (!Matcher::has_match_rule(Op_StrInflatedCopy)) return false;
+    if (!Matcher::match_rule_supported(Op_StrInflatedCopy)) return false;
     break;
   case vmIntrinsics::_compareToL:
   case vmIntrinsics::_compareToU:

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4228,6 +4228,8 @@ void GraphKit::inflate_string_slow(Node* src, Node* dst, Node* start, Node* coun
    * }
    */
   add_empty_predicates();
+  C->set_has_loops(true);
+
   RegionNode* head = new RegionNode(3);
   head->init_req(1, control());
   gvn().set_type(head, Type::CONTROL);


### PR DESCRIPTION
As shown on the bug, two JVM crashes are witnessed when running the provided test case after disabling match rule support for StrInflatedCopy.  

The cause for the first JVM crash is that we are calling has_match_rule for Op_StrInflatedCopy in is_intrinsic_supported.  
In this case, we have match rule for Op_StrInflatedCopy but that match rule is not supported.  
Patch fixed the first crash by changing the use of has_match_rule into match_rule_supported.  match_rule_supported  will check has_match_rule at entry point.  

In the case for the second JVM crash, the C2 code path is different when match rule for StrInflatedCopy is not supported.  
In PhaseStringOpts::copy_latin1_string, we will call GraphKit::inflate_string_slow instread of GraphKit::inflate_string.  
We emit one loop in GraphKit::inflate_string_slow, but the method is not marked may have some loops.  
Looks like this is missed by JDK-8253923.  Patch fixed the second crash by setting _has_loops to true in GraphKit::inflate_string_slow.  

Testing: tier 1-3 tested with release & fastdebug build on x86_64 linux with match rule support for StrInflatedCopy explicitly disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264096](https://bugs.openjdk.java.net/browse/JDK-8264096): slowdebug jvm crashes when StrInflatedCopy match rule is not supported


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Contributors
 * Yadong Wang `<yadonn.wang@huawei.com>`

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3166/head:pull/3166`
`$ git checkout pull/3166`

To update a local copy of the PR:
`$ git checkout pull/3166`
`$ git pull https://git.openjdk.java.net/jdk pull/3166/head`
