### PR TITLE
8264279: Shenandoah: Missing handshake after JDK-8263427

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -807,6 +807,12 @@ void ShenandoahConcurrentGC::op_weak_roots() {
     ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
     heap->workers()->run_task(&task);
   }
+
+  // Perform handshake to flush out dead oops
+  {
+    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
+    heap->rendezvous_threads();
+  }
 }
 
 void ShenandoahConcurrentGC::op_class_unloading() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1551,6 +1551,17 @@ public:
   bool is_thread_safe() { return true; }
 };
 
+class ShenandoahRendezvousClosure : public HandshakeClosure {
+public:
+  inline ShenandoahRendezvousClosure() : HandshakeClosure("ShenandoahRendezvous") {}
+  inline void do_thread(Thread* thread) {}
+};
+
+void ShenandoahHeap::rendezvous_threads() {
+  ShenandoahRendezvousClosure cl;
+  Handshake::execute(&cl);
+}
+
 void ShenandoahHeap::recycle_trash() {
   free_set()->recycle_trash();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -126,6 +126,7 @@ class ShenandoahHeap : public CollectedHeap {
   friend class ShenandoahConcurrentGC;
   friend class ShenandoahDegenGC;
   friend class ShenandoahFullGC;
+  friend class ShenandoahUnload;
 
 // ---------- Locks that guard important data structures in Heap
 //
@@ -371,8 +372,8 @@ private:
   void update_heap_region_states(bool concurrent);
   void rebuild_free_set(bool concurrent);
 
+  void rendezvous_threads();
   void recycle_trash();
-
 public:
   void notify_gc_progress()    { _progress_last_gc.set();   }
   void notify_gc_no_progress() { _progress_last_gc.unset(); }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -82,6 +82,7 @@ class outputStream;
   f(conc_weak_roots,                                "Concurrent Weak Roots")           \
   f(conc_weak_roots_work,                           "  Roots")                         \
   SHENANDOAH_PAR_PHASE_DO(conc_weak_roots_work_,    "    CWR: ", f)                    \
+  f(conc_weak_roots_rendezvous,                     "  Rendezvous")                    \
   f(conc_cleanup_early,                             "Concurrent Cleanup")              \
   f(conc_class_unload,                              "Concurrent Class Unloading")      \
   f(conc_class_unload_unlink,                       "  Unlink Stale")                  \

--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -133,12 +133,6 @@ void ShenandoahUnload::prepare() {
   DependencyContext::cleaning_start();
 }
 
-class ShenandoahRendezvousClosure : public HandshakeClosure {
-public:
-  inline ShenandoahRendezvousClosure() : HandshakeClosure("ShenandoahRendezvous") {}
-  inline void do_thread(Thread* thread) {}
-};
-
 void ShenandoahUnload::unload() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(ClassUnloading, "Filtered by caller");
@@ -172,8 +166,7 @@ void ShenandoahUnload::unload() {
   // Make sure stale metadata and nmethods are no longer observable
   {
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_class_unload_rendezvous);
-    ShenandoahRendezvousClosure cl;
-    Handshake::execute(&cl);
+    heap->rendezvous_threads();
   }
 
   // Purge stale metadata and nmethods that were unlinked


### PR DESCRIPTION
JDK-8263427 mistakenly removed handshake after concurrent weak roots, which is needed to flush out stale oops before we can safely recycle trash regions. Otherwise, those stale oops are suddenly resurrected, because they are above TAMS after regions are recycled.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264279](https://bugs.openjdk.java.net/browse/JDK-8264279): Shenandoah: Missing handshake after JDK-8263427


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3248/head:pull/3248` \
`$ git checkout pull/3248`

Update a local copy of the PR: \
`$ git checkout pull/3248` \
`$ git pull https://git.openjdk.java.net/jdk pull/3248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3248`

View PR using the GUI difftool: \
`$ git pr show -t 3248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3248.diff">https://git.openjdk.java.net/jdk/pull/3248.diff</a>

</details>
