### PR TITLE
8262316: Reducing locks in RSA Blinding

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,13 +435,15 @@ public final class RSACore {
         ConcurrentLinkedQueue<BlindingParameters> queue = blindingCache.get(n);
 
         if (queue == null) {
-            // Synchronizing not needed, if a queue is overwritten it is ok
+            // Synchronizing is not needed as threads overwriting the queue is
+            // just a few extra CPU cycles during startup.  Once the queue is
+            // established, it controls thread safety of the blinding objects.
+            // The WeakHashMap will clear all the objects when idle.
             queue = new ConcurrentLinkedQueue<>();
             blindingCache.putIfAbsent(n, queue);
         }
 
-        BlindingParameters bps;
-        bps = queue.poll();
+        BlindingParameters bps = queue.poll();
         if (bps == null) {
             bps = new BlindingParameters(e, d, n);
         }

--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -408,16 +408,16 @@ public final class RSACore {
             if ((this.e != null && this.e.equals(e)) ||
                 (this.d != null && this.d.equals(d))) {
 
-                BlindingRandomPair brp = null;
-                if (!u.equals(BigInteger.ZERO) &&
-                    !v.equals(BigInteger.ZERO)) {
-
-                    brp = new BlindingRandomPair(u, v);
-                    if (isReusable()) {
-                        u = u.modPow(BIG_TWO, n);
-                        v = v.modPow(BIG_TWO, n);
-                    }
-                } // Otherwise, need to reset the random pair.
+                BlindingRandomPair brp = new BlindingRandomPair(u, v);
+                if (u.compareTo(BigInteger.ONE) <= 0 ||
+                    v.compareTo(BigInteger.ONE) <= 0) {
+                    // Reset so the parameters will be not queued later
+                    u = BigInteger.ZERO;
+                    v = BigInteger.ZERO;
+                } else {
+                    u = u.modPow(BIG_TWO, n);
+                    v = v.modPow(BIG_TWO, n);
+                }
 
                 return brp;
             }
@@ -425,9 +425,9 @@ public final class RSACore {
             return null;
         }
 
+        // Check if reusable, return true if both u & v are not zero.
         boolean isReusable() {
-            return u.compareTo(BigInteger.ONE) > 0 && v.compareTo(
-                BigInteger.ONE) > 0;
+            return !u.equals(BigInteger.ZERO) && !v.equals(BigInteger.ZERO);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -411,7 +411,7 @@ public final class RSACore {
                     !v.equals(BigInteger.ZERO)) {
 
                     brp = new BlindingRandomPair(u, v);
-                    if (needsReset()) {
+                    if (isReusable()) {
                         u = u.modPow(BIG_TWO, n);
                         v = v.modPow(BIG_TWO, n);
                     }
@@ -423,7 +423,7 @@ public final class RSACore {
             return null;
         }
 
-        boolean needsReset() {
+        boolean isReusable() {
             return u.compareTo(BigInteger.ONE) > 0 && v.compareTo(
                 BigInteger.ONE) > 0;
         }
@@ -435,7 +435,7 @@ public final class RSACore {
         ConcurrentLinkedQueue<BlindingParameters> queue = blindingCache.get(n);
 
         if (queue == null) {
-            // Overwriting an existing queue is ok.
+            // Synchronizing not needed, if a queue is overwritten it is ok
             queue = new ConcurrentLinkedQueue<>();
             blindingCache.putIfAbsent(n, queue);
         }
@@ -453,7 +453,7 @@ public final class RSACore {
             brp = bps.getBlindingRandomPair(e, d, n);
         }
 
-        if (bps.needsReset()) {
+        if (bps.isReusable()) {
             queue.add(bps);
         }
         return brp;


### PR DESCRIPTION
Hi,

I need a review of the locking change to the RSA blinding code. The problem was reported that multithreaded performance suffered because there was one global lock on the many blindings operation.  The change reduces locking by using a ConcurrentLinkedQueue to store the different BlindingParameters that other threads maybe using.  The queue size is limited to prevent sudden surges in stored BlindingParameters and a WeakHashMap is still used so the objects can be freed when no longer used.  Performance doubles under high load.

thanks

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262316](https://bugs.openjdk.java.net/browse/JDK-8262316): Reducing locks in RSA Blinding


### Reviewers
 * @djelinski (no known github.com user name / role)
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3296/head:pull/3296` \
`$ git checkout pull/3296`

Update a local copy of the PR: \
`$ git checkout pull/3296` \
`$ git pull https://git.openjdk.java.net/jdk pull/3296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3296`

View PR using the GUI difftool: \
`$ git pr show -t 3296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3296.diff">https://git.openjdk.java.net/jdk/pull/3296.diff</a>

</details>
