### PR TITLE
8264149 BreakpointInfo::set allocates metaspace object in VM thread

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1112,13 +1112,7 @@ JRT_ENTRY(void, InterpreterRuntime::update_mdp_for_ret(JavaThread* thread, int r
 JRT_END
 
 JRT_ENTRY(MethodCounters*, InterpreterRuntime::build_method_counters(JavaThread* thread, Method* m))
-  MethodCounters* mcs = Method::build_method_counters(m, thread);
-  if (HAS_PENDING_EXCEPTION) {
-    // Only metaspace OOM is expected. No Java code executed.
-    assert((PENDING_EXCEPTION->is_a(vmClasses::OutOfMemoryError_klass())), "we expect only an OOM error here");
-    CLEAR_PENDING_EXCEPTION;
-  }
-  return mcs;
+  return Method::build_method_counters(thread, m);
 JRT_END
 
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -158,7 +158,7 @@ class InterpreterRuntime: AllStatic {
 #ifdef ASSERT
   static void    verify_mdp(Method* method, address bcp, address mdp);
 #endif // ASSERT
-  static MethodCounters* build_method_counters(JavaThread* thread, Method* m);
+  static MethodCounters* build_method_counters(JavaThread* current, Method* m);
 };
 
 

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -83,6 +83,13 @@ void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
   return Metaspace::allocate(loader_data, word_size, type, THREAD);
 }
 
+void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
+                                 size_t word_size,
+                                 MetaspaceObj::Type type) throw() {
+  // Klass has it's own operator new
+  return Metaspace::allocate(loader_data, word_size, type);
+}
+
 bool MetaspaceObj::is_valid(const MetaspaceObj* p) {
   // Weed out obvious bogus values first without traversing metaspace
   if ((size_t)p < os::min_page_size()) {

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -79,14 +79,14 @@ void  StackObj::operator delete [](void* p)           { ShouldNotCallThis(); }
 void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
                                  size_t word_size,
                                  MetaspaceObj::Type type, TRAPS) throw() {
-  // Klass has it's own operator new
+  // Klass has its own operator new
   return Metaspace::allocate(loader_data, word_size, type, THREAD);
 }
 
 void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
                                  size_t word_size,
                                  MetaspaceObj::Type type) throw() {
-  // Klass has it's own operator new
+  assert(!Thread::current()->is_Java_thread(), "only allowed by non-Java thread");
   return Metaspace::allocate(loader_data, word_size, type);
 }
 

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -345,6 +345,9 @@ class MetaspaceObj {
                      size_t word_size,
                      Type type, Thread* thread) throw();
                      // can't use TRAPS from this header file.
+  void* operator new(size_t size, ClassLoaderData* loader_data,
+                     size_t word_size,
+                     Type type) throw();
   void operator delete(void* p) { ShouldNotCallThis(); }
 
   // Declare a *static* method with the same signature in any subclass of MetaspaceObj

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -124,6 +124,10 @@ public:
   static MetaWord* allocate(ClassLoaderData* loader_data, size_t word_size,
                             MetaspaceObj::Type type, TRAPS);
 
+  // Nothrow version of allocate which can be called by a non-Java thread.
+  static MetaWord* allocate(ClassLoaderData* loader_data, size_t word_size,
+                            MetaspaceObj::Type type);
+
   static bool contains(const void* ptr);
   static bool contains_non_shared(const void* ptr);
 

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -124,7 +124,8 @@ public:
   static MetaWord* allocate(ClassLoaderData* loader_data, size_t word_size,
                             MetaspaceObj::Type type, TRAPS);
 
