### PR TITLE
8263632: Improve exception handling of APIs in classLoader.cpp

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -556,7 +556,6 @@ void ClassLoader::setup_module_search_path(Thread* current, const char* path) {
   if (new_entry != NULL) {
     add_to_module_path_entries(path, new_entry);
   }
-  return;
 }
 
 #endif // INCLUDE_CDS

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -516,7 +516,7 @@ void ClassLoader::setup_bootstrap_search_path(Thread* current) {
 void ClassLoader::setup_app_search_path(Thread* current, const char *class_path) {
   Arguments::assert_is_dumping_archive();
 
-  ResourceMark rm;
+  ResourceMark rm(current);
   ClasspathStream cp_stream(class_path);
 
   while (cp_stream.has_next()) {

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -222,12 +222,12 @@ class ClassLoader: AllStatic {
   CDS_ONLY(static ClassPathEntry* _last_app_classpath_entry;)
   CDS_ONLY(static ClassPathEntry* _module_path_entries;)
   CDS_ONLY(static ClassPathEntry* _last_module_path_entry;)
-  CDS_ONLY(static void setup_app_search_path(const char* class_path, TRAPS);)
-  CDS_ONLY(static void setup_module_search_path(const char* path, TRAPS);)
-  static void add_to_app_classpath_entries(const char* path,
+  CDS_ONLY(static void setup_app_search_path(Thread* current, const char* class_path);)
+  CDS_ONLY(static void setup_module_search_path(Thread* current, const char* path);)
+  static void add_to_app_classpath_entries(Thread* current,
+                                           const char* path,
                                            ClassPathEntry* entry,
-                                           bool check_for_duplicates,
-                                           TRAPS);
+                                           bool check_for_duplicates);
   CDS_ONLY(static void add_to_module_path_entries(const char* path,
                                            ClassPathEntry* entry);)
  public:
@@ -241,8 +241,8 @@ class ClassLoader: AllStatic {
   //   - setup the boot loader's system class path
   //   - setup the boot loader's patch mod entries, if present
   //   - create the ModuleEntry for java.base
-  static void setup_bootstrap_search_path(TRAPS);
-  static void setup_bootstrap_search_path_impl(const char *class_path, TRAPS);
+  static void setup_bootstrap_search_path(Thread* current);
+  static void setup_bootstrap_search_path_impl(Thread* current, const char *class_path);
   static void setup_patch_mod_entries();
   static void create_javabase();
 
@@ -256,19 +256,12 @@ class ClassLoader: AllStatic {
   static void release_load_zip_library();
   static inline void load_zip_library_if_needed();
   static jzfile* open_zip_file(const char* canonical_path, char** error_msg, JavaThread* thread);
-  static ClassPathEntry* create_class_path_entry(const char *path, const struct stat* st,
-                                                 bool throw_exception,
-                                                 bool is_boot_append,
-                                                 bool from_class_path_attr, TRAPS);
 
  public:
-  static ClassPathEntry* create_class_path_entry_or_fail(const char *path, const struct stat* st,
-                                                         bool is_boot_append,
-                                                         bool from_class_path_attr, TRAPS);
-  static ClassPathEntry* create_class_path_entry_or_null(Thread* current,
-                                                         const char *path, const struct stat* st,
-                                                         bool is_boot_append,
-                                                         bool from_class_path_attr);
+  static ClassPathEntry* create_class_path_entry(Thread* current,
+                                                 const char *path, const struct stat* st,
+                                                 bool is_boot_append,
+                                                 bool from_class_path_attr);
 
   // Canonicalizes path names, so strcmp will work properly. This is mainly
   // to avoid confusing the zip library
@@ -277,11 +270,11 @@ class ClassLoader: AllStatic {
                                               int class_name_len);
   static PackageEntry* get_package_entry(Symbol* pkg_name, ClassLoaderData* loader_data);
   static int crc32(int crc, const char* buf, int len);
-  static bool update_class_path_entry_list(const char *path,
+  static bool update_class_path_entry_list(Thread* current,
+                                           const char *path,
                                            bool check_for_duplicates,
                                            bool is_boot_append,
-                                           bool from_class_path_attr,
-                                           TRAPS);
+                                           bool from_class_path_attr);
   static void print_bootclasspath();
 
   // Timing
@@ -346,7 +339,7 @@ class ClassLoader: AllStatic {
   // Initialization
   static void initialize(TRAPS);
   static void classLoader_init2(Thread* current);
-  CDS_ONLY(static void initialize_shared_path(TRAPS);)
+  CDS_ONLY(static void initialize_shared_path(Thread* current);)
   CDS_ONLY(static void initialize_module_path(TRAPS);)
 
   static int compute_Object_vtable();

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -256,12 +256,19 @@ class ClassLoader: AllStatic {
   static void release_load_zip_library();
   static inline void load_zip_library_if_needed();
   static jzfile* open_zip_file(const char* canonical_path, char** error_msg, JavaThread* thread);
-
- public:
   static ClassPathEntry* create_class_path_entry(const char *path, const struct stat* st,
                                                  bool throw_exception,
                                                  bool is_boot_append,
                                                  bool from_class_path_attr, TRAPS);
+
+ public:
+  static ClassPathEntry* create_class_path_entry_or_fail(const char *path, const struct stat* st,
+                                                         bool is_boot_append,
+                                                         bool from_class_path_attr, TRAPS);
+  static ClassPathEntry* create_class_path_entry_or_null(Thread* current,
+                                                         const char *path, const struct stat* st,
+                                                         bool is_boot_append,
+                                                         bool from_class_path_attr);
 
   // Canonicalizes path names, so strcmp will work properly. This is mainly
   // to avoid confusing the zip library
@@ -311,12 +318,13 @@ class ClassLoader: AllStatic {
   static void close_jrt_image();
 
   // Add a module's exploded directory to the boot loader's exploded module build list
-  static void add_to_exploded_build_list(Symbol* module_name, TRAPS);
+  static void add_to_exploded_build_list(Thread* current, Symbol* module_name);
 
   // Attempt load of individual class from either the patched or exploded modules build lists
-  static ClassFileStream* search_module_entries(const GrowableArray<ModuleClassPathList*>* const module_list,
+  static ClassFileStream* search_module_entries(Thread* current,
+                                                const GrowableArray<ModuleClassPathList*>* const module_list,
                                                 const char* const class_name,
-                                                const char* const file_name, TRAPS);
+                                                const char* const file_name);
 
   // Load individual .class file
   static InstanceKlass* load_class(Symbol* class_name, bool search_append_only, TRAPS);
@@ -337,7 +345,7 @@ class ClassLoader: AllStatic {
 
   // Initialization
   static void initialize(TRAPS);
-  static void classLoader_init2(TRAPS);
+  static void classLoader_init2(Thread* current);
   CDS_ONLY(static void initialize_shared_path(TRAPS);)
   CDS_ONLY(static void initialize_module_path(TRAPS);)
 

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -327,10 +327,7 @@ ClassPathEntry* ClassLoaderExt::find_classpath_entry_from_cache(Thread* current,
   }
   ClassPathEntry* new_entry = NULL;
 
-  ExceptionMark em(current);
-  Thread* THREAD = current; // For exception macros.
-  new_entry = create_class_path_entry(path, &st, /*throw_exception=*/false,
-                                      false, false, CATCH); // will never throw
+  new_entry = create_class_path_entry_or_null(current, path, &st, false, false);
   if (new_entry == NULL) {
     return NULL;
   }

--- a/src/hotspot/share/classfile/classLoaderExt.hpp
+++ b/src/hotspot/share/classfile/classLoaderExt.hpp
@@ -45,8 +45,8 @@ private:
   };
 
   static char* get_class_path_attr(const char* jar_path, char* manifest, jint manifest_size);
-  static void setup_app_search_path(TRAPS); // Only when -Xshare:dump
-  static void process_module_table(ModuleEntryTable* met, TRAPS);
+  static void setup_app_search_path(Thread* current); // Only when -Xshare:dump
+  static void process_module_table(Thread* current, ModuleEntryTable* met);
   // index of first app JAR in shared classpath entry table
   static jshort _app_class_paths_start_index;
   // index of first modular JAR in shared modulepath entry table
@@ -61,13 +61,13 @@ private:
   static ClassPathEntry* find_classpath_entry_from_cache(Thread* current, const char* path);
 
 public:
-  static void process_jar_manifest(ClassPathEntry* entry, bool check_for_duplicates, TRAPS);
+  static void process_jar_manifest(Thread* current, ClassPathEntry* entry, bool check_for_duplicates);
 
   // Called by JVMTI code to add boot classpath
   static void append_boot_classpath(ClassPathEntry* new_entry);
 
-  static void setup_search_paths(TRAPS);
-  static void setup_module_paths(TRAPS);
+  static void setup_search_paths(Thread* current);
+  static void setup_module_paths(Thread* current);
 
   static char* read_manifest(Thread* current, ClassPathEntry* entry, jint *manifest_size) {
     // Remove all the new-line continuations (which wrap long lines at 72 characters, see

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -451,7 +451,7 @@ void Modules::define_module(Handle module, jboolean is_open, jstring version,
   // If the module is defined to the boot loader and an exploded build is being
   // used, prepend <java.home>/modules/modules_name to the system boot class path.
   if (h_loader.is_null() && !ClassLoader::has_jrt_entry()) {
-    ClassLoader::add_to_exploded_build_list(module_symbol, CHECK);
+    ClassLoader::add_to_exploded_build_list(THREAD, module_symbol);
   }
 
 #ifdef COMPILER2

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -117,7 +117,7 @@ void vmClasses::resolve_all(TRAPS) {
 
   // Create the ModuleEntry for java.base.  This call needs to be done here,
   // after vmSymbols::initialize() is called but before any classes are pre-loaded.
-  ClassLoader::classLoader_init2(CHECK);
+  ClassLoader::classLoader_init2(THREAD);
 
   // Preload commonly used klasses
   vmClassID scan = vmClassID::FIRST;

--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -2340,7 +2340,7 @@ ClassPathEntry* FileMapInfo::get_classpath_entry_for_jvmti(int i, TRAPS) {
         jio_snprintf(msg, strlen(path) + 127, "error in opening JAR file %s", path);
         THROW_MSG_(vmSymbols::java_io_IOException(), msg, NULL);
       } else {
-        ent = ClassLoader::create_class_path_entry(path, &st, /*throw_exception=*/true, false, false, CHECK_NULL);
+        ent = ClassLoader::create_class_path_entry_or_fail(path, &st, false, false, CHECK_NULL);
       }
     }
 

--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -2336,11 +2336,16 @@ ClassPathEntry* FileMapInfo::get_classpath_entry_for_jvmti(int i, TRAPS) {
       const char* path = scpe->name();
       struct stat st;
       if (os::stat(path, &st) != 0) {
-        char *msg = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, strlen(path) + 128); ;
-        jio_snprintf(msg, strlen(path) + 127, "error in opening JAR file %s", path);
+        char *msg = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, strlen(path) + 128);
+        jio_snprintf(msg, strlen(path) + 127, "error in finding JAR file %s", path);
         THROW_MSG_(vmSymbols::java_io_IOException(), msg, NULL);
       } else {
-        ent = ClassLoader::create_class_path_entry_or_fail(path, &st, false, false, CHECK_NULL);
+        ent = ClassLoader::create_class_path_entry(THREAD, path, &st, false, false);
+        if (ent == NULL) {
+          char *msg = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, strlen(path) + 128);
+          jio_snprintf(msg, strlen(path) + 127, "error in opening JAR file %s", path);
+          THROW_MSG_(vmSymbols::java_io_IOException(), msg, NULL);
+        }
       }
     }
 

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -602,12 +602,7 @@ void MetaspaceShared::prepare_for_dumping() {
   Arguments::assert_is_dumping_archive();
   Arguments::check_unsupported_dumping_properties();
 
-  EXCEPTION_MARK;
-  ClassLoader::initialize_shared_path(THREAD);
-  if (HAS_PENDING_EXCEPTION) {
-    java_lang_Throwable::print(PENDING_EXCEPTION, tty);
-    vm_exit_during_initialization("ClassLoader::initialize_shared_path() failed unexpectedly");
-  }
+  ClassLoader::initialize_shared_path(Thread::current());
 }
 
 // Preload classes from a list, populate the shared spaces and dump to a


### PR DESCRIPTION
Please review this change which includes:

-  adding `ClassLoader::create_class_path_entry_or_fail()` and `ClassLoader::create_class_path_entry_or_fail()` functions for better readability. They will call the existing `ClassLoader::create_class_path_entry()`.
- replacing the TRAPS parameter with `Thread* current` for the functions which never throw exception.

Testing: tiers 1,2 (passed); tiers 3,4 (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263632](https://bugs.openjdk.java.net/browse/JDK-8263632): Improve exception handling of APIs in classLoader.cpp


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 9bf7c0b09c5a3553720acdc4dde1d1c76696d60e
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 52632b62d9d52f1fcfec89b5a0a28b795dc42ae3
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to c2d1cde7852298044efe6210f287b33d47be58af


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3203/head:pull/3203`
`$ git checkout pull/3203`

To update a local copy of the PR:
`$ git checkout pull/3203`
`$ git pull https://git.openjdk.java.net/jdk pull/3203/head`
