### PR TITLE
8253266 : JList and JTable constructors should clear OPAQUE_SET before calling updateUI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -463,7 +463,6 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
         this.dataModel = dataModel;
         selectionModel = createSelectionModel();
         setAutoscrolls(true);
-        setOpaque(true);
         updateUI();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -5592,7 +5592,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      */
     protected void initializeLocalVars() {
         updateSelectionOnSort = true;
-        setOpaque(true);
         createDefaultRenderers();
         createDefaultEditors();
 

--- a/src/java.desktop/share/classes/javax/swing/JToolTip.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolTip.java
@@ -83,7 +83,6 @@ public class JToolTip extends JComponent implements Accessible {
 
     /** Creates a tool tip. */
     public JToolTip() {
-        setOpaque(true);
         updateUI();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -726,7 +726,6 @@ public class JTree extends JComponent implements Scrollable, Accessible
         selectionModel = new DefaultTreeSelectionModel();
         cellRenderer = null;
         scrollsOnExpand = true;
-        setOpaque(true);
         expandsSelectedPaths = true;
         updateUI();
         setModel(newModel);

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -287,7 +287,6 @@ public class JViewport extends JComponent implements Accessible
     public JViewport() {
         super();
         setLayout(createLayoutManager());
-        setOpaque(true);
         updateUI();
         setInheritsPopupMenu(true);
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -21578,7 +21578,7 @@
                            <visible>true</visible>
                            <shapes>
                               <!--<rectangle x1="3.9545454545454546" x2="6.0" y1="26.49999999999998" y2="10.772727272727275" rounding="2.000000000000001">-->
-                                 
+
                               <rectangle x1="4" x2="6.0" y1="10" y2="26.5" rounding="2">
                                  <gradient cycleMethod="NO_CYCLE">
                                     <stop position="0.0" midpoint="0.5">
@@ -27248,7 +27248,7 @@
          <borderStates/>
          <regions/>
       </uiComponent>
-      <uiComponent opaque="false" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
+      <uiComponent opaque="true" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
          <stateTypes/>
          <contentMargins top="4" bottom="4" left="4" right="4"/>
          <style>

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -27248,7 +27248,7 @@
          <borderStates/>
          <regions/>
       </uiComponent>
-      <uiComponent opaque="true" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
+      <uiComponent opaque="false" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
          <stateTypes/>
          <contentMargins top="4" bottom="4" left="4" right="4"/>
          <style>

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -21578,7 +21578,7 @@
                            <visible>true</visible>
                            <shapes>
                               <!--<rectangle x1="3.9545454545454546" x2="6.0" y1="26.49999999999998" y2="10.772727272727275" rounding="2.000000000000001">-->
-
+                                 
                               <rectangle x1="4" x2="6.0" y1="10" y2="26.5" rounding="2">
                                  <gradient cycleMethod="NO_CYCLE">
                                     <stop position="0.0" midpoint="0.5">

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthToolTipUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthToolTipUI.java
@@ -70,6 +70,7 @@ public class SynthToolTipUI extends BasicToolTipUI
     @Override
     protected void installDefaults(JComponent c) {
         updateStyle(c);
+        LookAndFeel.installProperty(c, "opaque", Boolean.TRUE);
     }
 
     private void updateStyle(JComponent c) {

--- a/test/jdk/javax/swing/JList/TestOpaqueListTable.java
+++ b/test/jdk/javax/swing/JList/TestOpaqueListTable.java
@@ -42,46 +42,101 @@ public class TestOpaqueListTable {
                 UIManager.setLookAndFeel(LF.getClassName());
                 SwingUtilities.invokeAndWait(() -> {
                     JList list = new JList();
-                    if (list.isOpaque() == false) {
+                    JTable table = new JTable();
+                    JTree tree = new JTree();
+                    JToolTip toolTip = new JToolTip();
+                    JViewport viewport = new JViewport();
+                    String opaqueValue =  new String(" ");
+
+                    if (!list.isOpaque()) {
+                        opaqueValue += "JList, ";
+                    }
+                    if (!table.isOpaque()) {
+                        opaqueValue += "JTable, ";
+                    }
+                    if (!tree.isOpaque()) {
+                        opaqueValue += "JTree, ";
+                    }
+                    if (!toolTip.isOpaque()) {
+                        opaqueValue += "JToolTip, ";
+
+                    }
+                    if (!viewport.isOpaque()) {
+                        opaqueValue += "JViewport, ";
+                    }
+
+                    if(!opaqueValue.equals(" ")) {
                         throw new RuntimeException("Default value of " +
-                                "\"opaque\" property for JList is changed ");
+                                "\"opaque\" property for " + opaqueValue
+                                + " is changed ");
                     }
 
                     LookAndFeel.installProperty(list, "opaque", false);
-                    if (list.isOpaque()) {
-                        throw new RuntimeException(
-                                "setUIProperty failed to clear JList opaque" +
-                                        " when opaque is not set by client");
-                    }
-
-                    JTable table = new JTable();
-                    if (table.isOpaque() == false) {
-                        throw new RuntimeException("Default value of " +
-                                "\"opaque\" property for JTable is changed ");
-                    }
-
                     LookAndFeel.installProperty(table, "opaque", false);
+                    LookAndFeel.installProperty(tree, "opaque", false);
+                    LookAndFeel.installProperty(toolTip,"opaque",false);
+                    LookAndFeel.installProperty(viewport,"opaque",false);
+
+                    opaqueValue = " ";
+                    if (list.isOpaque()) {
+                        opaqueValue += "JList, ";
+                    }
                     if (table.isOpaque()) {
+                        opaqueValue += "JTable, ";
+                    }
+                    if (tree.isOpaque()) {
+                        opaqueValue += "JTree, ";
+                    }
+                    if (toolTip.isOpaque()) {
+                        opaqueValue += "JToolTip, ";
+                    }
+                    if (viewport.isOpaque()) {
+                        opaqueValue += "JViewport, ";
+                    }
+                    if (!opaqueValue.equals(" ")) {
                         throw new RuntimeException(
-                                "setUIProperty failed to clear JTable opaque" +
+                                "setUIProperty failed to clear " +
+                                        opaqueValue +" opaque" +
                                         " when opaque is not set by client");
                     }
+
 
                     list.setOpaque(true);
+                    table.setOpaque(true);
+                    tree.setOpaque(true);
+                    toolTip.setOpaque(true);
+                    viewport.setOpaque(true);
+
                     LookAndFeel.installProperty(list,"opaque",false);
+                    LookAndFeel.installProperty(table, "opaque", false);
+                    LookAndFeel.installProperty(tree, "opaque", false);
+                    LookAndFeel.installProperty(toolTip, "opaque", false);
+                    LookAndFeel.installProperty(viewport, "opaque", false);
+
+                    opaqueValue = " ";
+
                     if (!list.isOpaque()) {
-                        throw new RuntimeException(
-                                "setUIProperty cleared the JList Opaque" +
-                                        " when opaque is set by client");
+                        opaqueValue += "JList";
+                    }
+                    if (!table.isOpaque()) {
+                        opaqueValue += "JTable";
+                    }
+                    if (!tree.isOpaque()) {
+                        opaqueValue += "JTree";
+                    }
+                    if (!toolTip.isOpaque()) {
+                        opaqueValue += "JToolTip";
+                    }
+                    if (!viewport.isOpaque()) {
+                        opaqueValue += "JViewport";
                     }
 
-                    table.setOpaque(true);
-                    LookAndFeel.installProperty(table, "opaque", false);
-                    if (!table.isOpaque()) {
+                    if (!opaqueValue.equals(" ")) {
                         throw new RuntimeException("" +
-                                "setUIProperty cleared the JTable Opaque" +
-                                " when opaque is set by client");
+                                "setUIProperty cleared the " +opaqueValue +
+                                " Opaque when opaque is set by client");
                     }
+
                 });
             } catch (UnsupportedLookAndFeelException e) {
                 System.out.println("Note: LookAndFeel " + LF.getClassName()

--- a/test/jdk/javax/swing/JList/TestOpaqueListTable.java
+++ b/test/jdk/javax/swing/JList/TestOpaqueListTable.java
@@ -42,13 +42,24 @@ public class TestOpaqueListTable {
                 UIManager.setLookAndFeel(LF.getClassName());
                 SwingUtilities.invokeAndWait(() -> {
                     JList list = new JList();
+                    if (list.isOpaque() == false) {
+                        throw new RuntimeException("Default value of " +
+                                "\"opaque\" property for JList is changed ");
+                    }
+
                     LookAndFeel.installProperty(list, "opaque", false);
                     if (list.isOpaque()) {
                         throw new RuntimeException(
                                 "setUIProperty failed to clear JList opaque" +
                                         " when opaque is not set by client");
                     }
+
                     JTable table = new JTable();
+                    if (table.isOpaque() == false) {
+                        throw new RuntimeException("Default value of " +
+                                "\"opaque\" property for JTable is changed ");
+                    }
+
                     LookAndFeel.installProperty(table, "opaque", false);
                     if (table.isOpaque()) {
                         throw new RuntimeException(

--- a/test/jdk/javax/swing/JList/TestOpaqueListTable.java
+++ b/test/jdk/javax/swing/JList/TestOpaqueListTable.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.*;
+
+/**
+ *  @test
+ *  @bug 8253266
+ *  @summary setUIProperty should work when opaque property is not set by
+ *  client
+ *  @key headful
+ *  @run main TestOpaqueListTable
+ */
+
+public class TestOpaqueListTable {
+
+    public static void main(String[] args) throws Exception {
+        UIManager.LookAndFeelInfo[] installedLookAndFeels;
+        installedLookAndFeels = UIManager.getInstalledLookAndFeels();
+        for (UIManager.LookAndFeelInfo LF : installedLookAndFeels) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+                SwingUtilities.invokeAndWait(() -> {
+                    JList list = new JList();
+                    LookAndFeel.installProperty(list, "opaque", false);
+                    if (list.isOpaque()) {
+                        throw new RuntimeException(
+                                "setUIProperty failed to clear JList opaque" +
+                                        " when opaque is not set by client");
+                    }
+                    JTable table = new JTable();
+                    LookAndFeel.installProperty(table, "opaque", false);
+                    if (table.isOpaque()) {
+                        throw new RuntimeException(
+                                "setUIProperty failed to clear JTable opaque" +
+                                        " when opaque is not set by client");
+                    }
+
+                    list.setOpaque(true);
+                    LookAndFeel.installProperty(list,"opaque",false);
+                    if (!list.isOpaque()) {
+                        throw new RuntimeException(
+                                "setUIProperty cleared the JList Opaque" +
+                                        " when opaque is set by client");
+                    }
+
+                    table.setOpaque(true);
+                    LookAndFeel.installProperty(table, "opaque", false);
+                    if (!table.isOpaque()) {
+                        throw new RuntimeException("" +
+                                "setUIProperty cleared the JTable Opaque" +
+                                " when opaque is set by client");
+                    }
+                });
+            } catch (UnsupportedLookAndFeelException e) {
+                System.out.println("Note: LookAndFeel " + LF.getClassName()
+                        + " is not supported on this configuration");
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JList/TestOpaqueListTable.java
+++ b/test/jdk/javax/swing/JList/TestOpaqueListTable.java
@@ -21,7 +21,15 @@
  * questions.
  */
 
-import javax.swing.*;
+import javax.swing.JList;
+import javax.swing.JTable;
+import javax.swing.JToolTip;
+import javax.swing.JTree;
+import javax.swing.JViewport;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 /**
  *  @test


### PR DESCRIPTION
Hi All,
Please review the following fix for jdk17.

Issue : LookAndFeel.installProperty(list, "opaque", false) is not able to set the opaque property for JList and JTable.
LookAndFeel.installProperty calls the setUIProperty, and setUIProperty checks for OPAQUE_SET to change the opaque property as requested by the client.
OPAQUE_SET is always set to true when there is call to setOpaque(boolean).So when the constructor calls setOpaque(true) OPAQUE_SET is set to true and wont allow the setUIProperty to change the opaque property.
installProperty should work as the opaque property is not set by the client.

Fix. Fix is to remove the call to the setOpaque() from the constructor of JList and JTable. This will allow the client to change the opaque property calling LookAndFeel.installProperty() when the property is already not set.

Test : Added a  test  to check the same. Also tested internal tests which all are passing.
Link is in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253266](https://bugs.openjdk.java.net/browse/JDK-8253266): JList and JTable constructors should clear OPAQUE_SET before calling updateUI


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 67fbef160e7715e8a4ba30c068a37cc97a637fef


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3167/head:pull/3167` \
`$ git checkout pull/3167`

Update a local copy of the PR: \
`$ git checkout pull/3167` \
`$ git pull https://git.openjdk.java.net/jdk pull/3167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3167`

View PR using the GUI difftool: \
`$ git pr show -t 3167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3167.diff">https://git.openjdk.java.net/jdk/pull/3167.diff</a>

</details>
