### PR TITLE
8244540: Print more information with -XX:+PrintSharedArchiveAndExit

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -275,6 +275,13 @@ void SymbolTable::symbols_do(SymbolClosure *cl) {
   _local_table->do_safepoint_scan(sd);
 }
 
+// Call function for all symbols in shared table. Used by -XX:+PrintSharedArchiveAndExit
+void SymbolTable::shared_symbols_do(SymbolClosure *cl) {
+  SharedSymbolIterator iter(cl);
+  _shared_table.iterate(&iter);
+  _dynamic_shared_table.iterate(&iter);
+}
+
 Symbol* SymbolTable::lookup_dynamic(const char* name,
                                     int len, unsigned int hash) {
   Symbol* sym = do_lookup(name, len, hash);

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,6 +207,7 @@ public:
   static void symbols_do(SymbolClosure *cl);
 
   // Sharing
+  static void shared_symbols_do(SymbolClosure *cl);  // no safepoint iteration.
 private:
   static void copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
                                        CompactHashtableWriter* ch_table);

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -316,6 +316,7 @@ public:
   static void serialize_vm_classes(class SerializeClosure* soc);
   static void print() { return print_on(tty); }
   static void print_on(outputStream* st) NOT_CDS_RETURN;
+  static void print_shared_archive(outputStream* st, bool is_static = true) NOT_CDS_RETURN;
   static void print_table_statistics(outputStream* st) NOT_CDS_RETURN;
   static bool empty_dumptime_table() NOT_CDS_RETURN_(true);
   static void start_dumping() NOT_CDS_RETURN;

--- a/src/hotspot/share/memory/filemap.hpp
+++ b/src/hotspot/share/memory/filemap.hpp
@@ -544,6 +544,10 @@ public:
     header()->print(st);
   }
 
+  const char* vm_version() {
+    return header()->jvm_ident();
+  }
+
  private:
   void  seek_to_position(size_t pos);
   char* skip_first_path_entry(const char* path) NOT_CDS_RETURN_(NULL);

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1403,12 +1403,12 @@ void MetaspaceShared::initialize_shared_spaces() {
       tty->print_cr("Static archive version %d", static_mapinfo->version());
     }
 
+    SystemDictionaryShared::print_shared_archive(tty);
     if (dynamic_mapinfo != nullptr) {
       tty->print_cr("\n\nDynamic archive name: %s", dynamic_mapinfo->full_path());
       tty->print_cr("Dynamic archive version %d", dynamic_mapinfo->version());
+      SystemDictionaryShared::print_shared_archive(tty, false/*dynamic*/);
     }
-
-    SystemDictionaryShared::print_on(tty);
 
     // collect shared symbols and strings
     CountSharedSymbols cl;

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1332,6 +1332,34 @@ void MetaspaceShared::unmap_archive(FileMapInfo* mapinfo) {
   }
 }
 
+// For -XX:PrintSharedArchiveAndExit
+class CountSharedSymbols : public SymbolClosure {
+ private:
+   int _count;
+ public:
+   CountSharedSymbols() : _count(0) {}
+  void do_symbol(Symbol** sym) {
+    _count++;
+  }
+  int total() { return _count; }
+
+};
+
+// For -XX:PrintSharedArchiveAndExit
+class CountSharedStrings : public OopClosure {
+ private:
+  int _count;
+ public:
+  CountSharedStrings() : _count(0) {}
+  void do_oop(oop* p) {
+    _count++;
+  }
+  void do_oop(narrowOop* p) {
+    _count++;
+  }
+  int total() { return _count; }
+};
+
 // Read the miscellaneous data from the shared file, and
 // serialize it out to its various destinations.
 
