### PR TITLE
8264502: (fc) FileDispatcherImpl.setDirect0 might return uninitialized variable on some platforms

### DIFF
--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -375,7 +375,7 @@ Java_sun_nio_ch_FileDispatcherImpl_setDirect0(JNIEnv *env, jclass clazz,
         result = (int)file_stat.f_frsize;
     }
 #else
-    result == -1;
+    result = -1;
 #endif
     return result;
 }


### PR DESCRIPTION
Hi,

please review this small patch which fixes a possible return of an uninitialized variable.

Thanks,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264502](https://bugs.openjdk.java.net/browse/JDK-8264502): (fc) FileDispatcherImpl.setDirect0 might return uninitialized variable on some platforms


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to e6a4cf9dc5b8366ada0f80a4beb6f4e97483c422
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3284/head:pull/3284` \
`$ git checkout pull/3284`

Update a local copy of the PR: \
`$ git checkout pull/3284` \
`$ git pull https://git.openjdk.java.net/jdk pull/3284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3284`

View PR using the GUI difftool: \
`$ git pr show -t 3284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3284.diff">https://git.openjdk.java.net/jdk/pull/3284.diff</a>

</details>
