### PR TITLE
8264150: CDS dumping code calls TRAPS functions in VM thread

### DIFF
--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -1032,6 +1032,10 @@ static void create_default_methods(InstanceKlass* klass,
   Method::sort_methods(total_default_methods, /*set_idnums=*/false);
 
   klass->set_default_methods(total_default_methods);
+  // Create an array for mapping default methods to their vtable indices in
+  // this class, since default methods vtable indices are the indices for
+  // the defining class.
+  klass->create_new_default_vtable_indices(new_size, CHECK);
 }
 
 static void sort_methods(GrowableArray<Method*>* methods) {

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -173,6 +173,7 @@ void MemAllocator::Allocation::check_for_valid_allocation_state() const {
   assert(!_thread->has_pending_exception(),
          "shouldn't be allocating with pending exception");
   // Allocation of an oop can always invoke a safepoint.
+  assert(_thread->is_Java_thread(), "non Java threads shouldn't allocate on the Heap");
   _thread->check_for_valid_safepoint_state();
 }
 #endif

--- a/src/hotspot/share/memory/dynamicArchive.cpp
+++ b/src/hotspot/share/memory/dynamicArchive.cpp
@@ -253,8 +253,8 @@ void DynamicArchiveBuilder::sort_methods(InstanceKlass* ik) const {
   if (ik->default_methods() != NULL) {
     Method::sort_methods(ik->default_methods(), /*set_idnums=*/false, dynamic_dump_method_comparator);
   }
-  ik->vtable().initialize_vtable(true, THREAD); assert(!HAS_PENDING_EXCEPTION, "cannot fail");
-  ik->itable().initialize_itable(true, THREAD); assert(!HAS_PENDING_EXCEPTION, "cannot fail");
+  ik->vtable().initialize_vtable();
+  ik->itable().initialize_itable();
 
   // Set all the pointer marking bits after sorting.
   remark_pointers_for_instance_klass(ik, true);

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -172,9 +172,6 @@ class Universe: AllStatic {
   static void initialize_basic_type_mirrors(TRAPS);
   static void fixup_mirrors(TRAPS);
 
-  static void reinitialize_vtable_of(Klass* k, TRAPS);
-  static void reinitialize_vtables(TRAPS);
-  static void reinitialize_itables(TRAPS);
   static void compute_base_vtable_size();             // compute vtable size of class Object
 
   static void genesis(TRAPS);                         // Create the initial world

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -103,7 +103,7 @@ ArrayKlass::ArrayKlass(Symbol* name, KlassID id) :
 // since a GC can happen. At this point all instance variables of the ArrayKlass must be setup.
 void ArrayKlass::complete_create_array_klass(ArrayKlass* k, Klass* super_klass, ModuleEntry* module_entry, TRAPS) {
   k->initialize_supers(super_klass, NULL, CHECK);
-  k->vtable().initialize_vtable(false, CHECK);
+  k->vtable().initialize_vtable();
 
   // During bootstrapping, before java.base is defined, the module_entry may not be present yet.
   // These classes will be put on a fixup list and their module fields will be patched once

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -988,8 +988,8 @@ bool InstanceKlass::link_class_impl(TRAPS) {
         need_init_table = false;
       }
       if (need_init_table) {
-        vtable().initialize_vtable(true, CHECK_false);
-        itable().initialize_itable(true, CHECK_false);
+        vtable().initialize_vtable_and_check_constraints(CHECK_false);
+        itable().initialize_itable_and_check_constraints(CHECK_false);
       }
 #ifdef ASSERT
       vtable().verify(tty, true);
@@ -2599,8 +2599,8 @@ void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handl
     // have been redefined.
     bool trace_name_printed = false;
     adjust_default_methods(&trace_name_printed);
-    vtable().initialize_vtable(false, CHECK);
-    itable().initialize_itable(false, CHECK);
+    vtable().initialize_vtable();
+    itable().initialize_itable();
   }
 #endif
 

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -48,6 +48,8 @@ class klassVtable {
   int          _verify_count;     // to make verify faster
 #endif
 
+  void check_constraints(GrowableArray<InstanceKlass*>* supers, TRAPS);
+
  public:
   klassVtable(Klass* klass, void* base, int length) : _klass(klass) {
     _tableOffset = (address)base - (address)klass; _length = length;
@@ -63,7 +65,9 @@ class klassVtable {
   // searching; all methods return -1 if not found
   int index_of_miranda(Symbol* name, Symbol* signature);
 
-  void initialize_vtable(bool checkconstraints, TRAPS);   // initialize vtable of a new klass
+  // initialize vtable of a new klass
+  void initialize_vtable(GrowableArray<InstanceKlass*>* supers = NULL);
+  void initialize_vtable_and_check_constraints(TRAPS);
 
   // computes vtable length (in words) and the number of miranda methods
   static void compute_vtable_size_and_num_mirandas(int* vtable_length,
@@ -115,10 +119,11 @@ class klassVtable {
                                      AccessFlags access_flags,
                                      u2 major_version);
 
-  bool update_inherited_vtable(const methodHandle& target_method,
+  bool update_inherited_vtable(Thread* current,
+                               const methodHandle& target_method,
                                int super_vtable_len,
                                int default_index,
-                               bool checkconstraints, TRAPS);
+                               GrowableArray<InstanceKlass*>* supers);
  InstanceKlass* find_transitive_override(InstanceKlass* initialsuper,
                                          const methodHandle& target_method, int vtable_index,
                                          Handle target_loader, Symbol* target_classname);
@@ -278,7 +283,9 @@ class klassItable {
   int                  _size_offset_table; // size of offset table (in itableOffset entries)
   int                  _size_method_table; // size of methodtable (in itableMethodEntry entries)
 
-  void initialize_itable_for_interface(int method_table_offset, InstanceKlass* interf_h, bool checkconstraints, TRAPS);
+  void initialize_itable_for_interface(int method_table_offset, InstanceKlass* interf_h,
+                                       GrowableArray<Method*>* supers, int start_offset);
+  void check_constraints(GrowableArray<Method*>* supers, TRAPS);
  public:
   klassItable(InstanceKlass* klass);
 
@@ -291,7 +298,8 @@ class klassItable {
   int size_offset_table()                { return _size_offset_table; }
 
   // Initialization
-  void initialize_itable(bool checkconstraints, TRAPS);
+  void initialize_itable_and_check_constraints(TRAPS);
+  void initialize_itable(GrowableArray<Method*>* supers = NULL);
 
 #if INCLUDE_JVMTI
   // RedefineClasses() API support:
@@ -306,7 +314,7 @@ class klassItable {
 #endif // INCLUDE_JVMTI
 
   // Setup of itable
-  static int assign_itable_indices_for_interface(Thread* current, InstanceKlass* klass);
+  static int assign_itable_indices_for_interface(InstanceKlass* klass);
   static int method_count_for_interface(InstanceKlass* klass);
   static int compute_itable_size(Array<InstanceKlass*>* transitive_interfaces);
   static void setup_itable_offset_table(InstanceKlass* klass);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4370,9 +4370,8 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
   // compare_and_normalize_class_versions has already checked:
   //  - classloaders unchanged, signatures unchanged
   //  - all instanceKlasses for redefined classes reused & contents updated
-  the_class->vtable().initialize_vtable(false, THREAD);
-  the_class->itable().initialize_itable(false, THREAD);
-  assert(!HAS_PENDING_EXCEPTION || (THREAD->pending_exception()->is_a(vmClasses::ThreadDeath_klass())), "redefine exception");
+  the_class->vtable().initialize_vtable();
+  the_class->itable().initialize_itable();
 
   // Leave arrays of jmethodIDs and itable index cache unchanged
 


### PR DESCRIPTION
This change initializes the vtables/itables without checking constraints.  After initializing but before the class is visible in the SystemDictionary, constraints are checked in a separate loop.

Tested with tier1-6 which includes jck tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264150](https://bugs.openjdk.java.net/browse/JDK-8264150): CDS dumping code calls TRAPS functions in VM thread


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3277/head:pull/3277` \
`$ git checkout pull/3277`

Update a local copy of the PR: \
`$ git checkout pull/3277` \
`$ git pull https://git.openjdk.java.net/jdk pull/3277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3277`

View PR using the GUI difftool: \
`$ git pr show -t 3277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3277.diff">https://git.openjdk.java.net/jdk/pull/3277.diff</a>

</details>
