### PR TITLE
JDK-8264112 (fs) Reorder methods/constructor/fields in UnixUserDefinedFileAttributeView.java

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -49,6 +49,14 @@ abstract class UnixUserDefinedFileAttributeView
     private static final int MIN_LISTXATTR_BUF_SIZE = 1024;
     private static final int MAX_LISTXATTR_BUF_SIZE = 32 * 1024;
 
+    private final UnixPath file;
+    private final boolean followLinks;
+
+    UnixUserDefinedFileAttributeView(UnixPath file, boolean followLinks) {
+        this.file = file;
+        this.followLinks = followLinks;
+    }
+
     private byte[] nameAsBytes(UnixPath file, String name) throws IOException {
         if (name == null)
             throw new NullPointerException("'name' is null");
@@ -60,6 +68,11 @@ abstract class UnixUserDefinedFileAttributeView
         }
         return bytes;
     }
+
+    /**
+     * @return the maximum supported length of xattr names (in bytes, including namespace)
+     */
+    protected abstract int maxNameLength();
 
     // Parses buffer as array of NULL-terminated C strings.
     private static List<String> asList(long address, int size) {
@@ -96,19 +109,6 @@ abstract class UnixUserDefinedFileAttributeView
             }
         }
     }
-
-    private final UnixPath file;
-    private final boolean followLinks;
-
-    UnixUserDefinedFileAttributeView(UnixPath file, boolean followLinks) {
-        this.file = file;
-        this.followLinks = followLinks;
-    }
-
-    /**
-     * @return the maximum supported length of xattr names (in bytes, including namespace)
-     */
-    protected abstract int maxNameLength();
 
     @Override
     public List<String> list() throws IOException  {


### PR DESCRIPTION
Reordered fields and methods: First declare static variables, then instance variables, the constructor, methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264112](https://bugs.openjdk.java.net/browse/JDK-8264112): (fs) Reorder methods/constructor/fields in UnixUserDefinedFileAttributeView.java


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3267/head:pull/3267` \
`$ git checkout pull/3267`

Update a local copy of the PR: \
`$ git checkout pull/3267` \
`$ git pull https://git.openjdk.java.net/jdk pull/3267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3267`

View PR using the GUI difftool: \
`$ git pr show -t 3267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3267.diff">https://git.openjdk.java.net/jdk/pull/3267.diff</a>

</details>
