### PR TITLE
8248418: jpackage fails to extract main class and version from app module linked in external runtime

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -837,8 +837,6 @@ jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-
 
 # jdk_jpackage
 
-tools/jpackage/share/jdk/jpackage/tests/ModulePathTest3.java#id0    8248418 generic-all
-
 ############################################################################
 
 # Client manual tests

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ModulePathTest3.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ModulePathTest3.java
@@ -57,18 +57,6 @@ import org.w3c.dom.Document;
  *  --jpt-run=jdk.jpackage.tests.ModulePathTest3
  */
 
-/*
- * @test
- * @summary jpackage for app's module linked in external runtime
- * @library ../../../../helpers
- * @build jdk.jpackage.test.*
- * @modules jdk.jpackage/jdk.jpackage.internal
- * @compile ModulePathTest3.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
- *  --jpt-run=jdk.jpackage.tests.ModulePathTest3
- *  --jpt-exclude=test8248418
- */
-
 public final class ModulePathTest3 {
 
     public ModulePathTest3(String jlinkOutputSubdir, String runtimeSubdir) {
@@ -83,15 +71,6 @@ public final class ModulePathTest3 {
     @Test
     public void test8248254() throws XPathExpressionException, IOException {
         testIt("me.mymodule/me.mymodule.Main");
-    }
-
-    /**
-     * Test case for JDK-8248418.
-     * App's module with version specified in runtime directory.
-     */
-    @Test
-    public void test8248418() throws XPathExpressionException, IOException {
-        testIt("me.mymodule/me.mymodule.Main@3.7");
     }
 
     private void testIt(String mainAppDesc) throws XPathExpressionException,


### PR DESCRIPTION
Remove the test for failing jpackage use case scenario that we don't intent to fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248418](https://bugs.openjdk.java.net/browse/JDK-8248418): jpackage fails to extract main class and version from app module linked in external runtime


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3249/head:pull/3249` \
`$ git checkout pull/3249`

Update a local copy of the PR: \
`$ git checkout pull/3249` \
`$ git pull https://git.openjdk.java.net/jdk pull/3249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3249`

View PR using the GUI difftool: \
`$ git pr show -t 3249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3249.diff">https://git.openjdk.java.net/jdk/pull/3249.diff</a>

</details>
