### PR TITLE
8264240: [macos_aarch64] enable appcds support after JDK-8263002

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -264,9 +264,7 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_CDS],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(cds, [
     AC_MSG_CHECKING([if platform is supported by CDS])
-    if test "x$OPENJDK_TARGET_OS" = xaix || \
-        ( test "x$OPENJDK_TARGET_OS" = "xmacosx" && \
-        test "x$OPENJDK_TARGET_CPU" = "xaarch64" ) ; then
+    if test "x$OPENJDK_TARGET_OS" = xaix; then
       AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
       AVAILABLE=false
     else


### PR DESCRIPTION
Please review this small patch for macos_aarch64.
It reverts small part of jep-391 where we disabled cds for macos_aarch64.
After JDK-8263002 is fixed, the appcds can be enabled back on macos_aarch64.
CDS related tests in tier1 now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264240](https://bugs.openjdk.java.net/browse/JDK-8264240): [macos_aarch64] enable appcds support after JDK-8263002


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3221/head:pull/3221`
`$ git checkout pull/3221`

To update a local copy of the PR:
`$ git checkout pull/3221`
`$ git pull https://git.openjdk.java.net/jdk pull/3221/head`
