### PR TITLE
JDK-8264110 (fs) possible UnsupportedOperationException in UnixUserDefinedFileAttributeView.read(...)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -184,10 +184,17 @@ abstract class UnixUserDefinedFileAttributeView
                 long address = nb.address();
                 int n = read(name, address, rem);
 
-                // copy from buffer into backing array
-                int off = dst.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
-                unsafe.copyMemory(null, address, dst.array(), off, n);
-                dst.position(pos + n);
+                if (dst.hasArray()) {
+                    // copy from buffer into backing array
+                    int off = dst.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                    unsafe.copyMemory(null, address, dst.array(), off, n);
+                    dst.position(pos + n);
+                } else {
+                    // backing array not accessible so transfer via temporary array
+                    byte[] tmp = new byte[n];
+                    unsafe.copyMemory(null, address, tmp, 0, n);
+                    dst.put(tmp);
+                }
 
                 return n;
             }


### PR DESCRIPTION
During `write()`, we check whether the `src` buffer exposes a raw byte array:

https://github.com/openjdk/jdk/blob/4e74de4b2eec611b49ee8defae1ab06351280008/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java#L247-L258

The same is now also done during `read()`. This should allow using arbitrary ByteBuffer implementations as `dst` and restores a certain symmetry between read and write.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264110](https://bugs.openjdk.java.net/browse/JDK-8264110): (fs) possible UnsupportedOperationException in UnixUserDefinedFileAttributeView.read(...)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3217/head:pull/3217`
`$ git checkout pull/3217`

To update a local copy of the PR:
`$ git checkout pull/3217`
`$ git pull https://git.openjdk.java.net/jdk pull/3217/head`
