### PR TITLE
8264524: jdk/internal/platform/docker/TestDockerMemoryMetrics.java fails due to swapping not working

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,10 +91,6 @@ public class MetricsMemoryTester {
                     break;
                 }
             }
-
-            // We are not killed by the OOM killer.
-            System.out.println("Not OOM killed");
-
             if (!atLeastOneAllocationWorked) {
                 System.out.println("Allocation failed immediately. Ignoring test!");
                 return;

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,6 +91,10 @@ public class MetricsMemoryTester {
                     break;
                 }
             }
+
+            // We are not killed by the OOM killer.
+            System.out.println("Not OOM killed");
+
             if (!atLeastOneAllocationWorked) {
                 System.out.println("Allocation failed immediately. Ignoring test!");
                 return;

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -104,6 +104,8 @@ public class TestDockerMemoryMetrics {
         Common.logNewTestCase("testMemoryFailCount" + value);
 
         // Check whether swapping really works for this test
+        // On some systems there is no swap space enabled. And running
+        // 'java -Xms{mem-limit} -Xmx{mem-limit} -version' would fail due to swap space size being 0.
         DockerRunOptions preOpts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "-version");
         preOpts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,14 @@ public class TestDockerMemoryMetrics {
                 .addJavaOpts("-cp", "/test-classes/")
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
                 .addClassOptions("failcount");
-        DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
+
+        OutputAnalyzer oa = DockerTestUtils.dockerRunJava(opts);
+        String output = oa.getOutput();
+        if (output.contains("Not OOM killed")) {
+            if (!output.contains("Ignoring test")) {
+                oa.shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
+            }
+        }
     }
 
     private static void testMemoryAndSwapLimit(String memory, String memandswap) throws Exception {


### PR DESCRIPTION
Hi all,

jdk/internal/platform/docker/TestDockerMemoryMetrics.java fails on some of our testing platforms.
This is because testMemoryFailCount [1] fails due to OOM killed.
This test fails to avoid OOM killed [2] if memory.failcnt is always 0.

The fix will print "Not OOM killed" if OOM killed doesn't happen.
And also fix another bug if the test get returned here [3].

Testing: 
  - jdk/internal/platform/docker/ hotspot/jtreg/containers on Linux/x64

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java#L80
[2] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java#L87
[3] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java#L96

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264524](https://bugs.openjdk.java.net/browse/JDK-8264524): jdk/internal/platform/docker/TestDockerMemoryMetrics.java fails due to swapping not working


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3286/head:pull/3286` \
`$ git checkout pull/3286`

Update a local copy of the PR: \
`$ git checkout pull/3286` \
`$ git pull https://git.openjdk.java.net/jdk pull/3286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3286`

View PR using the GUI difftool: \
`$ git pr show -t 3286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3286.diff">https://git.openjdk.java.net/jdk/pull/3286.diff</a>

</details>
