### PR TITLE
8264161: BigDecimal#stripTrailingZeros can throw undocumented ArithmeticException

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -3090,6 +3090,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      *
      * @return a numerically equal {@code BigDecimal} with any
      * trailing zeros removed.
+     * @throws ArithmeticException (overflow) if the new scale is out of range.
      * @since 1.5
      */
     public BigDecimal stripTrailingZeros() {
@@ -4921,6 +4922,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      *
      * @return new {@code BigDecimal} with a scale possibly reduced
      * to be closed to the preferred scale.
+     * @throws ArithmeticException (overflow) if the new scale is out of range.
      */
     private static BigDecimal createAndStripZerosToMatchScale(BigInteger intVal, int scale, long preferredScale) {
         BigInteger qr[]; // quotient-remainder pair
@@ -4945,6 +4947,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      *
      * @return new {@code BigDecimal} with a scale possibly reduced
      * to be closed to the preferred scale.
+     * @throws ArithmeticException (overflow) if the new scale is out of range.
      */
     private static BigDecimal createAndStripZerosToMatchScale(long compactVal, int scale, long preferredScale) {
         while (Math.abs(compactVal) >= 10L && scale > preferredScale) {


### PR DESCRIPTION
Adds missing @throws declarations for ArithmeticException to the public
function
java.math.BigDecimal#stripTrailingZeros
as well as the private helper functions
java.math.BigDecimal#createAndStripZerosToMatchScale(long, int, long)
java.math.BigDecimal#createAndStripZerosToMatchScale(BigInteger, int, long)

stripTrailingZeros calls one of the two helper functions, both of which
can repeatedly decrease the scale by 1 until it underflows. If it does,
the call to checkScale will result in an ArithmeticException (overflow).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264161](https://bugs.openjdk.java.net/browse/JDK-8264161): BigDecimal#stripTrailingZeros can throw undocumented ArithmeticException ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3189/head:pull/3189` \
`$ git checkout pull/3189`

Update a local copy of the PR: \
`$ git checkout pull/3189` \
`$ git pull https://git.openjdk.java.net/jdk pull/3189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3189`

View PR using the GUI difftool: \
`$ git pr show -t 3189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3189.diff">https://git.openjdk.java.net/jdk/pull/3189.diff</a>

</details>
