### PR TITLE
8264018: AArch64: NEON loadV2 and storeV2 addressing is wrong

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -6260,6 +6260,7 @@ operand iRegL2I(iRegL reg) %{
   interface(REG_INTER)
 %}
 
+opclass vmem2(indirect, indIndex, indOffI2, indOffL2);
 opclass vmem4(indirect, indIndex, indOffI4, indOffL4);
 opclass vmem8(indirect, indIndex, indOffI8, indOffL8);
 opclass vmem16(indirect, indIndex, indOffI16, indOffL16);

--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -41,6 +41,39 @@ instruct loadV2(vecD dst, vmem2 mem)
   ins_pipe(vload_reg_mem64);
 %}
 
+// Load Vector (32 bits)
+instruct loadV4(vecD dst, vmem4 mem)
+%{
+  predicate(n->as_LoadVector()->memory_size() == 4);
+  match(Set dst (LoadVector mem));
+  ins_cost(4 * INSN_COST);
+  format %{ "ldrs   $dst,$mem\t# vector (32 bits)" %}
+  ins_encode( aarch64_enc_ldrvS(dst, mem) );
+  ins_pipe(vload_reg_mem64);
+%}
+
+// Load Vector (64 bits)
+instruct loadV8(vecD dst, vmem8 mem)
+%{
+  predicate(n->as_LoadVector()->memory_size() == 8);
+  match(Set dst (LoadVector mem));
+  ins_cost(4 * INSN_COST);
+  format %{ "ldrd   $dst,$mem\t# vector (64 bits)" %}
+  ins_encode( aarch64_enc_ldrvD(dst, mem) );
+  ins_pipe(vload_reg_mem64);
+%}
+
+// Load Vector (128 bits)
+instruct loadV16(vecX dst, vmem16 mem)
+%{
+  predicate(UseSVE == 0 && n->as_LoadVector()->memory_size() == 16);
+  match(Set dst (LoadVector mem));
+  ins_cost(4 * INSN_COST);
+  format %{ "ldrq   $dst,$mem\t# vector (128 bits)" %}
+  ins_encode( aarch64_enc_ldrvQ(dst, mem) );
+  ins_pipe(vload_reg_mem128);
+%}
+
 // Store Vector (16 bits)
 instruct storeV2(vecD src, vmem2 mem)
 %{
@@ -50,6 +83,39 @@ instruct storeV2(vecD src, vmem2 mem)
   format %{ "strh   $mem,$src\t# vector (16 bits)" %}
   ins_encode( aarch64_enc_strvH(src, mem) );
   ins_pipe(vstore_reg_mem64);
+%}
+
+// Store Vector (32 bits)
+instruct storeV4(vecD src, vmem4 mem)
+%{
+  predicate(n->as_StoreVector()->memory_size() == 4);
+  match(Set mem (StoreVector mem src));
+  ins_cost(4 * INSN_COST);
+  format %{ "strs   $mem,$src\t# vector (32 bits)" %}
+  ins_encode( aarch64_enc_strvS(src, mem) );
+  ins_pipe(vstore_reg_mem64);
+%}
+
+// Store Vector (64 bits)
+instruct storeV8(vecD src, vmem8 mem)
+%{
+  predicate(n->as_StoreVector()->memory_size() == 8);
+  match(Set mem (StoreVector mem src));
+  ins_cost(4 * INSN_COST);
+  format %{ "strd   $mem,$src\t# vector (64 bits)" %}
+  ins_encode( aarch64_enc_strvD(src, mem) );
+  ins_pipe(vstore_reg_mem64);
+%}
+
+// Store Vector (128 bits)
+instruct storeV16(vecX src, vmem16 mem)
+%{
+  predicate(n->as_StoreVector()->memory_size() == 16);
+  match(Set mem (StoreVector mem src));
+  ins_cost(4 * INSN_COST);
+  format %{ "strq   $mem,$src\t# vector (128 bits)" %}
+  ins_encode( aarch64_enc_strvQ(src, mem) );
+  ins_pipe(vstore_reg_mem128);
 %}
 
 instruct reinterpretD(vecD dst)
@@ -3701,72 +3767,6 @@ instruct vabd2D(vecX dst, vecX src1, vecX src2)
             as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
   %}
   ins_pipe(vunop_fp128);
