### PR TITLE
8263603: Remove leftovers of "FPE_FLT..." type signals from regular signal handling code

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -489,7 +489,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       } else if (sig == SIGFPE &&
                   (info->si_code >= FPE_FLTDIV && info->si_code <= FPE_FLTSUB)) {
         tty->print_cr("\nUnexpected si_code %d (of type FPE_FLT...) with SIGFPE.\n", info->si_code);
-        fatal("Unexpected FPE_FLT signal, this is probably a bug in the OS");
+        assert(false, "Unexpected FPE_FLT signal, this is probably a bug in the OS");
 
 #else
       if (sig == SIGFPE /* && info->si_code == FPE_INTDIV */) {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -249,14 +249,17 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       }
       else
 
-      if (sig == SIGFPE  &&
-          (info->si_code == FPE_INTDIV || info->si_code == FPE_FLTDIV)) {
+      if (sig == SIGFPE && info->si_code == FPE_INTDIV) {
         stub =
           SharedRuntime::
           continuation_for_implicit_exception(thread,
                                               pc,
                                               SharedRuntime::
                                               IMPLICIT_DIVIDE_BY_ZERO);
+      } else if (sig == SIGFPE &&
+                  (info->si_code >= FPE_FLTDIV && info->si_code <= FPE_FLTSUB)) {
+        tty->print_cr("\nUnexpected si_code %d (of type FPE_FLT...) with SIGFPE.\n", info->si_code);
+        fatal("Unexpected FPE_FLT signal, this is probably a bug in the OS");
       } else if (sig == SIGSEGV &&
                  MacroAssembler::uses_implicit_null_check((void*)addr)) {
           // Determination of interpreter/vtable stub/compiled code null exception

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -259,7 +259,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       } else if (sig == SIGFPE &&
                   (info->si_code >= FPE_FLTDIV && info->si_code <= FPE_FLTSUB)) {
         tty->print_cr("\nUnexpected si_code %d (of type FPE_FLT...) with SIGFPE.\n", info->si_code);
-        fatal("Unexpected FPE_FLT signal, this is probably a bug in the OS");
+        assert(false, "Unexpected FPE_FLT signal, this is probably a bug in the OS");
       } else if (sig == SIGSEGV &&
                  MacroAssembler::uses_implicit_null_check((void*)addr)) {
           // Determination of interpreter/vtable stub/compiled code null exception

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -278,6 +278,10 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                                               pc,
                                               SharedRuntime::
                                               IMPLICIT_DIVIDE_BY_ZERO);
+      } else if (sig == SIGFPE &&
+                  (info->si_code >= FPE_FLTDIV && info->si_code <= FPE_FLTSUB)) {
+        tty->print_cr("\nUnexpected si_code %d (of type FPE_FLT...) with SIGFPE.\n", info->si_code);
+        fatal("Unexpected FPE_FLT signal, this is probably a bug in the OS");
 #else
       if (sig == SIGFPE /* && info->si_code == FPE_INTDIV */) {
         // HACK: si_code does not work on linux 2.2.12-20!!!

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -281,7 +281,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       } else if (sig == SIGFPE &&
                   (info->si_code >= FPE_FLTDIV && info->si_code <= FPE_FLTSUB)) {
         tty->print_cr("\nUnexpected si_code %d (of type FPE_FLT...) with SIGFPE.\n", info->si_code);
-        fatal("Unexpected FPE_FLT signal, this is probably a bug in the OS");
+        assert(false, "Unexpected FPE_FLT signal, this is probably a bug in the OS");
 #else
       if (sig == SIGFPE /* && info->si_code == FPE_INTDIV */) {
         // HACK: si_code does not work on linux 2.2.12-20!!!

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -271,8 +271,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       else
 
 #ifdef AMD64
-      if (sig == SIGFPE  &&
-          (info->si_code == FPE_INTDIV || info->si_code == FPE_FLTDIV)) {
+      if (sig == SIGFPE && info->si_code == FPE_INTDIV) {
         stub =
           SharedRuntime::
           continuation_for_implicit_exception(thread,


### PR DESCRIPTION
hello everyone,

Signal handling code is complex as it is, this enhancement removes, incorrect, catching & handling of `FPE_FLT` types of signals.

It's incorrect, because:

- We wouldn't want to generate/catch a floating point div by zero instructions, which by default do not cause a crash (only integer div by 0 cause crash)

- We can't catch them because that would require us to set **FPU** to raise such signals, which we don't do

- Even if we wanted to generate **FPU** signals, those only originate in **x87 FPU**, which we are not using (we use **SSE** instructions for floating point arithmetic instead) on **x86_64** architecture. Finally the API to turn it on is not even available on macOS at all (it's seems to be available on Linux, but I don't know what it actually does on **64 bit** architecture, if anything)

If we were to catch `FPE_FLT` signal it most likely is a bug in the OS itself, like for example [JDK-8261397](https://bugs.openjdk.java.net/browse/JDK-8261397)

In anticipation of such scenarios we have a generic handling of `FPE_FLT`, but we report it as OS bug that needs to be investigated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263603](https://bugs.openjdk.java.net/browse/JDK-8263603): Remove leftovers of "FPE_FLT..." type signals from regular signal handling code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3175/head:pull/3175` \
`$ git checkout pull/3175`

Update a local copy of the PR: \
`$ git checkout pull/3175` \
`$ git pull https://git.openjdk.java.net/jdk pull/3175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3175`

View PR using the GUI difftool: \
`$ git pr show -t 3175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3175.diff">https://git.openjdk.java.net/jdk/pull/3175.diff</a>

</details>
