### PR TITLE
8264193: Remove TRAPS parameters for modules and defaultmethods

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6256,8 +6256,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
                                                     _major_version,
                                                     loader,
                                                     _class_name,
-                                                    _local_interfaces,
-                                                    CHECK);
+                                                    _local_interfaces);
 
   // Size of Java itable (in words)
   _itable_size = _access_flags.is_interface() ? 0 :

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -342,9 +342,9 @@ class MethodFamily : public ResourceObj {
     _members.append(method_state);
   }
 
-  Symbol* generate_no_defaults_message(TRAPS) const;
-  Symbol* generate_method_message(Symbol *klass_name, Method* method, TRAPS) const;
-  Symbol* generate_conflicts_message(GrowableArray<MethodState>* methods, TRAPS) const;
+  Symbol* generate_no_defaults_message() const;
+  Symbol* generate_method_message(Symbol *klass_name, Method* method) const;
+  Symbol* generate_conflicts_message(GrowableArray<MethodState>* methods) const;
 
  public:
 
@@ -377,7 +377,7 @@ class MethodFamily : public ResourceObj {
   Symbol* get_exception_name() { return _exception_name; }
 
   // Either sets the target or the exception error message
-  void determine_target_or_set_exception_message(InstanceKlass* root, TRAPS) {
+  void determine_target_or_set_exception_message(InstanceKlass* root) {
     if (has_target() || throws_exception()) {
       return;
     }
@@ -400,11 +400,11 @@ class MethodFamily : public ResourceObj {
       assert(_members.at(default_index)._state == QUALIFIED, "");
       _selected_target = _members.at(default_index)._method;
     } else {
-      generate_and_set_exception_message(root, num_defaults, default_index, CHECK);
+      generate_and_set_exception_message(root, num_defaults, default_index);
     }
   }
 
-  void generate_and_set_exception_message(InstanceKlass* root, int num_defaults, int default_index, TRAPS) {
+  void generate_and_set_exception_message(InstanceKlass* root, int num_defaults, int default_index) {
     assert(num_defaults != 1, "invariant - should've been handled calling method");
 
     GrowableArray<Method*> qualified_methods;
@@ -419,14 +419,14 @@ class MethodFamily : public ResourceObj {
       // then do not generate an overpass method because it will hide the
       // static method during resolution.
       if (qualified_methods.length() == 0) {
-        _exception_message = generate_no_defaults_message(CHECK);
+        _exception_message = generate_no_defaults_message();
       } else {
         assert(root != NULL, "Null root class");
-        _exception_message = generate_method_message(root->name(), qualified_methods.at(0), CHECK);
+        _exception_message = generate_method_message(root->name(), qualified_methods.at(0));
       }
       _exception_name = vmSymbols::java_lang_AbstractMethodError();
     } else {
-      _exception_message = generate_conflicts_message(&_members,CHECK);
+      _exception_message = generate_conflicts_message(&_members);
       _exception_name = vmSymbols::java_lang_IncompatibleClassChangeError();
       LogTarget(Debug, defaultmethods) lt;
       if (lt.is_enabled()) {
@@ -457,11 +457,11 @@ class MethodFamily : public ResourceObj {
   }
 };
 
-Symbol* MethodFamily::generate_no_defaults_message(TRAPS) const {
+Symbol* MethodFamily::generate_no_defaults_message() const {
   return SymbolTable::new_symbol("No qualifying defaults found");
 }
 
-Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method, TRAPS) const {
+Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method) const {
   stringStream ss;
   ss.print("Method ");
   Symbol* name = method->name();
@@ -474,7 +474,7 @@ Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method
   return SymbolTable::new_symbol(ss.base(), (int)ss.size());
 }
 
-Symbol* MethodFamily::generate_conflicts_message(GrowableArray<MethodState>* methods, TRAPS) const {
+Symbol* MethodFamily::generate_conflicts_message(GrowableArray<MethodState>* methods) const {
   stringStream ss;
   ss.print("Conflicting default methods:");
   for (int i = 0; i < methods->length(); ++i) {
@@ -625,7 +625,7 @@ static bool already_in_vtable_slots(GrowableArray<EmptyVtableSlot*>* slots, Meth
 }
 
 static void find_empty_vtable_slots(GrowableArray<EmptyVtableSlot*>* slots,
-    InstanceKlass* klass, const GrowableArray<Method*>* mirandas, TRAPS) {
+    InstanceKlass* klass, const GrowableArray<Method*>* mirandas) {
 
   assert(klass != NULL, "Must be valid class");
 
@@ -781,7 +781,7 @@ static void create_defaults_and_exceptions(
 
 static void generate_erased_defaults(
     FindMethodsByErasedSig* visitor,
-    InstanceKlass* klass, EmptyVtableSlot* slot, bool is_intf, TRAPS) {
+    InstanceKlass* klass, EmptyVtableSlot* slot, bool is_intf) {
 
   // the visitor needs to be initialized or re-initialized before use
   // - this facilitates reusing the same visitor instance on multiple
@@ -793,7 +793,7 @@ static void generate_erased_defaults(
   MethodFamily* family;
   visitor->get_discovered_family(&family);
   if (family != NULL) {
-    family->determine_target_or_set_exception_message(klass, CHECK);
+    family->determine_target_or_set_exception_message(klass);
     slot->bind_family(family);
   }
 }
@@ -835,7 +835,7 @@ void DefaultMethods::generate_default_methods(
 
   LogTarget(Debug, defaultmethods) lt;
   if (lt.is_enabled()) {
-    ResourceMark rm;
+    ResourceMark rm(THREAD);
     lt.print("%s %s requires default method processing",
              klass->is_interface() ? "Interface" : "Class",
              klass->name()->as_klass_external_name());
@@ -845,7 +845,7 @@ void DefaultMethods::generate_default_methods(
   }
 
   GrowableArray<EmptyVtableSlot*> empty_slots;
-  find_empty_vtable_slots(&empty_slots, klass, mirandas, CHECK);
+  find_empty_vtable_slots(&empty_slots, klass, mirandas);
 
   if (empty_slots.length() > 0) {
     FindMethodsByErasedSig findMethodsByErasedSig;
@@ -859,7 +859,7 @@ void DefaultMethods::generate_default_methods(
         slot->print_on(&ls);
         ls.cr();
       }
-      generate_erased_defaults(&findMethodsByErasedSig, klass, slot, klass->is_interface(), CHECK);
+      generate_erased_defaults(&findMethodsByErasedSig, klass, slot, klass->is_interface());
     }
     log_debug(defaultmethods)("Creating defaults and overpasses...");
     create_defaults_and_exceptions(&empty_slots, klass, CHECK);
@@ -868,7 +868,7 @@ void DefaultMethods::generate_default_methods(
 }
 
 static int assemble_method_error(
-    BytecodeConstantPool* cp, BytecodeBuffer* buffer, Symbol* errorName, Symbol* message, TRAPS) {
+    BytecodeConstantPool* cp, BytecodeBuffer* buffer, Symbol* errorName, Symbol* message) {
 
   Symbol* init = vmSymbols::object_initializer_name();
   Symbol* sig = vmSymbols::string_void_signature();
@@ -992,7 +992,7 @@ static void create_defaults_and_exceptions(GrowableArray<EmptyVtableSlot*>* slot
           buffer->clear();
         }
         int max_stack = assemble_method_error(&bpool, buffer,
-           method->get_exception_name(), method->get_exception_message(), CHECK);
+           method->get_exception_name(), method->get_exception_message());
         AccessFlags flags = accessFlags_from(
           JVM_ACC_PUBLIC | JVM_ACC_SYNTHETIC | JVM_ACC_BRIDGE);
         Method* m = new_method(&bpool, buffer, slot->name(), slot->signature(),

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -109,7 +109,7 @@ static ModuleEntry* get_module_entry(Handle module, TRAPS) {
 }
 
 
-static PackageEntry* get_locked_package_entry(ModuleEntry* module_entry, const char* package_name, int len, TRAPS) {
+static PackageEntry* get_locked_package_entry(ModuleEntry* module_entry, const char* package_name, int len) {
   assert(Module_lock->owned_by_self(), "should have the Module_lock");
   assert(package_name != NULL, "Precondition");
   TempNewSymbol pkg_symbol = SymbolTable::new_symbol(package_name, len);
@@ -120,9 +120,7 @@ static PackageEntry* get_locked_package_entry(ModuleEntry* module_entry, const c
   return package_entry;
 }
 
-static PackageEntry* get_package_entry_by_name(Symbol* package,
-                                               Handle h_loader,
-                                               TRAPS) {
+static PackageEntry* get_package_entry_by_name(Symbol* package, Handle h_loader) {
   if (package != NULL) {
     PackageEntryTable* const package_entry_table =
       get_package_entry_table(h_loader);
@@ -132,8 +130,8 @@ static PackageEntry* get_package_entry_by_name(Symbol* package,
   return NULL;
 }
 
-bool Modules::is_package_defined(Symbol* package, Handle h_loader, TRAPS) {
-  PackageEntry* res = get_package_entry_by_name(package, h_loader, CHECK_false);
+bool Modules::is_package_defined(Symbol* package, Handle h_loader) {
+  PackageEntry* res = get_package_entry_by_name(package, h_loader);
   return res != NULL;
 }
 
@@ -586,7 +584,7 @@ void Modules::add_module_exports(Handle from_module, jstring package_name, Handl
   const char* pkg = as_internal_package(JNIHandles::resolve_non_null(package_name), buf, sizeof(buf), package_len);
   {
     MutexLocker ml(THREAD, Module_lock);
-    package_entry = get_locked_package_entry(from_module_entry, pkg, package_len, CHECK);
+    package_entry = get_locked_package_entry(from_module_entry, pkg, package_len);
     // Do nothing if modules are the same
     // If the package is not found we'll throw an exception later
     if (from_module_entry != to_module_entry &&
@@ -708,7 +706,7 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
   return JNIHandles::make_local(THREAD, module);
 }
 
-jobject Modules::get_named_module(Handle h_loader, const char* package_name, TRAPS) {
+oop Modules::get_named_module(Handle h_loader, const char* package_name) {
   assert(ModuleEntryTable::javabase_defined(),
          "Attempt to call get_named_module before " JAVA_BASE_NAME " is defined");
   assert(h_loader.is_null() || java_lang_ClassLoader::is_subclass(h_loader->klass()),
@@ -720,11 +718,11 @@ jobject Modules::get_named_module(Handle h_loader, const char* package_name, TRA
   }
   TempNewSymbol package_sym = SymbolTable::new_symbol(package_name);
   const PackageEntry* const pkg_entry =
-    get_package_entry_by_name(package_sym, h_loader, THREAD);
+    get_package_entry_by_name(package_sym, h_loader);
   const ModuleEntry* const module_entry = (pkg_entry != NULL ? pkg_entry->module() : NULL);
 
   if (module_entry != NULL && module_entry->module() != NULL && module_entry->is_named()) {
-    return JNIHandles::make_local(THREAD, module_entry->module());
+    return module_entry->module();
   }
   return NULL;
 }
@@ -757,7 +755,7 @@ void Modules::add_module_exports_to_all_unnamed(Handle module, jstring package_n
   PackageEntry* package_entry = NULL;
   {
     MutexLocker m1(THREAD, Module_lock);
-    package_entry = get_locked_package_entry(module_entry, pkg, pkg_len, CHECK);
+    package_entry = get_locked_package_entry(module_entry, pkg, pkg_len);
 
     // Mark package as exported to all unnamed modules.
     if (package_entry != NULL) {

--- a/src/hotspot/share/classfile/modules.hpp
+++ b/src/hotspot/share/classfile/modules.hpp
@@ -101,12 +101,10 @@ public:
   static jobject get_module(jclass clazz, TRAPS);
 
   // Return the java.lang.Module object for this class loader and package.
-  // Returns NULL if the class loader has not loaded any classes in the package.
+  // Returns NULL if the package name is empty, if the resulting package
+  // entry is NULL, if the module is not found or is unnamed.
   // The package should contain /'s, not .'s, as in java/lang, not java.lang.
-  // NullPointerException is thrown if package is null.
-  // IllegalArgumentException is thrown if loader is neither null nor a subtype of
-  // java/lang/ClassLoader.
-  static jobject get_named_module(Handle h_loader, const char* package, TRAPS);
+  static oop get_named_module(Handle h_loader, const char* package);
 
   // Marks the specified package as exported to all unnamed modules.
   // If either module or package is null then NullPointerException is thrown.
@@ -115,7 +113,7 @@ public:
   static void add_module_exports_to_all_unnamed(Handle module, jstring package, TRAPS);
 
   // Return TRUE iff package is defined by loader
-  static bool is_package_defined(Symbol* package_name, Handle h_loader, TRAPS);
+  static bool is_package_defined(Symbol* package_name, Handle h_loader);
   static ModuleEntryTable* get_module_entry_table(Handle h_loader);
 };
 

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -602,10 +602,9 @@ const char* const JDK_JFR_MODULE_NAME = "jdk.jfr";
 const char* const JDK_JFR_PACKAGE_NAME = "jdk/jfr";
 
 static bool is_jdk_jfr_module_in_readability_graph() {
-  Thread* const t = Thread::current();
   // take one of the packages in the module to be located and query for its definition.
   TempNewSymbol pkg_sym = SymbolTable::new_symbol(JDK_JFR_PACKAGE_NAME);
-  return Modules::is_package_defined(pkg_sym, Handle(), t);
+  return Modules::is_package_defined(pkg_sym, Handle());
 }
 
 static void print_module_resolution_error(outputStream* stream) {

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -68,8 +68,7 @@ void klassVtable::compute_vtable_size_and_num_mirandas(
     int* vtable_length_ret, int* num_new_mirandas,
     GrowableArray<Method*>* all_mirandas, const Klass* super,
     Array<Method*>* methods, AccessFlags class_flags, u2 major_version,
-    Handle classloader, Symbol* classname, Array<InstanceKlass*>* local_interfaces,
-    TRAPS) {
+    Handle classloader, Symbol* classname, Array<InstanceKlass*>* local_interfaces) {
   NoSafepointVerifier nsv;
 
   // set up default result values
@@ -258,7 +257,7 @@ void klassVtable::initialize_vtable(bool checkconstraints, TRAPS) {
     // Interfaces do not need interface methods in their vtables
     // This includes miranda methods and during later processing, default methods
     if (!ik()->is_interface()) {
-      initialized = fill_in_mirandas(initialized, THREAD);
+      initialized = fill_in_mirandas(THREAD, initialized);
     }
 
     // In class hierarchies where the accessibility is not increasing (i.e., going from private ->
@@ -937,8 +936,8 @@ void klassVtable::get_mirandas(GrowableArray<Method*>* new_mirandas,
 // return the new value of initialized.
 // Miranda methods use vtable entries, but do not get assigned a vtable_index
 // The vtable_index is discovered by searching from the end of the vtable
-int klassVtable::fill_in_mirandas(int initialized, TRAPS) {
-  ResourceMark rm(THREAD);
+int klassVtable::fill_in_mirandas(Thread* current, int initialized) {
+  ResourceMark rm(current);
   GrowableArray<Method*> mirandas(20);
   get_mirandas(&mirandas, NULL, ik()->super(), ik()->methods(),
                ik()->default_methods(), ik()->local_interfaces(),
@@ -1112,7 +1111,7 @@ void klassItable::initialize_itable(bool checkconstraints, TRAPS) {
   if (_klass->is_interface()) {
     // This needs to go after vtable indices are assigned but
     // before implementors need to know the number of itable indices.
-    assign_itable_indices_for_interface(InstanceKlass::cast(_klass), THREAD);
+    assign_itable_indices_for_interface(THREAD, InstanceKlass::cast(_klass));
   }
 
   // Cannot be setup doing bootstrapping, interfaces don't have
@@ -1158,9 +1157,9 @@ inline bool interface_method_needs_itable_index(Method* m) {
   return true;
 }
 
-int klassItable::assign_itable_indices_for_interface(InstanceKlass* klass, TRAPS) {
+int klassItable::assign_itable_indices_for_interface(Thread* current, InstanceKlass* klass) {
   // an interface does not have an itable, but its methods need to be numbered
-  ResourceMark rm(THREAD);
+  ResourceMark rm(current);
   log_develop_debug(itables)("%3d: Initializing itable indices for interface %s",
                              ++initialize_count, klass->name()->as_C_string());
   Array<Method*>* methods = klass->methods();

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,7 @@ class klassVtable {
                                                    u2 major_version,
                                                    Handle classloader,
                                                    Symbol* classname,
-                                                   Array<InstanceKlass*>* local_interfaces,
-                                                   TRAPS);
+                                                   Array<InstanceKlass*>* local_interfaces);
 
 #if INCLUDE_JVMTI
   // RedefineClasses() API support:
@@ -126,7 +125,7 @@ class klassVtable {
 
   // support for miranda methods
   bool is_miranda_entry_at(int i);
-  int fill_in_mirandas(int initialized, TRAPS);
+  int fill_in_mirandas(Thread* current, int initialized);
   static bool is_miranda(Method* m, Array<Method*>* class_methods,
                          Array<Method*>* default_methods, const Klass* super,
                          bool is_interface);
@@ -307,7 +306,7 @@ class klassItable {
 #endif // INCLUDE_JVMTI
 
   // Setup of itable
-  static int assign_itable_indices_for_interface(InstanceKlass* klass, TRAPS);
+  static int assign_itable_indices_for_interface(Thread* current, InstanceKlass* klass);
   static int method_count_for_interface(InstanceKlass* klass);
   static int compute_itable_size(Array<InstanceKlass*>* transitive_interfaces);
   static void setup_itable_offset_table(InstanceKlass* klass);

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -223,12 +223,8 @@ JvmtiEnv::GetNamedModule(jobject class_loader, const char* package_name, jobject
   if (h_loader.not_null() && !java_lang_ClassLoader::is_subclass(h_loader->klass())) {
     return JVMTI_ERROR_ILLEGAL_ARGUMENT;
   }
-  jobject module = Modules::get_named_module(h_loader, package_name, THREAD);
-  if (HAS_PENDING_EXCEPTION) {
-    CLEAR_PENDING_EXCEPTION;
-    return JVMTI_ERROR_INTERNAL; // unexpected exception
-  }
-  *module_ptr = module;
+  oop module = Modules::get_named_module(h_loader, package_name);
+  *module_ptr = module != NULL ? JNIHandles::make_local(THREAD, module) : NULL;
   return JVMTI_ERROR_NONE;
 } /* end GetNamedModule */
 


### PR DESCRIPTION
Please review this change for JDK-8264193 to remove unneeded TRAPS parameters from modules and default methods files.  Besides removing TRAPS, Modules::get_named_module() was changed to return an oop instead of a jobject, removing its need for a TRAPS parameter.

This change was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264193](https://bugs.openjdk.java.net/browse/JDK-8264193): Remove TRAPS parameters for modules and defaultmethods


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3247/head:pull/3247` \
`$ git checkout pull/3247`

Update a local copy of the PR: \
`$ git checkout pull/3247` \
`$ git pull https://git.openjdk.java.net/jdk pull/3247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3247`

View PR using the GUI difftool: \
`$ git pr show -t 3247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3247.diff">https://git.openjdk.java.net/jdk/pull/3247.diff</a>

</details>