-%}
-
-// Load Vector (32 bits)
-instruct loadV4(vecD dst, vmem4 mem)
-%{
-  predicate(n->as_LoadVector()->memory_size() == 4);
-  match(Set dst (LoadVector mem));
-  ins_cost(4 * INSN_COST);
-  format %{ "ldrs   $dst,$mem\t# vector (32 bits)" %}
-  ins_encode( aarch64_enc_ldrvS(dst, mem) );
-  ins_pipe(vload_reg_mem64);
-%}
-
-// Load Vector (64 bits)
-instruct loadV8(vecD dst, vmem8 mem)
-%{
-  predicate(n->as_LoadVector()->memory_size() == 8);
-  match(Set dst (LoadVector mem));
-  ins_cost(4 * INSN_COST);
-  format %{ "ldrd   $dst,$mem\t# vector (64 bits)" %}
-  ins_encode( aarch64_enc_ldrvD(dst, mem) );
-  ins_pipe(vload_reg_mem64);
-%}
-
-// Load Vector (128 bits)
-instruct loadV16(vecX dst, vmem16 mem)
-%{
-  predicate(UseSVE == 0 && n->as_LoadVector()->memory_size() == 16);
-  match(Set dst (LoadVector mem));
-  ins_cost(4 * INSN_COST);
-  format %{ "ldrq   $dst,$mem\t# vector (128 bits)" %}
-  ins_encode( aarch64_enc_ldrvQ(dst, mem) );
-  ins_pipe(vload_reg_mem128);
-%}
-
-// Store Vector (32 bits)
-instruct storeV4(vecD src, vmem4 mem)
-%{
-  predicate(n->as_StoreVector()->memory_size() == 4);
-  match(Set mem (StoreVector mem src));
-  ins_cost(4 * INSN_COST);
-  format %{ "strs   $mem,$src\t# vector (32 bits)" %}
-  ins_encode( aarch64_enc_strvS(src, mem) );
-  ins_pipe(vstore_reg_mem64);
-%}
-
-// Store Vector (64 bits)
-instruct storeV8(vecD src, vmem8 mem)
-%{
-  predicate(n->as_StoreVector()->memory_size() == 8);
-  match(Set mem (StoreVector mem src));
-  ins_cost(4 * INSN_COST);
-  format %{ "strd   $mem,$src\t# vector (64 bits)" %}
-  ins_encode( aarch64_enc_strvD(src, mem) );
-  ins_pipe(vstore_reg_mem64);
-%}
-
-// Store Vector (128 bits)
-instruct storeV16(vecX src, vmem16 mem)
-%{
-  predicate(n->as_StoreVector()->memory_size() == 16);
-  match(Set mem (StoreVector mem src));
-  ins_cost(4 * INSN_COST);
-  format %{ "strq   $mem,$src\t# vector (128 bits)" %}
-  ins_encode( aarch64_enc_strvQ(src, mem) );
-  ins_pipe(vstore_reg_mem128);
 %}
 
 instruct replicate8B(vecD dst, iRegIorL2I src)

--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -31,7 +31,7 @@
 // ------------------------------ Load/store/reinterpret -----------------------
 
 // Load Vector (16 bits)
-instruct loadV2(vecD dst, memory mem)
+instruct loadV2(vecD dst, vmem2 mem)
 %{
   predicate(n->as_LoadVector()->memory_size() == 2);
   match(Set dst (LoadVector mem));
@@ -42,7 +42,7 @@ instruct loadV2(vecD dst, memory mem)
 %}
 
 // Store Vector (16 bits)
-instruct storeV2(vecD src, memory mem)
+instruct storeV2(vecD src, vmem2 mem)
 %{
   predicate(n->as_StoreVector()->memory_size() == 2);
   match(Set mem (StoreVector mem src));

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -70,7 +70,13 @@ instruct $3V$4`'(vec$5 $7, vmem$4 mem)
 %}')dnl
 dnl        $1    $2 $3     $4  $5 $6   $7   $8
 VLoadStore(ldrh, H, load,  2,  D, 16,  dst, )
+VLoadStore(ldrs, S, load,  4,  D, 32,  dst, )
+VLoadStore(ldrd, D, load,  8,  D, 64,  dst, )
+VLoadStore(ldrq, Q, load, 16,  X, 128, dst, UseSVE == 0 && )
 VLoadStore(strh, H, store, 2,  D, 16,  src, )
+VLoadStore(strs, S, store, 4,  D, 32,  src, )
+VLoadStore(strd, D, store, 8,  D, 64,  src, )
+VLoadStore(strq, Q, store, 16, X, 128, src, )
 dnl
 define(`REINTERPRET', `
 instruct reinterpret$1`'(vec$1 dst)
@@ -1498,13 +1504,6 @@ dnl   $1    $2    $3 $4 $5 $6 $7
 VFABD(fabd, fabd, 2, F, D, S, 64)
 VFABD(fabd, fabd, 4, F, X, S, 128)
 VFABD(fabd, fabd, 2, D, X, D, 128)
-dnl
-VLoadStore(ldrs, S, load,  4,  D, 32,  dst, )
-VLoadStore(ldrd, D, load,  8,  D, 64,  dst, )
-VLoadStore(ldrq, Q, load, 16,  X, 128, dst, UseSVE == 0 && )
-VLoadStore(strs, S, store, 4,  D, 32,  src, )
-VLoadStore(strd, D, store, 8,  D, 64,  src, )
-VLoadStore(strq, Q, store, 16, X, 128, src, )
 dnl
 define(`VREPLICATE', `
 instruct replicate$3$4$5`'(vec$6 dst, $7 ifelse($7, immI0, zero, $7, immI, con, src))

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -59,7 +59,7 @@ dnl
 // ------------------------------ Load/store/reinterpret -----------------------
 define(`VLoadStore', `
 // ifelse(load, $3, Load, Store) Vector ($6 bits)
-instruct $3V$4`'(vec$5 $7, ifelse($4, 2, memory, vmem$4) mem)
+instruct $3V$4`'(vec$5 $7, vmem$4 mem)
 %{
   predicate($8`n->as_'ifelse(load, $3, Load, Store)Vector()->memory_size() == $4);
   match(Set ifelse(load, $3, dst (LoadVector mem), mem (StoreVector mem src)));


### PR DESCRIPTION
AArch64 c2 loadV2 and storeV2 are used for Vector API mask value load/store with size of halfword. Their load/store immediate offset should be similar to other vector load/store, e.g. loadV4/storeV4, valid only for unscaled signed offset of imm9 or scaled unsigned offset of imm12:scale. This patch also groups other loadVs/storeVs together in the ad file.

Verified with tier1 and jtreg vector api cases, though I cannot reproduce this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264018](https://bugs.openjdk.java.net/browse/JDK-8264018): AArch64: NEON loadV2 and storeV2 addressing is wrong


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3168/head:pull/3168`
`$ git checkout pull/3168`

To update a local copy of the PR:
`$ git checkout pull/3168`
`$ git pull https://git.openjdk.java.net/jdk pull/3168/head`
