### PR TITLE
8264526: javax/swing/text/html/parser/Parser/8078268/bug8078268.java timeout

### DIFF
--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -39,6 +39,7 @@ public class bug8078268 {
     static volatile Exception exception;
 
     public static void main(String[] args) throws Exception {
+        long timeout = 10_000;
         long s = System.currentTimeMillis();
         SwingUtilities.invokeLater(new Runnable() {
             @Override
@@ -53,14 +54,14 @@ public class bug8078268 {
                 }
             }
         });
-        while (!parsingDone && exception == null && System.currentTimeMillis() - s < 5_000) {
+        while (!parsingDone && exception == null && System.currentTimeMillis() - s < timeout) {
             Thread.sleep(200);
         }
         final long took = System.currentTimeMillis() - s;
         if (exception != null) {
             throw exception;
         }
-        if (took > 5_000) {
+        if (took > timeout) {
             throw new RuntimeException("Parsing takes too long.");
         }
     }


### PR DESCRIPTION
Hi all,

I'd like to fix the timeout of javax/swing/text/html/parser/Parser/8078268/bug8078268.java. 
It seems to take about 6~7 seconds to run on some of our testing platforms.
But the timeout of the test is hard-coded as 5 seconds.

The fix just increases the timeout from 5 seconds to 10 seconds.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264526](https://bugs.openjdk.java.net/browse/JDK-8264526): javax/swing/text/html/parser/Parser/8078268/bug8078268.java timeout


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3287/head:pull/3287` \
`$ git checkout pull/3287`

Update a local copy of the PR: \
`$ git checkout pull/3287` \
`$ git pull https://git.openjdk.java.net/jdk pull/3287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3287`

View PR using the GUI difftool: \
`$ git pr show -t 3287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3287.diff">https://git.openjdk.java.net/jdk/pull/3287.diff</a>

</details>
