### PR TITLE
8264328: Broken license in javax/swing/JComboBox/8072767/bug8072767.java

### DIFF
--- a/test/jdk/javax/swing/JComboBox/8072767/bug8072767.java
+++ b/test/jdk/javax/swing/JComboBox/8072767/bug8072767.java
@@ -1,8 +1,5 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This test has a broken license:
```
/*
 * To change this license header, choose License Headers in Project Properties.
 * To change this template file, choose Tools | Templates
 /*
 * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264328](https://bugs.openjdk.java.net/browse/JDK-8264328): Broken license in javax/swing/JComboBox/8072767/bug8072767.java


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3230/head:pull/3230`
`$ git checkout pull/3230`

To update a local copy of the PR:
`$ git checkout pull/3230`
`$ git pull https://git.openjdk.java.net/jdk pull/3230/head`
