### PR TITLE
8264151: ciMethod::ensure_method_data() should return false is loading resulted in empty state

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -966,6 +966,9 @@ bool ciMethod::ensure_method_data(const methodHandle& h_m) {
   if (h_m()->method_data() != NULL) {
     _method_data = CURRENT_ENV->get_method_data(h_m()->method_data());
     _method_data->load_data();
+    if (_method_data->is_empty()) { // This may happen because of the compilation replay
+      return false;
+    }
     return true;
   } else {
     _method_data = CURRENT_ENV->get_empty_methodData();

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -965,11 +965,7 @@ bool ciMethod::ensure_method_data(const methodHandle& h_m) {
   }
   if (h_m()->method_data() != NULL) {
     _method_data = CURRENT_ENV->get_method_data(h_m()->method_data());
-    _method_data->load_data();
-    if (_method_data->is_empty()) { // This may happen because of the compilation replay
-      return false;
-    }
-    return true;
+    return _method_data->load_data();
   } else {
     _method_data = CURRENT_ENV->get_empty_methodData();
     return false;

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -170,10 +170,10 @@ void ciMethodData::load_remaining_extra_data() {
   }
 }
 
-void ciMethodData::load_data() {
+bool ciMethodData::load_data() {
   MethodData* mdo = get_MethodData();
   if (mdo == NULL) {
-    return;
+    return false;
   }
 
   // To do: don't copy the data if it is not "ripe" -- require a minimum #
@@ -263,8 +263,12 @@ void ciMethodData::load_data() {
 #ifndef PRODUCT
   if (ReplayCompiles) {
     ciReplay::initialize(this);
+    if (is_empty()) {
+      return false;
+    }
   }
 #endif
+  return true;
 }
 
 void ciReceiverTypeData::translate_receiver_data_from(const ProfileData* data) {

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -507,7 +507,7 @@ public:
   void set_parameter_type(int i, ciKlass* k);
   void set_return_type(int bci, ciKlass* k);
 
-  void load_data();
+  bool load_data();
 
   // Convert a dp (data pointer) to a di (data index).
   int dp_to_di(address dp) {


### PR DESCRIPTION
ciMethodData::load_data() can set the state of the MDO to empty (if it's replaying a compile). In this case we should return false from ensure_method_data().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264151](https://bugs.openjdk.java.net/browse/JDK-8264151): ciMethod::ensure_method_data() should return false is loading resulted in empty state


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3184/head:pull/3184`
`$ git checkout pull/3184`

To update a local copy of the PR:
`$ git checkout pull/3184`
`$ git pull https://git.openjdk.java.net/jdk pull/3184/head`
