### PR TITLE
8264482: container info misleads on non-container environment

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     virtual char * cpu_cpuset_cpus() = 0;
     virtual char * cpu_cpuset_memory_nodes() = 0;
     virtual jlong read_memory_limit_in_bytes() = 0;
-    virtual const char * container_type() = 0;
+    virtual const char * resource_controller_type() = 0;
     virtual CachingCgroupController* memory_controller() = 0;
     virtual CachingCgroupController* cpu_controller() = 0;
 };

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
 
     int cpu_shares();
 
-    const char * container_type() {
+    const char * resource_controller_type() {
       return "cgroupv1";
     }
     CachingCgroupController * memory_controller() { return _memory; }

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2021, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     jlong memory_max_usage_in_bytes();
     char * cpu_cpuset_cpus();
     char * cpu_cpuset_memory_nodes();
-    const char * container_type() {
+    const char * resource_controller_type() {
       return "cgroupv2";
     }
     CachingCgroupController * memory_controller() { return _memory; }

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
 
 bool  OSContainer::_is_initialized   = false;
 bool  OSContainer::_is_containerized = false;
+const char * OSContainer::_runtime = NULL;
 CgroupSubsystem* cgroup_subsystem;
 
 /* init
@@ -48,6 +49,7 @@ void OSContainer::init() {
 
   _is_initialized = true;
   _is_containerized = false;
+  _runtime = NULL;
 
   log_trace(os, container)("OSContainer::init: Initializing Container Support");
   if (!UseContainerSupport) {
@@ -68,6 +70,29 @@ void OSContainer::init() {
 
   _is_containerized = true;
 
+  if (getpid() == 1) {
+    // This process is in container
+    _runtime = os::strdup_check_oom(getenv("container"));
+  } else {
+    // This process might be child of container process.
+    // So we check environment variable in PID 1.
+    int env_fd = open("/proc/1/environ", O_RDONLY);
+    if (env_fd != -1) {
+      const int buf_sz = 8192;
+      char buf[buf_sz];
+      int read_sz = read(env_fd, buf, buf_sz);
+      close(env_fd);
+      if (read_sz > 0) {
+        buf[read_sz - 1] = '\0';
+        const char *envname = "container=";
+        char *container_env = (char *)memmem(buf, read_sz, envname, strlen(envname));
+        if (container_env != NULL) {
+          _runtime = os::strdup_check_oom(container_env + strlen(envname));
+        }
+      }
+    }
+  }
+  log_info(os, container)("Container runtime: %s", _runtime == NULL ? "none" : _runtime);
 }
 
 const char * OSContainer::container_type() {

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,9 +70,9 @@ void OSContainer::init() {
 
 }
 
-const char * OSContainer::container_type() {
+const char * OSContainer::resource_controller_type() {
   assert(cgroup_subsystem != NULL, "cgroup subsystem not available");
-  return cgroup_subsystem->container_type();
+  return cgroup_subsystem->resource_controller_type();
 }
 
 jlong OSContainer::memory_limit_in_bytes() {

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,12 +40,10 @@ class OSContainer: AllStatic {
   static bool   _is_initialized;
   static bool   _is_containerized;
   static int    _active_processor_count;
-  static const char * _runtime;
 
  public:
   static void init();
   static inline bool is_containerized();
-  static inline const char * runtime();
   static const char * container_type();
 
   static jlong memory_limit_in_bytes();
@@ -68,10 +66,6 @@ class OSContainer: AllStatic {
 
 inline bool OSContainer::is_containerized() {
   return _is_containerized;
-}
-
-inline const char * OSContainer::runtime() {
-  return _runtime;
 }
 
 #endif // OS_LINUX_OSCONTAINER_LINUX_HPP

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,12 @@ class OSContainer: AllStatic {
   static bool   _is_initialized;
   static bool   _is_containerized;
   static int    _active_processor_count;
+  static const char * _runtime;
 
  public:
   static void init();
   static inline bool is_containerized();
+  static inline const char * runtime();
   static const char * container_type();
 
   static jlong memory_limit_in_bytes();
@@ -66,6 +68,10 @@ class OSContainer: AllStatic {
 
 inline bool OSContainer::is_containerized() {
   return _is_containerized;
+}
+
+inline const char * OSContainer::runtime() {
+  return _runtime;
 }
 
 #endif // OS_LINUX_OSCONTAINER_LINUX_HPP

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ class OSContainer: AllStatic {
  public:
   static void init();
   static inline bool is_containerized();
-  static const char * container_type();
+  static const char * resource_controller_type();
 
   static jlong memory_limit_in_bytes();
   static jlong memory_and_swap_limit_in_bytes();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -197,15 +197,18 @@ julong os::Linux::available_memory() {
   if (OSContainer::is_containerized()) {
     jlong mem_limit, mem_usage;
     if ((mem_limit = OSContainer::memory_limit_in_bytes()) < 1) {
-      log_debug(os, container)("cgroup memory limit %s: " JLONG_FORMAT ", using host value",
+      log_debug(os, container)("%s memory limit %s: " JLONG_FORMAT ", using host value",
+                             OSContainer::resource_controller_type(),
                              mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
     }
     if (mem_limit > 0 && (mem_usage = OSContainer::memory_usage_in_bytes()) < 1) {
-      log_debug(os, container)("cgroup memory usage failed: " JLONG_FORMAT ", using host value", mem_usage);
+      log_debug(os, container)("%s memory usage failed: " JLONG_FORMAT ", using host value",
+                             OSContainer::resource_controller_type(), mem_usage);
     }
     if (mem_limit > 0 && mem_usage > 0 ) {
       avail_mem = mem_limit > mem_usage ? (julong)mem_limit - (julong)mem_usage : 0;
-      log_trace(os)("available cgroup memory: " JULONG_FORMAT, avail_mem);
+      log_trace(os)("available %s memory: " JULONG_FORMAT,
+                             OSContainer::resource_controller_type(), avail_mem);
       return avail_mem;
     }
   }
@@ -221,10 +224,12 @@ julong os::physical_memory() {
   if (OSContainer::is_containerized()) {
     jlong mem_limit;
     if ((mem_limit = OSContainer::memory_limit_in_bytes()) > 0) {
-      log_trace(os)("total cgroup memory: " JLONG_FORMAT, mem_limit);
+      log_trace(os)("total %s memory: " JLONG_FORMAT,
+                             OSContainer::resource_controller_type(), mem_limit);
       return mem_limit;
     }
-    log_debug(os, container)("cgroup memory limit %s: " JLONG_FORMAT ", using host value",
+    log_debug(os, container)("%s memory limit %s: " JLONG_FORMAT ", using host value",
+                            OSContainer::resource_controller_type(),
                             mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
   }
 
@@ -2219,10 +2224,7 @@ bool os::Linux::print_container_info(outputStream* st) {
     return false;
   }
 
-  st->print_cr("cgroup information:");
-
-  const char *p_ct = OSContainer::container_type();
-  st->print_cr("cgroup_type: %s", p_ct != NULL ? p_ct : "not supported");
+  st->print_cr("%s information:", OSContainer::resource_controller_type());
 
   char *p = OSContainer::cpu_cpuset_cpus();
   st->print_cr("cpu_cpuset_cpus: %s", p != NULL ? p : "not supported");

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2221,11 +2221,8 @@ bool os::Linux::print_container_info(outputStream* st) {
 
   st->print_cr("cgroup information:");
 
-  const char *cp = OSContainer::container_type();
-  st->print_cr("cgroup_type: %s", cp != NULL ? cp : "not supported");
-
-  cp = OSContainer::runtime();
-  st->print_cr("container runtime: %s", cp != NULL ? cp : "none");
+  const char *p_ct = OSContainer::container_type();
+  st->print_cr("cgroup_type: %s", p_ct != NULL ? p_ct : "not supported");
 
   char *p = OSContainer::cpu_cpuset_cpus();
   st->print_cr("cpu_cpuset_cpus: %s", p != NULL ? p : "not supported");

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -197,15 +197,15 @@ julong os::Linux::available_memory() {
   if (OSContainer::is_containerized()) {
     jlong mem_limit, mem_usage;
     if ((mem_limit = OSContainer::memory_limit_in_bytes()) < 1) {
-      log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value",
+      log_debug(os, container)("cgroup memory limit %s: " JLONG_FORMAT ", using host value",
                              mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
     }
     if (mem_limit > 0 && (mem_usage = OSContainer::memory_usage_in_bytes()) < 1) {
-      log_debug(os, container)("container memory usage failed: " JLONG_FORMAT ", using host value", mem_usage);
+      log_debug(os, container)("cgroup memory usage failed: " JLONG_FORMAT ", using host value", mem_usage);
     }
     if (mem_limit > 0 && mem_usage > 0 ) {
       avail_mem = mem_limit > mem_usage ? (julong)mem_limit - (julong)mem_usage : 0;
-      log_trace(os)("available container memory: " JULONG_FORMAT, avail_mem);
+      log_trace(os)("available cgroup memory: " JULONG_FORMAT, avail_mem);
       return avail_mem;
     }
   }
@@ -221,10 +221,10 @@ julong os::physical_memory() {
   if (OSContainer::is_containerized()) {
     jlong mem_limit;
     if ((mem_limit = OSContainer::memory_limit_in_bytes()) > 0) {
-      log_trace(os)("total container memory: " JLONG_FORMAT, mem_limit);
+      log_trace(os)("total cgroup memory: " JLONG_FORMAT, mem_limit);
       return mem_limit;
     }
-    log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value",
+    log_debug(os, container)("cgroup memory limit %s: " JLONG_FORMAT ", using host value",
                             mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
   }
 
@@ -2219,10 +2219,13 @@ bool os::Linux::print_container_info(outputStream* st) {
     return false;
   }
 
-  st->print_cr("container (cgroup) information:");
+  st->print_cr("cgroup information:");
 
-  const char *p_ct = OSContainer::container_type();
-  st->print_cr("container_type: %s", p_ct != NULL ? p_ct : "not supported");
+  const char *cp = OSContainer::container_type();
+  st->print_cr("cgroup_type: %s", cp != NULL ? cp : "not supported");
+
+  cp = OSContainer::runtime();
+  st->print_cr("container runtime: %s", cp != NULL ? cp : "none");
 
   char *p = OSContainer::cpu_cpuset_cpus();
   st->print_cr("cpu_cpuset_cpus: %s", p != NULL ? p : "not supported");


### PR DESCRIPTION
hs_err log and `VM.info` dcmd shows cgroup information as container information even though the process run on non-container environment as following.

```
container (cgroup) information:
container_type: cgroupv2
cpu_cpuset_cpus: not supported
cpu_memory_nodes: not supported
active_processor_count: 4
cpu_quota: not supported
cpu_period: not supported
cpu_shares: not supported
memory_limit_in_bytes: unlimited
memory_and_swap_limit_in_bytes: unlimited
memory_soft_limit_in_bytes: unlimited
memory_usage_in_bytes: 164163584
memory_max_usage_in_bytes: not supported
```

We can use cgroup outside of container, so it is useful to show. However cgroup is different from container. We should distinguish them.
And also it is useful if we can see container runtime in this section. So I added it. We can see following contents in this section after this change.

```
cgroup information:
cgroup_type: cgroupv2
container runtime: podman
cpu_cpuset_cpus: not supported
cpu_memory_nodes: not supported
active_processor_count: 4
cpu_quota: not supported
cpu_period: not supported
cpu_shares: not supported
memory_limit_in_bytes: unlimited
memory_and_swap_limit_in_bytes: unlimited
memory_soft_limit_in_bytes: unlimited
memory_usage_in_bytes: 256176128
memory_max_usage_in_bytes: not supported
```

In case of systemd, it checks PID (PID 1 or not) and `$container` in PID 1. We should check them to know the JVM runs on the container or not.

https://github.com/systemd/systemd/blob/68337e55f62cf49b7bdfb73dc5662e23b0ea17fa/src/basic/virt.c#L619

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264482](https://bugs.openjdk.java.net/browse/JDK-8264482): container info misleads on non-container environment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3280/head:pull/3280` \
`$ git checkout pull/3280`

Update a local copy of the PR: \
`$ git checkout pull/3280` \
`$ git pull https://git.openjdk.java.net/jdk pull/3280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3280`

View PR using the GUI difftool: \
`$ git pr show -t 3280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3280.diff">https://git.openjdk.java.net/jdk/pull/3280.diff</a>

</details>