-  // Nothrow version of allocate which can be called by a non-Java thread.
+  // Non-TRAPS version of allocate which can be called by a non-Java thread, that returns
+  // NULL on failure.
   static MetaWord* allocate(ClassLoaderData* loader_data, size_t word_size,
                             MetaspaceObj::Type type);
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -568,7 +568,7 @@ MethodCounters* Method::build_method_counters(Thread* current, Method* m) {
   if (counters == NULL) {
     CompileBroker::log_metaspace_failure();
     ClassLoaderDataGraph::set_metaspace_oom(true);
-    return NULL;   // return the exception (which is cleared)
+    return NULL;
   }
   if (!mh->init_method_counters(counters)) {
     MetadataFactory::free_metadata(mh->method_holder()->class_loader_data(), counters);

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -228,7 +228,7 @@ class Method : public Metadata {
   void clear_all_breakpoints();
   // Tracking number of breakpoints, for fullspeed debugging.
   // Only mutated by VM thread.
-  u2   number_of_breakpoints()             const {
+  u2   number_of_breakpoints() const {
     MethodCounters* mcs = method_counters();
     if (mcs == NULL) {
       return 0;
@@ -236,20 +236,20 @@ class Method : public Metadata {
       return mcs->number_of_breakpoints();
     }
   }
-  void incr_number_of_breakpoints(TRAPS)         {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void incr_number_of_breakpoints(Thread* current) {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->incr_number_of_breakpoints();
     }
   }
-  void decr_number_of_breakpoints(TRAPS)         {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void decr_number_of_breakpoints(Thread* current) {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->decr_number_of_breakpoints();
     }
   }
   // Initialization only
-  void clear_number_of_breakpoints()             {
+  void clear_number_of_breakpoints() {
     MethodCounters* mcs = method_counters();
     if (mcs != NULL) {
       mcs->clear_number_of_breakpoints();
@@ -292,8 +292,8 @@ class Method : public Metadata {
 
 #if COMPILER2_OR_JVMCI
   // Count of times method was exited via exception while interpreting
-  void interpreter_throwout_increment(TRAPS) {
-    MethodCounters* mcs = get_method_counters(CHECK);
+  void interpreter_throwout_increment(Thread* current) {
+    MethodCounters* mcs = get_method_counters(current);
     if (mcs != NULL) {
       mcs->interpreter_throwout_increment();
     }
@@ -432,7 +432,7 @@ class Method : public Metadata {
 
   static void build_interpreter_method_data(const methodHandle& method, TRAPS);
 
-  static MethodCounters* build_method_counters(Method* m, TRAPS);
+  static MethodCounters* build_method_counters(Thread* current, Method* m);
 
   int interpreter_invocation_count()            { return invocation_count();          }
 
@@ -944,9 +944,9 @@ public:
   void print_made_not_compilable(int comp_level, bool is_osr, bool report, const char* reason);
 
  public:
-  MethodCounters* get_method_counters(TRAPS) {
+  MethodCounters* get_method_counters(Thread* current) {
     if (_method_counters == NULL) {
-      build_method_counters(this, CHECK_AND_CLEAR_NULL);
+      build_method_counters(current, this);
     }
     return _method_counters;
   }

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -55,12 +55,12 @@ MethodCounters::MethodCounters(const methodHandle& mh) :
   _backedge_mask = right_n_bits(CompilerConfig::scaled_freq_log(Tier0BackedgeNotifyFreqLog, scale)) << InvocationCounter::count_shift;
 }
 
-MethodCounters* MethodCounters::allocate(const methodHandle& mh) {
+MethodCounters* MethodCounters::allocate_no_exception(const methodHandle& mh) {
   ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
   return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType) MethodCounters(mh);
 }
 
-MethodCounters* MethodCounters::allocate(const methodHandle& mh, TRAPS) {
+MethodCounters* MethodCounters::allocate_with_exception(const methodHandle& mh, TRAPS) {
   ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
   return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType, THREAD) MethodCounters(mh);
 }

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -60,6 +60,11 @@ MethodCounters* MethodCounters::allocate(const methodHandle& mh) {
   return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType) MethodCounters(mh);
 }
 
+MethodCounters* MethodCounters::allocate(const methodHandle& mh, TRAPS) {
+  ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
+  return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType, THREAD) MethodCounters(mh);
+}
+
 void MethodCounters::clear_counters() {
   invocation_counter()->reset();
   backedge_counter()->reset();

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -55,9 +55,9 @@ MethodCounters::MethodCounters(const methodHandle& mh) :
   _backedge_mask = right_n_bits(CompilerConfig::scaled_freq_log(Tier0BackedgeNotifyFreqLog, scale)) << InvocationCounter::count_shift;
 }
 
-MethodCounters* MethodCounters::allocate(const methodHandle& mh, TRAPS) {
+MethodCounters* MethodCounters::allocate(const methodHandle& mh) {
   ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
-  return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType, THREAD) MethodCounters(mh);
+  return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType) MethodCounters(mh);
 }
 
 void MethodCounters::clear_counters() {

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -69,7 +69,7 @@ class MethodCounters : public Metadata {
  public:
   virtual bool is_methodCounters() const { return true; }
 
-  static MethodCounters* allocate(const methodHandle& mh, TRAPS);
+  static MethodCounters* allocate(const methodHandle& mh);
 
   void deallocate_contents(ClassLoaderData* loader_data) {}
 

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -70,6 +70,7 @@ class MethodCounters : public Metadata {
   virtual bool is_methodCounters() const { return true; }
 
   static MethodCounters* allocate(const methodHandle& mh);
+  static MethodCounters* allocate(const methodHandle& mh, TRAPS);
 
   void deallocate_contents(ClassLoaderData* loader_data) {}
 

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -69,8 +69,8 @@ class MethodCounters : public Metadata {
  public:
   virtual bool is_methodCounters() const { return true; }
 
-  static MethodCounters* allocate(const methodHandle& mh);
-  static MethodCounters* allocate(const methodHandle& mh, TRAPS);
+  static MethodCounters* allocate_no_exception(const methodHandle& mh);
+  static MethodCounters* allocate_with_exception(const methodHandle& mh, TRAPS);
 
   void deallocate_contents(ClassLoaderData* loader_data) {}
 


### PR DESCRIPTION
This change creates a Metaspace::allocate function that doesn't pass TRAPS to be used by MethodCounters.  TRAPS and exceptions shouldn't be thrown from non-JavaThreads.

Tested with tier1-7.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264149](https://bugs.openjdk.java.net/browse/JDK-8264149): BreakpointInfo::set allocates metaspace object in VM thread


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3207/head:pull/3207` \
`$ git checkout pull/3207`

Update a local copy of the PR: \
`$ git checkout pull/3207` \
`$ git pull https://git.openjdk.java.net/jdk pull/3207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3207`

View PR using the GUI difftool: \
`$ git pr show -t 3207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3207.diff">https://git.openjdk.java.net/jdk/pull/3207.diff</a>

</details>
