### PR TITLE
8264273: macOS: zero VM is broken due to no member named 'is_cpu_emulated' after JDK-8261966

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1404,7 +1404,7 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   }
 
   const char* emulated = "";
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(ZERO)
   if (VM_Version::is_cpu_emulated()) {
     emulated = " (EMULATED)";
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1033,7 +1033,7 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
 void os::print_cpu_info(outputStream* st, char* buf, size_t buflen) {
   // cpu
   st->print("CPU:");
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(ZERO)
    if (VM_Version::is_cpu_emulated()) {
      st->print(" (EMULATED)");
    }


### PR DESCRIPTION
Hi all,

Zero VM on macOS is broken after JDK-8261966.
Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264273](https://bugs.openjdk.java.net/browse/JDK-8264273): macOS: zero VM is broken due to no member named 'is_cpu_emulated' after JDK-8261966


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3216/head:pull/3216`
`$ git checkout pull/3216`

To update a local copy of the PR:
`$ git checkout pull/3216`
`$ git pull https://git.openjdk.java.net/jdk pull/3216/head`
