### PR TITLE
8264020: Optimize double negation elimination

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -236,8 +236,9 @@ Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
   }
 
   // Convert "0 - (x-y)" into "y-x", leave the double negation "-(-y)" to SubNode::Identity().
-  if(t1 == TypeInt::ZERO && op2 == Op_SubI && phase->type(in2->in(1)) != TypeInt::ZERO)
-    return new SubINode( in2->in(2), in2->in(1) );
+  if (t1 == TypeInt::ZERO && op2 == Op_SubI && phase->type(in2->in(1)) != TypeInt::ZERO) {
+    return new SubINode(in2->in(2), in2->in(1));
+  }
 
   // Convert "0 - (x+con)" into "-con-x"
   jint con;
@@ -374,8 +375,9 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Convert "0 - (x-y)" into "y-x", leave the double negation "-(-y)" to SubNode::Identity.
-  if(t1 == TypeLong::ZERO && op2 == Op_SubL && phase->type(in2->in(1)) != TypeLong::ZERO)
-    return new SubLNode( in2->in(2), in2->in(1) );
+  if (t1 == TypeLong::ZERO && op2 == Op_SubL && phase->type(in2->in(1)) != TypeLong::ZERO) {
+    return new SubLNode(in2->in(2), in2->in(1));
+  }
 
   // Convert "(X+A) - (X+B)" into "A - B"
   if( op1 == Op_AddL && op2 == Op_AddL && in1->in(1) == in2->in(1) )

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,8 +235,8 @@ Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
     return new SubINode(phase->intcon(0), in2->in(1));
   }
 
-  // Convert "0 - (x-y)" into "y-x"
-  if( t1 == TypeInt::ZERO && op2 == Op_SubI )
+  // Convert "0 - (x-y)" into "y-x", leave the double negation "-(-y)" to SubNode::Identity().
+  if(t1 == TypeInt::ZERO && op2 == Op_SubI && phase->type(in2->in(1)) != TypeInt::ZERO)
     return new SubINode( in2->in(2), in2->in(1) );
 
   // Convert "0 - (x+con)" into "-con-x"
@@ -373,8 +373,8 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
   }
 
-  // Convert "0 - (x-y)" into "y-x"
-  if( phase->type( in1 ) == TypeLong::ZERO && op2 == Op_SubL )
+  // Convert "0 - (x-y)" into "y-x", leave the double negation "-(-y)" to SubNode::Identity.
+  if(t1 == TypeLong::ZERO && op2 == Op_SubL && phase->type(in2->in(1)) != TypeLong::ZERO)
     return new SubLNode( in2->in(2), in2->in(1) );
 
   // Convert "(X+A) - (X+B)" into "A - B"


### PR DESCRIPTION
For the double negation '-(-x)', c2 could reduce the redundant 'sub'
through SubNode::Ideal. But every time when 'sub' is removed, there
would generate two useless nodes SubNode(x, 0)[1] and AddNode(x, -0)[2],
which would be removed by later phases but should have optimized better
to 'x' itself without generating those new stuffs.

This patch is a small fix for SubNode's Ideal, by leaving this special
case to 'Identity' which handled double negation already[3].

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/subnode.cpp#L238
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/subnode.cpp#L181
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/subnode.cpp#L55

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264020](https://bugs.openjdk.java.net/browse/JDK-8264020): Optimize double negation elimination


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3231/head:pull/3231` \
`$ git checkout pull/3231`

Update a local copy of the PR: \
`$ git checkout pull/3231` \
`$ git pull https://git.openjdk.java.net/jdk pull/3231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3231`

View PR using the GUI difftool: \
`$ git pr show -t 3231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3231.diff">https://git.openjdk.java.net/jdk/pull/3231.diff</a>

</details>
