### PR TITLE
8264429: Test runtime/cds/appcds/VerifyWithDefaultArchive.java assumes OpenJDK build

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/VerifyWithDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/VerifyWithDefaultArchive.java
@@ -38,7 +38,7 @@ public class VerifyWithDefaultArchive {
     public static void main(String... args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:cds", "-XX:+VerifySharedSpaces", "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
-        out.shouldContain("OpenJDK");
+        out.shouldNotContain("relocation bitmap CRC error");
         out.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
The test runtime/cds/appcds/VerifyWithDefaultArchive.java assumes OpenJDK build since it checks for `out.shouldContain("OpenJDK")`. Relax this restriction now.

Thanks~
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264429](https://bugs.openjdk.java.net/browse/JDK-8264429): Test runtime/cds/appcds/VerifyWithDefaultArchive.java assumes OpenJDK build


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3268/head:pull/3268` \
`$ git checkout pull/3268`

Update a local copy of the PR: \
`$ git checkout pull/3268` \
`$ git pull https://git.openjdk.java.net/jdk pull/3268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3268`

View PR using the GUI difftool: \
`$ git pr show -t 3268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3268.diff">https://git.openjdk.java.net/jdk/pull/3268.diff</a>

</details>
