### PR TITLE
8264538: Rename SystemDictionary::parse_stream

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -121,21 +121,30 @@ class SystemDictionary : AllStatic {
                                               Handle protection_domain,
                                               bool is_superclass,
                                               TRAPS);
+ private:
+  // Parse the stream to create an unsafe anonymous or hidden class.
+  // Used by JVMTI RedefineClasses and by Unsafe_DefineAnonymousClass
+  // and jvm_lookup_define_class.
+  static InstanceKlass* resolve_hidden_class_from_stream(ClassFileStream* st,
+                                                         Symbol* class_name,
+                                                         Handle class_loader,
+                                                         const ClassLoadInfo& cl_info,
+                                                         TRAPS);
 
-  // Parse new stream. This won't update the dictionary or class
-  // hierarchy, simply parse the stream. Used by JVMTI RedefineClasses
-  // and by Unsafe_DefineAnonymousClass and jvm_lookup_define_class.
-  static InstanceKlass* parse_stream(Symbol* class_name,
-                                     Handle class_loader,
-                                     ClassFileStream* st,
-                                     const ClassLoadInfo& cl_info,
-                                     TRAPS);
+  // Resolve a class from stream (called by jni_DefineClass and JVM_DefineClass)
+  // This class is added to the SystemDictionary.
+  static InstanceKlass* resolve_class_from_stream(ClassFileStream* st,
+                                                  Symbol* class_name,
+                                                  Handle class_loader,
+                                                  const ClassLoadInfo& cl_info,
+                                                  TRAPS);
 
