### PR TITLE
JDK-8264221: Rewrite confusing stream API chain in SnippetMaps

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
 import static jdk.jshell.Util.PREFIX_PATTERN;
 import static jdk.jshell.Util.REPL_PACKAGE;
 import static jdk.internal.jshell.debug.InternalDebugControl.DBG_DEP;
@@ -107,8 +106,7 @@ final class SnippetMaps {
             }
         }
         if (plus != null) {
-            plus.stream()
-                    .forEach(psi -> sb.append(psi.importLine(state)));
+            plus.forEach(psi -> sb.append(psi.importLine(state)));
         }
         return sb.toString();
     }
@@ -167,17 +165,19 @@ final class SnippetMaps {
                                .toList();
         for (String k : klasses) {
             if (k.equals(full)) {
-                return full.substring(full.lastIndexOf(".")+1, full.length());
+                return full.substring(full.lastIndexOf(".")+1);
             }
+        }
+        if (pkg.isEmpty()) {
+            return full;
         }
         Stream<String> pkgs = importSnippets()
                                .filter(isi -> isi.isStar)
                                .map(isi -> isi.fullname.substring(0, isi.fullname.lastIndexOf(".")));
-        return Stream.concat(Stream.of("java.lang"), pkgs)
-                     .filter(ipkg -> !ipkg.isEmpty() && ipkg.equals(pkg))
-                     .map(ipkg -> full.substring(pkg.length() + 1))
-                     .findFirst()
-                     .orElse(full);
+        if (Stream.concat(Stream.of("java.lang"), pkgs).anyMatch(pkg::equals)) {
+            return full.substring(pkg.length() + 1);
+        }
+        return full;
     }
 
     /**


### PR DESCRIPTION
I also simplified a couple of other places: replaced `stream().forEach()` with just `forEach()` and removed redundant `length()` argument in `substring()` call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264221](https://bugs.openjdk.java.net/browse/JDK-8264221): Rewrite confusing stream API chain in SnippetMaps


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3209/head:pull/3209` \
`$ git checkout pull/3209`

Update a local copy of the PR: \
`$ git checkout pull/3209` \
`$ git pull https://git.openjdk.java.net/jdk pull/3209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3209`

View PR using the GUI difftool: \
`$ git pr show -t 3209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3209.diff">https://git.openjdk.java.net/jdk/pull/3209.diff</a>

</details>
