### PR TITLE
8264165: jpackage BasicTest fails after JDK-8220266: Check help text contains plaform specific parameters

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -167,7 +167,7 @@ Generic Options:\n\
 {2}\n\
 \Options for creating the application package:\n\
 \  --about-url <url>\n\
-\          URL of the application's home page\n\
+\          URL of the application''s home page\n\
 \  --app-image <file path>\n\
 \          Location of the predefined application image that is used\n\
 \          to build an installable package\n\

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_ja.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_ja.properties
@@ -167,7 +167,7 @@ Generic Options:\n\
 {2}\n\
 \Options for creating the application package:\n\
 \  --about-url <url>\n\
-\          URL of the application's home page\n\
+\          URL of the application''s home page\n\
 \  --app-image <file path>\n\
 \          Location of the predefined application image that is used\n\
 \          to build an installable package\n\

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_zh_CN.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources_zh_CN.properties
@@ -167,7 +167,7 @@ Generic Options:\n\
 {2}\n\
 \Options for creating the application package:\n\
 \  --about-url <url>\n\
-\          URL of the application's home page\n\
+\          URL of the application''s home page\n\
 \  --app-image <file path>\n\
 \          Location of the predefined application image that is used\n\
 \          to build an installable package\n\

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
@@ -138,7 +138,7 @@ public final class BasicTest {
 
         TKit.trace("Check parameters in help text");
         TKit.assertNotEquals(0, countStrings.apply(List.of(expectedPrefix)),
-                "Check help text contains plaform specific parameters");
+                "Check help text contains platform specific parameters");
         TKit.assertEquals(0, countStrings.apply(unexpectedPrefixes),
                 "Check help text doesn't contain unexpected parameters");
     }


### PR DESCRIPTION
Add missing escape single quote (') and typo fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264165](https://bugs.openjdk.java.net/browse/JDK-8264165): jpackage BasicTest fails after JDK-8220266: Check help text contains plaform specific parameters


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3193/head:pull/3193`
`$ git checkout pull/3193`

To update a local copy of the PR:
`$ git checkout pull/3193`
`$ git pull https://git.openjdk.java.net/jdk pull/3193/head`
