### PR TITLE
8264400: (fs) WindowsFileStore equality depends on how the FileStore was constructed

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,7 +232,15 @@ class WindowsFileStore
         if (!(ob instanceof WindowsFileStore))
             return false;
         WindowsFileStore other = (WindowsFileStore)ob;
-        return root.equals(other.root);
+        if (root.equals(other.root))
+            return true;
+        if (root.equalsIgnoreCase(other.root)) {
+             VolumeInformation otherInfo = other.volumeInformation();
+            return volInfo.volumeName().equals(otherInfo.volumeName()) &&
+                volInfo.fileSystemName().equals(otherInfo.fileSystemName()) &&
+                volInfo.volumeSerialNumber() == otherInfo.volumeSerialNumber();
+        }
+        return false;
     }
 
     @Override

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -52,7 +52,7 @@ class WindowsFileStore
     private final int volType;
     private final String displayName;   // returned by toString
 
-    private int hashCode = 0;
+    private int hashCode;
 
     private WindowsFileStore(String root) throws WindowsException {
         assert root.charAt(root.length()-1) == '\\';

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -231,27 +231,27 @@ class WindowsFileStore
         if (name.equals("owner"))
             return supportsFileAttributeView(FileOwnerAttributeView.class);
         if (name.equals("user"))
-            return supportsFileAttributeView(UserDefinedFileAttributeView.class); return false;
+            return supportsFileAttributeView(UserDefinedFileAttributeView.class);
+        return false;
     }
 
     @Override
     public boolean equals(Object ob) {
         if (ob == this)
             return true;
-        if (!(ob instanceof WindowsFileStore))
-            return false;
-        WindowsFileStore other = (WindowsFileStore)ob;
-        if (root.equals(other.root))
-            return true;
-        if (volType == DRIVE_FIXED && other.volumeType() == DRIVE_FIXED)
-            return root.equalsIgnoreCase(other.root);
+        if (ob instanceof WindowsFileStore other) {
+            if (root.equals(other.root))
+                return true;
+            if (volType == DRIVE_FIXED && other.volumeType() == DRIVE_FIXED)
+                return root.equalsIgnoreCase(other.root);
+        }
         return false;
     }
 
     @Override
     public int hashCode() {
         if (hashCode == 0) { // Don't care about race
-            hashCode = volType == DRIVE_FIXED ?
+            hashCode = (volType == DRIVE_FIXED) ?
                 root.toLowerCase(Locale.ROOT).hashCode() : root.hashCode();
         }
         return hashCode;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -52,8 +52,7 @@ class WindowsFileStore
     private final int volType;
     private final String displayName;   // returned by toString
 
-    private boolean hasHashCode = false; // as hashCode can be any int
-    private int hashCode;
+    private int hashCode = 0;
 
     private WindowsFileStore(String root) throws WindowsException {
         assert root.charAt(root.length()-1) == '\\';
@@ -251,10 +250,9 @@ class WindowsFileStore
 
     @Override
     public int hashCode() {
-        if (!hasHashCode) { // Don't care about race
+        if (hashCode == 0) { // Don't care about race
             hashCode = volType == DRIVE_FIXED ?
                 root.toLowerCase(Locale.ROOT).hashCode() : root.hashCode();
-            hasHashCode = true;
         }
         return hashCode;
     }

--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6873621 6979526 7006126 7020517
+ * @bug 4313887 6873621 6979526 7006126 7020517 8264400
  * @summary Unit test for java.nio.file.FileStore
  * @key intermittent
  * @library .. /test/lib
@@ -36,8 +36,8 @@ import java.nio.file.attribute.*;
 import java.io.File;
 import java.io.IOException;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.util.FileUtils;
-
 
 public class Basic {
 
@@ -79,6 +79,16 @@ public class Basic {
         assertTrue(store1.equals(store2));
         assertTrue(store2.equals(store1));
         assertTrue(store1.hashCode() == store2.hashCode());
+
+        if (Platform.isWindows()) {
+            /**
+             * Test: FileStore.equals() should not be case sensitive
+             */
+            FileSystem fs = FileSystems.getDefault();
+            FileStore upper = Files.getFileStore(fs.getPath("C:\\"));
+            FileStore lower = Files.getFileStore(fs.getPath("c:\\"));
+            assertTrue(lower.equals(upper));
+        }
 
         /**
          * Test: File and FileStore attributes

--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -84,7 +84,6 @@ public class Basic {
             /**
              * Test: FileStore.equals() should not be case sensitive
              */
-            FileSystem fs = FileSystems.getDefault();
             FileStore upper = Files.getFileStore(Path.of("C:\\"));
             FileStore lower = Files.getFileStore(Path.of("c:\\"));
             assertTrue(lower.equals(upper));

--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ public class Basic {
              * Test: FileStore.equals() should not be case sensitive
              */
             FileSystem fs = FileSystems.getDefault();
-            FileStore upper = Files.getFileStore(fs.getPath("C:\\"));
-            FileStore lower = Files.getFileStore(fs.getPath("c:\\"));
+            FileStore upper = Files.getFileStore(Path.of("C:\\"));
+            FileStore lower = Files.getFileStore(Path.of("c:\\"));
             assertTrue(lower.equals(upper));
         }
 


### PR DESCRIPTION
Please consider this change to make `sun.nio.fs.WindowsFileStore.equals()` return `true` if the root strings of the two objects are equal under case insensitive comparison, and the two `WindowsFileStore`s have the same volume information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264400](https://bugs.openjdk.java.net/browse/JDK-8264400): (fs) WindowsFileStore equality depends on how the FileStore was constructed


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to e1d7b21a15b08534ad4b0ed0453b08f750f3babb


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3279/head:pull/3279` \
`$ git checkout pull/3279`

Update a local copy of the PR: \
`$ git checkout pull/3279` \
`$ git pull https://git.openjdk.java.net/jdk pull/3279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3279`

View PR using the GUI difftool: \
`$ git pr show -t 3279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3279.diff">https://git.openjdk.java.net/jdk/pull/3279.diff</a>

</details>
