### PR TITLE
8264411: serviceability/jvmti/HeapMonitor tests intermittently fail due to large TLAB size

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitor.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitor.java
@@ -166,13 +166,13 @@ public class HeapMonitor {
 
     // Trigger GC then loop around an allocation loop and wait until Object Sampling
     // is enabled for every later allocation. It takes two steps:
-    // 1. Consume current TLAB, whose size can be varies with heap/GC configuration
+    // 1. Consume current TLAB, whose size can vary with heap/GC configuration
     // 2. Consume initial ThreadHeapSampler::_bytes_until_sample, which is around 512KB
     //
     // Step1 trigger GC to consume current TLAB
     System.gc();
-    // Step2 loop allocation consume "bytes until sample", each iteration allocate
-    // about 1600KB, 10 iterations can definitly consume initial "bytes until sample"
+    // Step2 loop allocation consumes "bytes until sample", each iteration allocates
+    // about 1600KB, so 10 iterations will definitly consume initial "bytes until sample"
     final int maxTries = 10;
     int[][][] result = new int[maxTries][][];
     for (int i = 0; i < maxTries; i++) {

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
@@ -46,6 +46,8 @@ public class HeapMonitorStatObjectCorrectnessTest {
     emptyStorage();
 
     HeapMonitor.enableSamplingEvents();
+    // retire TLAB with GC, ensure sample happens, not assume TLAB size
+    System.gc();
     for (int j = 0; j < maxIteration; j++) {
       obj = new BigObject();
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
@@ -46,7 +46,8 @@ public class HeapMonitorStatObjectCorrectnessTest {
     emptyStorage();
 
     HeapMonitor.enableSamplingEvents();
-    // retire TLAB with GC, ensure sample happens, not assume TLAB size
+    // Instead of relying on the allocation loop to fill and retire the TLAB, which might not happen,
+    // use System.gc() to retire the TLAB and ensure sampling happens
     System.gc();
     for (int j = 0; j < maxIteration; j++) {
       obj = new BigObject();


### PR DESCRIPTION
…ue to large TLAB size

serviceability/jvmti/HeapMonitor tests intermittently fail when using PS/Serial GC, original test has implicit assumptions on TLAB size and depends on allocate fix amount of objects to consume TLAB and trigger object sampling. These tests will fail if TLAB is above 20M (this can easily happen when using PS/Serial GC and heap is large), when allocation can not consume current TLAB and _byte_until_sample.

Fix in tests is adding an explicit GC to consume current TLAB.
Running on 256G memory machine, make run-test CONF=release TEST="test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/" 'JTREG=JOBS=12;VM_OPTIONS=-XX:ActiveProcessorCount=1'

before fix: 6 or 7 tests in 20 tests intermittently fail
after fix: no failure in 100 runs release/fastdebug

This might also fix https://bugs.openjdk.java.net/browse/JDK-8225313

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264411](https://bugs.openjdk.java.net/browse/JDK-8264411): serviceability/jvmti/HeapMonitor tests intermittently fail due to large TLAB size


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 3dd108d505fa13967d7f5c0a2701ab3a34ebca26
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3265/head:pull/3265` \
`$ git checkout pull/3265`

Update a local copy of the PR: \
`$ git checkout pull/3265` \
`$ git pull https://git.openjdk.java.net/jdk pull/3265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3265`

View PR using the GUI difftool: \
`$ git pr show -t 3265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3265.diff">https://git.openjdk.java.net/jdk/pull/3265.diff</a>

</details>
