### PR TITLE
8220266: add support for additional metadata in add/remove programs

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -198,6 +198,8 @@ public class Arguments {
 
         RELEASE ("linux-app-release", OptionCategories.PROPERTY),
 
+        ABOUT_URL ("about-url", OptionCategories.PROPERTY),
+
         JAVA_OPTIONS ("java-options", OptionCategories.PROPERTY, () -> {
             List<String> args = getArgumentList(popArg());
             args.forEach(a -> setOptionValue("java-options", a));
@@ -326,6 +328,10 @@ public class Arguments {
                     OptionCategories.PLATFORM_MAC),
 
         MAC_ENTITLEMENTS ("mac-entitlements", OptionCategories.PLATFORM_MAC),
+
+        WIN_HELP_URL ("win-help-url", OptionCategories.PLATFORM_WIN),
+
+        WIN_UPDATE_URL ("win-update-url", OptionCategories.PLATFORM_WIN),
 
         WIN_MENU_HINT ("win-menu", OptionCategories.PLATFORM_WIN, () -> {
             setOptionValue("win-menu", true);

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
@@ -193,6 +193,14 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
                     (s, p) -> Path.of(s)
             );
 
+    static final StandardBundlerParam<String> ABOUT_URL =
+            new StandardBundlerParam<>(
+                    Arguments.CLIOptions.ABOUT_URL.getId(),
+                    String.class,
+                    params -> null,
+                    (s, p) -> s
+            );
+
     static final StandardBundlerParam<String> VENDOR =
             new StandardBundlerParam<>(
                     Arguments.CLIOptions.VENDOR.getId(),

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ValidOptions.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ValidOptions.java
@@ -87,11 +87,16 @@ class ValidOptions {
         options.put(CLIOptions.INSTALL_DIR.getId(), USE.INSTALL);
         options.put(CLIOptions.PREDEFINED_APP_IMAGE.getId(), USE.INSTALL);
 
+        options.put(CLIOptions.ABOUT_URL.getId(), USE.INSTALL);
+
         options.put(CLIOptions.FILE_ASSOCIATIONS.getId(),
             (Platform.getPlatform() == Platform.MAC) ?  USE.ALL : USE.INSTALL);
 
         if (Platform.getPlatform() == Platform.WINDOWS) {
             options.put(CLIOptions.WIN_CONSOLE_HINT.getId(), USE.LAUNCHER);
+
+            options.put(CLIOptions.WIN_HELP_URL.getId(), USE.INSTALL);
+            options.put(CLIOptions.WIN_UPDATE_URL.getId(), USE.INSTALL);
 
             options.put(CLIOptions.WIN_MENU_HINT.getId(), USE.INSTALL);
             options.put(CLIOptions.WIN_MENU_GROUP.getId(), USE.INSTALL);

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -166,6 +166,8 @@ Generic Options:\n\
 \          option can be specified but not both.\n\
 {2}\n\
 \Options for creating the application package:\n\
+\  --about-url <url>\n\
+\          URL of the application's home page\n\
 \  --app-image <file path>\n\
 \          Location of the predefined application image that is used\n\
 \          to build an installable package\n\
@@ -205,6 +207,8 @@ MSG_Help_win_install=\
 \  --win-dir-chooser\n\
 \          Adds a dialog to enable the user to choose a directory in which\n\
 \          the product is installed\n\
+\  --win-help-url <url>\n\
+\          URL where user can obtain further information or technical support\n\
 \  --win-menu\n\
 \          Request to add a Start menu shortcut for this application\n\
 \  --win-menu-group <menu group name>\n\
@@ -216,6 +220,8 @@ MSG_Help_win_install=\
 \  --win-shortcut-prompt\n\
 \          Adds a dialog to enable the user to choose if shortcuts\n\
 \          will be created by installer\n\
+\  --win-update-url <url>\n\
+\          URL of available application update information\n\
 \  --win-upgrade-uuid <id string>\n\
 \          UUID associated with upgrades for this package\n\
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_ja.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_ja.properties
@@ -24,17 +24,185 @@
 #
 #
 
-MSG_Help=\u4F7F\u7528\u65B9\u6CD5: jpackage <options>\n\n\u4F7F\u7528\u4F8B:\n--------------\n    \u30DB\u30B9\u30C8\u30FB\u30B7\u30B9\u30C6\u30E0\u306B\u9069\u3057\u305F\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u3092\u751F\u6210\u3057\u307E\u3059\u3002\n        \u30E2\u30B8\u30E5\u30E9\u30FB\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u5834\u5408:\n            jpackage -n name -p modulePath -m moduleName/className\n        \u975E\u30E2\u30B8\u30E5\u30E9\u30FB\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u5834\u5408:\n            jpackage -i inputDir -n name \\\n                --main-class className --main-jar myJar.jar\n        \u4E8B\u524D\u4F5C\u6210\u3055\u308C\u305F\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u304B\u3089:\n            jpackage -n name --app-image appImageDir\n    \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u306E\u751F\u6210:\n        \u30E2\u30B8\u30E5\u30E9\u30FB\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u5834\u5408:\n            jpackage --type app-image -n name -p modulePath \\\n                -m moduleName/className\n        \u975E\u30E2\u30B8\u30E5\u30E9\u30FB\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u5834\u5408:\n            jpackage --type app-image -i inputDir -n name \\\n                --main-class className --main-jar myJar.jar\n        jlink\u306B\u72EC\u81EA\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u6307\u5B9A\u3059\u308B\u306B\u306F\u3001jlink\u3092\u5225\u500B\u306B\u5B9F\u884C\u3057\u307E\u3059\u3002\n            jlink --output appRuntimeImage -p modulePath --add-modules moduleName \\\n                --no-header-files [<additional jlink options>...]\n            jpackage --type app-image -n name \\\n                -m moduleName/className --runtime-image appRuntimeImage\n    Java\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u3092\u751F\u6210\u3057\u307E\u3059\u3002\n        jpackage -n name --runtime-image <runtime-image>\n\n\u4E00\u822C\u7684\u306A\u30AA\u30D7\u30B7\u30E7\u30F3:\n  @<filename> \n          \u30D5\u30A1\u30A4\u30EB\u304B\u3089\u306E\u8AAD\u53D6\u308A\u30AA\u30D7\u30B7\u30E7\u30F3\u304A\u3088\u3073\u30E2\u30FC\u30C9 \n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --type -t <type> \n          \u4F5C\u6210\u3059\u308B\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u30BF\u30A4\u30D7\n          \u6709\u52B9\u306A\u5024: {1} \n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u306A\u3044\u5834\u5408\u3001\u30D7\u30E9\u30C3\u30C8\u30D5\u30A9\u30FC\u30E0\u4F9D\u5B58\u306E\n          \u30C7\u30D5\u30A9\u30EB\u30C8\u30FB\u30BF\u30A4\u30D7\u304C\u4F5C\u6210\u3055\u308C\u307E\u3059\n  --app-version <version>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u304A\u3088\u3073\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u30D0\u30FC\u30B8\u30E7\u30F3\n  --copyright <copyright string>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u30B3\u30D4\u30FC\u30E9\u30A4\u30C8\n  --description <description string>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u8AAC\u660E\n  --help -h \n          \u4F7F\u7528\u65B9\u6CD5\u30C6\u30AD\u30B9\u30C8\u3068\u73FE\u5728\u306E\u30D7\u30E9\u30C3\u30C8\u30D5\u30A9\u30FC\u30E0\u306E\u6709\u52B9\u306A\u30AA\u30D7\u30B7\u30E7\u30F3\u306E\u30EA\u30B9\u30C8\u3068\u8AAC\u660E\u3092\n          \u51FA\u529B\u30B9\u30C8\u30EA\u30FC\u30E0\u306B\u51FA\u529B\u3057\u3066\u3001\u7D42\u4E86\u3057\u307E\u3059\n  --name -n <name>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u304A\u3088\u3073\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u540D\u524D\n  --dest -d <destination path>\n          \u751F\u6210\u3055\u308C\u305F\u51FA\u529B\u30D5\u30A1\u30A4\u30EB\u304C\u914D\u7F6E\u3055\u308C\u308B\u30D1\u30B9\n          \
-\u30C7\u30D5\u30A9\u30EB\u30C8\u306F\u73FE\u5728\u306E\u4F5C\u696D\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u3067\u3059\u3002\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n  --temp <file path>\n          \u4E00\u6642\u30D5\u30A1\u30A4\u30EB\u306E\u4F5C\u6210\u306B\u4F7F\u7528\u3055\u308C\u308B\u65B0\u898F\u307E\u305F\u306F\u7A7A\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          \u6307\u5B9A\u3057\u305F\u5834\u5408\u3001\u30BF\u30B9\u30AF\u5B8C\u4E86\u6642\u306B\u4E00\u6642\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306F\u524A\u9664\u3055\u308C\u306A\u3044\u305F\u3081\n          \u624B\u52D5\u3067\u524A\u9664\u3059\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059\n          \u6307\u5B9A\u3057\u306A\u304B\u3063\u305F\u5834\u5408\u3001\u4E00\u6642\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304C\u4F5C\u6210\u3055\u308C\n          \u30BF\u30B9\u30AF\u5B8C\u4E86\u6642\u306B\u524A\u9664\u3055\u308C\u307E\u3059\u3002\n  --vendor <vendor string>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u30D9\u30F3\u30C0\u30FC\n  --verbose\n          \u8A73\u7D30\u306A\u51FA\u529B\u3092\u6709\u52B9\u306B\u3057\u307E\u3059\n  --version\n          \u88FD\u54C1\u30D0\u30FC\u30B8\u30E7\u30F3\u3092\u51FA\u529B\u30B9\u30C8\u30EA\u30FC\u30E0\u306B\u51FA\u529B\u3057\u3066\u7D42\u4E86\u3057\u307E\u3059\n\n\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30A4\u30E1\u30FC\u30B8\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30AA\u30D7\u30B7\u30E7\u30F3:\n  --add-modules <module name>[,<module name>...]\n          \u8FFD\u52A0\u3059\u308B\u30E2\u30B8\u30E5\u30FC\u30EB\u306E\u30AB\u30F3\u30DE(",")\u533A\u5207\u308A\u30EA\u30B9\u30C8\u3002\n          \u3053\u306E\u30E2\u30B8\u30E5\u30FC\u30EB\u30FB\u30EA\u30B9\u30C8\u3068\u30E1\u30A4\u30F3\u30FB\u30E2\u30B8\u30E5\u30FC\u30EB(\u6307\u5B9A\u3057\u305F\u5834\u5408)\n          \u304C--add-module\u5F15\u6570\u3068\u3057\u3066jlink\u306B\u6E21\u3055\u308C\u307E\u3059\u3002\n          \u6307\u5B9A\u3057\u306A\u304B\u3063\u305F\u5834\u5408\u3001\u30E1\u30A4\u30F3\u30FB\u30E2\u30B8\u30E5\u30FC\u30EB\u306E\u307F(--module\u304C\n          \u6307\u5B9A\u3055\u308C\u305F\u5834\u5408)\u3001\u307E\u305F\u306F\u30C7\u30D5\u30A9\u30EB\u30C8\u306E\u30E2\u30B8\u30E5\u30FC\u30EB\u30FB\u30BB\u30C3\u30C8(--main-jar\u304C \n          \u6307\u5B9A\u3055\u308C\u305F\u5834\u5408)\u304C\u4F7F\u7528\u3055\u308C\u307E\u3059\u3002\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --module-path -p <module path>...\n          \u30D1\u30B9\u306E{0}\u533A\u5207\u308A\u30EA\u30B9\u30C8\n          \u5404\u30D1\u30B9\u306F\u3001\u30E2\u30B8\u30E5\u30FC\u30EB\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u307E\u305F\u306F\n          \u30E2\u30B8\u30E5\u30E9jar\u3078\u306E\u30D1\u30B9\u3067\u3059\u3002\n          (\u5404\u30D1\u30B9\u306F\u3001\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9\u3067\u3059)\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --jlink-options <jlink options> \n          jlink\u306B\u6E21\u3059\u30AA\u30D7\u30B7\u30E7\u30F3\u306E\u30B9\u30DA\u30FC\u30B9\u533A\u5207\u308A\u306E\u30EA\u30B9\u30C8 \n          \u6307\u5B9A\u3057\u306A\u3044\u5834\u5408\u3001"--strip-native-commands \n          --strip-debug --no-man-pages --no-header-files"\u306B\u30C7\u30D5\u30A9\u30EB\u30C8\u8A2D\u5B9A\u3055\u308C\u307E\u3059 \n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --runtime-image <file path>\n          \
-\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u306B\u30B3\u30D4\u30FC\u3055\u308C\u308B\u3001\u4E8B\u524D\u5B9A\u7FA9\u6E08\u307F\u306E\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30A4\u30E1\u30FC\u30B8\n          \u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          --runtime-image\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u306A\u3044\u5834\u5408\u3001jpackage\u306Fjlink\u3092\u5B9F\u884C\u3057\u3001\n          \u6B21\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u4F7F\u7528\u3057\u3066\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30A4\u30E1\u30FC\u30B8\u3092\u4F5C\u6210\u3057\u307E\u3059:\n          --strip-debug\u3001--no-header-files\u3001--no-man-pages\u304A\u3088\u3073\n          --strip-native-commands\u3002\n\n\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30AA\u30D7\u30B7\u30E7\u30F3:\n  --icon <icon file path>\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u30A2\u30A4\u30B3\u30F3\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n  --input -i <input path>\n          \u30D1\u30C3\u30B1\u30FC\u30B8\u5316\u3059\u308B\u30D5\u30A1\u30A4\u30EB\u3092\u542B\u3080\u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u3078\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          \u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306E\u3059\u3079\u3066\u306E\u30D5\u30A1\u30A4\u30EB\u306F\u3001\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u306B\n          \u30D1\u30C3\u30B1\u30FC\u30B8\u5316\u3055\u308C\u307E\u3059\u3002\n\n\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30AA\u30D7\u30B7\u30E7\u30F3:\n  --add-launcher <launcher name>=<file path>\n          \u30E9\u30F3\u30C1\u30E3\u306E\u540D\u524D\u3001\u304A\u3088\u3073\u30AD\u30FC\u3001\u5024\u306E\u30DA\u30A2\u306E\u30EA\u30B9\u30C8\n          \u3092\u542B\u3080\u30D7\u30ED\u30D1\u30C6\u30A3\u30FB\u30D5\u30A1\u30A4\u30EB\u3078\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          \u30AD\u30FC"module"\u3001"main-jar"\u3001"main-class"\u3001\n          "arguments"\u3001"java-options"\u3001"app-version"\u3001"icon"\u3001\n          "win-console"\u3092\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n          \u3053\u308C\u3089\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u5143\u306E\u30B3\u30DE\u30F3\u30C9\u30E9\u30A4\u30F3\u30FB\u30AA\u30D7\u30B7\u30E7\u30F3\u306B\u8FFD\u52A0\u3059\u308B\u304B\u3001\u3053\u308C\u3089\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\n          \u4F7F\u7528\u3057\u3066\u5143\u306E\u30B3\u30DE\u30F3\u30C9\u30E9\u30A4\u30F3\u30FB\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u4E0A\u66F8\u304D\u3057\u3066\u3001\u8FFD\u52A0\u306E\u4EE3\u66FF\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3057\u307E\u3059\u3002\n          \u30E1\u30A4\u30F3\u30FB\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30E9\u30F3\u30C1\u30E3\u306F\u30B3\u30DE\u30F3\u30C9\u30E9\u30A4\u30F3\u30FB\u30AA\u30D7\u30B7\u30E7\u30F3\u304B\u3089\u4F5C\u6210\u3055\u308C\u307E\u3059\u3002\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u4F7F\u7528\u3057\u3066\u8FFD\u52A0\u306E\u4EE3\u66FF\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3067\u304D\u3001\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u8907\u6570\u56DE\u4F7F\u7528\u3057\u3066\n          \
-\u8907\u6570\u306E\u8FFD\u52A0\u306E\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3067\u304D\u307E\u3059\u3002 \n  --arguments <main class arguments>\n          \u30E9\u30F3\u30C1\u30E3\u306B\u30B3\u30DE\u30F3\u30C9\u30FB\u30E9\u30A4\u30F3\u5F15\u6570\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u306A\u3044\u5834\u5408\u306B\u30E1\u30A4\u30F3\u30FB\u30AF\u30E9\u30B9\u306B\u6E21\u3059\n          \u30B3\u30DE\u30F3\u30C9\u30FB\u30E9\u30A4\u30F3\u5F15\u6570\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --java-options <java options>\n          Java\u30E9\u30F3\u30BF\u30A4\u30E0\u306B\u6E21\u3059\u30AA\u30D7\u30B7\u30E7\u30F3\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --main-class <class name>\n          \u5B9F\u884C\u3059\u308B\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30E1\u30A4\u30F3\u30FB\u30AF\u30E9\u30B9\u306E\u4FEE\u98FE\u540D\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u4F7F\u7528\u3067\u304D\u308B\u306E\u306F\u3001--main-jar\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u308B\u5834\u5408\u3060\u3051\u3067\u3059\u3002\n  --main-jar <main jar file>\n          \u30E1\u30A4\u30F3\u30FB\u30AF\u30E9\u30B9\u3092\u542B\u3080\u3001\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u30E1\u30A4\u30F3JAR\n          (\u5165\u529B\u30D1\u30B9\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9\u3068\u3057\u3066\u6307\u5B9A)\n          --module\u307E\u305F\u306F--main-jar\u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u6307\u5B9A\u3067\u304D\u307E\u3059\u304C\u3001\u4E21\u65B9\u306F\n          \u6307\u5B9A\u3067\u304D\u307E\u305B\u3093\u3002\n  --module -m <module name>[/<main class>]\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u30E1\u30A4\u30F3\u30FB\u30E2\u30B8\u30E5\u30FC\u30EB(\u304A\u3088\u3073\u30AA\u30D7\u30B7\u30E7\u30F3\u3067\u30E1\u30A4\u30F3\u30FB\u30AF\u30E9\u30B9)\n          \u3053\u306E\u30E2\u30B8\u30E5\u30FC\u30EB\u306F\u3001\u30E2\u30B8\u30E5\u30FC\u30EB\u30FB\u30D1\u30B9\u306B\u7F6E\u304B\u308C\u3066\u3044\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059\u3002\n          \u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u308B\u5834\u5408\u3001\u30E1\u30A4\u30F3\u30FB\u30E2\u30B8\u30E5\u30FC\u30EB\u306F\n          Java\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30A4\u30E1\u30FC\u30B8\u5185\u3067\u30EA\u30F3\u30AF\u3055\u308C\u307E\u3059\u3002--module\u307E\u305F\u306F--main-jar\n          \u30AA\u30D7\u30B7\u30E7\u30F3\u3092\u6307\u5B9A\u3067\u304D\u307E\u3059\u304C\u3001\u4E21\u65B9\u306F\u6307\u5B9A\u3067\u304D\u307E\u305B\u3093\u3002\n{2}\n\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30AA\u30D7\u30B7\u30E7\u30F3:\n  --app-image <file path>\n          \u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u53EF\u80FD\u306A\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u4F5C\u6210\u306B\u4F7F\u7528\u3059\u308B\u3001\u4E8B\u524D\u5B9A\u7FA9\u6E08\u307F\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30A4\u30E1\u30FC\u30B8\u306E\u5834\u6240\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n  --file-associations <file path>\n          \u30AD\u30FC\u3001\u5024\u306E\u30DA\u30A2\u306E\u30EA\u30B9\u30C8\u3092\u542B\u3080\u30D7\u30ED\u30D1\u30C6\u30A3\u30FB\u30D5\u30A1\u30A4\u30EB\u3078\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          \u30AD\u30FC"extension"\u3001"mime-type"\u3001"icon"\u3001"description"\n          \u3092\u4F7F\u7528\u3057\u3066\u95A2\u9023\u4ED8\u3051\u3092\u8A18\u8FF0\u3067\u304D\u307E\u3059\u3002\n          \
-\u3053\u306E\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u8907\u6570\u56DE\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002\n  --install-dir <file path>\n          {4}  --license-file <file path>\n          \u30E9\u30A4\u30BB\u30F3\u30B9\u30FB\u30D5\u30A1\u30A4\u30EB\u3078\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n  --resource-dir <path>\n          \u30AA\u30FC\u30D0\u30FC\u30E9\u30A4\u30C9jpackage\u30EA\u30BD\u30FC\u30B9\u3078\u306E\u30D1\u30B9\n          \u30A2\u30A4\u30B3\u30F3\u3001\u30C6\u30F3\u30D7\u30EC\u30FC\u30C8\u30FB\u30D5\u30A1\u30A4\u30EB\u304A\u3088\u3073jpackage\u306E\u305D\u306E\u4ED6\u306E\u30EA\u30BD\u30FC\u30B9\u306F\u3001\n          \u3053\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306B\u7F6E\u63DB\u30EA\u30BD\u30FC\u30B9\u3092\u8FFD\u52A0\u3059\u308B\u3053\u3068\u3067\u30AA\u30FC\u30D0\u30FC\u30E9\u30A4\u30C9\u3067\u304D\u307E\u3059\u3002\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n  --runtime-image <file-path>\n          \u30A4\u30F3\u30B9\u30C8\u30FC\u30EB\u3059\u308B\u4E8B\u524D\u5B9A\u7FA9\u6E08\u307F\u306E\u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30A4\u30E1\u30FC\u30B8\u306E\u30D1\u30B9\n          (\u7D76\u5BFE\u30D1\u30B9\u307E\u305F\u306F\u73FE\u5728\u306E\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u306E\u76F8\u5BFE\u30D1\u30B9)\n          \u30E9\u30F3\u30BF\u30A4\u30E0\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u306E\u4F5C\u6210\u6642\u306B\u306F\u3001\u30AA\u30D7\u30B7\u30E7\u30F3\u304C\u5FC5\u8981\u3067\u3059\u3002\n\n\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30D1\u30C3\u30B1\u30FC\u30B8\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30D7\u30E9\u30C3\u30C8\u30D5\u30A9\u30FC\u30E0\u4F9D\u5B58\u30AA\u30D7\u30B7\u30E7\u30F3:\n{3}
+MSG_Help=Usage: jpackage <options>\n\
+\n\
+Sample usages:\n\
+--------------\n\
+\    Generate an application package suitable for the host system:\n\
+\        For a modular application:\n\
+\            jpackage -n name -p modulePath -m moduleName/className\n\
+\        For a non-modular application:\n\
+\            jpackage -i inputDir -n name \\\n\
+\                --main-class className --main-jar myJar.jar\n\
+\        From a pre-built application image:\n\
+\            jpackage -n name --app-image appImageDir\n\
+\    Generate an application image:\n\
+\        For a modular application:\n\
+\            jpackage --type app-image -n name -p modulePath \\\n\
+\                -m moduleName/className\n\
+\        For a non-modular application:\n\
+\            jpackage --type app-image -i inputDir -n name \\\n\
+\                --main-class className --main-jar myJar.jar\n\
+\        To provide your own options to jlink, run jlink separately:\n\
+\            jlink --output appRuntimeImage -p modulePath \\\n\
+\                --add-modules moduleName \\\n\
+\                --no-header-files [<additional jlink options>...]\n\
+\            jpackage --type app-image -n name \\\n\
+\                -m moduleName/className --runtime-image appRuntimeImage\n\
+\    Generate a Java runtime package:\n\
+\        jpackage -n name --runtime-image <runtime-image>\n\
+\n\
+Generic Options:\n\
+\  @<filename> \n\
+\          Read options and/or mode from a file \n\
+\          This option can be used multiple times.\n\
+\  --type -t <type> \n\
+\          The type of package to create\n\
+\          Valid values are: {1} \n\
+\          If this option is not specified a platform dependent\n\
+\          default type will be created.\n\
+\  --app-version <version>\n\
+\          Version of the application and/or package\n\
+\  --copyright <copyright string>\n\
+\          Copyright for the application\n\
+\  --description <description string>\n\
+\          Description of the application\n\
+\  --help -h \n\
+\          Print the usage text with a list and description of each valid\n\
+\          option for the current platform to the output stream, and exit\n\
+\  --name -n <name>\n\
+\          Name of the application and/or package\n\
+\  --dest -d <destination path>\n\
+\          Path where generated output file is placed\n\
+\          Defaults to the current working directory.\n\
+\          (absolute path or relative to the current directory)\n\
+\  --temp <file path>\n\
+\          Path of a new or empty directory used to create temporary files\n\
+\          (absolute path or relative to the current directory)\n\
+\          If specified, the temp dir will not be removed upon the task\n\
+\          completion and must be removed manually\n\
+\          If not specified, a temporary directory will be created and\n\
+\          removed upon the task completion.\n\
+\  --vendor <vendor string>\n\
+\          Vendor of the application\n\
+\  --verbose\n\
+\          Enables verbose output\n\
+\  --version\n\
+\          Print the product version to the output stream and exit\n\
+\n\
+\Options for creating the runtime image:\n\
+\  --add-modules <module name>[,<module name>...]\n\
+\          A comma (",") separated list of modules to add.\n\
+\          This module list, along with the main module (if specified)\n\
+\          will be passed to jlink as the --add-module argument.\n\
+\          if not specified, either just the main module (if --module is\n\
+\          specified), or the default set of modules (if --main-jar is \n\
+\          specified) are used.\n\
+\          This option can be used multiple times.\n\
+\  --module-path -p <module path>...\n\
+\          A {0} separated list of paths\n\
+\          Each path is either a directory of modules or the path to a\n\
+\          modular jar.\n\
+\          (each path is absolute or relative to the current directory)\n\
+\          This option can be used multiple times.\n\
+\  --jlink-options <jlink options> \n\
+\          A space separated list of options to pass to jlink \n\
+\          If not specified, defaults to "--strip-native-commands \n\
+\          --strip-debug --no-man-pages --no-header-files" \n\
+\          This option can be used multiple times.\n\
+\  --runtime-image <file path>\n\
+\          Path of the predefined runtime image that will be copied into\n\
+\          the application image\n\
+\          (absolute path or relative to the current directory)\n\
+\          If --runtime-image is not specified, jpackage will run jlink to\n\
+\          create the runtime image using options:\n\
+\          --strip-debug, --no-header-files, --no-man-pages, and\n\
+\          --strip-native-commands.\n\
+\n\
+\Options for creating the application image:\n\
+\  --icon <icon file path>\n\
+\          Path of the icon of the application package\n\
+\          (absolute path or relative to the current directory)\n\
+\  --input -i <input path>\n\
+\          Path of the input directory that contains the files to be packaged\n\
+\          (absolute path or relative to the current directory)\n\
+\          All files in the input directory will be packaged into the\n\
+\          application image.\n\
+\n\
+\Options for creating the application launcher(s):\n\
+\  --add-launcher <launcher name>=<file path>\n\
+\          Name of launcher, and a path to a Properties file that contains\n\
+\          a list of key, value pairs\n\
+\          (absolute path or relative to the current directory)\n\
+\          The keys "module", "main-jar", "main-class",\n\
+\          "arguments", "java-options", "app-version", "icon", and\n\
+\          "win-console" can be used.\n\
+\          These options are added to, or used to overwrite, the original\n\
+\          command line options to build an additional alternative launcher.\n\
+\          The main application launcher will be built from the command line\n\
+\          options. Additional alternative launchers can be built using\n\
+\          this option, and this option can be used multiple times to\n\
+\          build multiple additional launchers. \n\
+\  --arguments <main class arguments>\n\
+\          Command line arguments to pass to the main class if no command\n\
+\          line arguments are given to the launcher\n\
+\          This option can be used multiple times.\n\
+\  --java-options <java options>\n\
+\          Options to pass to the Java runtime\n\
+\          This option can be used multiple times.\n\
+\  --main-class <class name>\n\
+\          Qualified name of the application main class to execute\n\
+\          This option can only be used if --main-jar is specified.\n\
+\  --main-jar <main jar file>\n\
+\          The main JAR of the application; containing the main class\n\
+\          (specified as a path relative to the input path)\n\
+\          Either --module or --main-jar option can be specified but not\n\
+\          both.\n\
+\  --module -m <module name>[/<main class>]\n\
+\          The main module (and optionally main class) of the application\n\
+\          This module must be located on the module path.\n\
+\          When this option is specified, the main module will be linked\n\
+\          in the Java runtime image.  Either --module or --main-jar\n\
+\          option can be specified but not both.\n\
+{2}\n\
+\Options for creating the application package:\n\
+\  --about-url <url>\n\
+\          URL of the application's home page\n\
+\  --app-image <file path>\n\
+\          Location of the predefined application image that is used\n\
+\          to build an installable package\n\
+\          (absolute path or relative to the current directory)\n\
+\  --file-associations <file path>\n\
+\          Path to a Properties file that contains list of key, value pairs\n\
+\          (absolute path or relative to the current directory)\n\
+\          The keys "extension", "mime-type", "icon", and "description"\n\
+\          can be used to describe the association.\n\
+\          This option can be used multiple times.\n\
+\  --install-dir <file path>\n\
+\          {4}\
+\  --license-file <file path>\n\
+\          Path to the license file\n\
+\          (absolute path or relative to the current directory)\n\
+\  --resource-dir <path>\n\
+\          Path to override jpackage resources\n\
+\          Icons, template files, and other resources of jpackage can be\n\
+\          over-ridden by adding replacement resources to this directory.\n\
+\          (absolute path or relative to the current directory)\n\
+\  --runtime-image <file path>\n\
+\          Path of the predefined runtime image to install\n\
+\          (absolute path or relative to the current directory)\n\
+\          Option is required when creating a runtime package.\n\
+\n\
+\Platform dependent options for creating the application package:\n\
+{3}
 
 MSG_Help_win_launcher=\n\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u30FB\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3059\u308B\u305F\u3081\u306E\u30D7\u30E9\u30C3\u30C8\u30D5\u30A9\u30FC\u30E0\u4F9D\u5B58\u30AA\u30D7\u30B7\u30E7\u30F3:\n  --win-console\n          \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306E\u30B3\u30F3\u30BD\u30FC\u30EB\u30FB\u30E9\u30F3\u30C1\u30E3\u3092\u4F5C\u6210\u3057\u307E\u3059\u3002\u30B3\u30F3\u30BD\u30FC\u30EB\u30FB\n          \u30A4\u30F3\u30BF\u30E9\u30AF\u30B7\u30E7\u30F3\u304C\u5FC5\u8981\u306A\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3\u306B\u6307\u5B9A\u3059\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059\n
 MSG_Help_win_install=\
 \  --win-dir-chooser\n\
 \          Adds a dialog to enable the user to choose a directory in which\n\
 \          the product is installed\n\
+\  --win-help-url <url>\n\
+\          URL where user can obtain further information or technical support\n\
 \  --win-menu\n\
 \          Request to add a Start menu shortcut for this application\n\
 \  --win-menu-group <menu group name>\n\
@@ -46,6 +214,8 @@ MSG_Help_win_install=\
 \  --win-shortcut-prompt\n\
 \          Adds a dialog to enable the user to choose if shortcuts\n\
 \          will be created by installer\n\
+\  --win-update-url <url>\n\
+\          URL of available application update information\n\
 \  --win-upgrade-uuid <id string>\n\
 \          UUID associated with upgrades for this package\n\
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_zh_CN.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_zh_CN.properties
@@ -24,16 +24,185 @@
 #
 #
 
-MSG_Help=\u7528\u6CD5\uFF1Ajpackage <options>\n\n\u793A\u4F8B\u7528\u6CD5:\n--------------\n    \u751F\u6210\u9002\u5408\u4E3B\u673A\u7CFB\u7EDF\u7684\u5E94\u7528\u7A0B\u5E8F\u5305\uFF1A\n        \u5BF9\u4E8E\u6A21\u5757\u5316\u5E94\u7528\u7A0B\u5E8F\uFF1A\n            jpackage -n name -p modulePath -m moduleName/className\n        \u5BF9\u4E8E\u975E\u6A21\u5757\u5316\u5E94\u7528\u7A0B\u5E8F\uFF1A\n            jpackage -i inputDir -n name \\\n                --main-class className --main-jar myJar.jar\n        \u4ECE\u9884\u6784\u5EFA\u7684\u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\uFF1A\n            jpackage -n name --app-image appImageDir\n    \u751F\u6210\u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\uFF1A\n        \u5BF9\u4E8E\u6A21\u5757\u5316\u5E94\u7528\u7A0B\u5E8F\uFF1A\n            jpackage --type app-image -n name -p modulePath \\\n                -m moduleName/className\n        \u5BF9\u4E8E\u975E\u6A21\u5757\u5316\u5E94\u7528\u7A0B\u5E8F\uFF1A\n            jpackage --type app-image -i inputDir -n name \\\n                --main-class className --main-jar myJar.jar\n        \u8981\u4E3A jlink \u63D0\u4F9B\u60A8\u81EA\u5DF1\u7684\u9009\u9879\uFF0C\u8BF7\u5355\u72EC\u8FD0\u884C jlink\uFF1A\n            jlink --output appRuntimeImage -p modulePath --add-modules moduleName \\\n                --no-header-files [<additional jlink options>...]\n            jpackage --type app-image -n name \\\n                -m moduleName/className --runtime-image appRuntimeImage\n    \u751F\u6210 Java \u8FD0\u884C\u65F6\u7A0B\u5E8F\u5305\uFF1A\n        jpackage -n name --runtime-image <runtime-image>\n\n\u4E00\u822C\u9009\u9879\uFF1A\n  @<filename> \n          \u4ECE\u6587\u4EF6\u8BFB\u53D6\u9009\u9879\u548C/\u6216\u6A21\u5F0F \n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --type -t <type> \n          \u8981\u521B\u5EFA\u7684\u7A0B\u5E8F\u5305\u7684\u7C7B\u578B\n          \u6709\u6548\u503C\u4E3A\uFF1A{1} \n          \u5982\u679C\u672A\u6307\u5B9A\u6B64\u9009\u9879\uFF0C\u5219\u5C06\u521B\u5EFA\u4E0E\u5E73\u53F0\u76F8\u5173\u7684\n          \u9ED8\u8BA4\u7C7B\u578B\u3002\n  --app-version <version>\n          \u5E94\u7528\u7A0B\u5E8F\u548C/\u6216\u7A0B\u5E8F\u5305\u7684\u7248\u672C\n  --copyright <copyright string>\n          \u5E94\u7528\u7A0B\u5E8F\u7684\u7248\u6743\n  --description <description string>\n          \u5E94\u7528\u7A0B\u5E8F\u7684\u8BF4\u660E\n  --help -h \n          \u5C06\u7528\u6CD5\u6587\u672C\u8F93\u51FA\u5230\u8F93\u51FA\u6D41\u5E76\u9000\u51FA\uFF0C\u7528\u6CD5\u6587\u672C\u4E2D\u5305\u542B\n          \u9002\u7528\u4E8E\u5F53\u524D\u5E73\u53F0\u7684\u6BCF\u4E2A\u6709\u6548\u9009\u9879\u7684\u5217\u8868\u548C\u8BF4\u660E\n  --name -n <name>\n          \u5E94\u7528\u7A0B\u5E8F\u548C/\u6216\u7A0B\u5E8F\u5305\u7684\u540D\u79F0\n  --dest -d <destination path>\n          \u7528\u6765\u653E\u7F6E\u6240\u751F\u6210\u7684\u8F93\u51FA\u6587\u4EF6\u7684\u8DEF\u5F84\n          \u9ED8\u8BA4\u4E3A\u5F53\u524D\u7684\u5DE5\u4F5C\u76EE\u5F55\u3002\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n  --temp <file path>\n          \u7528\u6765\u521B\u5EFA\u4E34\u65F6\u6587\u4EF6\u7684\u65B0\u76EE\u5F55\u6216\u7A7A\u767D\u76EE\u5F55\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u5982\u679C\u6307\u5B9A\uFF0C\u5219\u5728\u4EFB\u52A1\u5B8C\u6210\u65F6\u5C06\u4E0D\u5220\u9664\u4E34\u65F6\u76EE\u5F55\uFF0C\n          \u5FC5\u987B\u624B\u52A8\u5220\u9664\u4E34\u65F6\u76EE\u5F55\n          \u5982\u679C\u672A\u6307\u5B9A\uFF0C\u5219\u5C06\u521B\u5EFA\u4E00\u4E2A\u4E34\u65F6\u76EE\u5F55\uFF0C\n          \u5E76\u5728\u4EFB\u52A1\u5B8C\u6210\u65F6\u5220\u9664\u8BE5\u4E34\u65F6\u76EE\u5F55\u3002\n  --vendor <vendor string>\n          \u5E94\u7528\u7A0B\u5E8F\u7684\u4F9B\u5E94\u5546\n  --verbose\n          \u542F\u7528\u8BE6\u7EC6\u7684\u8F93\u51FA\n  --version\n          \
-\u5C06\u4EA7\u54C1\u7248\u672C\u8F93\u51FA\u5230\u8F93\u51FA\u6D41\u5E76\u9000\u51FA\n\n\u7528\u6765\u521B\u5EFA\u8FD0\u884C\u65F6\u6620\u50CF\u7684\u9009\u9879\uFF1A\n  --add-modules <\u6A21\u5757\u540D\u79F0>[,<\u6A21\u5757\u540D\u79F0>...]\n          \u8981\u6DFB\u52A0\u7684\u6A21\u5757\u7684\u9017\u53F7 (",") \u5206\u9694\u5217\u8868\u3002\n          \u6B64\u6A21\u5757\u5217\u8868\u8FDE\u540C\u4E3B\u6A21\u5757\uFF08\u5982\u679C\u6307\u5B9A\uFF09\n          \u5C06\u4F5C\u4E3A --add-module \u53C2\u6570\u4F20\u9012\u5230 jlink\u3002\n          \u5982\u679C\u672A\u6307\u5B9A\uFF0C\u5219\u4EC5\u4F7F\u7528\u4E3B\u6A21\u5757\uFF08\u5982\u679C\u6307\u5B9A\u4E86 --module\uFF09\uFF0C\n          \u6216\u8005\u4F7F\u7528\u9ED8\u8BA4\u7684\u6A21\u5757\u96C6\uFF08\u5982\u679C\u6307\u5B9A\u4E86  \n          --main-jar\uFF09\u3002\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --module-path -p <module path>...\n          \u8DEF\u5F84\u7684 {0} \u5206\u9694\u5217\u8868\n          \u6BCF\u4E2A\u8DEF\u5F84\u8981\u4E48\u662F\u6A21\u5757\u7684\u76EE\u5F55\uFF0C\u8981\u4E48\u662F\n          \u6A21\u5757 jar \u7684\u8DEF\u5F84\u3002\n          \uFF08\u6BCF\u4E2A\u8DEF\u5F84\u53EF\u4EE5\u662F\u7EDD\u5BF9\u8DEF\u5F84\uFF0C\u4E5F\u53EF\u4EE5\u662F\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --jlink-options <jlink \u9009\u9879> \n          \u8981\u4F20\u9012\u7ED9 jlink \u7684\u9009\u9879\u5217\u8868\uFF08\u7528\u7A7A\u683C\u5206\u9694\uFF09 \n          \u5982\u679C\u672A\u6307\u5B9A\uFF0C\u5219\u9ED8\u8BA4\u4E3A "--strip-native-commands \n          --strip-debug --no-man-pages --no-header-files" \n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --runtime-image <file path>\n          \u5C06\u590D\u5236\u5230\u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\u7684\u9884\u5B9A\u4E49\n          \u8FD0\u884C\u65F6\u6620\u50CF\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u5982\u679C\u672A\u6307\u5B9A --runtime-image\uFF0Cjpackage \u5C06\u8FD0\u884C jlink \u4EE5\n          \u4F7F\u7528\u5982\u4E0B\u9009\u9879\u521B\u5EFA\u8FD0\u884C\u65F6\u6620\u50CF\uFF1A\n          --strip-debug\u3001--no-header-files\u3001--no-man-pages \u548C \n          --strip-native-commands\u3002\n\n\u7528\u6765\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\u7684\u9009\u9879\uFF1A\n  --icon <icon file path>\n          \u5E94\u7528\u7A0B\u5E8F\u5305\u56FE\u6807\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n  --input -i <input path>\n          \u5305\u542B\u8981\u6253\u5305\u7684\u6587\u4EF6\u7684\u8F93\u5165\u76EE\u5F55\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u8F93\u5165\u76EE\u5F55\u4E2D\u7684\u6240\u6709\u6587\u4EF6\u5C06\u6253\u5305\u5230\n          \u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\u4E2D\u3002\n\n\u7528\u6765\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u542F\u52A8\u7A0B\u5E8F\u7684\u9009\u9879\uFF1A\n  --add-launcher <launcher name>=<file path>\n          \u542F\u52A8\u7A0B\u5E8F\u7684\u540D\u79F0\u548C\u5305\u542B\u5173\u952E\u5B57-\u503C\u5BF9\u5217\u8868\u7684\n          \u5C5E\u6027\u6587\u4EF6\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u53EF\u4EE5\u4F7F\u7528\u5173\u952E\u5B57 "module"\u3001"main-jar"\u3001"main-class"\u3001\n          "arguments"\u3001"java-options"\u3001"app-version"\u3001"icon" \u548C \n          "win-console"\u3002\n          \u8FD9\u4E9B\u9009\u9879\u5C06\u6DFB\u52A0\u5230\u539F\u59CB\u547D\u4EE4\u884C\u9009\u9879\u4E2D\u6216\u8005\u7528\u6765\u8986\u76D6\n          \
-\u539F\u59CB\u547D\u4EE4\u884C\u9009\u9879\uFF0C\u4EE5\u6784\u5EFA\u989D\u5916\u7684\u66FF\u4EE3\u542F\u52A8\u7A0B\u5E8F\u3002\n          \u5C06\u4ECE\u547D\u4EE4\u884C\u9009\u9879\u6784\u5EFA\u4E3B\u5E94\u7528\u7A0B\u5E8F\u542F\u52A8\u7A0B\u5E8F\u3002\n          \u53EF\u4EE5\u4F7F\u7528\u6B64\u9009\u9879\u6784\u5EFA\u989D\u5916\u7684\u66FF\u4EE3\u542F\u52A8\u7A0B\u5E8F\uFF0C\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u6765\u6784\u5EFA\n          \u591A\u4E2A\u989D\u5916\u7684\u542F\u52A8\u7A0B\u5E8F\u3002 \n  --arguments <main class arguments>\n          \u5728\u6CA1\u6709\u4E3A\u542F\u52A8\u7A0B\u5E8F\u63D0\u4F9B\u547D\u4EE4\u884C\u53C2\u6570\u65F6\uFF0C\n          \u8981\u4F20\u9012\u5230\u4E3B\u7C7B\u7684\u547D\u4EE4\u884C\u53C2\u6570\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --java-options <java options>\n          \u8981\u4F20\u9012\u5230 Java \u8FD0\u884C\u65F6\u7684\u9009\u9879\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --main-class <class name>\n          \u8981\u6267\u884C\u7684\u5E94\u7528\u7A0B\u5E8F\u4E3B\u7C7B\u7684\u9650\u5B9A\u540D\u79F0\n          \u53EA\u6709\u5728\u6307\u5B9A\u4E86 --main-jar \u65F6\u624D\u80FD\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --main-jar <main jar file>\n          \u5E94\u7528\u7A0B\u5E8F\u7684\u4E3B JAR\uFF1B\u5305\u542B\u4E3B\u7C7B\n          \uFF08\u6307\u5B9A\u4E3A\u76F8\u5BF9\u4E8E\u8F93\u5165\u8DEF\u5F84\u7684\u8DEF\u5F84\uFF09\n          \u53EF\u4EE5\u6307\u5B9A --module \u6216 --main-jar \u9009\u9879\uFF0C\u4F46\u662F\u4E0D\u80FD\u540C\u65F6\u6307\u5B9A\n          \u4E24\u8005\u3002\n  --module -m <module name>[/<main class>]\n          \u5E94\u7528\u7A0B\u5E8F\u7684\u4E3B\u6A21\u5757\uFF08\u4EE5\u53CA\u53EF\u9009\u7684\u4E3B\u7C7B\uFF09\n          \u6B64\u6A21\u5757\u5FC5\u987B\u4F4D\u4E8E\u6A21\u5757\u8DEF\u5F84\u4E2D\u3002\n          \u5982\u679C\u6307\u5B9A\u4E86\u6B64\u9009\u9879\uFF0C\u5219\u5C06\u5728 Java \u8FD0\u884C\u65F6\u6620\u50CF\u4E2D\n          \u94FE\u63A5\u4E3B\u6A21\u5757\u3002\u53EF\u4EE5\u6307\u5B9A --module \u6216 --main-jar \u9009\u9879\uFF0C\n          \u4F46\u662F\u4E0D\u80FD\u540C\u65F6\u6307\u5B9A\u8FD9\u4E24\u4E2A\u9009\u9879\u3002\n{2}\n\u7528\u6765\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u5305\u7684\u9009\u9879\uFF1A\n  --app-image <file path>\n          \u7528\u6765\u6784\u5EFA\u53EF\u5B89\u88C5\u7A0B\u5E8F\u5305\u7684\n          \u9884\u5B9A\u4E49\u5E94\u7528\u7A0B\u5E8F\u6620\u50CF\u7684\u4F4D\u7F6E\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n  --file-associations <file path>\n          \u5305\u542B\u5173\u952E\u5B57-\u503C\u5BF9\u5217\u8868\u7684\u5C5E\u6027\u6587\u4EF6\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u53EF\u4EE5\u4F7F\u7528\u5173\u952E\u5B57 "extension"\u3001"mime-type"\u3001"icon" \u548C "description" \n          \u6765\u63CF\u8FF0\u6B64\u5173\u8054\u3002\n          \u53EF\u4EE5\u591A\u6B21\u4F7F\u7528\u6B64\u9009\u9879\u3002\n  --install-dir <file path>\n          {4}  --license-file <file path>\n          \u8BB8\u53EF\u8BC1\u6587\u4EF6\u7684\u8DEF\u5F84\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n  --resource-dir <path>\n          \u8986\u76D6 jpackage \u8D44\u6E90\u7684\u8DEF\u5F84\n          \u53EF\u4EE5\u901A\u8FC7\u5411\u8BE5\u76EE\u5F55\u4E2D\u6DFB\u52A0\u66FF\u4EE3\u8D44\u6E90\u6765\u8986\u76D6 jpackage \u7684\n          \u56FE\u6807\u3001\u6A21\u677F\u6587\u4EF6\u548C\u5176\u4ED6\u8D44\u6E90\u3002\n          \uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n  --runtime-image <file-path>\n          \u8981\u5B89\u88C5\u7684\u9884\u5B9A\u4E49\u8FD0\u884C\u65F6\u6620\u50CF\u7684\u8DEF\u5F84\n          \
-\uFF08\u7EDD\u5BF9\u8DEF\u5F84\u6216\u76F8\u5BF9\u4E8E\u5F53\u524D\u76EE\u5F55\u7684\u8DEF\u5F84\uFF09\n          \u5728\u521B\u5EFA\u8FD0\u884C\u65F6\u7A0B\u5E8F\u5305\u65F6\u9700\u8981\u4F7F\u7528\u9009\u9879\u3002\n\n\u7528\u6765\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u5305\u7684\u4E0E\u5E73\u53F0\u76F8\u5173\u7684\u9009\u9879\uFF1A\n{3}
+MSG_Help=Usage: jpackage <options>\n\
+\n\
+Sample usages:\n\
+--------------\n\
+\    Generate an application package suitable for the host system:\n\
+\        For a modular application:\n\
+\            jpackage -n name -p modulePath -m moduleName/className\n\
+\        For a non-modular application:\n\
+\            jpackage -i inputDir -n name \\\n\
+\                --main-class className --main-jar myJar.jar\n\
+\        From a pre-built application image:\n\
+\            jpackage -n name --app-image appImageDir\n\
+\    Generate an application image:\n\
+\        For a modular application:\n\
+\            jpackage --type app-image -n name -p modulePath \\\n\
+\                -m moduleName/className\n\
+\        For a non-modular application:\n\
+\            jpackage --type app-image -i inputDir -n name \\\n\
+\                --main-class className --main-jar myJar.jar\n\
+\        To provide your own options to jlink, run jlink separately:\n\
+\            jlink --output appRuntimeImage -p modulePath \\\n\
+\                --add-modules moduleName \\\n\
+\                --no-header-files [<additional jlink options>...]\n\
+\            jpackage --type app-image -n name \\\n\
+\                -m moduleName/className --runtime-image appRuntimeImage\n\
+\    Generate a Java runtime package:\n\
+\        jpackage -n name --runtime-image <runtime-image>\n\
+\n\
+Generic Options:\n\
+\  @<filename> \n\
+\          Read options and/or mode from a file \n\
+\          This option can be used multiple times.\n\
+\  --type -t <type> \n\
+\          The type of package to create\n\
+\          Valid values are: {1} \n\
+\          If this option is not specified a platform dependent\n\
+\          default type will be created.\n\
+\  --app-version <version>\n\
+\          Version of the application and/or package\n\
+\  --copyright <copyright string>\n\
+\          Copyright for the application\n\
+\  --description <description string>\n\
+\          Description of the application\n\
+\  --help -h \n\
+\          Print the usage text with a list and description of each valid\n\
+\          option for the current platform to the output stream, and exit\n\
+\  --name -n <name>\n\
+\          Name of the application and/or package\n\
+\  --dest -d <destination path>\n\
+\          Path where generated output file is placed\n\
+\          Defaults to the current working directory.\n\
+\          (absolute path or relative to the current directory)\n\
+\  --temp <file path>\n\
+\          Path of a new or empty directory used to create temporary files\n\
+\          (absolute path or relative to the current directory)\n\
+\          If specified, the temp dir will not be removed upon the task\n\
+\          completion and must be removed manually\n\
+\          If not specified, a temporary directory will be created and\n\
+\          removed upon the task completion.\n\
+\  --vendor <vendor string>\n\
+\          Vendor of the application\n\
+\  --verbose\n\
+\          Enables verbose output\n\
+\  --version\n\
+\          Print the product version to the output stream and exit\n\
+\n\
+\Options for creating the runtime image:\n\
+\  --add-modules <module name>[,<module name>...]\n\
+\          A comma (",") separated list of modules to add.\n\
+\          This module list, along with the main module (if specified)\n\
+\          will be passed to jlink as the --add-module argument.\n\
+\          if not specified, either just the main module (if --module is\n\
+\          specified), or the default set of modules (if --main-jar is \n\
+\          specified) are used.\n\
+\          This option can be used multiple times.\n\
+\  --module-path -p <module path>...\n\
+\          A {0} separated list of paths\n\
+\          Each path is either a directory of modules or the path to a\n\
+\          modular jar.\n\
+\          (each path is absolute or relative to the current directory)\n\
+\          This option can be used multiple times.\n\
+\  --jlink-options <jlink options> \n\
+\          A space separated list of options to pass to jlink \n\
+\          If not specified, defaults to "--strip-native-commands \n\
+\          --strip-debug --no-man-pages --no-header-files" \n\
+\          This option can be used multiple times.\n\
+\  --runtime-image <file path>\n\
+\          Path of the predefined runtime image that will be copied into\n\
+\          the application image\n\
+\          (absolute path or relative to the current directory)\n\
+\          If --runtime-image is not specified, jpackage will run jlink to\n\
+\          create the runtime image using options:\n\
+\          --strip-debug, --no-header-files, --no-man-pages, and\n\
+\          --strip-native-commands.\n\
+\n\
+\Options for creating the application image:\n\
+\  --icon <icon file path>\n\
+\          Path of the icon of the application package\n\
+\          (absolute path or relative to the current directory)\n\
+\  --input -i <input path>\n\
+\          Path of the input directory that contains the files to be packaged\n\
+\          (absolute path or relative to the current directory)\n\
+\          All files in the input directory will be packaged into the\n\
+\          application image.\n\
+\n\
+\Options for creating the application launcher(s):\n\
+\  --add-launcher <launcher name>=<file path>\n\
+\          Name of launcher, and a path to a Properties file that contains\n\
+\          a list of key, value pairs\n\
+\          (absolute path or relative to the current directory)\n\
+\          The keys "module", "main-jar", "main-class",\n\
+\          "arguments", "java-options", "app-version", "icon", and\n\
+\          "win-console" can be used.\n\
+\          These options are added to, or used to overwrite, the original\n\
+\          command line options to build an additional alternative launcher.\n\
+\          The main application launcher will be built from the command line\n\
+\          options. Additional alternative launchers can be built using\n\
+\          this option, and this option can be used multiple times to\n\
+\          build multiple additional launchers. \n\
+\  --arguments <main class arguments>\n\
+\          Command line arguments to pass to the main class if no command\n\
+\          line arguments are given to the launcher\n\
+\          This option can be used multiple times.\n\
+\  --java-options <java options>\n\
+\          Options to pass to the Java runtime\n\
+\          This option can be used multiple times.\n\
+\  --main-class <class name>\n\
+\          Qualified name of the application main class to execute\n\
+\          This option can only be used if --main-jar is specified.\n\
+\  --main-jar <main jar file>\n\
+\          The main JAR of the application; containing the main class\n\
+\          (specified as a path relative to the input path)\n\
+\          Either --module or --main-jar option can be specified but not\n\
+\          both.\n\
+\  --module -m <module name>[/<main class>]\n\
+\          The main module (and optionally main class) of the application\n\
+\          This module must be located on the module path.\n\
+\          When this option is specified, the main module will be linked\n\
+\          in the Java runtime image.  Either --module or --main-jar\n\
+\          option can be specified but not both.\n\
+{2}\n\
+\Options for creating the application package:\n\
+\  --about-url <url>\n\
+\          URL of the application's home page\n\
+\  --app-image <file path>\n\
+\          Location of the predefined application image that is used\n\
+\          to build an installable package\n\
+\          (absolute path or relative to the current directory)\n\
+\  --file-associations <file path>\n\
+\          Path to a Properties file that contains list of key, value pairs\n\
+\          (absolute path or relative to the current directory)\n\
+\          The keys "extension", "mime-type", "icon", and "description"\n\
+\          can be used to describe the association.\n\
+\          This option can be used multiple times.\n\
+\  --install-dir <file path>\n\
+\          {4}\
+\  --license-file <file path>\n\
+\          Path to the license file\n\
+\          (absolute path or relative to the current directory)\n\
+\  --resource-dir <path>\n\
+\          Path to override jpackage resources\n\
+\          Icons, template files, and other resources of jpackage can be\n\
+\          over-ridden by adding replacement resources to this directory.\n\
+\          (absolute path or relative to the current directory)\n\
+\  --runtime-image <file path>\n\
+\          Path of the predefined runtime image to install\n\
+\          (absolute path or relative to the current directory)\n\
+\          Option is required when creating a runtime package.\n\
+\n\
+\Platform dependent options for creating the application package:\n\
+{3}
 
 MSG_Help_win_launcher=\n\u7528\u6765\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u542F\u52A8\u7A0B\u5E8F\u7684\u4E0E\u5E73\u53F0\u76F8\u5173\u7684\u9009\u9879\uFF1A\n  --win-console\n          \u4E3A\u5E94\u7528\u7A0B\u5E8F\u521B\u5EFA\u63A7\u5236\u53F0\u542F\u52A8\u7A0B\u5E8F\uFF0C\u5E94\u5F53\u4E3A\n          \u9700\u8981\u63A7\u5236\u53F0\u4EA4\u4E92\u7684\u5E94\u7528\u7A0B\u5E8F\u6307\u5B9A\n
 MSG_Help_win_install=\
 \  --win-dir-chooser\n\
 \          Adds a dialog to enable the user to choose a directory in which\n\
 \          the product is installed\n\
+\  --win-help-url <url>\n\
+\          URL where user can obtain further information or technical support\n\
 \  --win-menu\n\
 \          Request to add a Start menu shortcut for this application\n\
 \  --win-menu-group <menu group name>\n\
@@ -45,6 +214,8 @@ MSG_Help_win_install=\
 \  --win-shortcut-prompt\n\
 \          Adds a dialog to enable the user to choose if shortcuts\n\
 \          will be created by installer\n\
+\  --win-update-url <url>\n\
+\          URL of available application update information\n\
 \  --win-upgrade-uuid <id string>\n\
 \          UUID associated with upgrades for this package\n\
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import static jdk.jpackage.internal.OverridableResource.createResource;
+import static jdk.jpackage.internal.StandardBundlerParam.ABOUT_URL;
 import static jdk.jpackage.internal.StandardBundlerParam.APP_NAME;
 import static jdk.jpackage.internal.StandardBundlerParam.INSTALLER_NAME;
 import static jdk.jpackage.internal.StandardBundlerParam.CONFIG_ROOT;
@@ -110,6 +112,13 @@ import org.xml.sax.SAXException;
  * files.
  * <li>JpIsSystemWide. Set to "yes" if --win-per-user-install command line
  * option was not specified. Undefined otherwise
+ * <li>JpAppSizeKb. Set to estimated size of the application in kilobytes
+ * <li>JpHelpURL. Set to value of --win-help-url command line option if it
+ * was specified. Undefined otherwise
+ * <li>JpAboutURL. Set to value of --about-url command line option if it
+ * was specified. Undefined otherwise
+ * <li>JpUpdateURL. Set to value of --win-update-url command line option if it
+ * was specified. Undefined otherwise
  * </ul>
  *
  * <p>
@@ -165,6 +174,20 @@ public class WinMsiBundler  extends AbstractBundler {
                     VERSION::fetchFrom,
                     (s, p) -> s
             );
+
+    private static final BundlerParamInfo<String> HELP_URL =
+            new StandardBundlerParam<>(
+            Arguments.CLIOptions.WIN_HELP_URL.getId(),
+            String.class,
+            null,
+            (s, p) -> s);
+
+    private static final BundlerParamInfo<String> UPDATE_URL =
+            new StandardBundlerParam<>(
+            Arguments.CLIOptions.WIN_UPDATE_URL.getId(),
+            String.class,
+            null,
+            (s, p) -> s);
 
     private static final BundlerParamInfo<String> UPGRADE_UUID =
             new StandardBundlerParam<>(
@@ -396,6 +419,21 @@ public class WinMsiBundler  extends AbstractBundler {
         }
     }
 
+    private long getAppImageSizeKb(Map<String, ? super Object> params) throws
+            IOException {
+        ApplicationLayout appLayout;
+        if (StandardBundlerParam.isRuntimeInstaller(params)) {
+            appLayout = ApplicationLayout.javaRuntime();
+        } else {
+            appLayout = ApplicationLayout.windowsAppImage();
+        }
+        appLayout = appLayout.resolveAt(WIN_APP_IMAGE.fetchFrom(params));
+
+        long size = appLayout.sizeInBytes() >> 10;
+
+        return size;
+    }
+
     private Map<String, String> prepareMainProjectFile(
             Map<String, ? super Object> params) throws IOException {
         Map<String, String> data = new HashMap<>();
@@ -421,6 +459,20 @@ public class WinMsiBundler  extends AbstractBundler {
         if (Files.exists(installerIcon)) {
             data.put("JpIcon", installerIcon.toString());
         }
+
+        Optional.ofNullable(HELP_URL.fetchFrom(params)).ifPresent(value -> {
+            data.put("JpHelpURL", value);
+        });
+
+        Optional.ofNullable(UPDATE_URL.fetchFrom(params)).ifPresent(value -> {
+            data.put("JpUpdateURL", value);
+        });
+
+        Optional.ofNullable(ABOUT_URL.fetchFrom(params)).ifPresent(value -> {
+            data.put("JpAboutURL", value);
+        });
+
+        data.put("JpAppSizeKb", Long.toString(getAppImageSizeKb(params)));
 
         final Path configDir = CONFIG_ROOT.fetchFrom(params);
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/main.wxs
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/main.wxs
@@ -75,16 +75,44 @@
     </Feature>
 
     <CustomAction Id="JpSetARPINSTALLLOCATION" Property="ARPINSTALLLOCATION" Value="[INSTALLDIR]" />
+    <CustomAction Id="JpSetARPCOMMENTS" Property="ARPCOMMENTS" Value="$(var.JpAppDescription)" />
+    <CustomAction Id="JpSetARPCONTACT" Property="ARPCONTACT" Value="$(var.JpAppVendor)" />
+    <CustomAction Id="JpSetARPSIZE" Property="ARPSIZE" Value="$(var.JpAppSizeKb)" />
+
+    <?ifdef JpHelpURL ?>
+      <CustomAction Id="JpSetARPHELPLINK" Property="ARPHELPLINK" Value="$(var.JpHelpURL)" />
+    <?endif?>
+
+    <?ifdef JpAboutURL ?>
+      <CustomAction Id="JpSetARPURLINFOABOUT" Property="ARPURLINFOABOUT" Value="$(var.JpAboutURL)" />
+    <?endif?>
+
+    <?ifdef JpUpdateURL ?>
+      <CustomAction Id="JpSetARPURLUPDATEINFO" Property="ARPURLUPDATEINFO" Value="$(var.JpUpdateURL)" />
+    <?endif?>
 
     <?ifdef JpIcon ?>
     <Property Id="ARPPRODUCTICON" Value="JpARPPRODUCTICON"/>
     <Icon Id="JpARPPRODUCTICON" SourceFile="$(var.JpIcon)"/>
     <?endif?>
-    
+
     <UIRef Id="JpUI"/>
 
     <InstallExecuteSequence>
       <Custom Action="JpSetARPINSTALLLOCATION" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPCOMMENTS" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPCONTACT" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPSIZE" After="CostFinalize">Not Installed</Custom>
+      <?ifdef JpHelpURL ?>
+        <Custom Action="JpSetARPHELPLINK" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+      <?ifdef JpAboutURL ?>
+        <Custom Action="JpSetARPURLINFOABOUT" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+      <?ifdef JpUpdateURL ?>
+        <Custom Action="JpSetARPURLUPDATEINFO" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+
       <?ifndef JpAllowUpgrades ?>
       <Custom Action="JpDisallowUpgrade" After="FindRelatedProducts">JP_UPGRADABLE_FOUND</Custom>
       <?endif?>

--- a/test/jdk/tools/jpackage/windows/WinUrlTest.java
+++ b/test/jdk/tools/jpackage/windows/WinUrlTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Annotations.Parameters;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import jdk.jpackage.test.PackageType;
+
+/**
+ * Test all possible combinations of --about-url, --win-update-url and
+ * --win-help-url parameters.
+ */
+
+/*
+ * @test
+ * @summary jpackage with --about-url, --win-update-url and --win-help-url
+ *          parameters
+ * @library ../helpers
+ * @key jpackagePlatformPackage
+ * @build jdk.jpackage.test.*
+ * @build WinUrlTest
+ * @requires (os.family == "windows")
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ *  --jpt-run=WinUrlTest
+ */
+public class WinUrlTest {
+
+    static enum URL {
+        About("--about-url"),
+        Update("--win-update-url"),
+        Help("--win-help-url");
+
+        URL(String cliOption) {
+            this.cliOption = cliOption;
+        }
+
+        final String cliOption;
+    }
+
+    public WinUrlTest(Boolean withAboutURL, Boolean withUpdateURL,
+            Boolean withHelpURL) {
+        urls = Stream.of(
+                withAboutURL ? URL.About : null,
+                withUpdateURL ? URL.Update : null,
+                withHelpURL ? URL.Help : null
+        ).filter(Objects::nonNull).toList();
+    }
+
+    @Parameters
+    public static List<Object[]> data() {
+        List<Object[]> data = new ArrayList<>();
+        for (var withAboutURL : List.of(Boolean.TRUE, Boolean.FALSE)) {
+            for (var withUpdateURL : List.of(Boolean.TRUE, Boolean.FALSE)) {
+                for (var withHelpURL : List.of(Boolean.TRUE, Boolean.FALSE)) {
+                    var args = new Object[]{withAboutURL, withUpdateURL, withHelpURL};
+                    if (Stream.of(args).anyMatch(Boolean.TRUE::equals)) {
+                        data.add(args);
+                    }
+                }
+            }
+        }
+
+        return data;
+    }
+
+    @Test
+    public void test() {
+        PackageTest test = new PackageTest()
+                .forTypes(PackageType.WINDOWS)
+                .configureHelloApp();
+
+        test.addInitializer(JPackageCommand::setFakeRuntime);
+        test.addInitializer(this::setPackageName);
+
+        urls.forEach(url -> {
+            test.addInitializer(cmd -> cmd.addArguments(url.cliOption,
+                    "http://localhost/" + url.name().toLowerCase()));
+        });
+
+        test.run();
+    }
+
+    private void setPackageName(JPackageCommand cmd) {
+        StringBuilder sb = new StringBuilder(cmd.name());
+        sb.append("With");
+        urls.forEach(url -> sb.append(url.name()));
+        cmd.setArgumentValue("--name", sb.toString());
+    }
+
+    private final List<URL> urls;
+}

--- a/test/jdk/tools/jpackage/windows/WinUrlTest.java
+++ b/test/jdk/tools/jpackage/windows/WinUrlTest.java
@@ -28,8 +28,6 @@ import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameters;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jdk.jpackage.test.PackageType;
 


### PR DESCRIPTION
Add support for `--about-url`, `--win-update-url` and `--win-help-url` parameters.
Implementation for `--about-url` is provided on Windows only.
This parameter may be supported on Linux as well. https://bugs.openjdk.java.net/browse/JDK-8264144 is tracking this task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220266](https://bugs.openjdk.java.net/browse/JDK-8220266): add support for additional metadata in add/remove programs


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3178/head:pull/3178`
`$ git checkout pull/3178`

To update a local copy of the PR:
`$ git checkout pull/3178`
`$ git pull https://git.openjdk.java.net/jdk pull/3178/head`
