### PR TITLE
8264466: Cut-paste error in InterfaceCalls JMH

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
@@ -260,7 +260,7 @@ public class InterfaceCalls {
     /** Interface call with five different receivers. */
     @Benchmark
     public void testCallPoly5(Blackhole bh) {
-        for (int kk = 0; kk < 3; kk++) {
+        for (int kk = 0; kk < 5; kk++) {
             bh.consume(as[kk].getInt());
         }
     }


### PR DESCRIPTION
I think this typo may have always been there. There is a perf difference between 3 and 5 so it's worth fixing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264466](https://bugs.openjdk.java.net/browse/JDK-8264466): Cut-paste error in InterfaceCalls JMH


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3276/head:pull/3276` \
`$ git checkout pull/3276`

Update a local copy of the PR: \
`$ git checkout pull/3276` \
`$ git pull https://git.openjdk.java.net/jdk pull/3276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3276`

View PR using the GUI difftool: \
`$ git pr show -t 3276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3276.diff">https://git.openjdk.java.net/jdk/pull/3276.diff</a>

</details>
