### PR TITLE
8264346: nullptr_t undefined in global namespace for clang+libstdc++

### DIFF
--- a/src/hotspot/share/oops/oopsHierarchy.hpp
+++ b/src/hotspot/share/oops/oopsHierarchy.hpp
@@ -100,8 +100,8 @@ public:
   bool operator==(const oop& o) const  { return _o == o._o; }
   bool operator!=(const oop& o) const  { return _o != o._o; }
 
-  bool operator==(nullptr_t) const     { return _o == nullptr; }
-  bool operator!=(nullptr_t) const     { return _o != nullptr; }
+  bool operator==(std::nullptr_t) const     { return _o == nullptr; }
+  bool operator!=(std::nullptr_t) const     { return _o != nullptr; }
 
   oop& operator=(const oop& o)         { _o = o._o; return *this; }
 };

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -34,6 +34,8 @@
 
 #include COMPILER_HEADER(utilities/globalDefinitions)
 
+#include <cstddef>
+
 class oopDesc;
 
 // Defaults for macros that might be defined per compiler.

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -31,6 +31,8 @@
 // globally used constants & types, class (forward)
 // declarations and a few frequently used utility functions.
 
+#include <cstddef>
+
 #include <ctype.h>
 #include <string.h>
 #include <stdarg.h>

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -31,8 +31,6 @@
 // globally used constants & types, class (forward)
 // declarations and a few frequently used utility functions.
 
-#include <cstddef>
-
 #include <ctype.h>
 #include <string.h>
 #include <stdarg.h>


### PR DESCRIPTION
There's a mismatch in some toolchains about what part should provide the nullptr_t definition. This patch takes the easy way out and include cstddef and changes the two usages nullptr_t to std::nullptr_t.

See the bug report for more details.

We could have redefined nullptr_t to resolve this, but that would have required more extensive testing, so I left that as a potential future cleanup.

I've tested this by compiling with clang on linux. I'm going to let GHA testing testing run, and will also run our tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264346](https://bugs.openjdk.java.net/browse/JDK-8264346): nullptr_t undefined in global namespace for clang+libstdc++


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 5a562c14e3fcd4cc1671b01a47bcb940fc606294
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3269/head:pull/3269` \
`$ git checkout pull/3269`

Update a local copy of the PR: \
`$ git checkout pull/3269` \
`$ git pull https://git.openjdk.java.net/jdk pull/3269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3269`

View PR using the GUI difftool: \
`$ git pr show -t 3269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3269.diff">https://git.openjdk.java.net/jdk/pull/3269.diff</a>

</details>