@@ -1366,10 +1394,30 @@ void MetaspaceShared::initialize_shared_spaces() {
   }
 
   if (PrintSharedArchiveAndExit) {
-    if (PrintSharedDictionary) {
-      tty->print_cr("\nShared classes:\n");
-      SystemDictionaryShared::print_on(tty);
+    // Print archive names
+    if (dynamic_mapinfo != nullptr) {
+      tty->print_cr("\n\nBase archive name: %s", Arguments::GetSharedArchivePath());
+      tty->print_cr("Base archive version %d", static_mapinfo->version());
+    } else {
+      tty->print_cr("Static archive name: %s", static_mapinfo->full_path());
+      tty->print_cr("Static archive version %d", static_mapinfo->version());
     }
+
+    if (dynamic_mapinfo != nullptr) {
+      tty->print_cr("\n\nDynamic archive name: %s", dynamic_mapinfo->full_path());
+      tty->print_cr("Dynamic archive version %d", dynamic_mapinfo->version());
+    }
+
+    SystemDictionaryShared::print_on(tty);
+
+    // collect shared symbols and strings
+    CountSharedSymbols cl;
+    SymbolTable::shared_symbols_do(&cl);
+    tty->print_cr("Number of shared symbols: %d", cl.total());
+    CountSharedStrings cs;
+    StringTable::shared_oops_do(&cs);
+    tty->print_cr("Number of shared strings: %d", cs.total());
+    tty->print_cr("VM version: %s\r\n", static_mapinfo->vm_version());
     if (FileMapInfo::current_info() == NULL || _archive_loading_failed) {
       tty->print_cr("archive is invalid");
       vm_exit(1);

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
@@ -82,6 +82,6 @@ public class PrintSharedArchiveAndExit {
               .shouldContain("Shared Builtin Dictionary")
               .shouldContain("Shared Unregistered Dictionary")
               .shouldMatch("Number of shared symbols: \\d+")
-              .shouldMatch("Number of shared strings: \\d+"); 
+              .shouldMatch("Number of shared strings: \\d+");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary test -XX:+PrintSharedArchiveAndExit output for shared class.
+ * @comment the code is mostly copied from HelloCustom
+ * @requires vm.cds
+ * @requires vm.cds.custom.loaders
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @compile test-classes/HelloUnload.java test-classes/CustomLoadee.java
+ * @build sun.hotspot.WhiteBox jdk.test.lib.classloader.ClassUnloadCommon
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_custom.jar CustomLoadee
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run driver PrintSharedArchiveAndExit
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import sun.hotspot.WhiteBox;
+
+public class PrintSharedArchiveAndExit {
+    public static void main(String[] args) throws Exception {
+        run();
+    }
+    public static void run(String... extra_runtime_args) throws Exception {
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+
+        String appJar = ClassFileInstaller.getJarPath("hello.jar");
+        String customJarPath = ClassFileInstaller.getJarPath("hello_custom.jar");
+
+        // Dump the archive
+        String classlist[] = new String[] {
+            "HelloUnload",
+            "java/lang/Object id: 1",
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath
+        };
+
+        OutputAnalyzer output;
+        TestCommon.testDump(appJar, classlist,
+                            // command-line arguments ...
+                            use_whitebox_jar);
+
+        output = TestCommon.exec(appJar,
+                                 TestCommon.concat(extra_runtime_args,
+                                     // command-line arguments ...
+                                     use_whitebox_jar,
+                                     "-XX:+UnlockDiagnosticVMOptions",
+                                     "-XX:+WhiteBoxAPI",
+                                     "-XX:+PrintSharedArchiveAndExit",
+                                     "HelloUnload", customJarPath, "true", "true"));
+        output.shouldMatch(".* archive version \\d+")
+              .shouldContain("java.lang.Object loaded by: boot_loader")
+              .shouldContain("HelloUnload loaded by: app_loader")
+              .shouldContain("CustomLoadee loaded by: unregistered_loader")
+              .shouldContain("Shared Builtin Dictionary")
+              .shouldContain("Shared Unregistered Dictionary")
+              .shouldMatch("Number of shared symbols: \\d+")
+              .shouldMatch("Number of shared strings: \\d+"); 
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
@@ -76,9 +76,9 @@ public class PrintSharedArchiveAndExit {
                                      "-XX:+PrintSharedArchiveAndExit",
                                      "HelloUnload", customJarPath, "true", "true"));
         output.shouldMatch(".* archive version \\d+")
-              .shouldContain("java.lang.Object loaded by: boot_loader")
-              .shouldContain("HelloUnload loaded by: app_loader")
-              .shouldContain("CustomLoadee loaded by: unregistered_loader")
+              .shouldContain("java.lang.Object boot_loader")
+              .shouldContain("HelloUnload app_loader")
+              .shouldContain("CustomLoadee unregistered_loader")
               .shouldContain("Shared Builtin Dictionary")
               .shouldContain("Shared Unregistered Dictionary")
               .shouldMatch("Number of shared symbols: \\d+")

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
@@ -82,6 +82,7 @@ public class PrintSharedArchiveAndExit {
               .shouldContain("Shared Builtin Dictionary")
               .shouldContain("Shared Unregistered Dictionary")
               .shouldMatch("Number of shared symbols: \\d+")
-              .shouldMatch("Number of shared strings: \\d+");
+              .shouldMatch("Number of shared strings: \\d+")
+              .shouldMatch("VM version: .*");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
@@ -86,9 +86,9 @@ public class PrintSharedArchiveAndExit extends DynamicArchiveTestBase {
                       .shouldMatch("Base archive name: .*.jsa")  // given name ends with .jsa, maynot default name.
                       .shouldMatch("Dynamic archive name: .*" + ARCHIVE_NAME)
                       .shouldMatch("Base archive version \\d+")
-                      .shouldContain("java.lang.Object loaded by: boot_loader")
-                      .shouldContain("HelloUnload loaded by: app_loader")
-                      .shouldContain("CustomLoadee loaded by: unregistered_loader")
+                      .shouldContain("java.lang.Object boot_loader")
+                      .shouldContain("HelloUnload app_loader")
+                      .shouldContain("CustomLoadee unregistered_loader")
                       .shouldContain("Shared Builtin Dictionary")
                       .shouldContain("Shared Unregistered Dictionary")
                       .shouldMatch("Number of shared symbols: \\d+")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
@@ -92,7 +92,8 @@ public class PrintSharedArchiveAndExit extends DynamicArchiveTestBase {
                       .shouldContain("Shared Builtin Dictionary")
                       .shouldContain("Shared Unregistered Dictionary")
                       .shouldMatch("Number of shared symbols: \\d+")
-                      .shouldMatch("Number of shared strings: \\d+");
+                      .shouldMatch("Number of shared strings: \\d+")
+                      .shouldMatch("VM version: .*");
                 });
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Hello World test for dynamic archive with custom loader
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes
+ * @build HelloUnload CustomLoadee jdk.test.lib.classloader.ClassUnloadCommon
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar HelloUnload
+ *                 jdk.test.lib.classloader.ClassUnloadCommon
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$1
+ *                 jdk.test.lib.classloader.ClassUnloadCommon$TestFailure
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_custom.jar CustomLoadee
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar PrintSharedArchiveAndExit
+ */
+
+import java.io.File;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class PrintSharedArchiveAndExit extends DynamicArchiveTestBase {
+    private static final String ARCHIVE_NAME = CDSTestUtils.getOutputFileName("top.jsa");
+
+    public static void main(String... args) throws Exception {
+        runTest(PrintSharedArchiveAndExit::testPrtNExit);
+    }
+
+    public static void testPrtNExit() throws Exception {
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+        String appJar = ClassFileInstaller.getJarPath("hello.jar");
+        String customJarPath = ClassFileInstaller.getJarPath("hello_custom.jar");
+        String mainAppClass = "HelloUnload";
+
+        dump(ARCHIVE_NAME,
+            use_whitebox_jar,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-Xlog:cds",
+            "-Xlog:cds+dynamic=debug",
+            "-cp", appJar,
+            mainAppClass, customJarPath, "false", "false")
+            .assertNormalExit(output -> {
+                output.shouldContain("Written dynamic archive 0x")
+                      .shouldNotContain("klasses.*=.*CustomLoadee")
+                      .shouldHaveExitValue(0);
+                });
+
+        run(ARCHIVE_NAME,
+            use_whitebox_jar,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-Xlog:class+load",
+            "-Xlog:cds=debug",
+            "-Xlog:cds+dynamic=info",
+            "-cp", appJar,
+            "-XX:+PrintSharedArchiveAndExit",
+            mainAppClass, customJarPath, "false", "true")
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0)
+                      .shouldMatch("Base archive name: .*.jsa")  // given name ends with .jsa, maynot default name.
+                      .shouldMatch("Dynamic archive name: .*" + ARCHIVE_NAME)
+                      .shouldMatch("Base archive version \\d+")
+                      .shouldContain("java.lang.Object loaded by: boot_loader")
+                      .shouldContain("HelloUnload loaded by: app_loader")
+                      .shouldContain("CustomLoadee loaded by: unregistered_loader")
+                      .shouldContain("Shared Builtin Dictionary")
+                      .shouldContain("Shared Unregistered Dictionary")
+                      .shouldMatch("Number of shared symbols: \\d+")
+                      .shouldMatch("Number of shared strings: \\d+");
+                });
+    }
+}


### PR DESCRIPTION
Hi, Please review
  Added more info in printout when -XX:+PrintSharedArchiveAndExit used:
  archive names (static/dynamic or static only)
  loaded classes and their loaders
  number of shared symbols
  number of shared strings
  full vm version stored in shared archive.
  added two tests for custom loader test and dynamic test.

  Tests: tier1,tier2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244540](https://bugs.openjdk.java.net/browse/JDK-8244540): Print more information with -XX:+PrintSharedArchiveAndExit


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 1a68b5ec3df92146b6f5feb3c8085d991b646cfc
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 1a68b5ec3df92146b6f5feb3c8085d991b646cfc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3187/head:pull/3187` \
`$ git checkout pull/3187`

Update a local copy of the PR: \
`$ git checkout pull/3187` \
`$ git pull https://git.openjdk.java.net/jdk pull/3187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3187`

View PR using the GUI difftool: \
`$ git pr show -t 3187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3187.diff">https://git.openjdk.java.net/jdk/pull/3187.diff</a>

</details>
