### PR TITLE
8264329: Z cannot be 1 for Diffie-Hellman key agreement

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
@@ -313,12 +313,13 @@ extends KeyAgreementSpi {
         // above, so user can recover w/o losing internal state
         generateSecret = false;
 
-        // No further process if z <= 1 or z == (p - 1).
+        // No further process if z <= 1 or z == (p - 1) (See section 5.7.1,
+        // NIST SP 800-56A Rev 3).
         BigInteger z = this.y.modPow(this.x, modulus);
         if ((z.compareTo(BigInteger.ONE) <= 0) ||
                 z.equals(modulus.subtract(BigInteger.ONE))) {
             throw new ProviderException(
-                    "Generated secret is out-of-rang of (1, p -1)");
+                    "Generated secret is out-of-range of (1, p -1)");
         }
 
         /*

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -313,6 +313,14 @@ extends KeyAgreementSpi {
         // above, so user can recover w/o losing internal state
         generateSecret = false;
 
+        // No further process if z <= 1 or z == (p - 1).
+        BigInteger z = this.y.modPow(this.x, modulus);
+        if ((z.compareTo(BigInteger.ONE) <= 0) ||
+                z.equals(modulus.subtract(BigInteger.ONE))) {
+            throw new ProviderException(
+                    "Generated secret is out-of-rang of (1, p -1)");
+        }
+
         /*
          * NOTE: BigInteger.toByteArray() returns a byte array containing
          * the two's-complement representation of this BigInteger with
@@ -327,7 +335,7 @@ extends KeyAgreementSpi {
          * exactly expectedLen bytes of magnitude, we strip any extra
          * leading 0's, or pad with 0's in case of a "short" secret.
          */
-        byte[] secret = this.y.modPow(this.x, modulus).toByteArray();
+        byte[] secret = z.toByteArray();
         if (secret.length == expectedLen) {
             System.arraycopy(secret, 0, sharedSecret, offset,
                              secret.length);


### PR DESCRIPTION
Per NIST SP 800-56A Rev 3 (section 5.7.1), the shared secret cannot be 1 or (p - 1).  This update adds this validation in the JDK provider implementation.

No new regression test, simple update and hard to construct a shared secret of 1 or (p - 1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264329](https://bugs.openjdk.java.net/browse/JDK-8264329): Z cannot be 1 for Diffie-Hellman key agreement


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to 7b05c3a2d61e18129701fb5fe6bf4c512af78d5d


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk pull/3232/head:pull/3232`
`$ git checkout pull/3232`

To update a local copy of the PR:
`$ git checkout pull/3232`
`$ git pull https://git.openjdk.java.net/jdk pull/3232/head`