-  // Resolve from stream (called by jni_DefineClass and JVM_DefineClass)
-  static InstanceKlass* resolve_from_stream(Symbol* class_name,
+ public:
+  // Resolve either a hidden or normal class from a stream of bytes, based on passed ClassLoadInfo
+  static InstanceKlass* resolve_from_stream(ClassFileStream* st,
+                                            Symbol* class_name,
                                             Handle class_loader,
-                                            Handle protection_domain,
-                                            ClassFileStream* st,
+                                            const ClassLoadInfo& cl_info,
                                             TRAPS);
 
   // Lookup an already loaded class. If not found NULL is returned.

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -123,8 +123,7 @@ class SystemDictionary : AllStatic {
                                               TRAPS);
  private:
   // Parse the stream to create an unsafe anonymous or hidden class.
-  // Used by JVMTI RedefineClasses and by Unsafe_DefineAnonymousClass
-  // and jvm_lookup_define_class.
+  // Used by Unsafe_DefineAnonymousClass and jvm_lookup_define_class.
   static InstanceKlass* resolve_hidden_class_from_stream(ClassFileStream* st,
                                                          Symbol* class_name,
                                                          Handle class_loader,
@@ -140,7 +139,7 @@ class SystemDictionary : AllStatic {
                                                   TRAPS);
 
  public:
-  // Resolve either a hidden or normal class from a stream of bytes, based on passed ClassLoadInfo
+  // Resolve either a hidden or normal class from a stream of bytes, based on ClassLoadInfo
   static InstanceKlass* resolve_from_stream(ClassFileStream* st,
                                             Symbol* class_name,
                                             Handle class_loader,

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -30,6 +30,8 @@
 #include "ci/ciReplay.hpp"
 #include "classfile/altHashing.hpp"
 #include "classfile/classFileStream.hpp"
+#include "classfile/classLoader.hpp"
+#include "classfile/classLoadInfo.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/javaThreadStatus.hpp"
@@ -283,10 +285,11 @@ JNI_ENTRY(jclass, jni_DefineClass(JNIEnv *env, const char *name, jobject loaderR
   ResourceMark rm(THREAD);
   ClassFileStream st((u1*)buf, bufLen, NULL, ClassFileStream::verify);
   Handle class_loader (THREAD, JNIHandles::resolve(loaderRef));
-  Klass* k = SystemDictionary::resolve_from_stream(class_name,
+  Handle protection_domain;
+  ClassLoadInfo cl_info(protection_domain);
+  Klass* k = SystemDictionary::resolve_from_stream(&st, class_name,
                                                    class_loader,
-                                                   Handle(),
-                                                   &st,
+                                                   cl_info,
                                                    CHECK_NULL);
 
   if (log_is_enabled(Debug, class, resolve)) {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -860,10 +860,10 @@ static jclass jvm_define_class_common(const char *name,
   ClassFileStream st((u1*)buf, len, source, ClassFileStream::verify);
   Handle class_loader (THREAD, JNIHandles::resolve(loader));
   Handle protection_domain (THREAD, JNIHandles::resolve(pd));
-  Klass* k = SystemDictionary::resolve_from_stream(class_name,
+  ClassLoadInfo cl_info(protection_domain);
+  Klass* k = SystemDictionary::resolve_from_stream(&st, class_name,
                                                    class_loader,
-                                                   protection_domain,
-                                                   &st,
+                                                   cl_info,
                                                    CHECK_NULL);
 
   if (log_is_enabled(Debug, class, resolve)) {
@@ -947,10 +947,10 @@ static jclass jvm_lookup_define_class(jclass lookup, const char *name,
 
   InstanceKlass* ik = NULL;
   if (!is_hidden) {
-    ik = SystemDictionary::resolve_from_stream(class_name,
+    ClassLoadInfo cl_info(protection_domain);
+    ik = SystemDictionary::resolve_from_stream(&st, class_name,
                                                class_loader,
-                                               protection_domain,
-                                               &st,
+                                               cl_info,
                                                CHECK_NULL);
 
     if (log_is_enabled(Debug, class, resolve)) {
@@ -966,11 +966,10 @@ static jclass jvm_lookup_define_class(jclass lookup, const char *name,
                           is_hidden,
                           is_strong,
                           vm_annotations);
-    ik = SystemDictionary::parse_stream(class_name,
-                                        class_loader,
-                                        &st,
-                                        cl_info,
-                                        CHECK_NULL);
+    ik = SystemDictionary::resolve_from_stream(&st, class_name,
+                                               class_loader,
+                                               cl_info,
+                                               CHECK_NULL);
 
     // The hidden class loader data has been artificially been kept alive to
     // this point. The mirror and any instances of this class have to keep

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1377,7 +1377,6 @@ jvmtiError VM_RedefineClasses::load_new_class_versions() {
                        "__VM_RedefineClasses__",
                        ClassFileStream::verify);
 
-    // Parse the stream.
     // Set redefined class handle in JvmtiThreadState class.
     // This redefined class is sent to agent event handler for class file
     // load hook event.
@@ -1387,6 +1386,8 @@ jvmtiError VM_RedefineClasses::load_new_class_versions() {
     ExceptionMark em(THREAD);
     Handle protection_domain(THREAD, the_class->protection_domain());
     ClassLoadInfo cl_info(protection_domain);
+    // Parse and create a class from the bytes, but this class isn't added
+    // to the dictionary, so do not call resolve_from_stream.
     InstanceKlass* scratch_class = KlassFactory::create_from_stream(&st,
                                                       the_class->name(),
                                                       the_class->class_loader_data(),

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -302,12 +302,6 @@
 //
 // - How do we serialize the RedefineClasses() API without deadlocking?
 //
-// - KlassFactory::create_from_stream() was called with a NULL protection
-//   domain since the initial version. This has been changed to pass
-//   the_class->protection_domain(). This change has been tested with
-//   all NSK tests and nothing broke, but what will adding it now break
-//   in ways that we don't test?
-//
 // - GenerateOopMap::rewrite_load_or_store() has a comment in its
 //   (indirect) use of the Relocator class that the max instruction
 //   size is 4 bytes. goto_w and jsr_w are 5 bytes and wide/iinc is

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -302,7 +302,7 @@
 //
 // - How do we serialize the RedefineClasses() API without deadlocking?
 //
-// - SystemDictionary::parse_stream() was called with a NULL protection
+// - KlassFactory::create_from_stream() was called with a NULL protection
 //   domain since the initial version. This has been changed to pass
 //   the_class->protection_domain(). This change has been tested with
 //   all NSK tests and nothing broke, but what will adding it now break

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -865,11 +865,10 @@ Unsafe_DefineAnonymousClass_impl(JNIEnv *env,
                         false,    // is_strong_hidden
                         true);    // can_access_vm_annotations
 
-  InstanceKlass* anonk = SystemDictionary::parse_stream(no_class_name,
-                                                        host_loader,
-                                                        &st,
-                                                        cl_info,
-                                                        CHECK_NULL);
+  InstanceKlass* anonk = SystemDictionary::resolve_from_stream(&st, no_class_name,
+                                                               host_loader,
+                                                               cl_info,
+                                                               CHECK_NULL);
   assert(anonk != NULL, "no klass created");
   return anonk;
 }


### PR DESCRIPTION
This function is used to call the classfile parser for hidden or anonymous classes, and for use with jvmti RedefineClasses. The latter only calls KlassFactory::create_from_stream and skips the rest of the code in SystemDictionary::parse_stream.

Renamed SystemDictionary::parse_stream -> resolve_hidden_class_from_stream
resolve_from_stream -> resolve_class_from_stream
and have SystemDictionary::resolve_from_stream() call the right version depending on ClassLoadInfo flags.  Callers of resolve_from_stream now pass protection domain via. ClassLoadInfo.

So the external API is resolve_from_stream.

Tested with tier1 on 4 Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264538](https://bugs.openjdk.java.net/browse/JDK-8264538): Rename SystemDictionary::parse_stream


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 8dfcb09342758544278eb73bcb6f843bfea9326d
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3289/head:pull/3289` \
`$ git checkout pull/3289`

Update a local copy of the PR: \
`$ git checkout pull/3289` \
`$ git pull https://git.openjdk.java.net/jdk pull/3289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3289`

View PR using the GUI difftool: \
`$ git pr show -t 3289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3289.diff">https://git.openjdk.java.net/jdk/pull/3289.diff</a>

</details>
