### PR TITLE
8262953: [TESTBUG] Test /runtime/containers/cgroup/PlainRead.java fails if CPU quoata is not enabled

### DIFF
--- a/test/hotspot/jtreg/containers/cgroup/PlainRead.java
+++ b/test/hotspot/jtreg/containers/cgroup/PlainRead.java
@@ -35,6 +35,7 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
 import sun.hotspot.WhiteBox;
+import java.util.ArrayList;
 
 public class PlainRead {
 
@@ -49,9 +50,21 @@ public class PlainRead {
     static final String good_value = "(\\d+|-1|-2|Unlimited)";
     static final String bad_value = "(failed)";
 
-    static final String[] variables = {"Memory Limit is:", "CPU Shares is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};
+    static ArrayList<String> variables = new ArrayList<>();
 
     static public void isContainer(OutputAnalyzer oa) {
+        variables.add("Memory Limit is:");
+        variables.add("CPU Shares is:");
+        variables.add("active_processor_count:");
+
+        // Kernel can be built without CONFIG_CFS_BANDWIDTH so
+        // both "cfs_quota_us" and "cfs_period_us" options of "cpu" controller can be unavailable
+        if (oa.getOutput().contains("CPU Quota is:")
+            || oa.getOutput().contains("CPU Period is:")) {
+                variables.add("CPU Quota is:");
+                variables.add("CPU Period is:");
+        }
+
         for (String v: variables) {
             match(oa, v, good_value);
         }


### PR DESCRIPTION
Hello!
Both _CPU Quota_ and _CPU Period_ are missing from output if kernel was built without `CONFIG_CFS_BANDWIDTH`.

This is my first contribution so please tell me if i am wrong somewhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262953](https://bugs.openjdk.java.net/browse/JDK-8262953): [TESTBUG] Test /runtime/containers/cgroup/PlainRead.java fails if CPU quoata is not enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3206/head:pull/3206` \
`$ git checkout pull/3206`

Update a local copy of the PR: \
`$ git checkout pull/3206` \
`$ git pull https://git.openjdk.java.net/jdk pull/3206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3206`

View PR using the GUI difftool: \
`$ git pr show -t 3206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3206.diff">https://git.openjdk.java.net/jdk/pull/3206.diff</a>

</details>
