### PR TITLE
8264218:  Public method javax.swing.JMenu.setComponentOrientation() has no spec

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1260,7 +1260,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * determined by the {@code ComponentOrientation} argument.
      *
      * @param o the new orientation for this menu and
-     *        its associated popup menu contained within it.
+     *          its associated popup menu.
      */
     public void setComponentOrientation(ComponentOrientation o) {
         super.setComponentOrientation(o);

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1256,16 +1256,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
     }
 
     /**
-     * Sets the orientation for this menu and the associated popup component
-     * determined by the <code>ComponentOrientation</code> argument.
-     *
-     * @param  o one of the following values:
-     * <ul>
-     * <li>java.awt.ComponentOrientation.LEFT_TO_RIGHT
-     * <li>java.awt.ComponentOrientation.RIGHT_TO_LEFT
-     * <li>java.awt.ComponentOrientation.UNKNOWN
-     * </ul>
-     * @see java.awt.ComponentOrientation
+     * {@inheritDoc}
      */
     public void setComponentOrientation(ComponentOrientation o) {
         super.setComponentOrientation(o);

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1256,7 +1256,11 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
     }
 
     /**
-     * {@inheritDoc}
+     * Sets the orientation for this menu and the associated popup component
+     * determined by the <code>ComponentOrientation</code> argument.
+     *
+     * @param o the new component orientation of this menu and
+     *        the popup menu component contained within it.
      */
     public void setComponentOrientation(ComponentOrientation o) {
         super.setComponentOrientation(o);

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1255,6 +1255,18 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
         }
     }
 
+    /**
+     * Sets the orientation for this menu and the associated popup component
+     * determined by the <code>ComponentOrientation</code> argument.
+     *
+     * @param  o one of the following values:
+     * <ul>
+     * <li>java.awt.ComponentOrientation.LEFT_TO_RIGHT
+     * <li>java.awt.ComponentOrientation.RIGHT_TO_LEFT
+     * <li>java.awt.ComponentOrientation.UNKNOWN
+     * </ul>
+     * @see java.awt.ComponentOrientation
+     */
     public void setComponentOrientation(ComponentOrientation o) {
         super.setComponentOrientation(o);
         if ( popupMenu != null ) {

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1256,7 +1256,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
     }
 
     /**
-     * Sets the orientation for this menu and the associated popup component
+     * Sets the orientation for this menu and its associated popup menu
      * determined by the <code>ComponentOrientation</code> argument.
      *
      * @param o the new component orientation of this menu and

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1257,10 +1257,10 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
 
     /**
      * Sets the orientation for this menu and its associated popup menu
-     * determined by the <code>ComponentOrientation</code> argument.
+     * determined by the {@code ComponentOrientation} argument.
      *
-     * @param o the new component orientation of this menu and
-     *        the popup menu component contained within it.
+     * @param o the new orientation for this menu and
+     *        its associated popup menu contained within it.
      */
     public void setComponentOrientation(ComponentOrientation o) {
         super.setComponentOrientation(o);


### PR DESCRIPTION
A public overriding method JMenu.setComponentOrientation(java.awt.ComponentOrientation)
has no spec.
Added spec for the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264218](https://bugs.openjdk.java.net/browse/JDK-8264218): Public method javax.swing.JMenu.setComponentOrientation() has no spec


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3213/head:pull/3213` \
`$ git checkout pull/3213`

Update a local copy of the PR: \
`$ git checkout pull/3213` \
`$ git pull https://git.openjdk.java.net/jdk pull/3213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3213`

View PR using the GUI difftool: \
`$ git pr show -t 3213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3213.diff">https://git.openjdk.java.net/jdk/pull/3213.diff</a>

</details>
