### PR TITLE
JDK-8264111 (fs) Leaking NativeBuffers in case of errors during UnixUserDefinedFileAttributeView.read/write

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -170,10 +170,14 @@ abstract class UnixUserDefinedFileAttributeView
         int rem = (pos <= lim ? lim - pos : 0);
 
         if (dst instanceof sun.nio.ch.DirectBuffer buf) {
-            long address = buf.address() + pos;
-            int n = read(name, address, rem);
-            dst.position(pos + n);
-            return n;
+            try {
+                long address = buf.address() + pos;
+                int n = read(name, address, rem);
+                dst.position(pos + n);
+                return n;
+            } finally {
+                Reference.reachabilityFence(buf);
+            }
         } else {
             try (NativeBuffer nb = NativeBuffers.getNativeBuffer(rem)) {
                 long address = nb.address();
@@ -227,10 +231,14 @@ abstract class UnixUserDefinedFileAttributeView
         int rem = (pos <= lim ? lim - pos : 0);
 
         if (src instanceof sun.nio.ch.DirectBuffer buf) {
-            long address = buf.address() + pos;
-            write(name, address, rem);
-            src.position(pos + rem);
-            return rem;
+            try {
+                long address = buf.address() + pos;
+                write(name, address, rem);
+                src.position(pos + rem);
+                return rem;
+            } finally {
+                Reference.reachabilityFence(buf);
+            }
         } else {
             try (NativeBuffer nb = NativeBuffers.getNativeBuffer(rem)) {
                 long address = nb.address();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -216,6 +216,7 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
+    @Override
     public int write(String name, ByteBuffer src) throws IOException {
         if (System.getSecurityManager() != null)
             checkAccess(file.getPathForPermissionCheck(), false, true);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -25,6 +25,7 @@
 
 package sun.nio.fs;
 
+import java.lang.ref.Reference;
 import java.nio.file.*;
 import java.nio.ByteBuffer;
 import java.io.IOException;


### PR DESCRIPTION
Added new private methods for `read(String name, long address, int rem)` and `write(String name, long address, int rem)` that take an address as an argument and thereby no longer need to deal with any NativeBuffers.

This allows a certain simplification of `read(String name, ByteBuffer dst)` and `write(String name, ByteBuffer src)` and use of `try (NativeBuffer nb = NativeBuffers.getNativeBuffer(rem)) {...}` which fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264111](https://bugs.openjdk.java.net/browse/JDK-8264111): (fs) Leaking NativeBuffers in case of errors during UnixUserDefinedFileAttributeView.read/write


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3171/head:pull/3171`
`$ git checkout pull/3171`

To update a local copy of the PR:
`$ git checkout pull/3171`
`$ git pull https://git.openjdk.java.net/jdk pull/3171/head`
