### PR TITLE
8264358: Don't create invalid oop in method handle tracing

### DIFF
--- a/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
@@ -444,7 +444,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
 
 #ifndef PRODUCT
 void trace_method_handle_stub(const char* adaptername,
-                              oop mh,
+                              oopDesc* mh,
                               intptr_t* saved_regs,
                               intptr_t* entry_sp) {  }
 

--- a/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -503,7 +503,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
 
 #ifndef PRODUCT
 void trace_method_handle_stub(const char* adaptername,
-                              oop mh,
+                              oopDesc* mh,
                               intptr_t* saved_regs,
                               intptr_t* entry_sp) {
   // called as a leaf from native code: do not block the JVM!


### PR DESCRIPTION
The `mh` field in:

```
struct MethodHandleStubArguments {
  const char* adaptername;
  oopDesc* mh;
  intptr_t* saved_regs;
  intptr_t* entry_sp;
};
```

doesn't always point to a valid object. The `oopDesc*` is then implicitly converted to an `oop` here:

```
void trace_method_handle_stub_wrapper(MethodHandleStubArguments* args) {
  trace_method_handle_stub(args->adaptername,
                           args->mh,
                           args->saved_regs,
                           args->entry_sp);
}
```

This gets caught by my ad-hoc verification code that verifies oops when they are created/used.

I propose that we don't create an oop until it `mh` is actually used, and it has been checked that the argument should contain a valid oop.  I started with a more elaborate fix that changed the type of `mh` to be `void*`, but then reverted to a more targetted fix to remove the early oopDesc* > oop conversion.

One thing that I am curious about is this code inside trace_method_handle_stub:
```
if (has_mh && oopDesc::is_oop(mh)) {
  mh->print_on(&ls);
```

Delaying the oopDesc* > oop conversion to after the `has_mh` check solves my verification failure, but I wonder if the `oopDesc::is_oop(mh)` call is really needed when we have the `has_mh` check?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264358](https://bugs.openjdk.java.net/browse/JDK-8264358): Don't create invalid oop in method handle tracing


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3242/head:pull/3242` \
`$ git checkout pull/3242`

Update a local copy of the PR: \
`$ git checkout pull/3242` \
`$ git pull https://git.openjdk.java.net/jdk pull/3242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3242`

View PR using the GUI difftool: \
`$ git pr show -t 3242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3242.diff">https://git.openjdk.java.net/jdk/pull/3242.diff</a>

</details>
