### PR TITLE
8264309: JFR: Improve .jfc parser

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParserHandler.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParserHandler.java
@@ -98,8 +98,4 @@ final class JFCParserHandler extends DefaultHandler {
             break;
         }
     }
-
-    public Map<String, String> getSettings() {
-        return settings;
-    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParserHandler.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParserHandler.java
@@ -42,9 +42,9 @@ final class JFCParserHandler extends DefaultHandler {
     private static final String ATTRIBUTE_VERSION = "version";
 
     final Map<String, String> settings = new LinkedHashMap<String, String>();
-    private String currentEventPath;
+    private final StringBuilder currentCharacters = new StringBuilder();
+    private String currentEventName;
     private String currentSettingsName;
-    private StringBuilder currentCharacters;
     String label;
     String provider;
     String description;
@@ -62,13 +62,13 @@ final class JFCParserHandler extends DefaultHandler {
             provider = getOptional(attributes, ATTRIBUTE_PROVIDER, "");
             break;
         case ELEMENT_EVENT_TYPE:
-            currentEventPath = attributes.getValue(ATTRIBUTE_NAME);
+            currentEventName = attributes.getValue(ATTRIBUTE_NAME);
             break;
         case ELEMENT_SETTING:
             currentSettingsName = attributes.getValue(ATTRIBUTE_NAME);
             break;
         }
-        currentCharacters = null;
+        currentCharacters.setLength(0);
     }
 
     private String getOptional(Attributes attributes, String name, String defaultValue) {
@@ -78,10 +78,9 @@ final class JFCParserHandler extends DefaultHandler {
 
     @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
-        if (currentCharacters == null) {
-            currentCharacters = new StringBuilder(length);
+        if (currentSettingsName != null) {
+            currentCharacters.append(ch, start, length);
         }
-        currentCharacters.append(ch, start, length);
     }
 
     @Override
@@ -90,11 +89,11 @@ final class JFCParserHandler extends DefaultHandler {
         case ELEMENT_CONFIGURATION:
             break;
         case ELEMENT_EVENT_TYPE:
-            currentEventPath = null;
+            currentEventName = null;
             break;
         case ELEMENT_SETTING:
-            String settingsValue = currentCharacters == null ? "" : currentCharacters.toString();
-            settings.put(currentEventPath + "#" + currentSettingsName, "" + settingsValue);
+            String settingsValue = currentCharacters.toString();
+            settings.put(currentEventName + "#" + currentSettingsName, settingsValue);
             currentSettingsName = null;
             break;
         }


### PR DESCRIPTION
Hi,

Could I have a review of a fix that removes unnecessary number of StringBuilder allocations. Events are now referred to by name, not path. The code should reflect that. The method getSettings() is not used and can be removed.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264309](https://bugs.openjdk.java.net/browse/JDK-8264309): JFR: Improve .jfc parser


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3222/head:pull/3222` \
`$ git checkout pull/3222`

Update a local copy of the PR: \
`$ git checkout pull/3222` \
`$ git pull https://git.openjdk.java.net/jdk pull/3222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3222`

View PR using the GUI difftool: \
`$ git pr show -t 3222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3222.diff">https://git.openjdk.java.net/jdk/pull/3222.diff</a>

</details>
