### PR TITLE
8264396: Use the blessed modifier order in jdk.internal.jvmstat

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AbstractPerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AbstractPerfDataBufferPrologue.java
@@ -61,28 +61,28 @@ public abstract class AbstractPerfDataBufferPrologue {
      * the following constants must match the field offsets and sizes
      * in the PerfDataPrologue structure in perfMemory.hpp
      */
-    final static int PERFDATA_PROLOG_OFFSET=0;
-    final static int PERFDATA_PROLOG_MAGIC_OFFSET=0;
-    final static int PERFDATA_PROLOG_BYTEORDER_OFFSET=4;
-    final static int PERFDATA_PROLOG_BYTEORDER_SIZE=1;         // sizeof(byte)
-    final static int PERFDATA_PROLOG_MAJOR_OFFSET=5;
-    final static int PERFDATA_PROLOG_MAJOR_SIZE=1;             // sizeof(byte)
-    final static int PERFDATA_PROLOG_MINOR_OFFSET=6;
-    final static int PERFDATA_PROLOG_MINOR_SIZE=1;             // sizeof(byte)
-    final static int PERFDATA_PROLOG_RESERVEDB1_OFFSET=7;
-    final static int PERFDATA_PROLOG_RESERVEDB1_SIZE=1;        // sizeof(byte)
+    static final int PERFDATA_PROLOG_OFFSET=0;
+    static final int PERFDATA_PROLOG_MAGIC_OFFSET=0;
+    static final int PERFDATA_PROLOG_BYTEORDER_OFFSET=4;
+    static final int PERFDATA_PROLOG_BYTEORDER_SIZE=1;         // sizeof(byte)
+    static final int PERFDATA_PROLOG_MAJOR_OFFSET=5;
+    static final int PERFDATA_PROLOG_MAJOR_SIZE=1;             // sizeof(byte)
+    static final int PERFDATA_PROLOG_MINOR_OFFSET=6;
+    static final int PERFDATA_PROLOG_MINOR_SIZE=1;             // sizeof(byte)
+    static final int PERFDATA_PROLOG_RESERVEDB1_OFFSET=7;
+    static final int PERFDATA_PROLOG_RESERVEDB1_SIZE=1;        // sizeof(byte)
 
-    final static int PERFDATA_PROLOG_SIZE=8;   // sizeof(struct PerfDataProlog)
+    static final int PERFDATA_PROLOG_SIZE=8;   // sizeof(struct PerfDataProlog)
 
     // these constants should match their #define counterparts in perfMemory.hpp
-    final static byte PERFDATA_BIG_ENDIAN=0;
-    final static byte PERFDATA_LITTLE_ENDIAN=1;
-    final static int  PERFDATA_MAGIC = 0xcafec0c0;
+    static final byte PERFDATA_BIG_ENDIAN=0;
+    static final byte PERFDATA_LITTLE_ENDIAN=1;
+    static final int  PERFDATA_MAGIC = 0xcafec0c0;
 
     // names for counters that expose the prolog fields
-    public final static String PERFDATA_MAJOR_NAME =
+    public static final String PERFDATA_MAJOR_NAME =
             "sun.perfdata.majorVersion";
-    public final static String PERFDATA_MINOR_NAME =
+    public static final String PERFDATA_MINOR_NAME =
             "sun.perfdata.minorVersion";
 
     /**

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AbstractPerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AbstractPerfDataBufferPrologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
@@ -54,21 +54,21 @@ public class PerfDataBuffer extends PerfDataBufferImpl {
      * the following constants must be kept in sync with struct
      * PerfDataEntry in perfMemory.hpp
      */
-    private final static int PERFDATA_ENTRYLENGTH_OFFSET=0;
-    private final static int PERFDATA_ENTRYLENGTH_SIZE=4;   // sizeof(int)
-    private final static int PERFDATA_NAMELENGTH_OFFSET=4;
-    private final static int PERFDATA_NAMELENGTH_SIZE=4;    // sizeof(int)
-    private final static int PERFDATA_VECTORLENGTH_OFFSET=8;
-    private final static int PERFDATA_VECTORLENGTH_SIZE=4;  // sizeof(int)
-    private final static int PERFDATA_DATATYPE_OFFSET=12;
-    private final static int PERFDATA_DATATYPE_SIZE=1;      // sizeof(byte)
-    private final static int PERFDATA_FLAGS_OFFSET=13;
-    private final static int PERFDATA_FLAGS_SIZE=1;        // sizeof(byte)
-    private final static int PERFDATA_DATAUNITS_OFFSET=14;
-    private final static int PERFDATA_DATAUNITS_SIZE=1;     // sizeof(byte)
-    private final static int PERFDATA_DATAATTR_OFFSET=15;
-    private final static int PERFDATA_DATAATTR_SIZE=1;      // sizeof(byte)
-    private final static int PERFDATA_NAME_OFFSET=16;
+    private static final int PERFDATA_ENTRYLENGTH_OFFSET=0;
+    private static final int PERFDATA_ENTRYLENGTH_SIZE=4;   // sizeof(int)
+    private static final int PERFDATA_NAMELENGTH_OFFSET=4;
+    private static final int PERFDATA_NAMELENGTH_SIZE=4;    // sizeof(int)
+    private static final int PERFDATA_VECTORLENGTH_OFFSET=8;
+    private static final int PERFDATA_VECTORLENGTH_SIZE=4;  // sizeof(int)
+    private static final int PERFDATA_DATATYPE_OFFSET=12;
+    private static final int PERFDATA_DATATYPE_SIZE=1;      // sizeof(byte)
+    private static final int PERFDATA_FLAGS_OFFSET=13;
+    private static final int PERFDATA_FLAGS_SIZE=1;        // sizeof(byte)
+    private static final int PERFDATA_DATAUNITS_OFFSET=14;
+    private static final int PERFDATA_DATAUNITS_SIZE=1;     // sizeof(byte)
+    private static final int PERFDATA_DATAATTR_OFFSET=15;
+    private static final int PERFDATA_DATAATTR_SIZE=1;      // sizeof(byte)
+    private static final int PERFDATA_NAME_OFFSET=16;
 
     PerfDataBufferPrologue prologue;
     int nextEntry;

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBufferPrologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBufferPrologue.java
@@ -56,19 +56,19 @@ public class PerfDataBufferPrologue extends AbstractPerfDataBufferPrologue {
      * the following constants must match the field offsets and sizes
      * in the PerfDataPrologue structure in perfMemory.hpp
      */
-    final static int PERFDATA_PROLOG_USED_OFFSET=8;
-    final static int PERFDATA_PROLOG_USED_SIZE=4;              // sizeof(int)
-    final static int PERFDATA_PROLOG_OVERFLOW_OFFSET=12;
-    final static int PERFDATA_PROLOG_OVERFLOW_SIZE=4;          // sizeof(int)
-    final static int PERFDATA_PROLOG_MODTIMESTAMP_OFFSET=16;
-    final static int PERFDATA_PROLOG_MODTIMESTAMP_SIZE=8;      // sizeof(long)
-    final static int PERFDATA_PROLOG_SIZE=24;  // sizeof(struct PerfDataProlog)
+    static final int PERFDATA_PROLOG_USED_OFFSET=8;
+    static final int PERFDATA_PROLOG_USED_SIZE=4;              // sizeof(int)
+    static final int PERFDATA_PROLOG_OVERFLOW_OFFSET=12;
+    static final int PERFDATA_PROLOG_OVERFLOW_SIZE=4;          // sizeof(int)
+    static final int PERFDATA_PROLOG_MODTIMESTAMP_OFFSET=16;
+    static final int PERFDATA_PROLOG_MODTIMESTAMP_SIZE=8;      // sizeof(long)
+    static final int PERFDATA_PROLOG_SIZE=24;  // sizeof(struct PerfDataProlog)
 
     // counter names for prologue psuedo counters
-    final static String PERFDATA_BUFFER_SIZE_NAME  = "sun.perfdata.size";
-    final static String PERFDATA_BUFFER_USED_NAME  = "sun.perfdata.used";
-    final static String PERFDATA_OVERFLOW_NAME     = "sun.perfdata.overflow";
-    final static String PERFDATA_MODTIMESTAMP_NAME = "sun.perfdata.timestamp";
+    static final String PERFDATA_BUFFER_SIZE_NAME  = "sun.perfdata.size";
+    static final String PERFDATA_BUFFER_USED_NAME  = "sun.perfdata.used";
+    static final String PERFDATA_OVERFLOW_NAME     = "sun.perfdata.overflow";
+    static final String PERFDATA_MODTIMESTAMP_NAME = "sun.perfdata.timestamp";
 
     /**
      * Create an instance of PerfDataBufferPrologue from the given

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBuffer.java
@@ -74,22 +74,22 @@ public class PerfDataBuffer extends PerfDataBufferImpl {
      * generally unused in this code, but they are kept consistent with
      * the data structure just in case some unforseen need arrises.
      */
-    private final static int PERFDATA_ENTRYLENGTH_OFFSET=0;
-    private final static int PERFDATA_ENTRYLENGTH_SIZE=4;   // sizeof(int)
-    private final static int PERFDATA_NAMEOFFSET_OFFSET=4;
-    private final static int PERFDATA_NAMEOFFSET_SIZE=4;    // sizeof(int)
-    private final static int PERFDATA_VECTORLENGTH_OFFSET=8;
-    private final static int PERFDATA_VECTORLENGTH_SIZE=4;  // sizeof(int)
-    private final static int PERFDATA_DATATYPE_OFFSET=12;
-    private final static int PERFDATA_DATATYPE_SIZE=1;      // sizeof(byte)
-    private final static int PERFDATA_FLAGS_OFFSET=13;
-    private final static int PERFDATA_FLAGS_SIZE=1;       // sizeof(byte)
-    private final static int PERFDATA_DATAUNITS_OFFSET=14;
-    private final static int PERFDATA_DATAUNITS_SIZE=1;     // sizeof(byte)
-    private final static int PERFDATA_DATAVAR_OFFSET=15;
-    private final static int PERFDATA_DATAVAR_SIZE=1;       // sizeof(byte)
-    private final static int PERFDATA_DATAOFFSET_OFFSET=16;
-    private final static int PERFDATA_DATAOFFSET_SIZE=4;    // sizeof(int)
+    private static final int PERFDATA_ENTRYLENGTH_OFFSET=0;
+    private static final int PERFDATA_ENTRYLENGTH_SIZE=4;   // sizeof(int)
+    private static final int PERFDATA_NAMEOFFSET_OFFSET=4;
+    private static final int PERFDATA_NAMEOFFSET_SIZE=4;    // sizeof(int)
+    private static final int PERFDATA_VECTORLENGTH_OFFSET=8;
+    private static final int PERFDATA_VECTORLENGTH_SIZE=4;  // sizeof(int)
+    private static final int PERFDATA_DATATYPE_OFFSET=12;
+    private static final int PERFDATA_DATATYPE_SIZE=1;      // sizeof(byte)
+    private static final int PERFDATA_FLAGS_OFFSET=13;
+    private static final int PERFDATA_FLAGS_SIZE=1;       // sizeof(byte)
+    private static final int PERFDATA_DATAUNITS_OFFSET=14;
+    private static final int PERFDATA_DATAUNITS_SIZE=1;     // sizeof(byte)
+    private static final int PERFDATA_DATAVAR_OFFSET=15;
+    private static final int PERFDATA_DATAVAR_SIZE=1;       // sizeof(byte)
+    private static final int PERFDATA_DATAOFFSET_OFFSET=16;
+    private static final int PERFDATA_DATAOFFSET_SIZE=4;    // sizeof(int)
 
     PerfDataBufferPrologue prologue;
     int nextEntry;

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBufferPrologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBufferPrologue.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v2_0/PerfDataBufferPrologue.java
@@ -51,8 +51,8 @@ import java.nio.*;
  */
 public class PerfDataBufferPrologue extends AbstractPerfDataBufferPrologue {
 
-    private final static int SUPPORTED_MAJOR_VERSION = 2;
-    private final static int SUPPORTED_MINOR_VERSION = 0;
+    private static final int SUPPORTED_MAJOR_VERSION = 2;
+    private static final int SUPPORTED_MINOR_VERSION = 0;
 
     /*
      * the following constants must match the field offsets and sizes
@@ -62,27 +62,27 @@ public class PerfDataBufferPrologue extends AbstractPerfDataBufferPrologue {
      * note that PERFDATA_PROLOG_ACCESSIBLE_OFFSET redefines
      * PERFDATA_PROLOG_RESERVEDB1_OFFSET from AbstractPerfDataBufferPrologue.
      */
-    final static int PERFDATA_PROLOG_ACCESSIBLE_OFFSET=7;
-    final static int PERFDATA_PROLOG_ACCESSIBLE_SIZE=1;        // sizeof(byte)
-    final static int PERFDATA_PROLOG_USED_OFFSET=8;
-    final static int PERFDATA_PROLOG_USED_SIZE=4;              // sizeof(int)
-    final static int PERFDATA_PROLOG_OVERFLOW_OFFSET=12;
-    final static int PERFDATA_PROLOG_OVERFLOW_SIZE=4;          // sizeof(int)
-    final static int PERFDATA_PROLOG_MODTIMESTAMP_OFFSET=16;
-    final static int PERFDATA_PROLOG_MODTIMESTAMP_SIZE=8;      // sizeof(long)
-    final static int PERFDATA_PROLOG_ENTRYOFFSET_OFFSET=24;
-    final static int PERFDATA_PROLOG_ENTRYOFFSET_SIZE=4;       // sizeof(int)
-    final static int PERFDATA_PROLOG_NUMENTRIES_OFFSET=28;
-    final static int PERFDATA_PROLOG_NUMENTRIES_SIZE=4;        // sizeof(int)
+    static final int PERFDATA_PROLOG_ACCESSIBLE_OFFSET=7;
+    static final int PERFDATA_PROLOG_ACCESSIBLE_SIZE=1;        // sizeof(byte)
+    static final int PERFDATA_PROLOG_USED_OFFSET=8;
+    static final int PERFDATA_PROLOG_USED_SIZE=4;              // sizeof(int)
+    static final int PERFDATA_PROLOG_OVERFLOW_OFFSET=12;
+    static final int PERFDATA_PROLOG_OVERFLOW_SIZE=4;          // sizeof(int)
+    static final int PERFDATA_PROLOG_MODTIMESTAMP_OFFSET=16;
+    static final int PERFDATA_PROLOG_MODTIMESTAMP_SIZE=8;      // sizeof(long)
+    static final int PERFDATA_PROLOG_ENTRYOFFSET_OFFSET=24;
+    static final int PERFDATA_PROLOG_ENTRYOFFSET_SIZE=4;       // sizeof(int)
+    static final int PERFDATA_PROLOG_NUMENTRIES_OFFSET=28;
+    static final int PERFDATA_PROLOG_NUMENTRIES_SIZE=4;        // sizeof(int)
 
-    final static int PERFDATA_PROLOG_SIZE=32;  // sizeof(struct PerfDataProlog)
+    static final int PERFDATA_PROLOG_SIZE=32;  // sizeof(struct PerfDataProlog)
 
     // names for counters that expose prologue fields
-    final static String PERFDATA_BUFFER_SIZE_NAME  = "sun.perfdata.size";
-    final static String PERFDATA_BUFFER_USED_NAME  = "sun.perfdata.used";
-    final static String PERFDATA_OVERFLOW_NAME     = "sun.perfdata.overflow";
-    final static String PERFDATA_MODTIMESTAMP_NAME = "sun.perfdata.timestamp";
-    final static String PERFDATA_NUMENTRIES_NAME   = "sun.perfdata.entries";
+    static final String PERFDATA_BUFFER_SIZE_NAME  = "sun.perfdata.size";
+    static final String PERFDATA_BUFFER_USED_NAME  = "sun.perfdata.used";
+    static final String PERFDATA_OVERFLOW_NAME     = "sun.perfdata.overflow";
+    static final String PERFDATA_MODTIMESTAMP_NAME = "sun.perfdata.timestamp";
+    static final String PERFDATA_NUMENTRIES_NAME   = "sun.perfdata.entries";
 
     /**
      * Create an instance of PerfDataBufferPrologue from the given


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264396](https://bugs.openjdk.java.net/browse/JDK-8264396): Use the blessed modifier order in jdk.internal.jvmstat


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 0583ebcc5c00c4e6d2bf602013c5b27effd137c5
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3252/head:pull/3252` \
`$ git checkout pull/3252`

Update a local copy of the PR: \
`$ git checkout pull/3252` \
`$ git pull https://git.openjdk.java.net/jdk pull/3252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3252`

View PR using the GUI difftool: \
`$ git pr show -t 3252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3252.diff">https://git.openjdk.java.net/jdk/pull/3252.diff</a>

</details>
