### PR TITLE
8264220: jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java fails to compile

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
@@ -27,6 +27,8 @@
  * @summary Listing (sub)packages at package level of API documentation
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ *          jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox javadoc.tester.*
  * @run main TestRelatedPackages
  */


### PR DESCRIPTION
Hi all,

jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java fails to compile.
Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264220](https://bugs.openjdk.java.net/browse/JDK-8264220): jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java fails to compile


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3208/head:pull/3208`
`$ git checkout pull/3208`

To update a local copy of the PR:
`$ git checkout pull/3208`
`$ git pull https://git.openjdk.java.net/jdk pull/3208/head`
