### PR TITLE
8264126: Remove TRAPS/THREAD parameter for class loading functions

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -425,8 +425,8 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
     return unloaded_klass;
   }
 
-  Handle loader(THREAD, (oop)NULL);
-  Handle domain(THREAD, (oop)NULL);
+  Handle loader;
+  Handle domain;
   if (accessing_klass != NULL) {
     loader = Handle(THREAD, accessing_klass->loader());
     domain = Handle(THREAD, accessing_klass->protection_domain());
@@ -445,7 +445,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
     MutexLocker ml(Compile_lock);
     Klass* kls;
     if (!require_local) {
-      kls = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader, THREAD);
+      kls = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader);
     } else {
       kls = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -442,10 +442,10 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
   Klass* found_klass;
   {
     ttyUnlocker ttyul;  // release tty lock to avoid ordering problems
-    MutexLocker ml(Compile_lock);
+    MutexLocker ml(current, Compile_lock);
     Klass* kls;
     if (!require_local) {
-      kls = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader);
+      kls = SystemDictionary::find_constrained_instance_or_array_klass(current, sym, loader);
     } else {
       kls = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -405,7 +405,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
                                        ciSymbol* name,
                                        bool require_local) {
   ASSERT_IN_VM;
-  EXCEPTION_CONTEXT;
+  Thread* current = Thread::current();
 
   // Now we need to check the SystemDictionary
   Symbol* sym = name->get_symbol();
@@ -428,8 +428,8 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
   Handle loader;
   Handle domain;
   if (accessing_klass != NULL) {
-    loader = Handle(THREAD, accessing_klass->loader());
-    domain = Handle(THREAD, accessing_klass->protection_domain());
+    loader = Handle(current, accessing_klass->loader());
+    domain = Handle(current, accessing_klass->protection_domain());
   }
 
   // setup up the proper type to return on OOM

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public:
   // SystemDictionary::check_signature_loaders(Symbol* signature,
   //                                           Klass* klass_being_linked,
   //                                           Handle loader1, Handle loader2,
-  //                                           bool is_method, TRAPS)
+  //                                           bool is_method)
 
   InstanceKlass* find_constrained_klass(Symbol* name, Handle loader);
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1816,7 +1816,7 @@ void SystemDictionary::update_dictionary(unsigned int hash,
 // loader constraints might know about a class that isn't fully loaded
 // yet and these will be ignored.
 Klass* SystemDictionary::find_constrained_instance_or_array_klass(
-                    Symbol* class_name, Handle class_loader) {
+                    Thread* current, Symbol* class_name, Handle class_loader) {
 
   // First see if it has been loaded directly.
   // Force the protection domain to be null.  (This removes protection checks.)
@@ -1838,7 +1838,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     if (t != T_OBJECT) {
       klass = Universe::typeArrayKlassObj(t);
     } else {
-      MutexLocker mu(SystemDictionary_lock);
+      MutexLocker mu(current, SystemDictionary_lock);
       klass = constraints()->find_constrained_klass(ss.as_symbol(), class_loader);
     }
     // If element class already loaded, allocate array klass
@@ -1846,7 +1846,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
       klass = klass->array_klass_or_null(ndims);
     }
   } else {
-    MutexLocker mu(SystemDictionary_lock);
+    MutexLocker mu(current, SystemDictionary_lock);
     // Non-array classes are easy: simply check the constraint table.
     klass = constraints()->find_constrained_klass(class_name, class_loader);
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1049,7 +1049,7 @@ InstanceKlass* SystemDictionary::load_shared_boot_class(Symbol* class_name,
 bool SystemDictionary::is_shared_class_visible(Symbol* class_name,
                                                InstanceKlass* ik,
                                                PackageEntry* pkg_entry,
-                                               Handle class_loader, TRAPS) {
+                                               Handle class_loader) {
   assert(!ModuleEntryTable::javabase_moduleEntry()->is_patched(),
          "Cannot use sharing if java.base is patched");
 
@@ -1081,17 +1081,17 @@ bool SystemDictionary::is_shared_class_visible(Symbol* class_name,
   if (MetaspaceShared::use_optimized_module_handling()) {
     // Class visibility has not changed between dump time and run time, so a class
     // that was visible (and thus archived) during dump time is always visible during runtime.
-    assert(SystemDictionary::is_shared_class_visible_impl(class_name, ik, pkg_entry, class_loader, THREAD),
+    assert(SystemDictionary::is_shared_class_visible_impl(class_name, ik, pkg_entry, class_loader),
            "visibility cannot change between dump time and runtime");
     return true;
   }
-  return is_shared_class_visible_impl(class_name, ik, pkg_entry, class_loader, THREAD);
+  return is_shared_class_visible_impl(class_name, ik, pkg_entry, class_loader);
 }
 
 bool SystemDictionary::is_shared_class_visible_impl(Symbol* class_name,
                                                     InstanceKlass* ik,
                                                     PackageEntry* pkg_entry,
-                                                    Handle class_loader, TRAPS) {
+                                                    Handle class_loader) {
   int scp_index = ik->shared_classpath_index();
   assert(!ik->is_shared_unregistered_class(), "this function should be called for built-in classes only");
   assert(scp_index >= 0, "must be");
@@ -1231,8 +1231,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   assert(!ik->is_unshareable_info_restored(), "shared class can be loaded only once");
   Symbol* class_name = ik->name();
 
-  bool visible = is_shared_class_visible(
-                          class_name, ik, pkg_entry, class_loader, CHECK_NULL);
+  bool visible = is_shared_class_visible(class_name, ik, pkg_entry, class_loader);
   if (!visible) {
     return NULL;
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1231,8 +1231,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   assert(!ik->is_unshareable_info_restored(), "shared class can be loaded only once");
   Symbol* class_name = ik->name();
 
-  bool visible = is_shared_class_visible(class_name, ik, pkg_entry, class_loader);
-  if (!visible) {
+  if (!is_shared_class_visible(class_name, ik, pkg_entry, class_loader)) {
     return NULL;
   }
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -349,11 +349,11 @@ private:
 
   static bool is_shared_class_visible(Symbol* class_name, InstanceKlass* ik,
                                       PackageEntry* pkg_entry,
-                                      Handle class_loader, TRAPS);
+                                      Handle class_loader);
   static bool is_shared_class_visible_impl(Symbol* class_name,
                                            InstanceKlass* ik,
                                            PackageEntry* pkg_entry,
-                                           Handle class_loader, TRAPS);
+                                           Handle class_loader);
   static bool check_shared_class_super_type(InstanceKlass* klass, InstanceKlass* super,
                                             Handle class_loader,  Handle protection_domain,
                                             bool is_superclass, TRAPS);

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -169,7 +169,8 @@ class SystemDictionary : AllStatic {
   // satisfied, and it is safe for classes in the given class loader
   // to manipulate strongly-typed values of the found class, subject
   // to local linkage and access checks.
-  static Klass* find_constrained_instance_or_array_klass(Symbol* class_name,
+  static Klass* find_constrained_instance_or_array_klass(Thread* current,
+                                                         Symbol* class_name,
                                                          Handle class_loader);
 
   static void classes_do(MetaspaceClosure* it);

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -170,8 +170,7 @@ class SystemDictionary : AllStatic {
   // to manipulate strongly-typed values of the found class, subject
   // to local linkage and access checks.
   static Klass* find_constrained_instance_or_array_klass(Symbol* class_name,
-                                                           Handle class_loader,
-                                                           Thread* THREAD);
+                                                         Handle class_loader);
 
   static void classes_do(MetaspaceClosure* it);
   // Iterate over all methods in all klasses
@@ -218,7 +217,7 @@ public:
 
 public:
   static Symbol* check_signature_loaders(Symbol* signature, Klass* klass_being_linked,
-                                         Handle loader1, Handle loader2, bool is_method, TRAPS);
+                                         Handle loader1, Handle loader2, bool is_method);
 
   // JSR 292
   // find a java.lang.invoke.MethodHandle.invoke* method for a given signature
@@ -366,7 +365,7 @@ protected:
   // Used by SystemDictionaryShared
 
   static bool add_loader_constraint(Symbol* name, Klass* klass_being_linked,  Handle loader1,
-                                    Handle loader2, TRAPS);
+                                    Handle loader2);
   static void post_class_load_event(EventClassLoad* event, const InstanceKlass* k, const ClassLoaderData* init_cld);
   static InstanceKlass* load_shared_lambda_proxy_class(InstanceKlass* ik,
                                                        Handle class_loader,

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1861,17 +1861,20 @@ void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKla
     return;
   }
 
-  if (Thread::current()->is_VM_thread()) {
-    assert(DynamicDumpSharedSpaces, "must be");
-    // We are re-laying out the vtable/itables of the *copy* of
-    // a class during the final stage of dynamic dumping. The
-    // linking constraints for this class has already been recorded.
-    return;
-  }
-  Arguments::assert_is_dumping_archive();
-  DumpTimeSharedClassInfo* info = find_or_allocate_info_for(klass);
-  if (info != NULL) {
-    info->record_linking_constraint(name, loader1, loader2);
+  if (DynamicDumpSharedSpaces) {
+    if (Thread::current()->is_VM_thread()) {
+      // We are re-laying out the vtable/itables of the *copy* of
+      // a class during the final stage of dynamic dumping. The
+      // linking constraints for this class has already been recorded.
+      return;
+    }
+  } else {
+    assert(!Thread::current()->is_VM_thread(), "must not be");
+    Arguments::assert_is_dumping_archive();
+    DumpTimeSharedClassInfo* info = find_or_allocate_info_for(klass);
+    if (info != NULL) {
+      info->record_linking_constraint(name, loader1, loader2);
+    }
   }
 }
 

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1861,20 +1861,18 @@ void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKla
     return;
   }
 
-  if (DynamicDumpSharedSpaces) {
-    if (Thread::current()->is_VM_thread()) {
-      // We are re-laying out the vtable/itables of the *copy* of
-      // a class during the final stage of dynamic dumping. The
-      // linking constraints for this class has already been recorded.
-      return;
-    }
-  } else {
-    assert(!Thread::current()->is_VM_thread(), "must not be");
-    Arguments::assert_is_dumping_archive();
-    DumpTimeSharedClassInfo* info = find_or_allocate_info_for(klass);
-    if (info != NULL) {
-      info->record_linking_constraint(name, loader1, loader2);
-    }
+  if (DynamicDumpSharedSpaces && Thread::current()->is_VM_thread()) {
+    // We are re-laying out the vtable/itables of the *copy* of
+    // a class during the final stage of dynamic dumping. The
+    // linking constraints for this class has already been recorded.
+    return;
+  }
+  assert(!Thread::current()->is_VM_thread(), "must be");
+
+  Arguments::assert_is_dumping_archive();
+  DumpTimeSharedClassInfo* info = find_or_allocate_info_for(klass);
+  if (info != NULL) {
+    info->record_linking_constraint(name, loader1, loader2);
   }
 }
 

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1823,7 +1823,7 @@ void SystemDictionaryShared::check_verification_constraints(InstanceKlass* klass
 // InstanceKlass::link_class(), so that these can be checked quickly
 // at runtime without laying out the vtable/itables.
 void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKlass* klass,
-                                                    Handle loader1, Handle loader2, TRAPS) {
+                                                    Handle loader1, Handle loader2) {
   // A linking constraint check is executed when:
   //   - klass extends or implements type S
   //   - klass overrides method S.M(...) with X.M
@@ -1861,7 +1861,7 @@ void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKla
     return;
   }
 
-  if (THREAD->is_VM_thread()) {
+  if (Thread::current()->is_VM_thread()) {
     assert(DynamicDumpSharedSpaces, "must be");
     // We are re-laying out the vtable/itables of the *copy* of
     // a class during the final stage of dynamic dumping. The
@@ -1901,7 +1901,7 @@ bool SystemDictionaryShared::check_linking_constraints(InstanceKlass* klass, TRA
                     ClassLoaderData::class_loader_data(loader1())->loader_name_and_id(),
                     ClassLoaderData::class_loader_data(loader2())->loader_name_and_id());
         }
-        if (!SystemDictionary::add_loader_constraint(name, klass, loader1, loader2, THREAD)) {
+        if (!SystemDictionary::add_loader_constraint(name, klass, loader1, loader2)) {
           // Loader constraint violation has been found. The caller
           // will re-layout the vtable/itables to produce the correct
           // exception.

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -299,7 +299,7 @@ public:
                                                           InstanceKlass* caller_ik, TRAPS) NOT_CDS_RETURN_(NULL);
   static bool check_linking_constraints(InstanceKlass* klass, TRAPS) NOT_CDS_RETURN_(false);
   static void record_linking_constraint(Symbol* name, InstanceKlass* klass,
-                                     Handle loader1, Handle loader2, TRAPS) NOT_CDS_RETURN;
+                                     Handle loader1, Handle loader2) NOT_CDS_RETURN;
   static bool is_builtin(InstanceKlass* k) {
     return (k->shared_classpath_index() != UNREGISTERED_INDEX);
   }

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -297,7 +297,7 @@ public:
   static InstanceKlass* get_shared_nest_host(InstanceKlass* lambda_ik) NOT_CDS_RETURN_(NULL);
   static InstanceKlass* prepare_shared_lambda_proxy_class(InstanceKlass* lambda_ik,
                                                           InstanceKlass* caller_ik, TRAPS) NOT_CDS_RETURN_(NULL);
-  static bool check_linking_constraints(InstanceKlass* klass, TRAPS) NOT_CDS_RETURN_(false);
+  static bool check_linking_constraints(Thread* current, InstanceKlass* klass) NOT_CDS_RETURN_(false);
   static void record_linking_constraint(Symbol* name, InstanceKlass* klass,
                                      Handle loader1, Handle loader2) NOT_CDS_RETURN;
   static bool is_builtin(InstanceKlass* k) {

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -675,7 +675,7 @@ void LinkResolver::check_method_loader_constraints(const LinkInfo& link_info,
     SystemDictionary::check_signature_loaders(link_info.signature(),
                                               /*klass_being_linked*/ NULL, // We are not linking class
                                               current_loader,
-                                              resolved_loader, true, CHECK);
+                                              resolved_loader, true);
   if (failed_type_symbol != NULL) {
     Klass* current_class = link_info.current_klass();
     ClassLoaderData* current_loader_data = current_class->class_loader_data();
@@ -712,8 +712,7 @@ void LinkResolver::check_field_loader_constraints(Symbol* field, Symbol* sig,
     SystemDictionary::check_signature_loaders(sig,
                                               /*klass_being_linked*/ NULL, // We are not linking class
                                               ref_loader, sel_loader,
-                                              false,
-                                              CHECK);
+                                              false);
   if (failed_type_symbol != NULL) {
     stringStream ss;
     const char* failed_type_name = failed_type_symbol->as_klass_external_name();

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1255,8 +1255,8 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
     return get_klass_by_name_impl(accessing_klass, cpool, strippedsym, require_local);
   }
 
-  Handle loader(THREAD, (oop)NULL);
-  Handle domain(THREAD, (oop)NULL);
+  Handle loader;
+  Handle domain;
   if (accessing_klass != NULL) {
     loader = Handle(THREAD, accessing_klass->class_loader());
     domain = Handle(THREAD, accessing_klass->protection_domain());
@@ -1267,7 +1267,7 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
     ttyUnlocker ttyul;  // release tty lock to avoid ordering problems
     MutexLocker ml(Compile_lock);
     if (!require_local) {
-      found_klass = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader, THREAD);
+      found_klass = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader);
     } else {
       found_klass = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1265,9 +1265,9 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
   Klass* found_klass;
   {
     ttyUnlocker ttyul;  // release tty lock to avoid ordering problems
-    MutexLocker ml(Compile_lock);
+    MutexLocker ml(THREAD, Compile_lock);
     if (!require_local) {
-      found_klass = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader);
+      found_klass = SystemDictionary::find_constrained_instance_or_array_klass(THREAD, sym, loader);
     } else {
       found_klass = SystemDictionary::find_instance_or_array_klass(sym, loader, domain);
     }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -984,7 +984,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
       // 1) the class is loaded by custom class loader or
       // 2) the class is loaded by built-in class loader but failed to add archived loader constraints
       bool need_init_table = true;
-      if (is_shared() && SystemDictionaryShared::check_linking_constraints(this, THREAD)) {
+      if (is_shared() && SystemDictionaryShared::check_linking_constraints(THREAD, this)) {
         need_init_table = false;
       }
       if (need_init_table) {

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -525,7 +525,7 @@ bool klassVtable::update_inherited_vtable(const methodHandle& target_method,
             Symbol* failed_type_symbol =
               SystemDictionary::check_signature_loaders(signature, _klass,
                                                         target_loader, super_loader,
-                                                        true, CHECK_(false));
+                                                        true);
             if (failed_type_symbol != NULL) {
               stringStream ss;
               ss.print("loader constraint violation for class %s: when selecting "
@@ -1269,7 +1269,7 @@ void klassItable::initialize_itable_for_interface(int method_table_offset, Insta
                                                       _klass,
                                                       method_holder_loader,
                                                       interface_loader,
-                                                      true, CHECK);
+                                                      true);
           if (failed_type_symbol != NULL) {
             stringStream ss;
             ss.print("loader constraint violation in interface itable"

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -320,8 +320,7 @@ Klass* ObjArrayKlass::array_klass_impl(bool or_null, int n, TRAPS) {
   if (higher_dimension_acquire() == NULL) {
     if (or_null) return NULL;
 
-    ResourceMark rm;
-    JavaThread *jt = THREAD->as_Java_thread();
+    ResourceMark rm(THREAD);
     {
       // Ensure atomic creation of higher dimensions
       MutexLocker mu(THREAD, MultiArray_lock);


### PR DESCRIPTION
find_constrained_instance_or_array_klass only passes THREAD so that it can be used in a MutexLocker for SystemDictionary_lock. This can use the MutexLocker that gets Thread::current() without any harm to performance.

The other functions add_loader_constraint, record_linking_constraints, and check_signature_loaders fall out from that.

check_signature_loaders should throw an exception but it unfortunately makes the caller construct the exception message so it doesn't.

Also: is_shared_class_visible{_impl}

Tested with tier1 on 4 Oracle platforms (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264126](https://bugs.openjdk.java.net/browse/JDK-8264126): Remove TRAPS/THREAD parameter for class loading functions


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 82b984e380380038e746d3d43961af7c2bb45381
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3176/head:pull/3176`
`$ git checkout pull/3176`

To update a local copy of the PR:
`$ git checkout pull/3176`
`$ git pull https://git.openjdk.java.net/jdk pull/3176/head`
