### PR TITLE
8261551: Remove special CDS handling in Metaspace::allocate

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -822,13 +822,6 @@ MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
   }
 
   if (result == NULL) {
-    if (DumpSharedSpaces) {
-      // CDS dumping keeps loading classes, so if we hit an OOM we probably will keep hitting OOM.
-      // We should abort to avoid generating a potentially bad archive.
-      vm_exit_during_cds_dumping(err_msg("Failed allocating metaspace object type %s of size " SIZE_FORMAT ". CDS dump aborted.",
-          MetaspaceObj::type_name(type), word_size * BytesPerWord),
-        err_msg("Please increase MaxMetaspaceSize (currently " SIZE_FORMAT " bytes).", MaxMetaspaceSize));
-    }
     report_metadata_oome(loader_data, word_size, type, mdtype, THREAD);
     assert(HAS_PENDING_EXCEPTION, "sanity");
     return NULL;

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -612,7 +612,8 @@ void MetaspaceShared::prepare_for_dumping() {
 
 // Preload classes from a list, populate the shared spaces and dump to a
 // file.
-void MetaspaceShared::preload_and_dump(TRAPS) {
+void MetaspaceShared::preload_and_dump() {
+  EXCEPTION_MARK;
   ResourceMark rm(THREAD);
   preload_and_dump_impl(THREAD);
   if (HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/memory/metaspaceShared.hpp
+++ b/src/hotspot/share/memory/metaspaceShared.hpp
@@ -77,7 +77,7 @@ class MetaspaceShared : AllStatic {
   };
 
   static void prepare_for_dumping() NOT_CDS_RETURN;
-  static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
+  static void preload_and_dump() NOT_CDS_RETURN;
 
 private:
   static void preload_and_dump_impl(TRAPS) NOT_CDS_RETURN;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3401,7 +3401,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif
 
   if (DumpSharedSpaces) {
-    MetaspaceShared::preload_and_dump(CHECK_JNI_ERR);
+    MetaspaceShared::preload_and_dump();
     ShouldNotReachHere();
   }
 

--- a/test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java
+++ b/test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class MaxMetaspaceSize {
       processArgs.add("-XX:MaxMetaspaceSize=1m");
     }
 
-    String msg = "Failed allocating metaspace object";
+    String msg = "OutOfMemoryError: Metaspace";
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(processArgs);
     CDSTestUtils.executeAndLog(pb, "dump").shouldContain(msg).shouldHaveExitValue(1);
   }


### PR DESCRIPTION
Please review this simple patch to remove the special handling of OOM conditions inside `Metaspace::allocate()` for CDS archive dumping. Now the OOM exception will be thrown normally and will be handled by `MetaspaceShared::preload_and_dump()` and `ClassListParser::parse()`.


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261551](https://bugs.openjdk.java.net/browse/JDK-8261551): Remove special CDS handling in Metaspace::allocate


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 5708f5efc224725bd9fca5690d7159f82ab83247
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 5708f5efc224725bd9fca5690d7159f82ab83247


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3185/head:pull/3185`
`$ git checkout pull/3185`

To update a local copy of the PR:
`$ git checkout pull/3185`
`$ git pull https://git.openjdk.java.net/jdk pull/3185/head`
