### PR TITLE
8264006: Fix AOT library loading on CPUs with 256-byte dcache line

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ void VM_Version::initialize() {
   }
 
   if (FLAG_IS_DEFAULT(ContendedPaddingWidth) && (dcache_line > ContendedPaddingWidth)) {
-      ContendedPaddingWidth = dcache_line;
+    ContendedPaddingWidth = dcache_line;
   }
 
   if (os::supports_map_sync()) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -969,6 +969,9 @@ void CodeCache::initialize() {
 
 void codeCache_init() {
   CodeCache::initialize();
+}
+
+void AOTLoader_init() {
   // Load AOT libraries and add AOT code heaps.
   AOTLoader::initialize();
 }

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@ void classLoader_init1();
 void compilationPolicy_init();
 void codeCache_init();
 void VM_Version_init();
+void AOTLoader_init();
 void stubRoutines_init1();
 jint universe_init();          // depends on codeCache_init and stubRoutines_init
 // depends on universe_init, must be before interpreter_init (currently only on SPARC)
@@ -115,7 +116,8 @@ jint init_globals() {
   classLoader_init1();
   compilationPolicy_init();
   codeCache_init();
-  VM_Version_init();
+  VM_Version_init();              // depends on codeCache_init for emitting code
+  AOTLoader_init();               // depends on VM_Version_init to adjust vm options
   stubRoutines_init1();
   jint status = universe_init();  // dependent on codeCache_init and
                                   // stubRoutines_init1 and metaspace_init.

--- a/test/hotspot/jtreg/compiler/aot/cli/jaotc/AtFileTest.java
+++ b/test/hotspot/jtreg/compiler/aot/cli/jaotc/AtFileTest.java
@@ -47,7 +47,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class AtFileTest {
     public static void main(String[] args) throws Exception {
-        Path file = Paths.get("jatoc.cmd");
+        Path file = Paths.get("jaotc.cmd");
         Files.write(file, List.of("--class-name",
                 JaotcTestHelper.getClassAotCompilationName(HelloWorldOne.class)));
         OutputAnalyzer oa = JaotcTestHelper.compileLibrary("@" + file.toString());


### PR DESCRIPTION
Recently we tested OpenJDK on some CPUs with 256-byte dcache line size.
HotSpot AOT tests failed because the shared library compiled with the
same VM options on the same machine are skipped when loaded back.

Below command sequence shows a simple way to reproduce this issue.

```
$ getconf -a | grep LEVEL1_DCACHE_LINESIZE
LEVEL1_DCACHE_LINESIZE 256

$ jaotc --output a.so Hello.class

$ java -XX:+UnlockExperimentalVMOptions -XX:+UseAOT -XX:AOTLibrary=./a.so -XX:+PrintAOT Hello
Shared file ./a.so error: ContendedPaddingWidth has different value '256' from current '128'
      4 1 skipped ./a.so aot library
```

The default value of VM option `ContendedPaddingWidth` is 128. But on CPUs
with L1 dcache line size larger than 128 bytes, the value is adjusted to
the cache line size in `VM_Version_init()`. This adjustment is done after
AOT library loading in `codeCache_init()`. So the AOT lib verifier still
assumes the `ContendedPaddingWidth` in the compiled library should be 128
and thus causes the loaded library skipped.

In my proposed fix, `AOTLoader::initialize()` is moved out of the general
codecache initialization and placed after `VM_Version_init()`. The order
of `codeCache_init()` and `VM_Version_init()` is not changed since there may
be code emitted during `VM_Version_init()`, which depends on the general
codecache init.

Tested `hotspot::hotspot_all_no_apps`, `jdk::jdk_core` and `langtools::tier1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264006](https://bugs.openjdk.java.net/browse/JDK-8264006): Fix AOT library loading on CPUs with 256-byte dcache line


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 17b36ef696d93f6435a31cd8407c4af852b52693
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 17b36ef696d93f6435a31cd8407c4af852b52693
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3169/head:pull/3169`
`$ git checkout pull/3169`

To update a local copy of the PR:
`$ git checkout pull/3169`
`$ git pull https://git.openjdk.java.net/jdk pull/3169/head`
