### PR TITLE
JDK-8264191: Javadoc search is broken in Internet Explorer

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -258,7 +258,7 @@ function doSearch(request, response) {
     function searchIndex(indexArray, category, nameFunc) {
         var primaryResults = searchIndexWithMatcher(indexArray, camelCaseMatcher, category, nameFunc);
         result = result.concat(primaryResults);
-        if (primaryResults.length <= MIN_RESULTS && camelCaseMatcher.flags.indexOf("i") === -1) {
+        if (primaryResults.length <= MIN_RESULTS && !camelCaseMatcher.ignoreCase) {
             var secondaryResults = searchIndexWithMatcher(indexArray, fallbackMatcher, category, nameFunc);
             result = result.concat(secondaryResults.filter(function (item) {
                 return primaryResults.indexOf(item) === -1;


### PR DESCRIPTION
The RegExp `flags` property is replaced with the much better supported `ignoreCase` property in this change.

https://caniuse.com/mdn-javascript_builtins_regexp_flags
https://caniuse.com/mdn-javascript_builtins_regexp_ignorecase

We don't have automated tests for the search script on browsers. I have tested the change by running `test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java` with GraalJS as well as doing manual testing with current Firefox, Safari, Chrome as well as IE 11 and Edge 44.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264191](https://bugs.openjdk.java.net/browse/JDK-8264191): Javadoc search is broken in Internet Explorer


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3202/head:pull/3202` \
`$ git checkout pull/3202`

Update a local copy of the PR: \
`$ git checkout pull/3202` \
`$ git pull https://git.openjdk.java.net/jdk pull/3202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3202`

View PR using the GUI difftool: \
`$ git pr show -t 3202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3202.diff">https://git.openjdk.java.net/jdk/pull/3202.diff</a>

</details>
