### PR TITLE
8037397: RegEx pattern matching loses character class after intersection (&&) operator

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2663,7 +2663,7 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                                     right = right.union(clazz(true));
                             } else { // abc&&def
                                 unread();
-                                if(right == null) {
+                                if (right == null) {
                                     right = clazz(false);
                                 } else {
                                     right = right.union(clazz(false));

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2663,7 +2663,11 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                                     right = right.union(clazz(true));
                             } else { // abc&&def
                                 unread();
-                                right = clazz(false);
+                                if(right == null) {
+                                    right = clazz(false);
+                                } else {
+                                    right = right.union(clazz(false));
+                                }
                             }
                             ch = peek();
                         }

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -36,7 +36,7 @@
  * 8151481 4867170 7080302 6728861 6995635 6736245 4916384 6328855 6192895
  * 6345469 6988218 6693451 7006761 8140212 8143282 8158482 8176029 8184706
  * 8194667 8197462 8184692 8221431 8224789 8228352 8230829 8236034 8235812
- * 8216332 8214245 8237599 8241055 8247546 8258259
+ * 8216332 8214245 8237599 8241055 8247546 8258259 8037397
  *
  * @library /test/lib
  * @library /lib/testlibrary/java/lang
@@ -71,6 +71,7 @@ import java.util.regex.Matcher;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import jdk.test.lib.RandomFactory;
@@ -196,6 +197,8 @@ public class RegExTest {
         lineBreakWithQuantifier();
         caseInsensitivePMatch();
         surrogatePairOverlapRegion();
+        droppedClassesWithIntersection();
+
 
         if (failure) {
             throw new
@@ -5255,5 +5258,36 @@ public class RegExTest {
             }
         }
         report("surrogatePairOverlapRegion");
+    }
+
+    //This test is for 8037397
+    private static void droppedClassesWithIntersection() {
+        String rx = "[A-Z&&[A-Z]0-9]";
+        String ry = "[A-Z&&[A-F][G-Z]0-9]";
+
+        Stream<Character> letterChars = IntStream.range('A', 'Z').mapToObj((i) -> (char) i);
+        Stream<Character> digitChars = IntStream.range('0', '9').mapToObj((i) -> (char) i);
+
+        boolean letterCharsMatch = letterChars.allMatch((ch) -> {
+            String chString = ch.toString();
+            return chString.matches(rx) && chString.matches(ry);
+        });
+
+        boolean digitCharsDontMatch = digitChars.noneMatch((ch) -> {
+            String chString = ch.toString();
+            return chString.matches(rx) && chString.matches(ry);
+        });
+
+
+        if (!letterCharsMatch) {
+            failCount++;
+            System.out.println("Compiling intersection pattern is dropping a character class in its matcher");
+        }
+
+        if (!digitCharsDontMatch) {
+            failCount++;
+            System.out.println("Compiling intersection pattern is matching digits where it should not");
+        }
+
     }
 }


### PR DESCRIPTION
Bug fix with the intersection `&&` operator in regex patterns. In JDK-8037397, some character classes on the right hand side of the operator are dropped in cases where nested `[..]` classes are used with non "nested" ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8037397](https://bugs.openjdk.java.net/browse/JDK-8037397): RegEx pattern matching loses character class after intersection (&&) operator


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3291/head:pull/3291` \
`$ git checkout pull/3291`

Update a local copy of the PR: \
`$ git checkout pull/3291` \
`$ git pull https://git.openjdk.java.net/jdk pull/3291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3291`

View PR using the GUI difftool: \
`$ git pr show -t 3291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3291.diff">https://git.openjdk.java.net/jdk/pull/3291.diff</a>

</details>
