### PR TITLE
8264190: Harden TLS interop tests

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
@@ -142,7 +142,7 @@ public class JdkServer extends AbstractServer {
 
     @Override
     public void close() throws IOException {
-        if (isAlive()) {
+        if (!serverSocket.isClosed()) {
             serverSocket.close();
         }
     }

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
@@ -106,7 +106,7 @@ public class JdkServer extends AbstractServer {
 
     @Override
     public void accept() throws IOException {
-        while (isAlive()) {
+        while (true) {
             try (SSLSocket socket = (SSLSocket) serverSocket.accept()) {
                 this.socket = socket;
                 System.out.println("Server accepted connection");

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
@@ -106,7 +106,7 @@ public class JdkServer extends AbstractServer {
 
     @Override
     public void accept() throws IOException {
-        while (true) {
+        while (isAlive()) {
             try (SSLSocket socket = (SSLSocket) serverSocket.accept()) {
                 this.socket = socket;
                 System.out.println("Server accepted connection");

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/Server.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/Server.java
@@ -42,7 +42,7 @@ public interface Server extends Peer {
     /*
      * Checks if the peer is alive.
      */
-    public boolean isAlive() throws IOException;
+    public boolean isAlive();
 
     /*
      * Signals the server to stop if necessary.

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
@@ -280,48 +280,6 @@ public class Utilities {
     }
 
     /*
-     * Executes shell command and return a OutputAnalyzer wrapping the process.
-     */
-    public static OutputAnalyzer shell(String command) throws IOException {
-        Process process = shellProc(command);
-        OutputAnalyzer oa = new OutputAnalyzer(process);
-        try {
-            process.waitFor();
-            return oa;
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Shell process is interruptted!", e);
-        }
-    }
-
-    /*
-     * Executes shell command and redirect the output to a local file,
-     * and return the process.
-     */
-    public static Process shellProc(String command, Path outputPath)
-            throws IOException {
-        String[] cmds = new String[3];
-        cmds[0] = "sh";
-        cmds[1] = "-c";
-        cmds[2] = command;
-        if (DEBUG) {
-            System.out.println("[sh -c " + command + "]");
-        }
-        ProcessBuilder pb = new ProcessBuilder(cmds);
-        pb.redirectErrorStream(true);
-        if (outputPath != null) {
-            pb.redirectOutput(outputPath.toFile());
-        }
-        return pb.start();
-    }
-
-    /*
-     * Executes shell command and return the process.
-     */
-    public static Process shellProc(String command) throws IOException {
-        return shellProc(command, null);
-    }
-
-    /*
      * Determines if the specified process is alive.
      */
     public static boolean isAliveProcess(Process process) {

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
@@ -377,14 +377,14 @@ public class Utilities {
      */
     public static boolean isSessionResumed(ResumptionMode mode,
             byte[] firstSessionId, byte[] secondSessionId,
-            long secondConnStartTime, long secondSessionCreationTime) {
+            long firstSessionCreationTime, long secondSessionCreationTime) {
         System.out.println("ResumptionMode: " + mode);
         System.out.println("firstSessionId: " + Arrays.toString(firstSessionId));
         System.out.println("secondSessionId: " + Arrays.toString(secondSessionId));
-        System.out.println("secondConnStartTime: " + secondConnStartTime);
+        System.out.println("firstSessionCreationTime: " + firstSessionCreationTime);
         System.out.println("secondSessionCreationTime: " + secondSessionCreationTime);
 
-        boolean resumed = secondConnStartTime > secondSessionCreationTime;
+        boolean resumed = firstSessionCreationTime == secondSessionCreationTime;
         if (mode == ResumptionMode.ID) {
             resumed = resumed && firstSessionId.length > 0
                     && Arrays.equals(firstSessionId, secondSessionId);

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/Utilities.java
@@ -219,15 +219,17 @@ public class Utilities {
      */
     public static <T> boolean waitFor(Predicate<T> predicate, T t) {
         long deadline = System.currentTimeMillis() + Utilities.TIMEOUT * 1000;
-        while (!predicate.test(t) && System.currentTimeMillis() < deadline) {
+        boolean predicateResult = predicate.test(t);
+        while (!predicateResult && System.currentTimeMillis() < deadline) {
             try {
                 TimeUnit.SECONDS.sleep(1);
+                predicateResult = predicate.test(t);
             } catch (InterruptedException e) {
                 throw new RuntimeException("Sleep is interrupted.", e);
             }
         }
 
-        return predicate.test(t);
+        return predicateResult;
     }
 
     /*


### PR DESCRIPTION
Occasional interop tests failures may occur when making use of the test/jdk/javax/net/ssl/TLSCommon/interop framework since there is no assurance the selected available port it is still free at the time a server using the framework starts up, for instance, by command line. To mitigate intermittent failures, this patch updates interop/BaseInteropTest.java in order to validate the server is alive and if not, retry to create a valid server.

In addition, Utilities::isSessionResumed implementation is now comparing equality of first and second session creation time to validate session resumption

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264190](https://bugs.openjdk.java.net/browse/JDK-8264190): Harden TLS interop tests


### Reviewers
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3218/head:pull/3218` \
`$ git checkout pull/3218`

Update a local copy of the PR: \
`$ git checkout pull/3218` \
`$ git pull https://git.openjdk.java.net/jdk pull/3218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3218`

View PR using the GUI difftool: \
`$ git pr show -t 3218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3218.diff">https://git.openjdk.java.net/jdk/pull/3218.diff</a>

</details>
