### PR TITLE
8264027: Refactor "CLEANUP" region printing

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1288,14 +1288,7 @@ void G1ConcurrentMark::reclaim_empty_regions() {
   if (!empty_regions_list.is_empty()) {
     log_debug(gc)("Reclaimed %u empty regions", empty_regions_list.length());
     // Now print the empty regions list.
-    G1HRPrinter* hrp = _g1h->hr_printer();
-    if (hrp->is_active()) {
-      FreeRegionListIterator iter(&empty_regions_list);
-      while (iter.more_available()) {
-        HeapRegion* hr = iter.get_next();
-        hrp->cleanup(hr);
-      }
-    }
+    _g1h->hr_printer()->cleanup(&empty_regions_list);
     // And actually make them available.
     _g1h->prepend_to_freelist(&empty_regions_list);
   }

--- a/src/hotspot/share/gc/g1/g1HRPrinter.cpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/g1/g1HRPrinter.hpp"
+#include "gc/g1/heapRegionSet.hpp"
+
+void G1HRPrinter::cleanup(FreeRegionList* cleanup_list) {
+  if (is_active()) {
+    FreeRegionListIterator iter(cleanup_list);
+    while (iter.more_available()) {
+      HeapRegion* hr = iter.get_next();
+      cleanup(hr);
+    }
+  }
+}

--- a/src/hotspot/share/gc/g1/g1HRPrinter.hpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
 #include "logging/log.hpp"
 
 #define SKIP_RETIRED_FULL_REGIONS 1
+
+class FreeRegionList;
 
 class G1HRPrinter {
 
@@ -85,6 +87,8 @@ public:
       print("CLEANUP", hr);
     }
   }
+
+  void cleanup(FreeRegionList* free_list);
 
   void post_compaction(HeapRegion* hr) {
     if (is_active()) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this small cleanup that refactors "CLEANUP" region status printing?

- where managing a `FreeRegionList` is not necessary, inline the call to the method (which is guarded by a check that if logging is not enabled, we do not print anything anyway)
- for the single remaining case, create a helper method in `G1HRPrinter`

The first item has been done as per the suggestion from @kstefanj [here](https://github.com/openjdk/jdk/pull/3154#pullrequestreview-619061961) ; the alternative would be to keep the free region lists and call `G1HRPrinter::cleanup` on it later, which I actually initially implemented. I could not find a difference performance-wise.

Testing: checked if there is some perf difference on a heap with 50k regions; tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264027](https://bugs.openjdk.java.net/browse/JDK-8264027): Refactor "CLEANUP" region printing


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3243/head:pull/3243` \
`$ git checkout pull/3243`

Update a local copy of the PR: \
`$ git checkout pull/3243` \
`$ git pull https://git.openjdk.java.net/jdk pull/3243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3243`

View PR using the GUI difftool: \
`$ git pr show -t 3243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3243.diff">https://git.openjdk.java.net/jdk/pull/3243.diff</a>

</details>
