### PR TITLE
8264223: CodeHeap::verify fails extra_hops assertion in fastdebug test

### DIFF
--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -835,7 +835,10 @@ void CodeHeap::verify() {
       }
     }
     assert(nseg == _next_segment, "CodeHeap: segment count mismatch. found %d, expected %d.", (int)nseg, (int)_next_segment);
-    assert((count == 0) || (extra_hops < (16 + 2*count)), "CodeHeap: many extra hops due to optimization. blocks: %d, extra hops: %d.", count, extra_hops);
+    assert(extra_hops <= _fragmentation_count, "CodeHeap: extra hops wrong. fragmentation: %d, extra hops: %d.", _fragmentation_count, extra_hops);
+    if (extra_hops >= (16 + 2 * count)) {
+      warning("CodeHeap: many extra hops due to optimization. blocks: %d, extra hops: %d.", count, extra_hops);
+    }
 
     // Verify that the number of free blocks is not out of hand.
     static int free_block_threshold = 10000;

--- a/test/hotspot/jtreg/compiler/codegen/Test6935535.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test6935535.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/Test6935535.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test6935535.java
@@ -29,6 +29,14 @@
  * @run main/othervm -Xcomp compiler.codegen.Test6935535
  */
 
+/**
+ * @test
+ * @bug 8264223
+ * @summary add CodeHeap verification
+ *
+ * @requires vm.debug
+ * @run main/othervm -Xcomp -XX:+VerifyCodeCache compiler.codegen.Test6935535
+ */
 package compiler.codegen;
 
 public class Test6935535 {


### PR DESCRIPTION
When test with -XX:+VerifyCodeCache, many tests fail due to extra_hops assertion in CodeHeap::verify. See full dump in JBS.

# Internal Error (src/hotspot/share/memory/heap.cpp:838), pid=1525697, tid=1525715
# assert((count == 0) || (extra_hops < (16 + 2*count))) failed: CodeHeap: many extra hops due to optimization. blocks: 234, extra hops: 484.
Discussion in https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2019-October/035508.html doesn't tell where assertion (extra_hops < (16 + 2*count) comes from.

In CodeHeap::mark_segmap_as_used wehn is_FreeBlock_join is true,  it creates extra hops in _segmap. _fragmentation_count in inced and trigger defrag_segmap when reach threshold. In my understanding, extra hop can not guarantee under (16 + 2*count). 

In following extreme case, before HeapBlock free, segmap is all 0 (each blob use 1 smallest segment), suppose free action is applied from right to left. This increase 9 unnecessary hop for 1 continous HeapBlock.  assertion (extra_hops < (16 + 2*count)  is not safe.
|0|0|0|0|0|0|0|0|0|0|
after free, it will be
|0|1|1|1|1|1|1|1|1|1|

Proposed fix is assert extra hops not exceed _fragmentation_count. And if it exceeds (16 + 2 * count), give warning on two many extra hops.

fastdebug tier1, tier2 with VerifyCodeCache passed on X86_64 linux, no extra assertion found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264223](https://bugs.openjdk.java.net/browse/JDK-8264223): CodeHeap::verify fails extra_hops assertion in fastdebug test


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3212/head:pull/3212` \
`$ git checkout pull/3212`

Update a local copy of the PR: \
`$ git checkout pull/3212` \
`$ git pull https://git.openjdk.java.net/jdk pull/3212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3212`

View PR using the GUI difftool: \
`$ git pr show -t 3212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3212.diff">https://git.openjdk.java.net/jdk/pull/3212.diff</a>

</details>
