### PR TITLE
[PATCH] Replace uses of StringBuffer with StringBuilder in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -255,7 +255,7 @@ public class CLHSDB {
         exceed the given number of characters per line. Strips
         extraneous whitespace. */
     private String formatMessage(String message, int charsPerLine) {
-        StringBuffer buf = new StringBuffer(message.length());
+        StringBuilder buf = new StringBuilder(message.length());
         StringTokenizer tokenizer = new StringTokenizer(message);
         int curLineLength = 0;
         while (tokenizer.hasMoreTokens()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -227,7 +227,7 @@ public class CommandProcessor {
             }
         }
         String join(String sep) {
-            StringBuffer result = new StringBuffer();
+            StringBuilder result = new StringBuilder();
             for (int w = i; w < length; w++) {
                 result.append(tokens[w]);
                 if (w + 1 < length) {
@@ -350,7 +350,7 @@ public class CommandProcessor {
     Address lookup(String symbol) {
         if (symbol.indexOf("::") != -1) {
             String[] parts = symbol.split("::");
-            StringBuffer mangled = new StringBuffer("__1c");
+            StringBuilder mangled = new StringBuilder("__1c");
             for (int i = 0; i < parts.length; i++) {
                 int len = parts[i].length();
                 if (len >= 26) {
@@ -1755,7 +1755,7 @@ public class CommandProcessor {
                 }
 
                 /* Compute filename for class. */
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 if (tokenCount > 1) {
                     buf.append(t.nextToken());
                 } else {
@@ -1967,7 +1967,7 @@ public class CommandProcessor {
                 ln = "";
                 err.println("History is empty");
             } else {
-                StringBuffer result = new StringBuffer();
+                StringBuilder result = new StringBuilder();
                 Matcher m = historyPattern.matcher(ln);
                 int start = 0;
                 while (m.find()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1811,7 +1811,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
       exceed the given number of characters per line. Strips
       extraneous whitespace. */
   private String formatMessage(String message, int charsPerLine) {
-    StringBuffer buf = new StringBuffer(message.length());
+    StringBuilder buf = new StringBuilder(message.length());
     StringTokenizer tokenizer = new StringTokenizer(message);
     int curLineLength = 0;
     while (tokenizer.hasMoreTokens()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class RMIHelper {
         // we have to transform this as //host[:port]/<serverNamePrefix>['_'<unique_id>]
 
         int index = debugServerID.indexOf('@');
-        StringBuffer nameBuf = new StringBuffer("//");
+        StringBuilder nameBuf = new StringBuilder("//");
         String uniqueID = null;
         if (index != -1) {
             nameBuf.append(debugServerID.substring(index + 1));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class DebuggerUtilities {
   }
 
   public String addressValueToString(long address) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val;
     // Make negative addresses have the correct size

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionSym.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionSym.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class BasicFunctionSym extends BasicBlockSym implements FunctionSym {
       return null;
     }
 
-    StringBuffer res = new StringBuffer();
+    StringBuilder res = new StringBuilder();
     res.append(getName());
     res.append("(");
     FunctionType type = (FunctionType) getType();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ public class DummyDebugger extends DebuggerBase {
   //
 
   String addressToString(DummyAddress addr) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val;
     if (addr == null) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecode.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer(getJavaBytecodeName());
+    StringBuilder buf = new StringBuilder(getJavaBytecodeName());
     if (code() != javaCode()) {
        buf.append(spaces);
        buf.append('[');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeBipush.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeBipush.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,10 +65,10 @@ public class BytecodeBipush extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("bipush");
     buf.append(spaces);
-    buf.append(Byte.toString(getValue()));
+    buf.append(getValue());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,11 +51,11 @@ public abstract class BytecodeGetPut extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(indexForFieldOrMethod()));
+    buf.append(indexForFieldOrMethod());
     buf.append(" [Field ");
     StringBuffer sigBuf = new StringBuffer();
     new SignatureConverter(signature(), sigBuf).dispatchField();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeIinc.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeIinc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,13 +66,13 @@ public class BytecodeIinc extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("iinc");
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(getLocalVarIndex()));
+    buf.append(getLocalVarIndex());
     buf.append(" by ");
-    buf.append(Integer.toString(getIncrement()));
+    buf.append(getIncrement());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,16 +106,16 @@ public class BytecodeInvoke extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(indexForFieldOrMethod()));
+    buf.append(indexForFieldOrMethod());
     if (isInvokedynamic()) {
       ConstantPool cp = method.getConstants();
       buf.append('(');
       int poolIndex = cp.invokeDynamicNameAndTypeRefIndexAt(indexForFieldOrMethod());
-      buf.append(Integer.toString(poolIndex));
+      buf.append(poolIndex);
       buf.append(')');
       buf.append(" [Name and Type ");
       buf.append(name().asString());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeJmp.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeJmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,10 @@ public abstract class BytecodeJmp extends Bytecode {
   public abstract int getTargetBCI();
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
-    buf.append(Integer.toString(getTargetBCI()));
+    buf.append(getTargetBCI());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadConstant.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,14 +195,14 @@ public class BytecodeLoadConstant extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(poolIndex()));
+    buf.append(poolIndex());
     if (hasCacheIndex()) {
        buf.append('(');
-       buf.append(Integer.toString(cacheIndex()));
+       buf.append(cacheIndex());
        buf.append(')');
     }
     buf.append(spaces);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadStore.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,11 +32,11 @@ public abstract class BytecodeLoadStore extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(getLocalVarIndex()));
+    buf.append(getLocalVarIndex());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLookupswitch.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLookupswitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,19 +78,19 @@ public class BytecodeLookupswitch extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("lookupswitch");
     buf.append(spaces);
     buf.append("default: ");
-    buf.append(Integer.toString(bci() + defaultOffset()));
+    buf.append(bci() + defaultOffset());
     buf.append(comma);
     int i = numberOfPairs() - 1;
     while (i-- > 0) {
       LookupswitchPair pair = pairAt(i);
       buf.append("case ");
-      buf.append(Integer.toString(pair.match()));
+      buf.append(pair.match());
       buf.append(':');
-      buf.append(Integer.toString(bci() + pair.offset()));
+      buf.append(bci() + pair.offset());
       buf.append(comma);
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeMultiANewArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeMultiANewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,10 @@ public class BytecodeMultiANewArray extends BytecodeWithKlass {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(super.toString());
     buf.append(spaces);
-    buf.append(Integer.toString(getDimension()));
+    buf.append(getDimension());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeNewArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeNewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class BytecodeNewArray extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("newarray");
     buf.append(spaces);
     buf.append(getTypeName());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeRet.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeRet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,11 +61,11 @@ public class BytecodeRet extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("ret");
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(getLocalVarIndex()));
+    buf.append(getLocalVarIndex());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeSipush.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeSipush.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,10 +65,10 @@ public class BytecodeSipush extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("sipush");
     buf.append(spaces);
-    buf.append(Short.toString(getValue()));
+    buf.append(getValue());
     return buf.toString();
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeTableswitch.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeTableswitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,20 +84,20 @@ public class BytecodeTableswitch extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("tableswitch");
     buf.append(spaces);
     buf.append("default: ");
-    buf.append(Integer.toString(bci() + defaultOffset()));
+    buf.append(bci() + defaultOffset());
     buf.append(comma);
     int lo = lowKey();
     int hi = highKey();
     int i  = hi - lo - 1 ;
     while (i-- > 0) {
        buf.append("case ");
-       buf.append(Integer.toString(lo + i));
+       buf.append(lo + i);
        buf.append(':');
-       buf.append(Integer.toString(bci() + destOffsetAt(i)));
+       buf.append(bci() + destOffsetAt(i));
        buf.append(comma);
     }
     return buf.toString();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,11 +41,11 @@ public class BytecodeWithKlass extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');
-    buf.append(Integer.toString(index()));
+    buf.append(index());
     buf.append(spaces);
     buf.append("[Class ");
     buf.append(getClassName().asString().replace('/', '.'));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class ObjectHistogramElement {
           ObjArrayKlass oak = (ObjArrayKlass) ak;
           Klass bottom = oak.getBottomKlass();
           int dim = (int) oak.getDimension();
-          StringBuffer buf = new StringBuffer();
+          StringBuilder buf = new StringBuilder();
           if (bottom instanceof TypeArrayKlass) {
             buf.append(((TypeArrayKlass) bottom).getElementTypeName());
           } else if (bottom instanceof InstanceKlass) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ public class OopUtilities {
       return null;
     }
     int length = (int)charArray.getLength();
-    StringBuffer buf = new StringBuffer(length);
+    StringBuilder buf = new StringBuilder(length);
     for (int i = 0; i < length; i++) {
       buf.append(charArray.getCharAt(i));
     }
@@ -111,7 +111,7 @@ public class OopUtilities {
       return null;
     }
     int length = (int)byteArray.getLength() >> coder;
-    StringBuffer buf = new StringBuffer(length);
+    StringBuilder buf = new StringBuilder(length);
     if (coder == 0) {
       // Latin1 encoded
       for (int i = 0; i < length; i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfDataEntry.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfDataEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -352,10 +352,10 @@ public class PerfDataEntry extends VMObject {
         } else { // vector
             if (dataType == BasicType.getTBoolean()) {
                 boolean[] res = booleanArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Boolean.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');
@@ -369,50 +369,50 @@ public class PerfDataEntry extends VMObject {
                                                  StandardCharsets.US_ASCII);
             } else if (dataType == BasicType.getTShort()) {
                 short[] res = shortArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Short.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');
                 str = buf.toString();
             } else if (dataType ==  BasicType.getTInt()) {
                 int[] res = intArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Integer.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');
                 str = buf.toString();
             } else if (dataType == BasicType.getTLong()) {
                 long[] res = longArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Long.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');
                 str = buf.toString();
             } else if (dataType == BasicType.getTFloat()) {
                 float[] res = floatArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Float.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');
                 str = buf.toString();
             } else if (dataType == BasicType.getTDouble()) {
                 double[] res = doubleArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
-                    buf.append(Double.toString(res[i]));
+                    buf.append(res[i]);
                     buf.append(", ");
                 }
                 buf.append(']');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,9 @@ public class VMVersionMismatchException extends RuntimeException {
     }
 
     public String getMessage() {
-        StringBuffer msg = new StringBuffer();
-        msg.append("Supported versions are ");
-        msg.append(supportedVersions);
-        msg.append(". Target VM is ");
-        msg.append(targetVersion);
-        return msg.toString();
+        String msg = "Supported versions are " + supportedVersions +
+                ". Target VM is " + targetVersion;
+        return msg;
     }
 
     public String getSupportedVersions() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -256,19 +256,19 @@ public class PStack extends Tool {
          JavaVFrame vf = jvframes[fCount];
          Frame f = vf.getFrame();
          if (fp.equals(f.getFP())) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             Method method = vf.getMethod();
             // a special char to identify java frames in output
             sb.append("* ");
             sb.append(method.externalNameAndSignature());
-            sb.append(" bci:" + vf.getBCI());
+            sb.append(" bci:").append(vf.getBCI());
             int lineNumber = method.getLineNumberFromBCI(vf.getBCI());
             if (lineNumber != -1) {
-                sb.append(" line:" + lineNumber);
+                sb.append(" line:").append(lineNumber);
             }
 
             if (verbose) {
-               sb.append(" Method*:" + method.getAddress());
+               sb.append(" Method*:").append(method.getAddress());
             }
 
             if (vf.isCompiledFrame()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
@@ -402,7 +402,7 @@ public class AnnotatedMemoryPanel extends JPanel {
   }
 
   private String bigIntToHexString(BigInteger bi) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val = bi.toString(16);
     for (int i = 0; i < ((2 * addressSize) - val.length()); i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -146,7 +146,7 @@ public class MemoryPanel extends JPanel {
         protected Transferable createTransferable(JComponent c) {
           JTable table = (JTable)c;
           if (haveSelection()) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             int iDir = (getRowAnchor() < getRowLead() ? 1 : -1);
             int jDir = (getColAnchor() < getColLead() ? 1 : -1);
 
@@ -553,7 +553,7 @@ public class MemoryPanel extends JPanel {
   }
 
   private String bigIntToHexString(BigInteger bi) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val = bi.toString(16);
     for (int i = 0; i < ((2 * addressSize) - val.length()); i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SAEditorPane.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SAEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class SAEditorPane extends JEditorPane {
    */
 
   public String getSelectedText() {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     Document doc = getDocument();
 
     int start = getSelectionStart();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SourceCodePanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SourceCodePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,7 +219,7 @@ public class SourceCodePanel extends JPanel {
       this.filename = filename;
       File file = new File(filename);
       int len = (int) file.length();
-      StringBuffer buf = new StringBuffer(len); // Approximation
+      StringBuilder buf = new StringBuilder(len); // Approximation
       char[] tmp = new char[4096];
       FileReader in = new FileReader(file);
       int res = 0;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SysPropsPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SysPropsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class SysPropsPanel extends JPanel {
     }
 
     private String getFlags() {
-       final StringBuffer buf = new StringBuffer();
+       final StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>System Properties</title></head><body>");
        buf.append("<table border='1'>");
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMFlagsPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMFlagsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class VMFlagsPanel extends JPanel {
 
     private String getFlags() {
        VM.Flag[] flags = VM.getVM().getCommandLineFlags();
-       StringBuffer buf = new StringBuffer();
+       StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>VM Command Line Flags</title></head><body>");
        if (flags == null) {
           buf.append("<b>Command Flag info not available (use 1.4.1_03 or later)!</b>");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMVersionInfoPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMVersionInfoPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class VMVersionInfoPanel extends JPanel {
 
     private String getVersionInfo() {
        VM vm = VM.getVM();
-       StringBuffer buf = new StringBuffer();
+       StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>VM Version Info</title></head>");
        buf.append("<body><table border='1'>");
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -883,10 +883,8 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
    }
 
    protected String genMultPCHref(String pcs) {
-      StringBuffer buf = new StringBuffer(genBaseHref());
-      buf.append("pc_multiple=");
-      buf.append(pcs);
-      return buf.toString();
+      String buf = genBaseHref() + "pc_multiple=" + pcs;
+      return buf;
    }
 
    protected String genPCHref(Address addr) {
@@ -1542,7 +1540,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
    }
 
    protected String genDumpKlassesHref(InstanceKlass[] klasses) {
-      StringBuffer buf = new StringBuffer(genBaseHref());
+      StringBuilder buf = new StringBuilder(genBaseHref());
       buf.append("jcore_multiple=");
       for (int k = 0; k < klasses.length; k++) {
          buf.append(klasses[k].getAddress().toString());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapGXLWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapGXLWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,7 +286,7 @@ public class HeapGXLWriter extends AbstractHeapGraphWriter {
     // escapes XML meta-characters and illegal characters
     private static String escapeXMLChars(String s) {
         // FIXME: is there a better way or API?
-        StringBuffer result = null;
+        StringBuilder result = null;
         for(int i = 0, max = s.length(), delta = 0; i < max; i++) {
             char c = s.charAt(i);
             String replacement = null;
@@ -311,7 +311,7 @@ public class HeapGXLWriter extends AbstractHeapGraphWriter {
 
             if (replacement != null) {
                 if (result == null) {
-                    result = new StringBuffer(s);
+                    result = new StringBuilder(s);
                 }
                 result.replace(i + delta, i + delta + 1, replacement);
                 delta += (replacement.length() - 1);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -774,7 +774,7 @@ public class ObjectReader {
       }
 
       protected String getClassName(int begin, int end) {
-         StringBuffer buf = new StringBuffer();
+         StringBuilder buf = new StringBuilder();
          for (int i = begin; i < end; i++) {
             char c = (char) (_signature.getByteAt(i) & 0xFF);
             if (c == '/') {


### PR DESCRIPTION
Found by IntelliJ IDEA inspection `Java | Java language level migration aids | Java 5 | 'StringBuffer' may be 'StringBuilder'`
As suggested in https://github.com/openjdk/jdk/pull/1507#issuecomment-757369003 I've created separate PR for module `jdk.hotspot.agent`
Similar cleanups in the past: https://bugs.openjdk.java.net/browse/JDK-8041679 https://bugs.openjdk.java.net/browse/JDK-8264029