### PR TITLE
8262060: compiler/whitebox/BlockingCompilation.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
@@ -48,20 +48,15 @@ import compiler.testlibrary.CompilerUtils;
 import sun.hotspot.WhiteBox;
 
 import java.lang.reflect.Method;
-import java.util.Random;
 
 public class BlockingCompilation {
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final Random RANDOM = new Random(42);
 
     public static int foo() {
-        return RANDOM.nextInt();
+        return 42; //constant's value is arbitrary and meaningless
     }
 
     public static void main(String[] args) throws Exception {
-        // Needed to avoid Random.nextInt (and subsequent 'foo') deoptimizations
-        ClassLoader.getSystemClassLoader().loadClass("java.util.concurrent.ThreadLocalRandom");
-
         Method m = BlockingCompilation.class.getMethod("foo");
         int[] levels = CompilerUtils.getAvailableCompilationLevels();
         int highest_level = levels[levels.length-1];

--- a/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
@@ -59,6 +59,9 @@ public class BlockingCompilation {
     }
 
     public static void main(String[] args) throws Exception {
+        // Needed to avoid Random.nextInt (and subsequent 'foo') deoptimizations
+        ClassLoader.getSystemClassLoader().loadClass("java.util.concurrent.ThreadLocalRandom");
+
         Method m = BlockingCompilation.class.getMethod("foo");
         int[] levels = CompilerUtils.getAvailableCompilationLevels();
         int highest_level = levels[levels.length-1];


### PR DESCRIPTION
Please review this small fix for a test.

Test fails sometimes when run with UsageTracker enabled. For some reason, a loading of ThreadLocalRandom can happen during the test run, and this invalidates Random.nextInt method (because it's not the only implementation now).

Fixed by pre-loading ThreadLocalRandom. Tested by multiple runs with UsageTracker enabled - approx. 1 out of 20-30 test runs fails without the fix and no failures spotted with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262060](https://bugs.openjdk.java.net/browse/JDK-8262060): compiler/whitebox/BlockingCompilation.java timed out


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3224/head:pull/3224` \
`$ git checkout pull/3224`

Update a local copy of the PR: \
`$ git checkout pull/3224` \
`$ git pull https://git.openjdk.java.net/jdk pull/3224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3224`

View PR using the GUI difftool: \
`$ git pr show -t 3224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3224.diff">https://git.openjdk.java.net/jdk/pull/3224.diff</a>

</details>
