### PR TITLE
8264326: Modernize javax.script.ScriptEngineManager and related classes' implementation

### DIFF
--- a/src/java.scripting/share/classes/javax/script/AbstractScriptEngine.java
+++ b/src/java.scripting/share/classes/javax/script/AbstractScriptEngine.java
@@ -25,8 +25,6 @@
 
 package javax.script;
 import java.io.Reader;
-import java.util.Map;
-import java.util.Iterator;
 
 /**
  * Provides a standard implementation for several of the variants of the <code>eval</code>
@@ -141,9 +139,9 @@ public abstract class AbstractScriptEngine  implements ScriptEngine {
     public void setBindings(Bindings bindings, int scope) {
 
         if (scope == ScriptContext.GLOBAL_SCOPE) {
-            context.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);;
+            context.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);
         } else if (scope == ScriptContext.ENGINE_SCOPE) {
-            context.setBindings(bindings, ScriptContext.ENGINE_SCOPE);;
+            context.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
         } else {
             throw new IllegalArgumentException("Invalid scope value.");
         }

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -354,11 +354,7 @@ public class ScriptEngineManager  {
      * @return List of all discovered <code>ScriptEngineFactory</code>s.
      */
     public List<ScriptEngineFactory> getEngineFactories() {
-        List<ScriptEngineFactory> res = new ArrayList<ScriptEngineFactory>(engineSpis.size());
-        for (ScriptEngineFactory spi : engineSpis) {
-            res.add(spi);
-        }
-        return Collections.unmodifiableList(res);
+        return List.copyOf(engineSpis);
     }
 
     /**

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -87,14 +87,8 @@ public class ScriptEngineManager  {
     private void initEngines(final ClassLoader loader) {
         Iterator<ScriptEngineFactory> itr = null;
         try {
-            ServiceLoader<ScriptEngineFactory> sl = AccessController.doPrivileged(
-                new PrivilegedAction<ServiceLoader<ScriptEngineFactory>>() {
-                    @Override
-                    public ServiceLoader<ScriptEngineFactory> run() {
-                        return getServiceLoader(loader);
-                    }
-                });
-
+            var sl = AccessController.doPrivileged(
+                (PrivilegedAction<ServiceLoader<ScriptEngineFactory>>)() -> getServiceLoader(loader));
             itr = sl.iterator();
         } catch (ServiceConfigurationError err) {
             System.err.println("Can't find ScriptEngineFactory providers: " +

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -85,7 +85,7 @@ public class ScriptEngineManager  {
     }
 
     private void initEngines(final ClassLoader loader) {
-        Iterator<ScriptEngineFactory> itr = null;
+        Iterator<ScriptEngineFactory> itr;
         try {
             var sl = AccessController.doPrivileged(
                 (PrivilegedAction<ServiceLoader<ScriptEngineFactory>>)() -> getServiceLoader(loader));
@@ -106,7 +106,6 @@ public class ScriptEngineManager  {
                 } catch (ServiceConfigurationError err) {
                     reportException("ScriptEngineManager providers.next(): ", err);
                     // one factory failed, but check other factories...
-                    continue;
                 }
             }
         } catch (ServiceConfigurationError err) {
@@ -114,7 +113,6 @@ public class ScriptEngineManager  {
             // do not throw any exception here. user may want to
             // manage his/her own factories using this manager
             // by explicit registratation (by registerXXX) methods.
-            return;
         }
     }
 

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -29,6 +29,7 @@ import java.security.*;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * The <code>ScriptEngineManager</code> implements a discovery and instantiation
@@ -246,37 +247,34 @@ public class ScriptEngineManager  {
 
     private ScriptEngine getEngineBy(String selector, Map<String, ScriptEngineFactory> associations, Function<ScriptEngineFactory, List<String>> valuesFn) {
         Objects.requireNonNull(selector);
-        //look for registered types first
-        Object obj;
-        if (null != (obj = associations.get(selector))) {
-            ScriptEngineFactory spi = (ScriptEngineFactory)obj;
-            try {
-                ScriptEngine engine = spi.getScriptEngine();
-                engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                return engine;
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-        }
+        Stream<ScriptEngineFactory> spis = Stream.concat(
+            //look for registered types first
+            Stream.ofNullable(associations.get(selector)),
 
-        for (ScriptEngineFactory spi : engineSpis) {
-            List<String> values = null;
-            try {
-                values = valuesFn.apply(spi);
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-            if (values != null && values.contains(selector)) {
+            engineSpis.stream().filter(spi -> {
+                try {
+                    List<String> matches = valuesFn.apply(spi);
+                    return matches != null && matches.contains(selector);
+                } catch (Exception exp) {
+                    if (DEBUG) exp.printStackTrace();
+                    return false;
+                }
+            })
+        );
+        return spis
+            .map(spi -> {
                 try {
                     ScriptEngine engine = spi.getScriptEngine();
                     engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
                     return engine;
                 } catch (Exception exp) {
                     if (DEBUG) exp.printStackTrace();
+                    return null;
                 }
-            }
-        }
-        return null;
+            })
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
     }
 
     /**

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.security.*;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
+import java.util.function.Function;
 
 /**
  * The <code>ScriptEngineManager</code> implements a discovery and instantiation
@@ -212,44 +213,7 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if shortName is null.
      */
     public ScriptEngine getEngineByName(String shortName) {
-        if (shortName == null) throw new NullPointerException();
-        //look for registered name first
-        Object obj;
-        if (null != (obj = nameAssociations.get(shortName))) {
-            ScriptEngineFactory spi = (ScriptEngineFactory)obj;
-            try {
-                ScriptEngine engine = spi.getScriptEngine();
-                engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                return engine;
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-        }
-
-        for (ScriptEngineFactory spi : engineSpis) {
-            List<String> names = null;
-            try {
-                names = spi.getNames();
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-
-            if (names != null) {
-                for (String name : names) {
-                    if (shortName.equals(name)) {
-                        try {
-                            ScriptEngine engine = spi.getScriptEngine();
-                            engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                            return engine;
-                        } catch (Exception exp) {
-                            if (DEBUG) exp.printStackTrace();
-                        }
-                    }
-                }
-            }
-        }
-
-        return null;
+        return getEngineBy(shortName, nameAssociations, ScriptEngineFactory::getNames);
     }
 
     /**
@@ -263,41 +227,7 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if extension is null.
      */
     public ScriptEngine getEngineByExtension(String extension) {
-        if (extension == null) throw new NullPointerException();
-        //look for registered extension first
-        Object obj;
-        if (null != (obj = extensionAssociations.get(extension))) {
-            ScriptEngineFactory spi = (ScriptEngineFactory)obj;
-            try {
-                ScriptEngine engine = spi.getScriptEngine();
-                engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                return engine;
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-        }
-
-        for (ScriptEngineFactory spi : engineSpis) {
-            List<String> exts = null;
-            try {
-                exts = spi.getExtensions();
-            } catch (Exception exp) {
-                if (DEBUG) exp.printStackTrace();
-            }
-            if (exts == null) continue;
-            for (String ext : exts) {
-                if (extension.equals(ext)) {
-                    try {
-                        ScriptEngine engine = spi.getScriptEngine();
-                        engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                        return engine;
-                    } catch (Exception exp) {
-                        if (DEBUG) exp.printStackTrace();
-                    }
-                }
-            }
-        }
-        return null;
+        return getEngineBy(extension, extensionAssociations, ScriptEngineFactory::getExtensions);
     }
 
     /**
@@ -311,10 +241,14 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if mimeType is null.
      */
     public ScriptEngine getEngineByMimeType(String mimeType) {
-        if (mimeType == null) throw new NullPointerException();
+        return getEngineBy(mimeType, mimeTypeAssociations, ScriptEngineFactory::getMimeTypes);
+    }
+
+    private ScriptEngine getEngineBy(String selector, Map<String, ScriptEngineFactory> associations, Function<ScriptEngineFactory, List<String>> valuesFn) {
+        if (selector == null) throw new NullPointerException();
         //look for registered types first
         Object obj;
-        if (null != (obj = mimeTypeAssociations.get(mimeType))) {
+        if (null != (obj = associations.get(selector))) {
             ScriptEngineFactory spi = (ScriptEngineFactory)obj;
             try {
                 ScriptEngine engine = spi.getScriptEngine();
@@ -326,15 +260,15 @@ public class ScriptEngineManager  {
         }
 
         for (ScriptEngineFactory spi : engineSpis) {
-            List<String> types = null;
+            List<String> values = null;
             try {
-                types = spi.getMimeTypes();
+                values = valuesFn.apply(spi);
             } catch (Exception exp) {
                 if (DEBUG) exp.printStackTrace();
             }
-            if (types == null) continue;
-            for (String type : types) {
-                if (mimeType.equals(type)) {
+            if (values == null) continue;
+            for (String value : values) {
+                if (selector.equals(value)) {
                     try {
                         ScriptEngine engine = spi.getScriptEngine();
                         engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -91,11 +91,7 @@ public class ScriptEngineManager  {
                 (PrivilegedAction<ServiceLoader<ScriptEngineFactory>>)() -> getServiceLoader(loader));
             itr = sl.iterator();
         } catch (ServiceConfigurationError err) {
-            System.err.println("Can't find ScriptEngineFactory providers: " +
-                          err.getMessage());
-            if (DEBUG) {
-                err.printStackTrace();
-            }
+            reportException("Can't find ScriptEngineFactory providers: ", err);
             // do not throw any exception here. user may want to
             // manage his/her own factories using this manager
             // by explicit registratation (by registerXXX) methods.
@@ -108,21 +104,13 @@ public class ScriptEngineManager  {
                     ScriptEngineFactory fact = itr.next();
                     engineSpis.add(fact);
                 } catch (ServiceConfigurationError err) {
-                    System.err.println("ScriptEngineManager providers.next(): "
-                                 + err.getMessage());
-                    if (DEBUG) {
-                        err.printStackTrace();
-                    }
+                    reportException("ScriptEngineManager providers.next(): ", err);
                     // one factory failed, but check other factories...
                     continue;
                 }
             }
         } catch (ServiceConfigurationError err) {
-            System.err.println("ScriptEngineManager providers.hasNext(): "
-                            + err.getMessage());
-            if (DEBUG) {
-                err.printStackTrace();
-            }
+            reportException("ScriptEngineManager providers.hasNext(): ", err);
             // do not throw any exception here. user may want to
             // manage his/her own factories using this manager
             // by explicit registratation (by registerXXX) methods.
@@ -237,7 +225,7 @@ public class ScriptEngineManager  {
                     List<String> matches = valuesFn.apply(spi);
                     return matches != null && matches.contains(selector);
                 } catch (Exception exp) {
-                    if (DEBUG) exp.printStackTrace();
+                    debugPrint(exp);
                     return false;
                 }
             })
@@ -249,13 +237,24 @@ public class ScriptEngineManager  {
                     engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
                     return engine;
                 } catch (Exception exp) {
-                    if (DEBUG) exp.printStackTrace();
+                    debugPrint(exp);
                     return null;
                 }
             })
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);
+    }
+
+    private static void reportException(String msg, Throwable exp) {
+        System.err.println(msg + exp.getMessage());
+        debugPrint(exp);
+    }
+
+    private static void debugPrint(Throwable exp) {
+        if (DEBUG) {
+            exp.printStackTrace();
+        }
     }
 
     /**

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -272,8 +272,7 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if any of the parameters is null.
      */
     public void registerEngineName(String name, ScriptEngineFactory factory) {
-        if (name == null || factory == null) throw new NullPointerException();
-        nameAssociations.put(name, factory);
+        associateFactory(nameAssociations, name, factory);
     }
 
     /**
@@ -287,8 +286,7 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if any of the parameters is null.
      */
     public void registerEngineMimeType(String type, ScriptEngineFactory factory) {
-        if (type == null || factory == null) throw new NullPointerException();
-        mimeTypeAssociations.put(type, factory);
+        associateFactory(mimeTypeAssociations, type, factory);
     }
 
     /**
@@ -301,8 +299,12 @@ public class ScriptEngineManager  {
      * @throws NullPointerException if any of the parameters is null.
      */
     public void registerEngineExtension(String extension, ScriptEngineFactory factory) {
-        if (extension == null || factory == null) throw new NullPointerException();
-        extensionAssociations.put(extension, factory);
+        associateFactory(extensionAssociations, extension, factory);
+    }
+
+    private static void associateFactory(Map<String, ScriptEngineFactory> associations, String association, ScriptEngineFactory factory) {
+        if (association == null || factory == null) throw new NullPointerException();
+        associations.put(association, factory);
     }
 
     private static final Comparator<ScriptEngineFactory> COMPARATOR = Comparator.comparing(

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -60,8 +60,7 @@ public class ScriptEngineManager  {
      * @see java.lang.Thread#getContextClassLoader
      */
     public ScriptEngineManager() {
-        ClassLoader ctxtLoader = Thread.currentThread().getContextClassLoader();
-        init(ctxtLoader);
+        this(Thread.currentThread().getContextClassLoader());
     }
 
     /**
@@ -74,18 +73,6 @@ public class ScriptEngineManager  {
      * @param loader ClassLoader used to discover script engine factories.
      */
     public ScriptEngineManager(ClassLoader loader) {
-        init(loader);
-    }
-
-    private void init(final ClassLoader loader) {
-        globalScope = new SimpleBindings();
-        engineSpis = new TreeSet<ScriptEngineFactory>(Comparator.comparing(
-            ScriptEngineFactory::getEngineName,
-            Comparator.nullsLast(Comparator.naturalOrder()))
-        );
-        nameAssociations = new HashMap<String, ScriptEngineFactory>();
-        extensionAssociations = new HashMap<String, ScriptEngineFactory>();
-        mimeTypeAssociations = new HashMap<String, ScriptEngineFactory>();
         initEngines(loader);
     }
 
@@ -327,18 +314,23 @@ public class ScriptEngineManager  {
         extensionAssociations.put(extension, factory);
     }
 
+    private static final Comparator<ScriptEngineFactory> COMPARATOR = Comparator.comparing(
+        ScriptEngineFactory::getEngineName,
+        Comparator.nullsLast(Comparator.naturalOrder())
+    );
+
     /** Set of script engine factories discovered. */
-    private TreeSet<ScriptEngineFactory> engineSpis;
+    private final TreeSet<ScriptEngineFactory> engineSpis = new TreeSet<>(COMPARATOR);
 
     /** Map of engine name to script engine factory. */
-    private HashMap<String, ScriptEngineFactory> nameAssociations;
+    private final HashMap<String, ScriptEngineFactory> nameAssociations = new HashMap<>();
 
     /** Map of script file extension to script engine factory. */
-    private HashMap<String, ScriptEngineFactory> extensionAssociations;
+    private final HashMap<String, ScriptEngineFactory> extensionAssociations = new HashMap<>();
 
     /** Map of script MIME type to script engine factory. */
-    private HashMap<String, ScriptEngineFactory> mimeTypeAssociations;
+    private final HashMap<String, ScriptEngineFactory> mimeTypeAssociations = new HashMap<>();
 
     /** Global bindings associated with script engines created by this manager. */
-    private Bindings globalScope;
+    private Bindings globalScope = new SimpleBindings();
 }

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -266,16 +266,13 @@ public class ScriptEngineManager  {
             } catch (Exception exp) {
                 if (DEBUG) exp.printStackTrace();
             }
-            if (values == null) continue;
-            for (String value : values) {
-                if (selector.equals(value)) {
-                    try {
-                        ScriptEngine engine = spi.getScriptEngine();
-                        engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
-                        return engine;
-                    } catch (Exception exp) {
-                        if (DEBUG) exp.printStackTrace();
-                    }
+            if (values != null && values.contains(selector)) {
+                try {
+                    ScriptEngine engine = spi.getScriptEngine();
+                    engine.setBindings(getBindings(), ScriptContext.GLOBAL_SCOPE);
+                    return engine;
+                } catch (Exception exp) {
+                    if (DEBUG) exp.printStackTrace();
                 }
             }
         }

--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -245,7 +245,7 @@ public class ScriptEngineManager  {
     }
 
     private ScriptEngine getEngineBy(String selector, Map<String, ScriptEngineFactory> associations, Function<ScriptEngineFactory, List<String>> valuesFn) {
-        if (selector == null) throw new NullPointerException();
+        Objects.requireNonNull(selector);
         //look for registered types first
         Object obj;
         if (null != (obj = associations.get(selector))) {

--- a/src/java.scripting/share/classes/javax/script/ScriptException.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptException.java
@@ -38,9 +38,9 @@ public class ScriptException extends Exception {
 
     private static final long serialVersionUID = 8265071037049225001L;
 
-    private String fileName;
-    private int lineNumber;
-    private int columnNumber;
+    private final String fileName;
+    private final int lineNumber;
+    private final int columnNumber;
 
     /**
      * Creates a <code>ScriptException</code> with a String to be used in its message.

--- a/src/java.scripting/share/classes/javax/script/SimpleBindings.java
+++ b/src/java.scripting/share/classes/javax/script/SimpleBindings.java
@@ -28,6 +28,7 @@ package javax.script;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -50,17 +51,14 @@ public class SimpleBindings implements Bindings {
      * @throws NullPointerException if m is null
      */
     public SimpleBindings(Map<String,Object> m) {
-        if (m == null) {
-            throw new NullPointerException();
-        }
-        this.map = m;
+        this.map = Objects.requireNonNull(m);
     }
 
     /**
      * Default constructor uses a {@code HashMap}.
      */
     public SimpleBindings() {
-        this(new HashMap<String,Object>());
+        this(new HashMap<>());
     }
 
     /**
@@ -91,9 +89,7 @@ public class SimpleBindings implements Bindings {
      *         if some key in the map is an empty String.
      */
     public void putAll(Map<? extends String, ? extends Object> toMerge) {
-        if (toMerge == null) {
-            throw new NullPointerException("toMerge map is null");
-        }
+        Objects.requireNonNull(toMerge, "toMerge map is null");
         for (Map.Entry<? extends String, ? extends Object> entry : toMerge.entrySet()) {
             String key = entry.getKey();
             checkKey(key);
@@ -211,9 +207,7 @@ public class SimpleBindings implements Bindings {
     }
 
     private void checkKey(Object key) {
-        if (key == null) {
-            throw new NullPointerException("key can not be null");
-        }
+        Objects.requireNonNull(key, "key can not be null");
         if (!(key instanceof String)) {
             throw new ClassCastException("key should be a String");
         }

--- a/src/java.scripting/share/classes/javax/script/SimpleBindings.java
+++ b/src/java.scripting/share/classes/javax/script/SimpleBindings.java
@@ -42,7 +42,7 @@ public class SimpleBindings implements Bindings {
     /**
      * The {@code Map} field stores the attributes.
      */
-    private Map<String,Object> map;
+    private final Map<String,Object> map;
 
     /**
      * Constructor uses an existing {@code Map} to store the values.

--- a/src/java.scripting/share/classes/javax/script/SimpleScriptContext.java
+++ b/src/java.scripting/share/classes/javax/script/SimpleScriptContext.java
@@ -338,11 +338,5 @@ public class SimpleScriptContext  implements ScriptContext {
         }
     }
 
-    private static List<Integer> scopes;
-    static {
-        scopes = new ArrayList<Integer>(2);
-        scopes.add(ENGINE_SCOPE);
-        scopes.add(GLOBAL_SCOPE);
-        scopes = Collections.unmodifiableList(scopes);
-    }
+    private static final List<Integer> scopes = List.of(ENGINE_SCOPE, GLOBAL_SCOPE);
 }


### PR DESCRIPTION
I noticed that `javax.script.ScriptEngineManager` `getEngineByXxx` methods had a lot of code duplication among themselves, and even within each method. I refactored them into a modern unified implementation. While there I also took the opportunity to introduce `Objects.requireNonNull` in place of null checks followed by NPE throws, mark private fields final where possible, use lambdas for `doPrivileged` block, use `List.of` and `List.copyOf` where possible, and generally sanitize/deduplicate.