### PR TITLE
Bulk placeholder replace in String

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4595,4 +4595,14 @@ public final class String
         return this;
     }
 
+    public String replace(Map<String, String> replacements) {
+        if (replacements.isEmpty()) {
+            return this;
+        }
+
+        return Pattern.compile(String.join("|", (Iterable<String>) replacements.keySet().stream().map(Pattern::quote)::iterator))
+            .matcher(this)
+            .replaceAll(matchResult -> Matcher.quoteReplacement(replacements.get(matchResult.group())));
+    }
+
 }


### PR DESCRIPTION
A common situation in backend code is a template string that needs to be filled with values.

One can certainly use String.formatted but it gets cumbersome quickly. You have to keep count and track of all the positions of the values. If one isn't required anymore, it forces you to update all of the other placeholders as well.

Another method would be to use String.replace with custom placeholders. This does not suffer the same problem as String.formatted in regards to positions. This approach does have a different problem though. In a chain of String.replace calls, a previous call might replace its own placeholders with placeholders of one of the following String.replace calls. This might lead to security concerns since the values of those replacements are often user-provided.

Therefore I propose the addition of a convenience method in the String class. The method takes a Map of String keys and String values. All occurrences of the keys in the String are replaced with the corresponding value in a fashion where the following replacements are not aware of the previous replacements and it allows custom placeholders.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3186/head:pull/3186`
`$ git checkout pull/3186`

To update a local copy of the PR:
`$ git checkout pull/3186`
`$ git pull https://git.openjdk.java.net/jdk pull/3186/head`
