### PR TITLE
8264285: Do not support FLAG_SET_XXX for VM flags of string type

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@ class JVMFlagAccess : AllStatic {
   inline static const FlagAccessImpl* access_impl(const JVMFlag* flag);
   static JVMFlag::Error set_impl(JVMFlagsEnum flag_enum, int type_enum, void* value, JVMFlagOrigin origin);
   static JVMFlag::Error set_impl(JVMFlag* flag, int type_enum, void* value, JVMFlagOrigin origin);
-  static JVMFlag::Error ccstrAtPut(JVMFlagsEnum flag, ccstr value, JVMFlagOrigin origin);
 
 public:
   static JVMFlag::Error check_range(const JVMFlag* flag, bool verbose);
@@ -86,6 +85,7 @@ public:
   // type_enum will result in an assert.
   template <typename T, int type_enum>
   static JVMFlag::Error set(JVMFlagsEnum flag_enum, T value, JVMFlagOrigin origin) {
+    static_assert(type_enum != JVMFlag::TYPE_ccstr && type_enum != JVMFlag::TYPE_ccstrlist, "not supported");
     return set_impl(flag_enum, type_enum, &value, origin);
   }
 

--- a/src/hotspot/share/runtime/globals_extension.hpp
+++ b/src/hotspot/share/runtime/globals_extension.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,12 @@ enum JVMFlagsEnum : int {
   NUM_JVMFlagsEnum
 };
 
-// Construct set functions for all flags
+// Set functions for all flags -- use a template so we can do static_assert
+// at individual call sites of FLAG_SET_{CMDLINE,ERGO,MGMT}
 
 #define FLAG_MEMBER_SETTER(name) Flag_##name##_set
 #define FLAG_MEMBER_SETTER_(type, name) \
+  template <int dummy> \
   inline JVMFlag::Error FLAG_MEMBER_SETTER(name)(type value, JVMFlagOrigin origin) { \
     return JVMFlagAccess::set<JVM_FLAG_TYPE(type)>(FLAG_MEMBER_ENUM(name), value, origin); \
   }
@@ -75,9 +77,9 @@ ALL_FLAGS(DEFINE_FLAG_MEMBER_SETTER,
 #define FLAG_SET_DEFAULT(name, value) ((name) = (value))
 
 #define FLAG_SET_CMDLINE(name, value) (JVMFlag::setOnCmdLine(FLAG_MEMBER_ENUM(name)), \
-                                       FLAG_MEMBER_SETTER(name)((value), JVMFlagOrigin::COMMAND_LINE))
-#define FLAG_SET_ERGO(name, value)    (FLAG_MEMBER_SETTER(name)((value), JVMFlagOrigin::ERGONOMIC))
-#define FLAG_SET_MGMT(name, value)    (FLAG_MEMBER_SETTER(name)((value), JVMFlagOrigin::MANAGEMENT))
+                                       FLAG_MEMBER_SETTER(name)<0>((value), JVMFlagOrigin::COMMAND_LINE))
+#define FLAG_SET_ERGO(name, value)    (FLAG_MEMBER_SETTER(name)<0>((value), JVMFlagOrigin::ERGONOMIC))
+#define FLAG_SET_MGMT(name, value)    (FLAG_MEMBER_SETTER(name)<0>((value), JVMFlagOrigin::MANAGEMENT))
 
 #define FLAG_SET_ERGO_IF_DEFAULT(name, value) \
   do {                                        \


### PR DESCRIPTION
We have two versions of `JVMFlagAccess::ccstrAtPut()` that are slightly different.

The following version is supposed to be used only by the `FLAG_SET_{CMDLINE,ERGO,MGMT}` macros. However, it's not used anywhere in the HotSpot source code:

```
JVMFlag::Error JVMFlagAccess::ccstrAtPut(JVMFlagsEnum flag, ccstr value, JVMFlagOrigin origin) {
  JVMFlag* faddr = JVMFlag::flag_from_enum(flag);
  assert(faddr->is_ccstr(), "wrong flag type");
  ccstr old_value = faddr->get_ccstr();
  trace_flag_changed<ccstr, EventStringFlagChanged>(faddr, old_value, value, origin);
  char* new_value = os::strdup_check_oom(value);
  faddr->set_ccstr(new_value);
  if (!faddr->is_default() && old_value != NULL) {
    // Prior value is heap allocated so free it.
    FREE_C_HEAP_ARRAY(char, old_value);
  }
  faddr->set_origin(origin);
  return JVMFlag::SUCCESS;
}
```

It's not clear whether this unused version is actually correct since the last JVMFlag rewrite in [JDK-8081833](https://bugs.openjdk.java.net/browse/JDK-8081833), due to complete lack of testing. Let's remove this version to simplify code maintenance.

If you need to modify flags of the string type, do not use `FLAG_SET_{CMDLINE,ERGO,MGMT}`. (A `static_assert` is added to prevent this). Instead, use the remaining version of `JVMFlagAccess::ccstrAtPut()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264285](https://bugs.openjdk.java.net/browse/JDK-8264285): Do not support FLAG_SET_XXX for VM flags of string type


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3219/head:pull/3219`
`$ git checkout pull/3219`

To update a local copy of the PR:
`$ git checkout pull/3219`
`$ git pull https://git.openjdk.java.net/jdk pull/3219/head`
