### PR TITLE
8263971: C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -240,9 +240,8 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
   return res;
 }
 
-static Node* find_or_make_CastII(PhaseIterGVN* igvn, Node* parent, Node* control,
-                                 const TypeInt* type) {
-  Node* n = new CastIINode(parent, type);
+static Node* find_or_make_CastII(PhaseIterGVN* igvn, Node* parent, Node* control, const TypeInt* type, bool carry_dependency) {
+  Node* n = new CastIINode(parent, type, carry_dependency);
   n->set_req(0, control);
   Node* existing = igvn->hash_find_insert(n);
   if (existing != NULL) {
@@ -275,8 +274,8 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     Node* x = z->in(1);
     Node* y = z->in(2);
 
-    Node* cx = find_or_make_CastII(igvn, x, in(0), rx->is_int());
-    Node* cy = find_or_make_CastII(igvn, y, in(0), ry->is_int());
+    Node* cx = find_or_make_CastII(igvn, x, in(0), rx->is_int(), _carry_dependency);
+    Node* cy = find_or_make_CastII(igvn, y, in(0), ry->is_int(), _carry_dependency);
     switch (op) {
       case Op_AddI:  return new AddINode(cx, cy);
       case Op_SubI:  return new SubINode(cx, cy);

--- a/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
@@ -28,6 +28,8 @@
  *
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM TestLostDependencyOnZeroTripGuard
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
@@ -27,7 +27,7 @@
  * @summary C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN
  *
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
@@ -26,7 +26,8 @@
  * @bug 8263971
  * @summary C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN
  *
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8263971
+ * @summary C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLostDependencyOnZeroTripGuard -XX:+StressGCM -XX:StressSeed=886771365 TestLostDependencyOnZeroTripGuard
+ *
+ */
+
+public class TestLostDependencyOnZeroTripGuard {
+
+    public static final int N = 400;
+
+    public int iArrFld[]=new int[N];
+
+    public void mainTest(String[] strArr1) {
+
+        int i=57657, i1=577, i2=6, i3=157, i4=12, i23=61271;
+        boolean bArr[]=new boolean[N];
+
+        for (i = 9; 379 > i; i++) {
+            i2 = 1;
+            do {
+                i1 <<= i3;
+            } while (++i2 < 68);
+            for (i23 = 68; i23 > 3; i23--) {
+                bArr[i23 + 1] = true;
+                try {
+                    i1 = (-42360 / i23);
+                    iArrFld[i + 1] = (i4 % 15384);
+                } catch (ArithmeticException a_e) {}
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        TestLostDependencyOnZeroTripGuard _instance = new TestLostDependencyOnZeroTripGuard();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.mainTest(strArr);
+        }
+    }
+}


### PR DESCRIPTION
For the inner for loop of the test case:

1- the control input of the DivI node in the loop body is cleared
  because the range of values for i23, the loop's iv, is known to
  never be null.

2- pre/main/post loops are added

3- the main loop is unrolled enough that it's fully unrolled but
  actually never entered

4- because the main loop is no longer a looop, DiVI nodes from the
main loop can float and are scheduled in the pre loop.

5- the main loop is never executed (the values of the iv for the main
loop after unrolling fall outside the (3, 68] range of values of the
initial loop), one of the main loop DivI nodes divides by 0 and
because it doesn't stay in the main loop, the crash occurs.

The calls to PhaseIdealLoop::cast_incr_before_loop() in
PhaseIdealLoop::insert_pre_post_loops() should guarantee that nodes
that uses the loop iv stay control dependent on the test that guards
the main loop. For that it inserts a CastII node with the
_carry_dependency flag set. With 8256730, that CastII for the main
loop is pushed through the iv AddI of the pre loop. In the process, it
looses the _carry_dependency flag which causes the CastII node to be
optimized out and the DivI nodes to float.

With the proposed fix, CastII nodes created by the logic from 8256730
have the _carry_dependency flag set if the CastII node that's
transform has it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263971](https://bugs.openjdk.java.net/browse/JDK-8263971): C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to 1fef7afebde65ab11783777c9a51b16ed5e29d27
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 1fef7afebde65ab11783777c9a51b16ed5e29d27


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3190/head:pull/3190` \
`$ git checkout pull/3190`

Update a local copy of the PR: \
`$ git checkout pull/3190` \
`$ git pull https://git.openjdk.java.net/jdk pull/3190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3190`

View PR using the GUI difftool: \
`$ git pr show -t 3190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3190.diff">https://git.openjdk.java.net/jdk/pull/3190.diff</a>

</details>
