### PR TITLE
8264428: Cleanup usages of StringBuffer in java.desktop

### DIFF
--- a/src/java.desktop/aix/classes/sun/awt/X11InputMethod.java
+++ b/src/java.desktop/aix/classes/sun/awt/X11InputMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,7 +231,7 @@ public abstract class X11InputMethod extends X11InputMethodBase {
 
         // Replace control character with a square box
         if (chgText != null) {
-            StringBuffer newChgText = new StringBuffer();
+            StringBuilder newChgText = new StringBuilder();
             for (int i=0; i < chgText.length(); i++){
                 char c = chgText.charAt(i);
                 if (Character.isISOControl(c)){

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,9 +122,9 @@ public class TIFFFieldNode extends IIOMetadataNode {
                 child = new IIOMetadataNode("TIFFUndefined");
 
                 byte[] data = field.getAsBytes();
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 for (int i = 0; i < count; i++) {
-                    sb.append(Integer.toString(data[i] & 0xff));
+                    sb.append((data[i] & 0xff));
                     if (i < count - 1) {
                         sb.append(",");
                     }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
@@ -124,7 +124,7 @@ public class TIFFFieldNode extends IIOMetadataNode {
                 byte[] data = field.getAsBytes();
                 StringBuilder sb = new StringBuilder();
                 for (int i = 0; i < count; i++) {
-                    sb.append((data[i] & 0xff));
+                    sb.append(data[i] & 0xff);
                     if (i < count - 1) {
                         sb.append(",");
                     }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -327,7 +327,7 @@ public class TIFFImageMetadata extends IIOMetadata {
         if (times == 1) {
             return s;
         }
-        StringBuffer sb = new StringBuffer((s.length() + 1)*times - 1);
+        StringBuilder sb = new StringBuilder((s.length() + 1)*times - 1);
         sb.append(s);
         for (int i = 1; i < times; i++) {
             sb.append(" ");
@@ -422,12 +422,12 @@ public class TIFFImageMetadata extends IIOMetadata {
                 bitsPerSample = new int[] {1};
             }
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < bitsPerSample.length; i++) {
             if (i > 0) {
                 sb.append(" ");
             }
-            sb.append(Integer.toString(bitsPerSample[i]));
+            sb.append(bitsPerSample[i]);
         }
         node = new IIOMetadataNode("BitsPerSample");
         if(isPaletteColor) {
@@ -441,7 +441,7 @@ public class TIFFImageMetadata extends IIOMetadata {
         f = getTIFFField(BaselineTIFFTagSet.TAG_FILL_ORDER);
         int fillOrder = f != null ?
             f.getAsInt(0) : BaselineTIFFTagSet.FILL_ORDER_LEFT_TO_RIGHT;
-        sb = new StringBuffer();
+        sb = new StringBuilder();
         for (int i = 0; i < bitsPerSample.length; i++) {
             if (i > 0) {
                 sb.append(" ");
@@ -451,7 +451,7 @@ public class TIFFImageMetadata extends IIOMetadata {
             int msb =
                 fillOrder == BaselineTIFFTagSet.FILL_ORDER_LEFT_TO_RIGHT ?
                 maxBitIndex : 0;
-            sb.append(Integer.toString(msb));
+            sb.append(msb);
         }
         node = new IIOMetadataNode("SampleMSB");
         if(isPaletteColor) {
@@ -1225,7 +1225,7 @@ public class TIFFImageMetadata extends IIOMetadata {
                         String minute = getAttribute(child, "minute");
                         String second = getAttribute(child, "second");
 
-                        StringBuffer sb = new StringBuffer();
+                        StringBuilder sb = new StringBuilder();
                         sb.append(year);
                         sb.append(":");
                         if(month.length() == 1) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -2414,13 +2414,13 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
                 int nch;
                 boolean lastWasCR = false;
                 int last;
-                StringBuffer sbuff = null;
+                StringBuilder sbuff = null;
 
                 // Read in a block at a time, mapping \r\n to \n, as well as single
                 // \r to \n.
                 while ((nch = in.read(buff, 0, buff.length)) != -1) {
                     if (sbuff == null) {
-                        sbuff = new StringBuffer(nch);
+                        sbuff = new StringBuilder(nch);
                     }
                     last = 0;
                     for(int counter = 0; counter < nch; counter++) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XAtomList.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XAtomList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,7 +155,7 @@ class XAtomList {
     }
 
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("[");
         Iterator<XAtom> iter = atoms.iterator();
         while (iter.hasNext()) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XCreateWindowParams.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XCreateWindowParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,11 +81,11 @@ public class XCreateWindowParams extends HashMap<Object, Object> {
         return this;
     }
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         Iterator<Map.Entry<Object, Object>> eIter = entrySet().iterator();
         while (eIter.hasNext()) {
             Map.Entry<Object, Object> entry = eIter.next();
-            buf.append(entry.getKey() + ": " + entry.getValue() + "\n");
+            buf.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
         }
         return buf.toString();
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XCreateWindowParams.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XCreateWindowParams.java
@@ -85,7 +85,10 @@ public class XCreateWindowParams extends HashMap<Object, Object> {
         Iterator<Map.Entry<Object, Object>> eIter = entrySet().iterator();
         while (eIter.hasNext()) {
             Map.Entry<Object, Object> entry = eIter.next();
-            buf.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+            buf.append(entry.getKey())
+               .append(": ")
+               .append(entry.getValue())
+               .append("\n");
         }
         return buf.toString();
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XlibWrapper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XlibWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -610,7 +610,7 @@ static native String XSetLocaleModifiers(String modifier_list);
     }
 
     static String hintsToString(long flags) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         if ((flags & XUtilConstants.PMaxSize) != 0) {
             buf.append("PMaxSize ");
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11FontManager.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11FontManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -481,11 +481,9 @@ public final class X11FontManager extends FcFontManager {
             return name; // what else can we do?
         }
 
-        StringBuffer sb =
-            new StringBuffer(name.substring(hPos[FAMILY_NAME_FIELD-1],
-                                            hPos[SETWIDTH_NAME_FIELD]));
-        sb.append(name.substring(hPos[CHARSET_REGISTRY_FIELD-1]));
-        String retval = sb.toString().toLowerCase (Locale.ENGLISH);
+        String sb = name.substring(hPos[FAMILY_NAME_FIELD-1], hPos[SETWIDTH_NAME_FIELD])
+                + name.substring(hPos[CHARSET_REGISTRY_FIELD-1]);
+        String retval = sb.toLowerCase(Locale.ENGLISH);
         return retval;
     }
 
@@ -529,15 +527,12 @@ public final class X11FontManager extends FcFontManager {
             && encoding.equals("fontspecific")){
             registry = "adobe";
         }
-        StringBuffer sb =
-            new StringBuffer(name.substring(hPos[FAMILY_NAME_FIELD-1],
-                                            hPos[SLANT_FIELD-1]+1));
-        sb.append(slant);
-        sb.append(name.substring(hPos[SLANT_FIELD],
-                                 hPos[SETWIDTH_NAME_FIELD]+1));
-        sb.append(registry);
-        sb.append(name.substring(hPos[CHARSET_ENCODING_FIELD-1]));
-        String retval = sb.toString().toLowerCase (Locale.ENGLISH);
+        String sb = name.substring(hPos[FAMILY_NAME_FIELD-1], hPos[SLANT_FIELD-1]+1)
+                + slant
+                + name.substring(hPos[SLANT_FIELD], hPos[SETWIDTH_NAME_FIELD]+1)
+                + registry
+                + name.substring(hPos[CHARSET_ENCODING_FIELD-1]);
+        String retval = sb.toLowerCase(Locale.ENGLISH);
         return retval;
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -787,7 +787,7 @@ public abstract class X11InputMethodBase extends InputMethodAdapter {
         }
 
         public String toString() {
-            StringBuffer s = new StringBuffer();
+            StringBuilder s = new StringBuilder();
             for (int i = 0; i < size;) {
                 s.append(intArray[i++]);
                 if (i < size)

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -575,10 +575,7 @@ class HTMLCodec extends InputStream {
         if (n >= 0 && len < width) {
             char[] array = new char[width - len];
             Arrays.fill(array, '0');
-            StringBuffer buffer = new StringBuffer(width);
-            buffer.append(array);
-            buffer.append(string);
-            string = buffer.toString();
+            string = String.valueOf(array) + string;
         }
         return string;
     }

--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
@@ -136,7 +136,7 @@ final class D3DContext extends BufferedContext {
 
         @Override
         public String toString() {
-            StringBuffer buf = new StringBuffer(super.toString());
+            StringBuilder buf = new StringBuilder(super.toString());
             if ((caps & CAPS_LCD_SHADER) != 0) {
                 buf.append("CAPS_LCD_SHADER|");
             }


### PR DESCRIPTION
There are few possible cleanups in java.desktop related to legacy StringBuffer usages:
1. In few places StringBuffer can be replaced with plain String concatenation.
2. StringBuffer can be replaced with StringBuilder. StringBuilder has better performance as it is not thread-safe.
3. There are few places where result of string concatenation is passed to StringBuffer.append method. Using separate `.append` calls is more clear.
4. In few places primitives are unnecessary converted to String before `.append` call. They can be replaced with specialized methods (like `.append(int)` calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264428](https://bugs.openjdk.java.net/browse/JDK-8264428): Cleanup usages of StringBuffer in java.desktop


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3251/head:pull/3251` \
`$ git checkout pull/3251`

Update a local copy of the PR: \
`$ git checkout pull/3251` \
`$ git pull https://git.openjdk.java.net/jdk pull/3251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3251`

View PR using the GUI difftool: \
`$ git pr show -t 3251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3251.diff">https://git.openjdk.java.net/jdk/pull/3251.diff</a>

</details>
