### PR TITLE
8169629: Annotations with lambda expressions cause AnnotationFormatError

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -370,6 +370,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
         if (!type.isInstance(o))
             return false;
         for (Method memberMethod : getMemberMethods()) {
+            if (memberMethod.isSynthetic())
+                continue;
             String member = memberMethod.getName();
             Object ourValue = memberValues.get(member);
             Object hisValue = null;
@@ -490,7 +492,20 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
          * 9.6.1. Annotation Type Elements
          */
         boolean valid = true;
+        Method currentMethod = null;
         for(Method method : memberMethods) {
+            currentMethod = method;
+            int modifiers = method.getModifiers();
+            // Skip over methods that may be a static initializer or
+            // similar construct. A static initializer may be used for
+            // purposes such as initializing a lambda stored in an
+            // interface field.
+            if (method.isSynthetic() &&
+                (modifiers & (Modifier.STATIC | Modifier.PRIVATE)) != 0 &&
+                method.getParameterCount() == 0) {
+                continue;
+            }
+
             /*
              * "By virtue of the AnnotationTypeElementDeclaration
              * production, a method declaration in an annotation type
@@ -501,7 +516,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
              * production, a method declaration in an annotation type
              * declaration cannot be default or static."
              */
-            if (method.getModifiers() != (Modifier.PUBLIC | Modifier.ABSTRACT) ||
+            if (modifiers != (Modifier.PUBLIC | Modifier.ABSTRACT) ||
                 method.isDefault() ||
                 method.getParameterCount() != 0 ||
                 method.getExceptionTypes().length != 0) {

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -492,9 +492,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
          * 9.6.1. Annotation Type Elements
          */
         boolean valid = true;
-        Method currentMethod = null;
         for(Method method : memberMethods) {
-            currentMethod = method;
             int modifiers = method.getModifiers();
             // Skip over methods that may be a static initializer or
             // similar construct. A static initializer may be used for

--- a/test/jdk/java/lang/annotation/EqualityTest.java
+++ b/test/jdk/java/lang/annotation/EqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,12 @@
 
 /*
  * @test
- * @bug 8071859
+ * @bug 8071859 8169629
  * @summary Check annotation equality behavior against the invocation handler
+ * @compile --release 8 EqualityTest.java
+ * @run main EqualityTest
+ * @compile EqualityTest.java
+ * @run main EqualityTest
  */
 
 import java.lang.annotation.*;
@@ -40,6 +44,7 @@ public class EqualityTest {
         testEquality(annotation, handler,    false);
         testEquality(annotation, annotation, true);
         testEquality(handler,    handler,    true);
+        testEquality(annotation, AnnotationHost.class.getAnnotation(TestAnnotation.class), true);
     }
 
     private static void testEquality(Object a, Object b, boolean expected) {
@@ -47,9 +52,14 @@ public class EqualityTest {
         if (result != b.equals(a) || result != expected)
             throw new RuntimeException("Unexpected result");
     }
+
+    @TestAnnotation
+    private static class AnnotationHost {}
 }
 
 @Retention(RetentionPolicy.RUNTIME)
 @interface TestAnnotation {
+    // Trigger creation of synthetic method to initialize r.
+    public static final Runnable r = () -> {};
 }
 


### PR DESCRIPTION
The stricter checks added by
    8035781: Improve equality for annotations
in creating the proxy objects used to implement annotations has an unintended by-catch of rejecting annotation's whose type has, say, a field initialized with a lambda expression. While uncommon, it is legal code to have a field in an annotation type.

The updated checks skip over the sort of synthetic method used for the initialization.

Some different compilation tactics were used before and after nest mates, so the test includes compilation and testing under both situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8169629](https://bugs.openjdk.java.net/browse/JDK-8169629): Annotations with lambda expressions cause AnnotationFormatError


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**) ⚠️ Review applies to 818df21d28956179987146909320aed5e5b6bea2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3294/head:pull/3294` \
`$ git checkout pull/3294`

Update a local copy of the PR: \
`$ git checkout pull/3294` \
`$ git pull https://git.openjdk.java.net/jdk pull/3294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3294`

View PR using the GUI difftool: \
`$ git pr show -t 3294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3294.diff">https://git.openjdk.java.net/jdk/pull/3294.diff</a>

</details>
