### PR TITLE
8264360: Loop strip mining verification fails with "should be on the backedge"

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1807,7 +1807,7 @@ void LoopNode::verify_strip_mined(int expect_skeleton) const {
           for (DUIterator_Fast jmax, j = be->fast_outs(jmax); j < jmax; j++) {
             Node* n = be->fast_out(j);
             if (n->is_Load()) {
-              assert(n->in(0) == be, "should be on the backedge");
+              assert(n->in(0) == be || n->find_prec_edge(be) > 0, "should be on the backedge");
               do {
                 n = n->raw_out(0);
               } while (!n->is_Phi());

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestLoadOnBackedgeWithPrec.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestLoadOnBackedgeWithPrec.java
@@ -39,11 +39,10 @@ class a {
 
 public class TestLoadOnBackedgeWithPrec {
     int c ;
-    a[] i =   {
-        new a()};
+    a[] i = {new a()};
     float j() {
         a k = new a();
-        float l = 5     ;
+        float l = 5;
         for (int d = 0; d < 8; ++d) {
             for (int e = 0; e < 9; ++e) {
                 k = k;
@@ -57,7 +56,7 @@ public class TestLoadOnBackedgeWithPrec {
                     new a(), new a(), new a(),
                     new a(), new a(), new a(),
                     new a(), new a(), new a()};
-                c = i[0].g   + k.g;
+                c = i[0].g + k.g;
             }
         }
         return k.h;

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestLoadOnBackedgeWithPrec.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestLoadOnBackedgeWithPrec.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8264360
+ * @summary Loop strip mining verification fails with "should be on the backedge"
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation TestLoadOnBackedgeWithPrec
+ *
+ */
+
+
+class a {
+    int g = 20;
+    float h = 2;
+    long b = 6;
+}
+
+public class TestLoadOnBackedgeWithPrec {
+    int c ;
+    a[] i =   {
+        new a()};
+    float j() {
+        a k = new a();
+        float l = 5     ;
+        for (int d = 0; d < 8; ++d) {
+            for (int e = 0; e < 9; ++e) {
+                k = k;
+                l *= k.g;
+            }
+            for (int f = 0; f < 9; ++f) {
+                new a();
+            }
+            {
+                a[] m = {
+                    new a(), new a(), new a(),
+                    new a(), new a(), new a(),
+                    new a(), new a(), new a()};
+                c = i[0].g   + k.g;
+            }
+        }
+        return k.h;
+    }
+    public static void main(String[] args) {
+        TestLoadOnBackedgeWithPrec n = new TestLoadOnBackedgeWithPrec();
+        for (int i = 0; i < 5_000; i++) {
+            n.j();
+        }
+    }
+}
+


### PR DESCRIPTION
The assert checks that loads that are found as uses of a loop back
edge have the back edge as control input. In this case, because that
code is executed during final graph reshaping (CastPPs are in the
process of being eliminated and memory operations inherit their
control inputs as precedence edges), the edge between a load and the
back edge is a precedence edge. Relaxing the assert is all that is
required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264360](https://bugs.openjdk.java.net/browse/JDK-8264360): Loop strip mining verification fails with "should be on the backedge"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 24fa528bea8ae7704b8086fb4caa348e2694104c
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3245/head:pull/3245` \
`$ git checkout pull/3245`

Update a local copy of the PR: \
`$ git checkout pull/3245` \
`$ git pull https://git.openjdk.java.net/jdk pull/3245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3245`

View PR using the GUI difftool: \
`$ git pr show -t 3245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3245.diff">https://git.openjdk.java.net/jdk/pull/3245.diff</a>

</details>
