### PR TITLE
8264179: [TESTBUG] Some compiler tests fail when running without C2

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
@@ -29,7 +29,7 @@
  * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.
  *
  * @run main/othervm -XX:+UseZGC compiler.loopopts.TestRangeCheckPredicatesControl
- * @run main/othervm -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java
@@ -27,9 +27,9 @@
  * @summary Test the complete cloning of skeleton predicates to unswitched loops as done when cloning them to the main loop.
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
  *                   compiler.loopopts.TestUnswitchCloneSkeletonPredicates
- * @run main/othervm -Xcomp -XX:-PartialPeelLoop -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
+ * @run main/othervm -Xcomp -XX:+IgnoreUnrecognizedVMOptions -XX:-PartialPeelLoop -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
  *                   compiler.loopopts.TestUnswitchCloneSkeletonPredicates
- * @run main/othervm -XX:-PartialPeelLoop compiler.loopopts.TestUnswitchCloneSkeletonPredicates
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-PartialPeelLoop compiler.loopopts.TestUnswitchCloneSkeletonPredicates
  */
 package compiler.loopopts;
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/Vec_MulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/Vec_MulAddS2I.java
@@ -27,6 +27,7 @@
  * @bug 8214751
  * @summary Test operations in C2 MulAddS2I and MulAddVS2VI nodes.
  * @library /test/lib
+ * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroNodeWrongMem.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroNodeWrongMem.java
@@ -26,7 +26,7 @@
  * @bug 8239367
  * @summary Wiring of memory in SubTypeCheck macro node causes graph should be schedulable
  *
- * @run main/othervm -Xcomp -XX:CompileOnly=TestSubTypeCheckMacroNodeWrongMem::test -XX:-DoEscapeAnalysis TestSubTypeCheckMacroNodeWrongMem
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestSubTypeCheckMacroNodeWrongMem::test -XX:+IgnoreUnrecognizedVMOptions -XX:-DoEscapeAnalysis TestSubTypeCheckMacroNodeWrongMem
  *
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8193518 8249608
  * @summary C2: Vector registers are sometimes corrupted at safepoint
- * @run main/othervm -XX:-BackgroundCompilation -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
  * @run main/othervm -XX:-BackgroundCompilation TestVectorsNotSavedAtSafepoint test2
  */
 


### PR DESCRIPTION
This fixes some compiler tests that fail when run without C2 due to C2-specific VM options by either adding `-XX:+IgnoreUnrecognizedVMOptions` or `@requires vm.compiler2.enabled` to let them pass without C2.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264179](https://bugs.openjdk.java.net/browse/JDK-8264179): [TESTBUG] Some compiler tests fail when running without C2


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3197/head:pull/3197`
`$ git checkout pull/3197`

To update a local copy of the PR:
`$ git checkout pull/3197`
`$ git pull https://git.openjdk.java.net/jdk pull/3197/head`
