### PR TITLE
8264109: Add vectorized implementation for VectorMask.andNot()

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,12 +148,6 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     public VectorMask<E> eq(VectorMask<E> m) {
         // FIXME: Generate good code here.
         return bOp(m, (i, a, b) -> a == b);
-    }
-
-    @Override
-    public VectorMask<E> andNot(VectorMask<E> m) {
-        // FIXME: Generate good code here.
-        return bOp(m, (i, a, b) -> a && !b);
     }
 
     /*package-private*/

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -150,6 +150,11 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         return bOp(m, (i, a, b) -> a == b);
     }
 
+    @Override
+    public VectorMask<E> andNot(VectorMask<E> m) {
+        return and(m.not());
+    }
+
     /*package-private*/
     static boolean anyTrueHelper(boolean[] bits) {
         // FIXME: Maybe use toLong() != 0 here.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -425,9 +425,7 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
      * @param m the second input mask
      * @return the result of logically subtracting the second mask from this mask
      */
-    public final VectorMask<E> andNot(VectorMask<E> m) {
-        return and(m.not());
-    }
+    public abstract VectorMask<E> andNot(VectorMask<E> m);
 
     /**
      * Logically negates this mask.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -425,7 +425,9 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
      * @param m the second input mask
      * @return the result of logically subtracting the second mask from this mask
      */
-    public abstract VectorMask<E> andNot(VectorMask<E> m);
+    public final VectorMask<E> andNot(VectorMask<E> m) {
+        return and(m.not());
+    }
 
     /**
      * Logically negates this mask.


### PR DESCRIPTION
Currently "VectorMask.andNot()" is not vectorized:
```
    public VectorMask<E> andNot(VectorMask<E> m) {
        // FIXME: Generate good code here.
        return bOp(m, (i, a, b) -> a && !b);
    }
```
This can be implemented with` "and(m.not())" `directly. Since `"VectorMask.and()/not()" `have been vectorized in hotspot, `"andNot"`
can be vectorized as well by calling them.

The performance gain is >100% for such a simple JMH:
```
  @Benchmark
  public Object andNot(Blackhole bh) {
    boolean[] mask = fm.apply(SPECIES.length());
    boolean[] r = fmt.apply(SPECIES.length());
    VectorMask<Byte> rm = VectorMask.fromArray(SPECIES, r, 0);

    for (int ic = 0; ic < INVOC_COUNT; ic++) {
      for (int i = 0; i < mask.length; i += SPECIES.length()) {
        VectorMask<Byte> vmask = VectorMask.fromArray(SPECIES, mask, i);
          rm = rm.andNot(vmask);
        }
    }
    return rm;
  }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264109](https://bugs.openjdk.java.net/browse/JDK-8264109): Add vectorized implementation for VectorMask.andNot()


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3211/head:pull/3211` \
`$ git checkout pull/3211`

Update a local copy of the PR: \
`$ git checkout pull/3211` \
`$ git pull https://git.openjdk.java.net/jdk pull/3211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3211`

View PR using the GUI difftool: \
`$ git pr show -t 3211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3211.diff">https://git.openjdk.java.net/jdk/pull/3211.diff</a>

</details>
