### PR TITLE
8264412: AArch64: CPU description should refer DMI

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -171,7 +171,7 @@ void VM_Version::get_os_cpu_info() {
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buf != NULL, "invalid argument");
-  assert(buflen >= 2, "invalid argument");
+  assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
     ssize_t read_sz = os::read(fd, buf, buflen);
@@ -179,8 +179,8 @@ static bool read_fully(const char *fname, char *buf, size_t buflen) {
 
     // Skip if the contents is just "\n" because some machine only sets
     // '\n' to the board name.
-    // (e.g. /sys/devices/virtual/dmi/id/board_name)
-    if ((read_sz > 0) && (strncmp(buf, "\n", 2) != 0)) {
+    // (e.g. esys/devices/virtual/dmi/id/board_name)
+    if (read_sz > 0 && !(read_sz == 1 && *buf == '\n')) {
       // Replace '\0' to ' '
       for (char *ch = buf; ch < buf + read_sz - 1; ch++) {
         if (*ch == '\0') {

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "runtime/os.hpp"
+#include "runtime/os.inline.hpp"
 #include "runtime/vm_version.hpp"
 
 #include <asm/hwcap.h>
@@ -171,22 +172,22 @@ void VM_Version::get_os_cpu_info() {
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buf != NULL, "invalid argument");
   assert(buflen >= 1, "invalid argument");
-  int fd = open(fname, O_RDONLY);
+  int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
-    ssize_t read_sz = read(fd, buf, buflen);
-    close(fd);
+    ssize_t read_sz = os::read(fd, buf, buflen);
+    os::close(fd);
 
     // Skip if the contents starts with '\n' because some machine only sets
     // '\n' to the board name.
     // (e.g. /sys/devices/virtual/dmi/id/board_name)
     if ((read_sz > 0) && (*buf != '\n')) {
-      buf[read_sz - 1] = '\0';
       // Replace '\0' to ' '
       for (char *ch = buf; ch < buf + read_sz - 1; ch++) {
         if (*ch == '\0') {
           *ch = ' ';
         }
       }
+      buf[read_sz - 1] = '\0';
       return true;
     }
   }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -191,9 +191,11 @@ static bool read_fully(const char *fname, char *buf, int buflen) {
 }
 
 void VM_Version::get_compatible_board(char *buf, int buflen) {
-  if (!read_fully("/proc/device-tree/compatible", buf, buflen)) {
-    if (!read_fully("/sys/devices/virtual/dmi/id/board_name", buf, buflen)) {
-      read_fully("/sys/devices/virtual/dmi/id/product_name", buf, buflen);
-    }
+  if (read_fully("/proc/device-tree/compatible", buf, buflen)) {
+    return;
   }
+  if (read_fully("/sys/devices/virtual/dmi/id/board_name", buf, buflen)) {
+    return;
+  }
+  read_fully("/sys/devices/virtual/dmi/id/product_name", buf, buflen);
 }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -171,16 +171,16 @@ void VM_Version::get_os_cpu_info() {
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buf != NULL, "invalid argument");
-  assert(buflen >= 1, "invalid argument");
+  assert(buflen >= 2, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
     ssize_t read_sz = os::read(fd, buf, buflen);
     os::close(fd);
 
-    // Skip if the contents starts with '\n' because some machine only sets
+    // Skip if the contents is just "\n" because some machine only sets
     // '\n' to the board name.
     // (e.g. /sys/devices/virtual/dmi/id/board_name)
-    if ((read_sz > 0) && (*buf != '\n')) {
+    if ((read_sz > 0) && (strncmp(buf, "\n", 2) != 0)) {
       // Replace '\0' to ' '
       for (char *ch = buf; ch < buf + read_sz - 1; ch++) {
         if (*ch == '\0') {


### PR DESCRIPTION
`jdk.CPUInformation` event on AArch64 has valid CPU description in [JDK-8262491](https://bugs.openjdk.java.net/browse/JDK-8262491), however it does not work on UEFI booted machine.

[JDK-8262491](https://bugs.openjdk.java.net/browse/JDK-8262491) refers device tree to get board name, however it does not exist on UEFI. We need to refer DMI.
However we need to have root privilege, so we refer /sys/devices/virtual/dmi/id to avoid it.

We can get board name from /sys/devices/virtual/dmi/id/board_name, but some machine set empty string to it. So we will refer /sys/devices/virtual/dmi/id/product_name as a fallback.

For example, we can get following CPU description on AWS A1 instance after this change:

```
jdk.CPUInformation {
  startTime = 05:28:24.506
  cpu = "AArch64"
  description = "AArch64 a1.2xlarge  0x41:0x0:0xd08:3, simd, crc, aes, sha1, sha256"
  sockets = 8
  cores = 8
  hwThreads = 8
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264412](https://bugs.openjdk.java.net/browse/JDK-8264412): AArch64: CPU description should refer DMI


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to a1b94754d60582119ea30bae2931e8231bd2acdd


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3259/head:pull/3259` \
`$ git checkout pull/3259`

Update a local copy of the PR: \
`$ git checkout pull/3259` \
`$ git pull https://git.openjdk.java.net/jdk pull/3259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3259`

View PR using the GUI difftool: \
`$ git pr show -t 3259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3259.diff">https://git.openjdk.java.net/jdk/pull/3259.diff</a>

</details>
