### PR TITLE
8264146 Make Mutex point to rather than embed _name

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -281,14 +281,9 @@ bool is_sometimes_ok(const char* name) {
 }
 
 Mutex::Mutex(int Rank, const char * name, bool allow_vm_block,
-             SafepointCheckRequired safepoint_check_required) : _owner(NULL) {
+             SafepointCheckRequired safepoint_check_required) : _owner(NULL), _name(name) {
   assert(os::mutex_init_done(), "Too early!");
-  if (name == NULL) {
-    strcpy(_name, "UNKNOWN");
-  } else {
-    strncpy(_name, name, MUTEX_NAME_LEN - 1);
-    _name[MUTEX_NAME_LEN - 1] = '\0';
-  }
+  assert(name != NULL, "Mutex requires a name");
 #ifdef ASSERT
   _allow_vm_block  = allow_vm_block;
   _rank            = Rank;

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,6 @@
 // usage bugs). If you call try_lock on a mutex you already own it will return false.
 // The underlying PlatformMutex may support recursive locking but this is not exposed
 // and we account for that possibility in try_lock.
-
-// The default length of mutex name was originally chosen to be 64 to avoid
-// false sharing. Now, PaddedMutex and PaddedMonitor are available for this purpose.
-// TODO: Check if _name[MUTEX_NAME_LEN] should better get replaced by const char*.
-static const int MUTEX_NAME_LEN = 64;
 
 class Mutex : public CHeapObj<mtSynchronizer> {
 
@@ -91,7 +86,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 
  protected:                              // Monitor-Mutex metadata
   os::PlatformMonitor _lock;             // Native monitor implementation
-  char _name[MUTEX_NAME_LEN];            // Name of mutex/monitor
+  const char* _name;                     // Name of mutex/monitor
 
   // Debugging fields for naming, deadlock detection, etc. (some only used in debug mode)
 #ifndef PRODUCT


### PR DESCRIPTION
This change removes the code that copies the name of a Mutex into a 64 char embedded array.
Tested with tier1 and performance tests on linux - startup/footprint , specjbb2015, dacapo and javac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264146](https://bugs.openjdk.java.net/browse/JDK-8264146): Make Mutex point to rather than embed _name


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3179/head:pull/3179`
`$ git checkout pull/3179`

To update a local copy of the PR:
`$ git checkout pull/3179`
`$ git pull https://git.openjdk.java.net/jdk pull/3179/head`
