### PR TITLE
8264489: Add more logging to LargeCopyWithMark.java

### DIFF
--- a/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
+++ b/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
@@ -26,7 +26,9 @@
  * @requires (sun.arch.data.model == "64"  & os.maxMemory > 4g)
  * @summary BufferedInputStream calculates negative array size with large
  *          streams and mark
- * @run main/othervm -Xmx4G -Xlog:gc,gc+heap,gc+ergo+heap -XX:+CrashOnOutOfMemoryError -XX:+IgnoreUnrecognizedVMOptions -XX:+G1ExitOnExpansionFailure LargeCopyWithMark
+ * @run main/othervm -Xmx4G -Xlog:gc,gc+heap,gc+ergo+heap -XX:+CrashOnOutOfMemoryError
+                     -XX:+IgnoreUnrecognizedVMOptions -XX:+G1ExitOnExpansionFailure
+                     LargeCopyWithMark
  */
 
 import java.io.BufferedInputStream;

--- a/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
+++ b/test/jdk/java/io/BufferedInputStream/LargeCopyWithMark.java
@@ -26,7 +26,7 @@
  * @requires (sun.arch.data.model == "64"  & os.maxMemory > 4g)
  * @summary BufferedInputStream calculates negative array size with large
  *          streams and mark
- * @run main/othervm -Xmx4G LargeCopyWithMark
+ * @run main/othervm -Xmx4G -Xlog:gc,gc+heap,gc+ergo+heap -XX:+CrashOnOutOfMemoryError -XX:+IgnoreUnrecognizedVMOptions -XX:+G1ExitOnExpansionFailure LargeCopyWithMark
  */
 
 import java.io.BufferedInputStream;


### PR DESCRIPTION
Add more logging to the LargeCopyWithMark.java test, to gather more information when this test fails with OOME. 

The intention is to gather more info for JDK-8239089.

I consider this patch trivial, and expect to push it after I've gotten one Review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264489](https://bugs.openjdk.java.net/browse/JDK-8264489): Add more logging to LargeCopyWithMark.java


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to a7260c86c02349125f010d3f7fd99f1407a3e691
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3282/head:pull/3282` \
`$ git checkout pull/3282`

Update a local copy of the PR: \
`$ git checkout pull/3282` \
`$ git pull https://git.openjdk.java.net/jdk pull/3282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3282`

View PR using the GUI difftool: \
`$ git pr show -t 3282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3282.diff">https://git.openjdk.java.net/jdk/pull/3282.diff</a>

</details>
