### PR TITLE
8238173: jshell - switch statement with a single default not return cause syntax error

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -685,6 +685,10 @@ class Eval {
             if (ei == null) {
                 // We got no type info, check for not a statement by trying
                 DiagList dl = trialCompile(guts);
+                if (dl.hasUnreachableError()) {
+                    guts = Wrap.methodUnreachableWrap(compileSource);
+                    dl = trialCompile(guts);
+                }
                 if (dl.hasNotStatement()) {
                     guts = Wrap.methodReturnWrap(compileSource);
                     dl = trialCompile(guts);

--- a/src/jdk.jshell/share/classes/jdk/jshell/ReplParserFactory.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ReplParserFactory.java
@@ -25,6 +25,7 @@
 
 package jdk.jshell;
 
+import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.parser.ScannerFactory;
@@ -49,11 +50,13 @@ class ReplParserFactory extends ParserFactory {
     }
 
     private final ScannerFactory scannerFactory;
+            final Source source;
 
     protected ReplParserFactory(Context context, boolean forceExpression) {
         super(context);
         this.forceExpression = forceExpression;
         this.scannerFactory = ScannerFactory.instance(context);
+        this.source = Source.instance(context);
     }
 
     @Override

--- a/test/langtools/jdk/jshell/ToolLocalSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolLocalSimpleTest.java
@@ -85,23 +85,4 @@ public class ToolLocalSimpleTest extends ToolSimpleTest {
         );
     }
 
-    @Test
-    public void testRawString() {
-        // can't set --enable-preview for local, ignore
-    }
-
-    @Test
-    public void testSwitchExpression() {
-        // can't set --enable-preview for local, ignore
-    }
-
-    @Test
-    public void testSwitchExpressionCompletion() {
-        // can't set --enable-preview for local, ignore
-    }
-
-    @Override
-    public void testRecords() {
-        // can't set --enable-preview for local, ignore
-    }
 }

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8153716 8143955 8151754 8150382 8153920 8156910 8131024 8160089 8153897 8167128 8154513 8170015 8170368 8172102 8172103  8165405 8173073 8173848 8174041 8173916 8174028 8174262 8174797 8177079 8180508 8177466 8172154 8192979 8191842 8198573 8198801 8210596 8210959 8215099 8199623 8236715 8239536 8247456 8246774
+ * @bug 8153716 8143955 8151754 8150382 8153920 8156910 8131024 8160089 8153897 8167128 8154513 8170015 8170368 8172102 8172103  8165405 8173073 8173848 8174041 8173916 8174028 8174262 8174797 8177079 8180508 8177466 8172154 8192979 8191842 8198573 8198801 8210596 8210959 8215099 8199623 8236715 8239536 8247456 8246774 8238173
  * @summary Simple jshell tool tests
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -939,5 +939,21 @@ public class ToolSimpleTest extends ReplToolTesting {
                     (a) -> assertCommandOutputContains(a, "b", "b ==> [bb]")
             );
         }
+    }
+
+    @Test
+    public void testSwitchStatementExpressionDisambiguation() {
+        test(false, new String[]{"--no-startup"},
+                (a) -> assertCommand(a, "switch (0) { default -> 0; }", "$1 ==> 0"),
+                (a) -> assertCommand(a, "int i;", "i ==> 0"),
+                (a) -> assertCommand(a, "switch (0) { case 0 -> i = 1; }", ""),
+                (a) -> assertCommand(a, "i", "i ==> 1"),
+                (a) -> assertCommandOutputStartsWith(a, "switch (0) { default -> throw new IllegalStateException(); }", "|  Exception java.lang.IllegalStateException")
+                );
+        test(false, new String[]{"--no-startup", "-C-source", "-C8"},
+                (a) -> assertCommand(a, "int i;", "i ==> 0"),
+                (a) -> assertCommand(a, "switch (0) { default: i = 1; }", ""),
+                (a) -> assertCommand(a, "i", "i ==> 1")
+                );
     }
 }


### PR DESCRIPTION
Improving disambiguation between switch expressions and switch statements: switches that do not yield a value from any arm should not be considered switch expressions; switches in source levels that don't support switch expressions should always be considered switch statements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238173](https://bugs.openjdk.java.net/browse/JDK-8238173): jshell - switch statement with a single default not return cause syntax error


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3173/head:pull/3173` \
`$ git checkout pull/3173`

Update a local copy of the PR: \
`$ git checkout pull/3173` \
`$ git pull https://git.openjdk.java.net/jdk pull/3173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3173`

View PR using the GUI difftool: \
`$ git pr show -t 3173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3173.diff">https://git.openjdk.java.net/jdk/pull/3173.diff</a>

</details>
