### PR TITLE
8259623: JfrTypeSet::_subsystem_callback is left dangling after use

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -425,15 +425,13 @@ static bool write_klasses() {
   KlassWriter kw(_writer, _class_unload);
   KlassWriterRegistration kwr(&kw, &reg);
   if (_leakp_writer == NULL) {
-    KlassCallback callback(&kwr);
-    _subsystem_callback = &callback;
+    KlassCallback callback(&_subsystem_callback, &kwr);
     do_klasses();
   } else {
     LeakKlassWriter lkw(_leakp_writer, _class_unload);
     CompositeKlassWriter ckw(&lkw, &kw);
     CompositeKlassWriterRegistration ckwr(&ckw, &reg);
-    CompositeKlassCallback callback(&ckwr);
-    _subsystem_callback = &callback;
+    CompositeKlassCallback callback(&_subsystem_callback, &ckwr);
     do_klasses();
   }
   if (is_initial_typeset_for_chunk()) {
@@ -474,8 +472,7 @@ static void register_klass(Klass* klass) {
 static void register_klasses() {
   assert(!_artifacts->has_klass_entries(), "invariant");
   KlassArtifactRegistrator reg(_artifacts);
-  RegisterKlassCallback callback(&reg);
-  _subsystem_callback = &callback;
+  RegisterKlassCallback callback(&_subsystem_callback, &reg);
   ClassLoaderDataGraph::classes_do(&register_klass);
 }
 
@@ -552,8 +549,7 @@ static void write_packages() {
     _artifacts->iterate_klasses(kpw);
     ClearArtifact<PkgPtr> clear;
     PackageWriterWithClear pwwc(&pw, &clear);
-    PackageCallback callback(&pwwc);
-    _subsystem_callback = &callback;
+    PackageCallback callback(&_subsystem_callback, &pwwc);
     do_packages();
   } else {
     LeakPackageWriter lpw(_leakp_writer, _class_unload);
@@ -562,8 +558,7 @@ static void write_packages() {
     _artifacts->iterate_klasses(kcpw);
     ClearArtifact<PkgPtr> clear;
     CompositePackageWriterWithClear cpwwc(&cpw, &clear);
-    CompositePackageCallback callback(&cpwwc);
-    _subsystem_callback = &callback;
+    CompositePackageCallback callback(&_subsystem_callback, &cpwwc);
     do_packages();
   }
   _artifacts->tally(pw);
@@ -573,8 +568,7 @@ typedef JfrArtifactCallbackHost<PkgPtr, ClearArtifact<PkgPtr> > ClearPackageCall
 
 static void clear_packages() {
   ClearArtifact<PkgPtr> clear;
-  ClearPackageCallback callback(&clear);
-  _subsystem_callback = &callback;
+  ClearPackageCallback callback(&_subsystem_callback, &clear);
   do_packages();
 }
 
@@ -651,8 +645,7 @@ static void write_modules() {
     _artifacts->iterate_klasses(kmw);
     ClearArtifact<ModPtr> clear;
     ModuleWriterWithClear mwwc(&mw, &clear);
-    ModuleCallback callback(&mwwc);
-    _subsystem_callback = &callback;
+    ModuleCallback callback(&_subsystem_callback, &mwwc);
     do_modules();
   } else {
     LeakModuleWriter lmw(_leakp_writer, _class_unload);
@@ -661,8 +654,7 @@ static void write_modules() {
     _artifacts->iterate_klasses(kcpw);
     ClearArtifact<ModPtr> clear;
     CompositeModuleWriterWithClear cmwwc(&cmw, &clear);
-    CompositeModuleCallback callback(&cmwwc);
-    _subsystem_callback = &callback;
+    CompositeModuleCallback callback(&_subsystem_callback, &cmwwc);
     do_modules();
   }
   _artifacts->tally(mw);
@@ -672,8 +664,7 @@ typedef JfrArtifactCallbackHost<ModPtr, ClearArtifact<ModPtr> > ClearModuleCallb
 
 static void clear_modules() {
   ClearArtifact<ModPtr> clear;
-  ClearModuleCallback callback(&clear);
-  _subsystem_callback = &callback;
+  ClearModuleCallback callback(&_subsystem_callback, &clear);
   do_modules();
 }
 
@@ -785,8 +776,7 @@ static void write_classloaders() {
     _artifacts->iterate_klasses(kmcw);
     ClearArtifact<CldPtr> clear;
     CldWriterWithClear cldwwc(&cldw, &clear);
-    CldCallback callback(&cldwwc);
-    _subsystem_callback = &callback;
+    CldCallback callback(&_subsystem_callback, &cldwwc);
     do_class_loaders();
   } else {
     LeakCldWriter lcldw(_leakp_writer, _class_unload);
@@ -797,8 +787,7 @@ static void write_classloaders() {
     _artifacts->iterate_klasses(kmccldw);
     ClearArtifact<CldPtr> clear;
     CompositeCldWriterWithClear ccldwwc(&ccldw, &clear);
-    CompositeCldCallback callback(&ccldwwc);
-    _subsystem_callback = &callback;
+    CompositeCldCallback callback(&_subsystem_callback, &ccldwwc);
     do_class_loaders();
   }
   _artifacts->tally(cldw);
@@ -808,8 +797,7 @@ typedef JfrArtifactCallbackHost<CldPtr, ClearArtifact<CldPtr> > ClearCLDCallback
 
 static void clear_classloaders() {
   ClearArtifact<CldPtr> clear;
-  ClearCLDCallback callback(&clear);
-  _subsystem_callback = &callback;
+  ClearCLDCallback callback(&_subsystem_callback, &clear);
   do_class_loaders();
 }
 

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSetUtils.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSetUtils.hpp
@@ -58,9 +58,17 @@ class JfrArtifactClosure {
 template <typename T, typename Callback>
 class JfrArtifactCallbackHost : public JfrArtifactClosure {
  private:
+  JfrArtifactClosure** _subsystem_callback_loc;
   Callback* _callback;
  public:
-  JfrArtifactCallbackHost(Callback* callback) : _callback(callback) {}
+  JfrArtifactCallbackHost(JfrArtifactClosure** subsystem_callback_loc, Callback* callback) :
+          _subsystem_callback_loc(subsystem_callback_loc), _callback(callback) {
+    assert(*_subsystem_callback_loc == NULL, "Subsystem callback should not be set yet");
+    *_subsystem_callback_loc = this;
+  }
+  ~JfrArtifactCallbackHost() {
+    *_subsystem_callback_loc = NULL;
+  }
   void do_artifact(const void* artifact) {
     (*_callback)(reinterpret_cast<T const&>(artifact));
   }


### PR DESCRIPTION
SonarCloud instance reports the bug in cases like:
  "Address of stack memory associated with local variable 'callback' is still referred to by the global variable '_subsystem_callback' upon returning to the caller. This will be a dangling reference"

For example:

```
static void clear_packages() {
  ClearArtifact<PkgPtr> clear;
  ClearPackageCallback callback(&clear);
  _subsystem_callback = &callback;
  do_packages();
}
```

I understand that `_subsystem_callback` is assigned to be used in do_packages(), but it would indeed be left dangling. The patch moves callback installation into the callback superclass itself. This way, we also guarantee that `_subsystem_callback` is not set before installation (i.e. check for overlapping callback installations), and make sure it is `NULL` after use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259623](https://bugs.openjdk.java.net/browse/JDK-8259623): JfrTypeSet::_subsystem_callback is left dangling after use


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3192/head:pull/3192`
`$ git checkout pull/3192`

To update a local copy of the PR:
`$ git checkout pull/3192`
`$ git pull https://git.openjdk.java.net/jdk pull/3192/head`
