### PR TITLE
8264374: Shenandoah: Remove leftover parallel reference processing argument

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -111,10 +111,6 @@ void ShenandoahArguments::initialize() {
     }
   }
 
-  if (FLAG_IS_DEFAULT(ParallelRefProcEnabled)) {
-    FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
-  }
-
   if (ShenandoahRegionSampling && FLAG_IS_DEFAULT(PerfDataMemorySize)) {
     // When sampling is enabled, max out the PerfData memory to get more
     // Shenandoah data in, including Matrix.


### PR DESCRIPTION
Shenandoah no longer uses parallel reference processor,  no reason to enable it.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264374](https://bugs.openjdk.java.net/browse/JDK-8264374): Shenandoah: Remove leftover parallel reference processing argument


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3246/head:pull/3246` \
`$ git checkout pull/3246`

Update a local copy of the PR: \
`$ git checkout pull/3246` \
`$ git pull https://git.openjdk.java.net/jdk pull/3246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3246`

View PR using the GUI difftool: \
`$ git pr show -t 3246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3246.diff">https://git.openjdk.java.net/jdk/pull/3246.diff</a>

</details>
