### PR TITLE
8264311: Heap object statistics

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2086,6 +2086,12 @@ const intx ObjectAlignmentInBytes = 8;
           false AARCH64_ONLY(DEBUG_ONLY(||true)),                           \
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
+                                                                            \
+  product(bool, HeapObjectStats, false, DIAGNOSTIC,                         \
+             "Enable gathering of heap object statistics")                  \
+                                                                            \
+  product(size_t, HeapObjectStatsSamplingInterval, 500, DIAGNOSTIC,         \
+             "Heap object statistics sampling interval (ms)")               \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -117,6 +117,7 @@
 #include "runtime/vmOperations.hpp"
 #include "runtime/vm_version.hpp"
 #include "services/attachListener.hpp"
+#include "services/heapObjectStatistics.hpp"
 #include "services/management.hpp"
 #include "services/memTracker.hpp"
 #include "services/threadService.hpp"
@@ -3288,6 +3289,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // Start the monitor deflation thread:
   MonitorDeflationThread::initialize();
 
+  // Start heap object statistics sampling
+  HeapObjectStatistics::initialize();
+
   // initialize compiler(s)
 #if defined(COMPILER1) || COMPILER2_OR_JVMCI
 #if INCLUDE_JVMCI
@@ -3736,6 +3740,8 @@ bool Threads::destroy_vm() {
   // we will deadlock on the Threads_lock. Once all interactions are
   // complete it is safe to directly delete the thread at any time.
   ThreadsSMRSupport::wait_until_not_protected(thread);
+
+  HeapObjectStatistics::shutdown();
 
   // Stop VM thread.
   {

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -81,6 +81,7 @@
   template(ChangeSingleStep)                      \
   template(HeapWalkOperation)                     \
   template(HeapIterateOperation)                  \
+  template(HeapObjectStatistics)                  \
   template(ReportJavaOutOfMemory)                 \
   template(JFRCheckpoint)                         \
   template(ShenandoahFullGC)                      \

--- a/src/hotspot/share/services/heapObjectStatistics.cpp
+++ b/src/hotspot/share/services/heapObjectStatistics.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shared/collectedHeap.hpp"
+#include "logging/logStream.hpp"
+#include "logging/logTag.hpp"
+#include "memory/allocation.hpp"
+#include "memory/iterator.hpp"
+#include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/vmThread.hpp"
+#include "services/heapObjectStatistics.hpp"
+#include "utilities/copy.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+HeapObjectStatistics* HeapObjectStatistics::_instance = NULL;
+
+class HeapObjectStatsObjectClosure : public ObjectClosure {
+private:
+  HeapObjectStatistics* const _stats;
+public:
+  HeapObjectStatsObjectClosure() : _stats(HeapObjectStatistics::instance()) {}
+  void do_object(oop obj) {
+    _stats->visit_object(obj);
+  }
+};
+
+class VM_HeapObjectStatistics : public VM_Operation {
+public:
+  VMOp_Type type() const { return VMOp_HeapObjectStatistics; }
+  bool doit_prologue() {
+    Heap_lock->lock();
+    return true;
+  }
+
+  void doit_epilogue() {
+    Heap_lock->unlock();
+  }
+
+  void doit() {
+    assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
+    assert(Heap_lock->is_locked(), "should have the Heap_lock");
+
+    CollectedHeap* heap = Universe::heap();
+    heap->ensure_parsability(false);
+
+    HeapObjectStatistics* stats = HeapObjectStatistics::instance();
+    stats->begin_sample();
+
+    HeapObjectStatsObjectClosure cl;
+    heap->object_iterate(&cl);
+  }
+};
+
+HeapObjectStatisticsTask::HeapObjectStatisticsTask() : PeriodicTask(HeapObjectStatsSamplingInterval) {}
+
+void HeapObjectStatisticsTask::task() {
+  VM_HeapObjectStatistics vmop;
+  VMThread::execute(&vmop);
+}
+
+void HeapObjectStatistics::initialize() {
+  assert(_instance == NULL, "Don't init twice");
+  if (HeapObjectStats) {
+    _instance = new HeapObjectStatistics();
+    _instance->start();
+  }
+}
+
+void HeapObjectStatistics::shutdown() {
+  if (HeapObjectStats) {
+    assert(_instance != NULL, "Must be initialized");
+    LogTarget(Info, heap, stats) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      ResourceMark rm;
+      _instance->print(&ls);
+    }
+    _instance->stop();
+    delete _instance;
+    _instance = NULL;
+  }
+}
+
+HeapObjectStatistics* HeapObjectStatistics::instance() {
+  assert(_instance != NULL, "Must be initialized");
+  return _instance;
+}
+
+void HeapObjectStatistics::increase_counter(uint64_t& counter, uint64_t val) {
+  uint64_t oldval = counter;
+  uint64_t newval = counter + val;
+  if (newval < oldval) {
+    log_warning(heap, stats)("HeapObjectStats counter overflow: resulting statistics will be useless");
+  }
+  counter = newval;
+}
+
+HeapObjectStatistics::HeapObjectStatistics() :
+  _task(), _num_samples(0), _num_objects(0), _num_ihashed(0), _num_locked(0), _lds(0) { }
+
+void HeapObjectStatistics::start() {
+  _task.enroll();
+}
+
+void HeapObjectStatistics::stop() {
+  _task.disenroll();
+}
+
+void HeapObjectStatistics::begin_sample() {
+  _num_samples++;
+}
+
+void HeapObjectStatistics::visit_object(oop obj) {
+  increase_counter(_num_objects);
+  if (!obj->mark().has_no_hash()) {
+    increase_counter(_num_ihashed);
+    if (obj->mark().age() > 0) {
+      increase_counter(_num_ihashed_moved);
+    }
+  }
+  if (obj->mark().is_locked()) {
+    increase_counter(_num_locked);
+  }
+  size_t size = obj->size();
+  increase_counter(_lds, obj->size());
+}
+
+void HeapObjectStatistics::print(outputStream* out) const {
+  if (!HeapObjectStats) {
+    return;
+  }
+  if (_num_samples == 0 || _num_objects == 0) {
+    return;
+  }
+
+  out->print_cr("Number of samples:  " UINT64_FORMAT, _num_samples);
+  out->print_cr("Average number of objects: " UINT64_FORMAT, _num_objects / _num_samples);
+  out->print_cr("Average object size: " UINT64_FORMAT " bytes, %.1f words", (_lds * HeapWordSize) / _num_objects, (float) _lds / _num_objects);
+  out->print_cr("Average number of hashed objects: " UINT64_FORMAT " (%.2f%%)", _num_ihashed / _num_samples, (float) (_num_ihashed * 100.0) / _num_objects);
+  out->print_cr("Average number of moved hashed objects: " UINT64_FORMAT " (%.2f%%)", _num_ihashed_moved / _num_samples, (float) (_num_ihashed_moved * 100.0) / _num_objects);
+  out->print_cr("Average number of locked objects: " UINT64_FORMAT " (%.2f%%)", _num_locked / _num_samples, (float) (_num_locked * 100) / _num_objects);
+  out->print_cr("Average LDS: " UINT64_FORMAT " bytes", _lds * HeapWordSize / _num_samples);
+  out->print_cr("Avg LDS with (assumed) 64bit header: " UINT64_FORMAT " bytes (%.1f%%)", (_lds - _num_objects) * HeapWordSize / _num_samples, ((float) _lds - _num_objects) * 100.0 / _lds);
+}

--- a/src/hotspot/share/services/heapObjectStatistics.hpp
+++ b/src/hotspot/share/services/heapObjectStatistics.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_SERVICES_HEAPOBJECTSTATISTICS_HPP
+#define SHARE_SERVICES_HEAPOBJECTSTATISTICS_HPP
+
+#include "memory/allocation.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "runtime/task.hpp"
+#include "runtime/vmOperation.hpp"
+
+class outputStream;
+
+class HeapObjectStatisticsTask : public PeriodicTask {
+public:
+  HeapObjectStatisticsTask();
+  void task();
+};
+
+class HeapObjectStatistics : public CHeapObj<mtGC> {
+private:
+  static const int HISTOGRAM_SIZE = 16;
+
+  static HeapObjectStatistics* _instance;
+
+  HeapObjectStatisticsTask _task;
+  uint64_t _num_samples;
+  uint64_t _num_objects;
+  uint64_t _num_ihashed;
+  uint64_t _num_ihashed_moved;
+  uint64_t _num_locked;
+  uint64_t _lds;
+
+  static void increase_counter(uint64_t& counter, uint64_t val = 1);
+
+  void print(outputStream* out) const;
+
+public:
+  static void initialize();
+  static void shutdown();
+
+  static HeapObjectStatistics* instance();
+
+  HeapObjectStatistics();
+  void start();
+  void stop();
+
+  void begin_sample();
+  void visit_object(oop object);
+};
+
+#endif // SHARE_SERVICES_HEAPOBJECTSTATISTICS_HPP


### PR DESCRIPTION
For Lilliput evaluation, it would be useful to be able to get some statistics about heap objects, e.g. how many objects there typically are, what is their (average) size, how big is the live data set, how many objecs have an identity hash code and how many objects are locked. Some of that information may be useful for general purpose too, e.g. the avg live data set and object size/count information might be quite useful to have.

Heap object statistics can be gathered and printed by invoking java with -XX:+UnlockDiagnosticVMOptions -XX:+HeapObjectStats -Xlog:heap+stats. It will impact performance of the workload. The sampling interval can be specificed by -XX:HeapObjectStatsSamplingInterval=X (in ms) and defaults to 500 (ms).

Testing:
 - [x] Some manual tests, verifying the plausability of the output by hand
 - [ ] tier1
 - [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8264311](https://bugs.openjdk.java.net/browse/JDK-8264311): Heap object statistics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3271/head:pull/3271` \
`$ git checkout pull/3271`

Update a local copy of the PR: \
`$ git checkout pull/3271` \
`$ git pull https://git.openjdk.java.net/jdk pull/3271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3271`

View PR using the GUI difftool: \
`$ git pr show -t 3271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3271.diff">https://git.openjdk.java.net/jdk/pull/3271.diff</a>

</details>
