### PR TITLE
8264557: Incorrect copyright year for test/micro/org/openjdk/bench/java/lang/MathBench.java after JDK-8264054

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

The copyright year for test/micro/org/openjdk/bench/java/lang/MathBench.java [1] is incorrect since it isn't newly added in 2021.
Let's fix it.

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/test/micro/org/openjdk/bench/java/lang/MathBench.java#L2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264557](https://bugs.openjdk.java.net/browse/JDK-8264557): Incorrect copyright year for test/micro/org/openjdk/bench/java/lang/MathBench.java after JDK-8264054


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3299/head:pull/3299` \
`$ git checkout pull/3299`

Update a local copy of the PR: \
`$ git checkout pull/3299` \
`$ git pull https://git.openjdk.java.net/jdk pull/3299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3299`

View PR using the GUI difftool: \
`$ git pr show -t 3299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3299.diff">https://git.openjdk.java.net/jdk/pull/3299.diff</a>

</details>
