### PR TITLE
8264166: OopStorage should support specifying MEMFLAGS for allocations

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -210,7 +210,7 @@ void StringTable::create_table() {
   log_trace(stringtable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                          _current_size, start_size_log_2);
   _local_table = new StringTableHash(start_size_log_2, END_SIZE, REHASH_LEN);
-  _oop_storage = OopStorageSet::create_weak("StringTable Weak");
+  _oop_storage = OopStorageSet::create_weak("StringTable Weak", mtSymbol);
   _oop_storage->register_num_dead_callback(&gc_notification);
 }
 

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -121,9 +121,11 @@ OopStorage::ActiveArray::~ActiveArray() {
   assert(_refcount == 0, "precondition");
 }
 
-OopStorage::ActiveArray* OopStorage::ActiveArray::create(size_t size, AllocFailType alloc_fail) {
+OopStorage::ActiveArray* OopStorage::ActiveArray::create(size_t size,
+                                                         MEMFLAGS memflags,
+                                                         AllocFailType alloc_fail) {
   size_t size_in_bytes = blocks_offset() + sizeof(Block*) * size;
-  void* mem = NEW_C_HEAP_ARRAY3(char, size_in_bytes, mtGC, CURRENT_PC, alloc_fail);
+  void* mem = NEW_C_HEAP_ARRAY3(char, size_in_bytes, memflags, CURRENT_PC, alloc_fail);
   if (mem == NULL) return NULL;
   return new (mem) ActiveArray(size);
 }
@@ -321,7 +323,7 @@ OopStorage::Block* OopStorage::Block::new_block(const OopStorage* owner) {
   // _data must be first member: aligning block => aligning _data.
   STATIC_ASSERT(_data_pos == 0);
   size_t size_needed = allocation_size();
-  void* memory = NEW_C_HEAP_ARRAY_RETURN_NULL(char, size_needed, mtGC);
+  void* memory = NEW_C_HEAP_ARRAY_RETURN_NULL(char, size_needed, owner->memflags());
   if (memory == NULL) {
     return NULL;
   }
@@ -499,7 +501,9 @@ bool OopStorage::expand_active_array() {
   size_t new_size = 2 * old_array->size();
   log_debug(oopstorage, blocks)("%s: expand active array " SIZE_FORMAT,
                                 name(), new_size);
-  ActiveArray* new_array = ActiveArray::create(new_size, AllocFailStrategy::RETURN_NULL);
+  ActiveArray* new_array = ActiveArray::create(new_size,
+                                               memflags(),
+                                               AllocFailStrategy::RETURN_NULL);
   if (new_array == NULL) return false;
   new_array->copy_from(old_array);
   replace_active_array(new_array);
@@ -739,9 +743,18 @@ static Mutex* make_oopstorage_mutex(const char* storage_name,
   return new PaddedMutex(rank, name, true, Mutex::_safepoint_check_never);
 }
 
-OopStorage::OopStorage(const char* name) :
+void* OopStorage::operator new(size_t size, MEMFLAGS memflags) {
+  assert(size >= sizeof(OopStorage), "precondition");
+  return NEW_C_HEAP_ARRAY(char, size, memflags);
+}
+
+void OopStorage::operator delete(void* obj, MEMFLAGS /* memflags */) {
+  FREE_C_HEAP_ARRAY(char, obj);
+}
+
+OopStorage::OopStorage(const char* name, MEMFLAGS memflags) :
   _name(os::strdup(name)),
-  _active_array(ActiveArray::create(initial_active_array_size)),
+  _active_array(ActiveArray::create(initial_active_array_size, memflags)),
   _allocation_list(),
   _deferred_updates(NULL),
   _allocation_mutex(make_oopstorage_mutex(name, "alloc", Mutex::oopstorage)),
@@ -749,6 +762,7 @@ OopStorage::OopStorage(const char* name) :
   _num_dead_callback(NULL),
   _allocation_count(0),
   _concurrent_iteration_count(0),
+  _memflags(memflags),
   _needs_cleanup(false)
 {
   _active_array->increment_refcount();
@@ -970,6 +984,8 @@ size_t OopStorage::total_memory_usage() const {
   total_size += blocks.size() * sizeof(Block*);
   return total_size;
 }
+
+MEMFLAGS OopStorage::memflags() const { return _memflags; }
 
 // Parallel iteration support
 

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,10 +72,13 @@ class outputStream;
 // interactions for this protocol.  Similarly, see the allocate() function for
 // a discussion of allocation.
 
-class OopStorage : public CHeapObj<mtGC> {
+class OopStorage {
 public:
-  explicit OopStorage(const char* name);
+  explicit OopStorage(const char* name, MEMFLAGS memflags);
   ~OopStorage();
+
+  void* operator new(size_t size, MEMFLAGS memflags);
+  void operator delete(void* obj, MEMFLAGS memflags);
 
   // These count and usage accessors are racy unless at a safepoint.
 
@@ -88,6 +91,9 @@ public:
   // Total number of blocks * memory allocation per block, plus
   // bookkeeping overhead, including this storage object.
   size_t total_memory_usage() const;
+
+  // The memory type for allocations.
+  MEMFLAGS memflags() const;
 
   enum EntryStatus {
     INVALID_ENTRY,
@@ -251,6 +257,10 @@ private:
   // mutable because this gets set even for const iteration.
   mutable int _concurrent_iteration_count;
 
+  // The memory type for allocations.
+  MEMFLAGS _memflags;
+
+  // Flag indicating this storage object is a candidate for empty block deletion.
   volatile bool _needs_cleanup;
 
   bool try_add_block();

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHARED_OOPSTORAGE_INLINE_HPP
 #define SHARE_GC_SHARED_OOPSTORAGE_INLINE_HPP
 
+#include "memory/allocation.hpp"
 #include "gc/shared/oopStorage.hpp"
 #include "metaprogramming/conditional.hpp"
 #include "metaprogramming/isConst.hpp"
@@ -57,7 +58,9 @@ class OopStorage::ActiveArray {
   Block** block_ptr(size_t index);
 
 public:
-  static ActiveArray* create(size_t size, AllocFailType alloc_fail = AllocFailStrategy::EXIT_OOM);
+  static ActiveArray* create(size_t size,
+                             MEMFLAGS memflags = mtGC,
+                             AllocFailType alloc_fail = AllocFailStrategy::EXIT_OOM);
   static void destroy(ActiveArray* ba);
 
   inline Block* at(size_t i) const;

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -25,8 +25,8 @@
 #ifndef SHARE_GC_SHARED_OOPSTORAGE_INLINE_HPP
 #define SHARE_GC_SHARED_OOPSTORAGE_INLINE_HPP
 
-#include "memory/allocation.hpp"
 #include "gc/shared/oopStorage.hpp"
+#include "memory/allocation.hpp"
 #include "metaprogramming/conditional.hpp"
 #include "metaprogramming/isConst.hpp"
 #include "oops/oop.hpp"

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -31,18 +31,18 @@
 
 OopStorage* OopStorageSet::_storages[all_count] = {};
 
-OopStorage* OopStorageSet::create_strong(const char* name) {
+OopStorage* OopStorageSet::create_strong(const char* name, MEMFLAGS memflags) {
   static uint registered_strong = 0;
   assert(registered_strong < strong_count, "More registered strong storages than slots");
-  OopStorage* storage = new OopStorage(name);
+  OopStorage* storage = new (memflags) OopStorage(name, memflags);
   _storages[strong_start + registered_strong++] = storage;
   return storage;
 }
 
-OopStorage* OopStorageSet::create_weak(const char* name) {
+OopStorage* OopStorageSet::create_weak(const char* name, MEMFLAGS memflags) {
   static uint registered_weak = 0;
   assert(registered_weak < weak_count, "More registered strong storages than slots");
-  OopStorage* storage = new OopStorage(name);
+  OopStorage* storage = new (memflags) OopStorage(name, memflags);
   _storages[weak_start + registered_weak++] = storage;
   return storage;
 }

--- a/src/hotspot/share/gc/shared/oopStorageSet.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,8 +79,8 @@ public:
   static OopStorage* storage(WeakId id) { return get_storage(id); }
   static OopStorage* storage(Id id) { return get_storage(id); }
 
-  static OopStorage* create_strong(const char* name);
-  static OopStorage* create_weak(const char* name);
+  static OopStorage* create_strong(const char* name, MEMFLAGS memflags);
+  static OopStorage* create_weak(const char* name, MEMFLAGS memflags);
 
   // Support iteration over the storage objects.
   template<typename StorageId> class Range;

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -74,7 +74,7 @@ void ObjectSampler::oop_storage_gc_notification(size_t num_dead) {
 }
 
 bool ObjectSampler::create_oop_storage() {
-  _oop_storage = OopStorageSet::create_weak("Weak JFR Old Object Samples");
+  _oop_storage = OopStorageSet::create_weak("Weak JFR Old Object Samples", mtTracing);
   assert(_oop_storage != NULL, "invariant");
   _oop_storage->register_num_dead_callback(&oop_storage_gc_notification);
   return true;

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -868,8 +868,8 @@ OopStorage* Universe::vm_global() {
 }
 
 void Universe::oopstorage_init() {
-  Universe::_vm_global = OopStorageSet::create_strong("VM Global");
-  Universe::_vm_weak = OopStorageSet::create_weak("VM Weak");
+  Universe::_vm_global = OopStorageSet::create_strong("VM Global", mtInternal);
+  Universe::_vm_weak = OopStorageSet::create_weak("VM Weak", mtInternal);
 }
 
 void universe_oopstorage_init() {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -699,8 +699,8 @@ OopStorage* JvmtiExport::weak_tag_storage() {
 void JvmtiExport::initialize_oop_storage() {
   // OopStorage needs to be created early in startup and unconditionally
   // because of OopStorageSet static array indices.
-  _jvmti_oop_storage = OopStorageSet::create_strong("JVMTI OopStorage");
-  _weak_tag_storage  = OopStorageSet::create_weak("JVMTI Tag Weak OopStorage");
+  _jvmti_oop_storage = OopStorageSet::create_strong("JVMTI OopStorage", mtServiceability);
+  _weak_tag_storage  = OopStorageSet::create_weak("JVMTI Tag Weak OopStorage", mtServiceability);
   _weak_tag_storage->register_num_dead_callback(&JvmtiTagMap::gc_notification);
 }
 

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ void ResolvedMethodTable::create_table() {
   _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT);
   log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                                _current_size, ResolvedMethodTableSizeLog);
-  _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak");
+  _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);
   _oop_storage->register_num_dead_callback(&gc_notification);
 }
 

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -51,8 +51,8 @@ OopStorage* JNIHandles::_global_handles = NULL;
 OopStorage* JNIHandles::_weak_global_handles = NULL;
 
 void jni_handles_init() {
-  JNIHandles::_global_handles = OopStorageSet::create_strong("JNI Global");
-  JNIHandles::_weak_global_handles = OopStorageSet::create_weak("JNI Weak");
+  JNIHandles::_global_handles = OopStorageSet::create_strong("JNI Global", mtInternal);
+  JNIHandles::_weak_global_handles = OopStorageSet::create_weak("JNI Weak", mtInternal);
 }
 
 jobject JNIHandles::make_local(oop obj) {

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -2187,7 +2187,7 @@ void ObjectMonitor::Initialize() {
 #undef NEWPERFVARIABLE
   }
 
-  _oop_storage = OopStorageSet::create_weak("ObjectSynchronizer Weak");
+  _oop_storage = OopStorageSet::create_weak("ObjectSynchronizer Weak", mtSynchronizer);
 
   DEBUG_ONLY(InitDone = true;)
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3132,7 +3132,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif // INCLUDE_JVMCI
 
   // Initialize OopStorage for threadObj
-  _thread_oop_storage = OopStorageSet::create_strong("Thread OopStorage");
+  _thread_oop_storage = OopStorageSet::create_strong("Thread OopStorage", mtThread);
 
   // Attach the main thread to this os thread
   JavaThread* main_thread = new JavaThread();

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -105,7 +105,8 @@ void ThreadService::init() {
   _thread_allocated_memory_enabled = true; // Always on, so enable it
 
   // Initialize OopStorage for thread stack sampling walking
-  _thread_service_storage = OopStorageSet::create_strong("ThreadService OopStorage");
+  _thread_service_storage = OopStorageSet::create_strong("ThreadService OopStorage",
+                                                         mtServiceability);
 }
 
 void ThreadService::reset_peak_thread_count() {

--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,7 @@ public:
 };
 
 OopStorageTest::OopStorageTest() :
-  _storage("Test Storage")
+  _storage("Test Storage", mtGC)
 { }
 
 OopStorageTest::~OopStorageTest() {

--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -88,7 +88,7 @@ WorkGang* OopStorageParIterPerf::workers() const {
 }
 
 OopStorageParIterPerf::OopStorageParIterPerf() :
-  _storage("Test Storage")
+  _storage("Test Storage", mtGC)
 {
   for (size_t i = 0; i < _storage_entries; ++i) {
     _entries[i] = _storage.allocate();


### PR DESCRIPTION
Please review this change to OopStorage to allow the MEMFLAGS value for associated allocations to be specified when the storage object is constructed.  This allows a subsystem that needs an OopStorage object to associate its allocation with others for that subsystem in NMT tracking and reporting.

Testing:
mach5 tier1.
Manually compared NMT output before and after this change for a test that generated a lot of one particular OopStorage entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264166](https://bugs.openjdk.java.net/browse/JDK-8264166): OopStorage should support specifying MEMFLAGS for allocations


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to a9c808be9f0a417109116985e1ca92cc54b0602a
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to a9c808be9f0a417109116985e1ca92cc54b0602a


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3188/head:pull/3188`
`$ git checkout pull/3188`

To update a local copy of the PR:
`$ git checkout pull/3188`
`$ git pull https://git.openjdk.java.net/jdk pull/3188/head`
