### PR TITLE
8264475: CopyArea ignores clip state in metal rendering pipeline

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -818,7 +818,7 @@ MTLBlitLoops_CopyArea(JNIEnv *env,
              * We need to consider common states like clipping while
              * performing copyArea, thats why we need to query encoder with
              * appropriate state from EncoderManager and not use
-             * direct MTLBlitCommandEncoder for texture mapping.
+             * direct MTLBlitCommandEncoder for texture copy.
              */
 
             id<MTLRenderCommandEncoder> interEncoder =

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -814,6 +814,13 @@ MTLBlitLoops_CopyArea(JNIEnv *env,
 
             id<MTLTexture> interTexture = interHandle.texture;
 
+            /*
+             * We need to consider common states like clipping while
+             * performing copyArea, thats why we need to query encoder with
+             * appropriate state from EncoderManager and not use
+             * direct MTLBlitCommandEncoder for texture mapping.
+             */
+
             id<MTLRenderCommandEncoder> interEncoder =
                 [mtlc.encoderManager getTextureEncoder:interTexture
                                            isSrcOpaque:dstOps->isOpaque

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTexurePool.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTexurePool.m
@@ -202,6 +202,8 @@
                                                                width:(NSUInteger) width
                                                               height:(NSUInteger) height
                                                            mipmapped:NO];
+    textureDescriptor.usage = MTLTextureUsageRenderTarget |
+        MTLTextureUsageShaderRead;
     if (isMultiSample) {
         textureDescriptor.textureType = MTLTextureType2DMultisample;
         textureDescriptor.sampleCount = MTLAASampleCount;


### PR DESCRIPTION
In MTLBlitLoops.copyArea() we use standalone encoder which has no clip state information because of which we ignore clip parameters set in rect clip and shape clip. We need to query and use encoders from EncoderManager to honour clip states in copyArea.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8264475](https://bugs.openjdk.java.net/browse/JDK-8264475): CopyArea ignores clip state in metal rendering pipeline
 * [JDK-8251036](https://bugs.openjdk.java.net/browse/JDK-8251036): SwingSet2 - Dragging internal frame inside jframe leaves artifacts with MetalLookAndFeel


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer) ⚠️ Review applies to 9b4a90ab8eb72c1074b82e49b2b4f8e96c08ac8a
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3283/head:pull/3283` \
`$ git checkout pull/3283`

Update a local copy of the PR: \
`$ git checkout pull/3283` \
`$ git pull https://git.openjdk.java.net/jdk pull/3283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3283`

View PR using the GUI difftool: \
`$ git pr show -t 3283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3283.diff">https://git.openjdk.java.net/jdk/pull/3283.diff</a>

</details>
