### PR TITLE
8260267: vmTestbase/gc/gctests/FinalizeLock/FinalizeLock.java fails with fatal error: Mark stack space exhausted

### DIFF
--- a/src/hotspot/share/gc/z/zMark.hpp
+++ b/src/hotspot/share/gc/z/zMark.hpp
@@ -53,6 +53,7 @@ private:
   size_t              _ntrycomplete;
   size_t              _ncontinue;
   uint                _nworkers;
+  static volatile bool  _push_local_stripe;
 
   size_t calculate_nstripes(uint nworkers) const;
 
@@ -108,6 +109,13 @@ public:
   void start();
   void mark(bool initial);
   bool end();
+
+  static void set_push_local_stripe(bool mode) {
+    Atomic::store(&_push_local_stripe, mode);
+  }
+  static bool push_local_stripe() {
+    return Atomic::load(&_push_local_stripe);
+  }
 
   void flush_and_free();
   bool flush_and_free(Thread* thread);

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.hpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.hpp
@@ -52,8 +52,11 @@ class ZMarkStackAllocator {
 private:
   ZCACHE_ALIGNED ZMarkStackMagazineList _freelist;
   ZCACHE_ALIGNED ZMarkStackSpace        _space;
+  ZCACHE_ALIGNED volatile int           _nmagazine;
 
   void prime_freelist();
+  void inc_nmagazine();
+  void dec_nmagazine();
   ZMarkStackMagazine* create_magazine_from_space(uintptr_t addr, size_t size);
 
 public:

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -42,6 +42,9 @@
           "Maximum number of bytes allocated for mark stacks")              \
           range(32*M, 1024*G)                                               \
                                                                             \
+  product(double, ZStackModeChangeRatio, 0.25,                              \
+          "Mark push mode is changed when usage is above the ratio")        \
+                                                                            \
   product(double, ZCollectionInterval, 0,                                   \
           "Force GC at a fixed time interval (in seconds)")                 \
                                                                             \


### PR DESCRIPTION
ZGC mark stack will be exhausted when the live object graph is very large, which due to the pseudo-BFS style visiting of the object graph (ZGC gc worker will push children to other stripes which behave like BFS, so the maximum mark stack size is O(num_objects).). But other gc like g1 or Shenandoah use DFS to visiting the object graph, and the mark stack usage merely exceeds 32M, which may due to the maximum mark stack size is related to the depth of the object graph O(depth_of_object_graph).

The following is the test case used to reproduce the crash,
```
import java.util.HashMap;
import java.util.HashSet;

class Test2 {
  public static int NODE_COUNT = 25000000;
  public static int NODE_COUNT_UB = 1 << 25;
  public static int STRING_GEN_INDEX = 1;
  public static int WATCHER_COUNT = 100;
  public static int MAP_COUNT = 8;
  public static int BIN_COUNT = 16;
  public static Object[] watchTable = new Object[MAP_COUNT];

  public static class Watcher {
    public static long counter = 0;
    public long index;
    Watcher() {
      index = counter;
      counter++;
    }
  }

  public static int gen_name() {
    int cur = STRING_GEN_INDEX++;
    int reminder = cur % BIN_COUNT;
    cur = cur - reminder + NODE_COUNT_UB * reminder;
    return cur;
  }

  public static HashMap<Integer, HashSet<Watcher>> get_map(int index) {
    return (HashMap<Integer, HashSet<Watcher>>)watchTable[index];
  }

  public static void gen_watcher() {
    int name = gen_name();
    HashSet<Watcher> set = new HashSet<Watcher>();
    for (int i = 0; i < WATCHER_COUNT; i++) {
       set.add(new Watcher());
    }
    for (int i = 0; i < MAP_COUNT; i++) {
      get_map(i).put(name, set);
    }
  }

  public static void setup() {
    for (int i = 0; i < MAP_COUNT; i++) {
      watchTable[i] = new HashMap<Integer, HashSet<Watcher>>();
    }
    for (int i = 0; i < NODE_COUNT; i++) {
      gen_watcher();
    }
  }

  public static void main(String[] args) {
    setup();
    for (int i = 0; i < 10; i++) {
      System.gc();
    }
    System.out.println("pass");
  }
}
```

The command to run the testcase is,
```
java -XX:+UseZGC -Xmx280g -XX:ZCollectionInterval=10  -Xlog:gc*=debug:file=gc.log:time,level,tags:filesize=5g Test2
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260267](https://bugs.openjdk.java.net/browse/JDK-8260267): vmTestbase/gc/gctests/FinalizeLock/FinalizeLock.java fails with fatal error: Mark stack space exhausted


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3262/head:pull/3262` \
`$ git checkout pull/3262`

Update a local copy of the PR: \
`$ git checkout pull/3262` \
`$ git pull https://git.openjdk.java.net/jdk pull/3262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3262`

View PR using the GUI difftool: \
`$ git pr show -t 3262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3262.diff">https://git.openjdk.java.net/jdk/pull/3262.diff</a>

</details>
