### PR TITLE
8255800: Raster creation methods need some specification clean up

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,8 +78,13 @@ public final class BandedSampleModel extends ComponentSampleModel
      * @param h         The height (in pixels) of the region of image
      *                  data described.
      * @param numBands  The number of bands for the image data.
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if {@code numBands} is not > 0
      * @throws IllegalArgumentException if {@code dataType} is not
-     *         one of the supported data types
+     *         one of the supported data types for this sample model.
      */
     public BandedSampleModel(int dataType, int w, int h, int numBands) {
         super(dataType, w, h, 1, w,
@@ -100,8 +105,21 @@ public final class BandedSampleModel extends ComponentSampleModel
      * @param scanlineStride The line stride of the of the image data.
      * @param bankIndices The bank index for each band.
      * @param bandOffsets The band offset for each band.
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if {@code scanlineStride} is less than 0
+     * @throws NullPointerException if {@code bankIndices} is {@code null}
+     * @throws NullPointerException if {@code bandOffsets} is {@code null}
+     * @throws IllegalArgumentException if {@code bandOffsets.length} is 0
+     * @throws IllegalArgumentException if the length of
+     *         {@code bankIndices} does not equal the length of
+     *         {@code bandOffsets}
+     * @throws IllegalArgumentException if any of the bank indices
+     *         of {@code bandIndices} is less than 0
      * @throws IllegalArgumentException if {@code dataType} is not
-     *         one of the supported data types
+     *         one of the supported data types for this sample model
      */
     public BandedSampleModel(int dataType,
                              int w, int h,
@@ -853,6 +871,9 @@ public final class BandedSampleModel extends ComponentSampleModel
     }
 
     private static int[] createOffsetArray(int numBands) {
+        if (numBands <= 0) {
+            throw new IllegalArgumentException("numBands must be > 0");
+        }
         int[] bandOffsets = new int[numBands];
         for (int i=0; i < numBands; i++) {
             bandOffsets[i] = 0;
@@ -861,6 +882,9 @@ public final class BandedSampleModel extends ComponentSampleModel
     }
 
     private static int[] createIndicesArray(int numBands) {
+        if (numBands <= 0) {
+            throw new IllegalArgumentException("numBands must be > 0");
+        }
         int[] bankIndices = new int[numBands];
         for (int i=0; i < numBands; i++) {
             bankIndices[i] = i;

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -118,19 +118,16 @@ public class ComponentSampleModel extends SampleModel
      * @param scanlineStride the line stride of the region of image
      *     data described
      * @param bandOffsets the offsets of all bands
-     * @throws IllegalArgumentException if {@code w} or
-     *         {@code h} is not greater than 0
-     * @throws IllegalArgumentException if {@code pixelStride}
-     *         is less than 0
-     * @throws IllegalArgumentException if {@code scanlineStride}
-     *         is less than 0
-     * @throws IllegalArgumentException if {@code numBands}
-     *         is less than 1
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
      * @throws IllegalArgumentException if the product of {@code w}
-     *         and {@code h} is greater than
-     *         {@code Integer.MAX_VALUE}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if {@code pixelStride} is less than 0
+     * @throws IllegalArgumentException if {@code scanlineStride} is less than 0
+     * @throws NullPointerException if {@code bandOffsets} is {@code null}
+     * @throws IllegalArgumentException if {@code bandOffsets.length} is 0
      * @throws IllegalArgumentException if {@code dataType} is not
-     *         one of the supported data types
+     *         one of the supported data types for this sample model.
      */
     public ComponentSampleModel(int dataType,
                                 int w, int h,
@@ -149,9 +146,6 @@ public class ComponentSampleModel extends SampleModel
         // TODO - bug 4296691 - remove this check
         if (scanlineStride < 0) {
             throw new IllegalArgumentException("Scanline stride must be >= 0");
-        }
-        if (numBands < 1) {
-            throw new IllegalArgumentException("Must have at least one band.");
         }
         if ((dataType < DataBuffer.TYPE_BYTE) ||
             (dataType > DataBuffer.TYPE_DOUBLE)) {
@@ -181,19 +175,22 @@ public class ComponentSampleModel extends SampleModel
      *     data described
      * @param bankIndices the bank indices of all bands
      * @param bandOffsets the band offsets of all bands
-     * @throws IllegalArgumentException if {@code w} or
-     *         {@code h} is not greater than 0
-     * @throws IllegalArgumentException if {@code pixelStride}
-     *         is less than 0
-     * @throws IllegalArgumentException if {@code scanlineStride}
-     *         is less than 0
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if {@code pixelStride} is less than 0
+     * @throws IllegalArgumentException if {@code scanlineStride} is less than 0
+     * @throws NullPointerException if {@code bankIndices} is {@code null}
+     * @throws NullPointerException if {@code bandOffsets} is {@code null}
+     * @throws IllegalArgumentException if {@code bandOffsets.length} is 0
      * @throws IllegalArgumentException if the length of
      *         {@code bankIndices} does not equal the length of
-     *         {@code bankOffsets}
+     *         {@code bandOffsets}
      * @throws IllegalArgumentException if any of the bank indices
      *         of {@code bandIndices} is less than 0
      * @throws IllegalArgumentException if {@code dataType} is not
-     *         one of the supported data types
+     *         one of the supported data types for this sample model
      */
     public ComponentSampleModel(int dataType,
                                 int w, int h,
@@ -207,6 +204,10 @@ public class ComponentSampleModel extends SampleModel
         this.scanlineStride  = scanlineStride;
         this.bandOffsets = bandOffsets.clone();
         this.bankIndices = bankIndices.clone();
+        if (this.bandOffsets.length != this.bankIndices.length) {
+            throw new IllegalArgumentException("Length of bandOffsets must "+
+                                               "equal length of bankIndices.");
+        }
         if (pixelStride < 0) {
             throw new IllegalArgumentException("Pixel stride must be >= 0");
         }
@@ -235,10 +236,6 @@ public class ComponentSampleModel extends SampleModel
         }
         numBanks         = maxBank+1;
         numBands         = this.bandOffsets.length;
-        if (this.bandOffsets.length != this.bankIndices.length) {
-            throw new IllegalArgumentException("Length of bandOffsets must "+
-                                               "equal length of bankIndices.");
-        }
         verify();
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,16 +195,29 @@ public class Raster {
      * @param location  the upper-left corner of the {@code Raster}
      * @return a WritableRaster object with the specified data type,
      *         width, height and number of bands.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
+     * @throws IllegalArgumentException if {@code dataType} is not
+     *         one of the supported data types
+     * @throws IllegalArgumentException if {@code bands} is less than 1
+     * @throws IllegalArgumentException if {@code w} and {@code h} are not
+     *         both > 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws RasterFormatException if computing either
      *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
+     *         {@code location.y + h} results in integer overflow
      */
     public static WritableRaster createInterleavedRaster(int dataType,
                                                          int w, int h,
                                                          int bands,
                                                          Point location) {
+        if (w <= 0 || h <= 0) {
+            throw new IllegalArgumentException("w and h must be > 0");
+        }
+        long lsz = (long)w * h;
+        if (lsz > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Dimensions (width="+w+
+                                               " height="+h+") are too large");
+        }
         int[] bandOffsets = new int[bands];
         for (int i = 0; i < bands; i++) {
             bandOffsets[i] = i;
@@ -240,15 +253,21 @@ public class Raster {
      * @return a WritableRaster object with the specified data type,
      *         width, height, scanline stride, pixel stride and band
      *         offsets.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
-     *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types, which are
      *         {@code DataBuffer.TYPE_BYTE}, or
      *         {@code DataBuffer.TYPE_USHORT}.
+     * @throws IllegalArgumentException if {@code w} and {@code h} are not
+     *         both > 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws RasterFormatException if computing either
+     *         {@code location.x + w} or
+     *         {@code location.y + h} results in integer overflow
+     * @throws IllegalArgumentException if {@code scanlineStride}
+     *         is less than 0
+     * @throws IllegalArgumentException if {@code pixelStride} is less than 0
+     * @throws NullPointerException if {@code bandOffsets} is null
      */
     public static WritableRaster createInterleavedRaster(int dataType,
                                                          int w, int h,
@@ -258,6 +277,20 @@ public class Raster {
                                                          Point location) {
         DataBuffer d;
 
+        if (w <= 0 || h <= 0) {
+            throw new IllegalArgumentException("w and h must be > 0");
+        }
+        long lsz = (long)w * h;
+        if (lsz > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Dimensions (width="+w+
+                                               " height="+h+") are too large");
+        }
+        if (pixelStride < 0) {
+            throw new IllegalArgumentException("pixelStride is < 0");
+        }
+        if (scanlineStride < 0) {
+            throw new IllegalArgumentException("scanlineStride is < 0");
+        }
         int size = scanlineStride * (h - 1) + // fisrt (h - 1) scans
             pixelStride * w; // last scan
 
@@ -283,7 +316,7 @@ public class Raster {
      * Creates a Raster based on a BandedSampleModel with the
      * specified data type, width, height, and number of bands.
      *
-     * <p> The upper left corner of the Raster is given by the
+     * <p> The upper left corner of the Raster is given by the,
      * location argument.  If location is null, (0, 0) will be used.
      * The dataType parameter should be one of the enumerated values
      * defined in the DataBuffer class.
@@ -297,11 +330,18 @@ public class Raster {
      * @param location  the upper-left corner of the {@code Raster}
      * @return a WritableRaster object with the specified data type,
      *         width, height and number of bands.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
+     * @throws IllegalArgumentException if {@code dataType} is not
+     *         one of the supported data types, which are
+     *         {@code DataBuffer.TYPE_BYTE},
+     *         {@code DataBuffer.TYPE_USHORT}
+     *         or {@code DataBuffer.TYPE_INT}
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if computing either
      *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
+     *         {@code location.y + h} results in integer overflow
      * @throws ArrayIndexOutOfBoundsException if {@code bands}
      *         is less than 1
      */
@@ -349,18 +389,23 @@ public class Raster {
      * @return a WritableRaster object with the specified data type,
      *         width, height, scanline stride, bank indices and band
      *         offsets.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
-     *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types, which are
      *         {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}
      *         or {@code DataBuffer.TYPE_INT}
+     * @throws IllegalArgumentException if {@code w} and {@code h}
+     *         are not both greater than 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException if computing either
+     *         {@code location.x + w} or
+     *         {@code location.y + h} results in integer overflow
+     * @throws IllegalArgumentException if {@code scanlineStride}
+     *         is less than 0
      * @throws ArrayIndexOutOfBoundsException if {@code bankIndices}
-     *         or {@code bandOffsets} is {@code null}
+     *         is {@code null}
+     * @throws NullPointerException if {@code bandOffsets} is {@code null}
      */
     public static WritableRaster createBandedRaster(int dataType,
                                                     int w, int h,
@@ -371,6 +416,14 @@ public class Raster {
         DataBuffer d;
         int bands = bandOffsets.length;
 
+        if (w <= 0 || h <= 0) {
+             throw new IllegalArgumentException("w and h must be positive");
+        }
+        long lsz = (long)w * h;
+        if (lsz > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Dimensions (width="+w+
+                                               " height="+h+") are too large");
+        }
         if (bankIndices == null) {
             throw new
                 ArrayIndexOutOfBoundsException("Bank indices array is null");
@@ -378,6 +431,14 @@ public class Raster {
         if (bandOffsets == null) {
             throw new
                 ArrayIndexOutOfBoundsException("Band offsets array is null");
+        }
+        if (location != null) {
+            if ((w + location.getX() > Integer.MAX_VALUE) ||
+                (h + location.getY() > Integer.MAX_VALUE)) {
+              throw new IllegalArgumentException(
+                 "location.x + w and location.y + h " +
+                 " cannot exceed Integer.MAX_VALUE");
+            }
         }
 
         // Figure out the #banks and the largest band offset
@@ -611,18 +672,29 @@ public class Raster {
      * @return a WritableRaster object with the specified
      *         {@code DataBuffer}, width, height, scanline stride,
      *         pixel stride and band offsets.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
-     *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types, which are
      *         {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}
+     * @throws NullPointerException if {@code dataBuffer} is null
+     * @throws IllegalArgumentException if {@code dataType} is not
+     *         one of the supported data types, which are
+     *         {@code DataBuffer.TYPE_BYTE}, or
+     *         {@code DataBuffer.TYPE_USHORT}.
      * @throws RasterFormatException if {@code dataBuffer} has more
      *         than one bank.
-     * @throws NullPointerException if {@code dataBuffer} is null
+     * @throws IllegalArgumentException if {@code w} and {@code h} are not
+     *         both > 0
+     * @throws IllegalArgumentException if the product of {@code w}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     * @throws RasterFormatException if computing either
+     *         {@code location.x + w} or
+     *         {@code location.y + h} results in integer overflow
+     * @throws IllegalArgumentException if {@code scanlineStride}
+     *         is less than 0
+     * @throws IllegalArgumentException if {@code pixelStride} is less than 0
+     * @throws NullPointerException if {@code bandOffsets} is null
+
      */
     public static WritableRaster createInterleavedRaster(DataBuffer dataBuffer,
                                                          int w, int h,
@@ -686,17 +758,22 @@ public class Raster {
      * @return a WritableRaster object with the specified
      *         {@code DataBuffer}, width, height, scanline stride,
      *         bank indices and band offsets.
-     * @throws RasterFormatException if {@code w} or {@code h}
-     *         is less than or equal to zero, or computing either
-     *         {@code location.x + w} or
-     *         {@code location.y + h} results in integer
-     *         overflow
+     * @throws NullPointerException if {@code dataBuffer} is null,
+     *         or {@code bankIndices} is null, or {@code bandOffsets} is null
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types, which are
      *         {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}
-     *         or {@code DataBuffer.TYPE_INT}
-     * @throws NullPointerException if {@code dataBuffer} is null
+     *         or {@code DataBuffer.TYPE_INT},
+     *         or if {@code w} or {@code h} is less than or equal to zero,
+     *         or if the product of {@code w} and {@code h} is greater
+     *         than {@code Integer.MAX_VALUE}
+     *         or if {@code scanlineStride} is less than zero,
+     *         or if the length of {@code bankIndices} does not
+     *         equal the length of {@code bandOffsets}
+     * @throws RasterFormatException if computing either
+     *         {@code location.x + w} or
+     *         {@code location.y + h} results in integer overflow
      */
     public static WritableRaster createBandedRaster(DataBuffer dataBuffer,
                                                     int w, int h,
@@ -708,10 +785,18 @@ public class Raster {
         if (dataBuffer == null) {
             throw new NullPointerException("DataBuffer cannot be null");
         }
-        if (location == null) {
-           location = new Point(0,0);
+        if (bankIndices == null) {
+            throw new NullPointerException("bankIndices cannot be null");
         }
-        int dataType = dataBuffer.getDataType();
+        if (bandOffsets == null) {
+            throw new NullPointerException("bandOffsets cannot be null");
+        }
+        if (w <= 0 || h <= 0) {
+            throw new IllegalArgumentException("Width ("+w+") and height ("+h+") must be > 0");
+        }
+        if (scanlineStride < 0) {
+            throw new IllegalArgumentException("Scanline stride must be >= 0");
+        }
 
         int bands = bankIndices.length;
         if (bandOffsets.length != bands) {
@@ -719,6 +804,11 @@ public class Raster {
                                    "bankIndices.length != bandOffsets.length");
         }
 
+        if (location == null) {
+           location = new Point(0,0);
+        }
+
+        int dataType = dataBuffer.getDataType();
         BandedSampleModel bsm =
             new BandedSampleModel(dataType, w, h,
                                   scanlineStride,
@@ -772,7 +862,7 @@ public class Raster {
      *         {@code location.x + w} or
      *         {@code location.y + h} results in integer
      *         overflow
-     * @throws IllegalArgumentException if {@code dataType} is not
+     * @throws IllegalArgumentException if {@code dataBuffer} is not
      *         one of the supported data types, which are
      *         {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -294,6 +294,17 @@ public class Raster {
         int size = scanlineStride * (h - 1) + // fisrt (h - 1) scans
             pixelStride * w; // last scan
 
+        if (location == null) {
+            location = new Point(0, 0);
+        } else {
+            if ((w + location.getX() > Integer.MAX_VALUE) ||
+                (h + location.getY() > Integer.MAX_VALUE)) {
+              throw new RasterFormatException(
+                 "location.x + w and location.y + h " +
+                 " cannot exceed Integer.MAX_VALUE");
+            }
+        }
+
         switch(dataType) {
         case DataBuffer.TYPE_BYTE:
             d = new DataBufferByte(size);
@@ -706,9 +717,18 @@ public class Raster {
         if (dataBuffer == null) {
             throw new NullPointerException("DataBuffer cannot be null");
         }
+
         if (location == null) {
             location = new Point(0, 0);
+        } else {
+            if ((w + location.getX() > Integer.MAX_VALUE) ||
+                (h + location.getY() > Integer.MAX_VALUE)) {
+              throw new RasterFormatException(
+                 "location.x + w and location.y + h " +
+                 " cannot exceed Integer.MAX_VALUE");
+            }
         }
+
         int dataType = dataBuffer.getDataType();
 
         PixelInterleavedSampleModel csm =
@@ -806,6 +826,13 @@ public class Raster {
 
         if (location == null) {
            location = new Point(0,0);
+        } else {
+            if ((w + location.getX() > Integer.MAX_VALUE) ||
+                (h + location.getY() > Integer.MAX_VALUE)) {
+              throw new RasterFormatException(
+                 "location.x + w and location.y + h " +
+                 " cannot exceed Integer.MAX_VALUE");
+            }
         }
 
         int dataType = dataBuffer.getDataType();

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -316,7 +316,7 @@ public class Raster {
      * Creates a Raster based on a BandedSampleModel with the
      * specified data type, width, height, and number of bands.
      *
-     * <p> The upper left corner of the Raster is given by the,
+     * <p> The upper left corner of the Raster is given by the
      * location argument.  If location is null, (0, 0) will be used.
      * The dataType parameter should be one of the enumerated values
      * defined in the DataBuffer class.

--- a/src/java.desktop/share/classes/java/awt/image/SampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,10 +114,13 @@ public abstract class SampleModel
      * @throws IllegalArgumentException if {@code w} or {@code h}
      *         is not greater than 0
      * @throws IllegalArgumentException if the product of {@code w}
-     *         and {@code h} is greater than
-     *         {@code Integer.MAX_VALUE}
+     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types
+     * @throws IllegalArgumentException if {@code numBands} is less than 1
+     * @throws IllegalArgumentException if {@code dataType} is not
+     *         one of the pre-defined data type tags in the
+     *         {@code DataBuffer} class
      */
     public SampleModel(int dataType, int w, int h, int numBands)
     {

--- a/src/java.desktop/share/classes/java/awt/image/SampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SampleModel.java
@@ -116,11 +116,9 @@ public abstract class SampleModel
      * @throws IllegalArgumentException if the product of {@code w}
      *         and {@code h} is greater than {@code Integer.MAX_VALUE}
      * @throws IllegalArgumentException if {@code dataType} is not
-     *         one of the supported data types
-     * @throws IllegalArgumentException if {@code numBands} is less than 1
-     * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the pre-defined data type tags in the
      *         {@code DataBuffer} class
+     * @throws IllegalArgumentException if {@code numBands} is less than 1
      */
     public SampleModel(int dataType, int w, int h, int numBands)
     {

--- a/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
+++ b/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
@@ -1,0 +1,1250 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+*/
+
+/*
+ * @test
+ * @bug 8255800
+ * @summary verify Raster + SampleModel creation vs spec.
+ */
+
+import java.awt.Point;
+import java.awt.image.BandedSampleModel;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.DataBufferFloat;
+import java.awt.image.Raster;
+import java.awt.image.RasterFormatException;
+
+public class CreateRasterExceptionTest {
+
+    static int[] bankIndices = new int[] { 0, 0};
+    static int[] negBankIndices = new int[] { -1, 0};
+    static int[] bandOffsets = new int[] { 0, 0};
+    static int[] bandOffsets2 = new int[] { 0, 0, 0, 0};
+    static int[] zeroBandOffsets = new int[] {};
+    static DataBuffer dBuffer = new DataBufferByte(15);
+
+    static void noException() {
+         Thread.dumpStack();
+         throw new RuntimeException("No expected exception");
+    }
+
+    /* Except a version starting with "17" or higher */
+    static void checkIsOldVersion(Throwable t) {
+        String version = System.getProperty("java.version");
+        version = version.split("\\D")[0];
+        int v = Integer.parseInt(version);
+        if (v >= 17) {
+            t.printStackTrace();
+            throw new RuntimeException(
+                           "Unexpected exception for version " + v);
+        }
+    }
+
+    public static void main(String[] args) {
+         componentSampleModelTests1();
+         componentSampleModelTests2();
+         bandedSampleModelTests1();
+         bandedSampleModelTests2();
+         bandedRasterTests1();
+         bandedRasterTests2();
+         bandedRasterTests3();
+         interleavedRasterTests1();
+         interleavedRasterTests2();
+         interleavedRasterTests3();
+         System.out.println();
+         System.out.println(" ** Test Passed **");
+    }
+
+
+    /*   public ComponentSampleModel(int dataType,
+     *                          int w, int h,
+     *                          int pixelStride,
+     *                          int scanlineStride,
+     *                          int[] bandOffsets);
+     */
+    static void componentSampleModelTests1() {
+
+        System.out.println();
+        System.out.println("** componentSampleModelTests1");
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, -5, 1, 3, 15,
+                                     bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                         "Got expected exception for negative width");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT,
+                   Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 2,
+                   3, 15, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                        "Got expected exception for exceeding max int");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if {@code pixelStride}
+              * is less than 0
+              */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, -3, 15,
+                                     bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative pixel stride");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, -15,
+                                     bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets} is
+             * {@code null}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     bankIndices, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                        "Got expected exception for null bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if
+             * {@code bandOffsets.length}is 0
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     bankIndices, zeroBandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                        "Got expected exception for 0 bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            new ComponentSampleModel(-1234, 5, 1, 3, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                      "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+    /* public ComponentSampleModel(int dataType,
+     *                          int w, int h,
+     *                          int pixelStride,
+     *                          int scanlineStride,
+     *                          int[] bankIndices,
+     *                          int[] bandOffsets);
+     */
+    static void componentSampleModelTests2() {
+
+        System.out.println();
+        System.out.println("** componentSampleModelTests2");
+
+        try {
+            /* @throws IllegalArgumentException if {@code w}
+             * and {@code h} are not both greater than 0
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, -5, 1, 3, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                     "Got expected exception for negative width");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT,
+                   Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 2,
+                   3, 15, bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                     "Got expected exception for exceeding max int");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if {@code pixelStride}
+              * is less than 0
+              */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, -3, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative pixel stride");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, -15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+         /*
+          * @throws NullPointerException if {@code bankIndices}
+          *  is {@code null}
+          */
+             new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                      null, bandOffsets);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bankIndices");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets} is
+             * {@code null}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     bankIndices, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if
+             * {@code bandOffsets.length} is 0
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     bankIndices, zeroBandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for 0 bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the length of
+             * {@code bankIndices} does not equal the length of
+             * {@code bandOffsets}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     bankIndices, bandOffsets2);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for " +
+                "bandOffsets.length != bankIndices.length");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the length of
+             * {@code bankIndices} does not equal the length of
+             * {@code bandOffsets}
+             */
+            new ComponentSampleModel(DataBuffer.TYPE_INT, 5, 1, 3, 15,
+                                     negBankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for " +
+                "negative bank Index");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            new ComponentSampleModel(-1234, 5, 1, 3, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+    /* public BandedSampleModel(int dataType, int w, int h,
+     * int numBands);
+     */
+    static void bandedSampleModelTests1() {
+
+        System.out.println();
+        System.out.println("** bandedSampleModelTests1");
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, -5, 1, 1);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for negative width");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT,
+                   Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 2, 1);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for exceeding max int");
+            System.out.println(t);
+        }
+
+        /* Testing this both with 0 and negative (next test) */
+        try {
+            /* @throws IllegalArgumentException if {@code numBands}
+             *  is <= 0
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 0);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for 0 numBands");
+            System.out.println(t);
+        }
+
+        /* Before JDK 17, a negative value for num bands would throw
+         * NegativeArraySizeException, but a zero value would throw
+         * IllegalArgumentException so allow NegativeArraySizeException
+         * on < 17 here to make it easier to run this test on both
+         * versions and verify all behaviours.
+         */
+        try {
+            /* @throws IllegalArgumentException if {@code numBands}
+             *  is <= 0
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, -1);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for < 0 numBands");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println(
+                   "Got expected exception for < 0 numBands");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType}
+             * is not one of the supported data types for this
+             * sample model
+             */
+            new BandedSampleModel(-1234, 5, 1, 3);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+    /*
+     * public BandedSampleModel(int dataType,
+     *                          int w, int h,
+     *                          int scanlineStride,
+     *                          int[] bankIndices,
+     *                          int[] bandOffsets);
+     */
+    static void bandedSampleModelTests2() {
+
+        System.out.println();
+        System.out.println("** bandedSampleModelTests2");
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, -5, 1, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                      "Got expected exception for negative width");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT,
+                   Integer.MAX_VALUE / 8, Integer.MAX_VALUE / 8,
+                   Integer.MAX_VALUE, bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for exceeding max int");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, -15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+         /*
+          * @throws NullPointerException if {@code bankIndices}
+          * is {@code null}
+          */
+             new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 15,
+                                      null, bandOffsets);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bankIndices");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets} is
+             * {@code null}
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 15,
+                                     bankIndices, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if
+             * {@code bandOffsets.length} is 0
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 15,
+                                     bankIndices, zeroBandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for 0 bandOffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the length of
+             * {@code bankIndices} does not equal the length of
+             * {@code bandOffsets}
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 15,
+                                     bankIndices, bandOffsets2);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for " +
+                "bandOffsets.length != bankIndices.length");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the length of
+             * {@code bankIndices} does not equal the length of
+             * {@code bandOffsets}
+             */
+            new BandedSampleModel(DataBuffer.TYPE_INT, 5, 1, 15,
+                                     negBankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for " +
+                "negative bank Index");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            new BandedSampleModel(-1234, 5, 1, 15,
+                                     bankIndices, bandOffsets);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+      /* createBandedRaster(int dataType, int w, int h,
+       *                    int bands, Point location);
+       */
+    static void bandedRasterTests1() {
+
+        System.out.println();
+        System.out.println("** bandedRasterTests1");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            /* Old API had @throws RasterFormatException if w or h < 0
+             * Old JDK never actually does. And it is worse.
+             * If one or the other is zero, we get IAE.
+             * If one is positive, the other negative
+             * we get NegativeArraySizeException.
+             * If BOTH are negative, we are back to IAE.
+             * This needs to be consistent.
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                                      1,  -1, 3, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8, 3, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                    Integer.MAX_VALUE-2, 1, 1, pt);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException | OutOfMemoryError t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws ArrayIndexOutOfBoundsException if {@code bands}
+             *         is less than 1
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                                      1, 1, 0, null);
+            noException();
+        } catch (ArrayIndexOutOfBoundsException t) {
+            System.out.println("Got expected exception for zero bands");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_FLOAT,
+                                       5, 1, 3, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+    /*
+     *  createBandedRaster(int dataType,
+     *                     int w, int h,
+     *                     int scanlineStride,
+     *                     int[] bankIndices,
+     *                     int[] bandOffsets,
+     *                     Point location)
+     */
+    static void bandedRasterTests2() {
+
+        System.out.println();
+        System.out.println("** bandedRasterTests2");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            /* Old API had @throws RasterFormatException if w or h < 0
+             * Old JDK never actually does. And it is worse.
+             * If one or the other * is zero, we get IAE.
+             * If one is positive, the other negative
+             * we get NegativeArraySizeException.
+             * If BOTH are negative, we are back to IAE.
+             * This needs to be consistent.
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT, 1, -1, 3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8,
+                    Integer.MAX_VALUE,
+                    bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createBandedRaster(DataBuffer.TYPE_INT,
+                    Integer.MAX_VALUE-2, Integer.MAX_VALUE,
+                    Integer.MAX_VALUE, bankIndices, bandOffsets, pt);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT, 1, 1, -3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws ArrayIndexOutOfBoundsException if
+             * {@code bankIndices} is null
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT, 1, 1, 0,
+                                      null, bandOffsets, null);
+            noException();
+        } catch (ArrayIndexOutOfBoundsException t) {
+            System.out.println(
+                   "Got expected exception for null bankIndices");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets}
+             * is null
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_INT, 1, 1, 0,
+                                      bankIndices, null, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandoffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            Raster.createBandedRaster(DataBuffer.TYPE_FLOAT, 5, 1, 3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+    /*
+     *  createBandedRaster(DataBuffer dataBuffer,
+     *                     int w, int h,
+     *                     int scanlineStride,
+     *                     int[] bankIndices,
+     *                     int[] bandOffsets,
+     *                     Point location)
+     */
+    static void bandedRasterTests3() {
+
+        System.out.println();
+        System.out.println("** bandedRasterTests3");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w} and
+             * {@code h} are not both greater than 0
+             */
+            Raster.createBandedRaster(dBuffer, 1, -1, 3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createBandedRaster(dBuffer,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8,
+                    Integer.MAX_VALUE, bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+        }
+
+        try {
+            /* @throws RasterFormatException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createBandedRaster(dBuffer,
+                    Integer.MAX_VALUE-2, 1, Integer.MAX_VALUE,
+                    bankIndices, bandOffsets, pt);
+            noException();
+        } catch (RasterFormatException t) {
+            System.out.println(
+                   "Got expected raster exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            Raster.createBandedRaster(dBuffer, 1, 1, -3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bankIndices}
+             *         is null
+             */
+            Raster.createBandedRaster(dBuffer, 1, 1, 0,
+                                      null, bandOffsets, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bankIndices");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code dataBuffer}
+             * is null
+             */
+            Raster.createBandedRaster(null, 1, 1, 3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null dataBuffer");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the length of
+             * {@code bankIndices} does not  equal the length of
+             *  {@code bandOffsets}
+             */
+            Raster.createBandedRaster(dBuffer, 1, 1, 3,
+                                      bankIndices, bandOffsets2, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for different arrlen");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets}
+             * is null
+             */
+            Raster.createBandedRaster(dBuffer, 1, 1, 0,
+                                      bankIndices, null, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandoffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /*
+             * @throws IllegalArgumentException if {@code dataType}
+             * is not one of the supported data types, which are
+             * {@code DataBuffer.TYPE_BYTE},
+             * {@code DataBuffer.TYPE_USHORT}
+             * or {@code DataBuffer.TYPE_INT},
+             */
+            DataBufferFloat dbFloat = new DataBufferFloat(20);
+            Raster.createBandedRaster(dbFloat, 1, 1, 3,
+                                      bankIndices, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad dataBuffer");
+            System.out.println(t);
+        }
+    }
+
+    /* createInterleavedRaster(int dataType, int w, int h,
+     *                        int bands, Point location);
+     */
+    static void interleavedRasterTests1() {
+
+        System.out.println();
+        System.out.println("** interleavedRasterTests1");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w}
+             * and {@code h} are not both greater than 0
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                            1, -1, 3, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8, 1, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws RasterFormatException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                    Integer.MAX_VALUE-2, 1, 1, pt);
+            noException();
+        } catch (RasterFormatException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code bands}
+             *         is less than 1
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                            1, 1, 0, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception zero bands");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+             Raster.createInterleavedRaster(DataBuffer.TYPE_INT,
+                                                5, 1, 3, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+     /* createInterleavedRaster(int dataType,
+      *                         int w, int h,
+      *                         int scanlineStride,
+      *                         int pixelStride,
+      *                         int[] bandOffsets,
+      *                         Point location)
+      */
+    static void interleavedRasterTests2() {
+
+        System.out.println();
+        System.out.println("** interleavedRasterTests2 ");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w}
+             * and {@code h} are not both greater than 0
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                       1, -1, 3, 1, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8,
+                    Integer.MAX_VALUE/2 , 1,
+                    bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws RasterFormatException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                    Integer.MAX_VALUE-2, 1,
+                    Integer.MAX_VALUE, 1, bandOffsets, pt);
+            noException();
+        } catch (RasterFormatException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if
+              * {@code scanlineStride} is less than 0
+              */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                      1, 1, -3, 1, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if {@code pixelStride}
+              * is less than 0
+              */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                      1, 1, 3, -1, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for pixelStride < 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+            checkIsOldVersion(t);
+            System.out.println(
+                   "Got expected exception for pixelStride < 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets}
+             * is null
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                  1, 1, 0, 1, null, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandoffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataType} is
+             * not one of the supported data types for this sample model
+             */
+            Raster.createInterleavedRaster(DataBuffer.TYPE_INT,
+                                        5, 1, 3, 1, bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+
+     /* createInterleavedRaster(DataBuffer dBuffer,
+      *                         int w, int h,
+      *                         int scanlineStride,
+      *                         int pixelStride,
+      *                         int[] bandOffsets,
+      *                         Point location)
+      */
+    static void interleavedRasterTests3() {
+
+        System.out.println();
+        System.out.println("** interleavedRasterTests3 ");
+
+        Point p = new Point();
+
+        try {
+            /* @throws IllegalArgumentException if {@code w}
+             * and {@code h} are not both greater than 0
+             */
+            Raster.createInterleavedRaster(dBuffer, 1, -1, 3, 1,
+                                      bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for width <= 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if the product of
+             * {@code w} and {@code h} is greater than
+             * {@code Integer.MAX_VALUE}
+             */
+            Raster.createInterleavedRaster(dBuffer,
+                    Integer.MAX_VALUE/8, Integer.MAX_VALUE/8,
+                     Integer.MAX_VALUE/4, 1,
+                    bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws RasterFormatException if computing either
+             * {@code location.x + w} or
+             * {@code location.y + h} results in integer overflow
+             */
+            Point pt = new Point(5, 1);
+            Raster.createInterleavedRaster(dBuffer,
+                    Integer.MAX_VALUE-2, 1,
+                    Integer.MAX_VALUE, 1, bandOffsets, pt);
+            noException();
+        } catch (RasterFormatException t) {
+            System.out.println("Got expected exception for overflow");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException
+              * if {@code scanlineStride} is less than 0
+              */
+            Raster.createInterleavedRaster(dBuffer, 5, 1, -15, 1,
+                                      bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                "Got expected exception for negative scanline stride");
+            System.out.println(t);
+        }
+
+        try {
+             /* @throws IllegalArgumentException if {@code pixelStride}
+              * is less than 0
+              */
+            Raster.createInterleavedRaster(dBuffer, 5, 1, 15, -1,
+                                      bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for pixelStride < 0");
+            System.out.println(t);
+        } catch (NegativeArraySizeException t) {
+if (t != null) throw t;
+            checkIsOldVersion(t);
+            System.out.println(
+                   "Got expected exception for pixelStride < 0");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws NullPointerException if {@code bandOffsets}
+             * is null
+             */
+            Raster.createInterleavedRaster(dBuffer, 5, 1, 15, 1,
+                                      null, null);
+            noException();
+        } catch (NullPointerException t) {
+            System.out.println(
+                   "Got expected exception for null bandoffsets");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws IllegalArgumentException if {@code dataBuffer}
+             * is not one of the supported data types
+             */
+            DataBufferFloat dbFloat = new DataBufferFloat(20);
+            Raster.createInterleavedRaster(dbFloat, 5, 1, 15, 1,
+                                      bandOffsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+
+        try {
+            /* @throws RasterFormatException if {@code dataBuffer}
+             * has more than one bank.
+             */
+            DataBufferByte dbb = new DataBufferByte(100, 2);
+            Raster.createInterleavedRaster(dbb, 5, 1, 15, 1,
+                                      bandOffsets, null);
+            noException();
+        } catch (RasterFormatException t) {
+            System.out.println(
+                   "Got expected exception for bad databuffer type");
+            System.out.println(t);
+        }
+    }
+}

--- a/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
+++ b/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
@@ -705,8 +705,8 @@ public class CreateRasterExceptionTest {
              */
             Point pt = new Point(5, 1);
             Raster.createBandedRaster(DataBuffer.TYPE_INT,
-                    Integer.MAX_VALUE-2, Integer.MAX_VALUE,
-                    Integer.MAX_VALUE, bankIndices, bandOffsets, pt);
+                    Integer.MAX_VALUE-2, 1,
+                    Integer.MAX_VALUE-2, bankIndices, bandOffsets, pt);
             noException();
         } catch (IllegalArgumentException t) {
             System.out.println("Got expected exception for overflow");


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8255800 could have been a one line spec clean up but
it didn't take a lot of looking to realize there were many more inconsistencies between spec and implementation.
I've spent a lot of time on what is just small number of factory methods in Raster because there are so
many possible exceptions and in some cases they rely on other API they call to generate exceptions and
these may have not been documented or documented acc. to some long lost behavior.
I've mostly tried to ONLY change spec. But I couldn't help myself when some checks were missed that
ended up with bizarre and dubious behavior - throwing NegativeArrayIndexException which just about
always has to be an internal bug !

The supplied test passes on JDK 16 as well as this code, because the (relatively) small number of
cases where JDK 16 threw NegativeArrayIndexException are caught and allowed only for releases < 17
So where you see those in the test it corresponds to the behavioral changes from NegativeArrayIndexException
to IllegalArgumentException.
JCK conformance tests still pass so they must not test those conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255800](https://bugs.openjdk.java.net/browse/JDK-8255800): Raster creation methods need some specification clean up


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3223/head:pull/3223` \
`$ git checkout pull/3223`

Update a local copy of the PR: \
`$ git checkout pull/3223` \
`$ git pull https://git.openjdk.java.net/jdk pull/3223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3223`

View PR using the GUI difftool: \
`$ git pr show -t 3223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3223.diff">https://git.openjdk.java.net/jdk/pull/3223.diff</a>

</details>
