### PR TITLE
8264544: Case-insensitive comparison issue with supplementary characters.

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,12 +342,12 @@ final class StringUTF16 {
             cp1 = codePointIncluding(value, cp1, k1, toffset, tlast);
             if (cp1 < 0) {
                 k1++;
-                cp1 -= cp1;
+                cp1 = -cp1;
             }
             cp2 = codePointIncluding(other, cp2, k2, ooffset, olast);
             if (cp2 < 0) {
                 k2++;
-                cp2 -= cp2;
+                cp2 = -cp2;
             }
 
             int diff = compareCodePointCI(cp1, cp2);

--- a/test/jdk/java/lang/String/CompactString/CompareToIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/CompareToIgnoreCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import static org.testng.Assert.assertEquals;
 
 /*
  * @test
- * @bug 8077559 8248655
+ * @bug 8077559 8248655 8264544
  * @summary Tests Compact String. This one is for String.compareToIgnoreCase.
  * @run testng/othervm -XX:+CompactStrings CompareToIgnoreCase
  * @run testng/othervm -XX:-CompactStrings CompareToIgnoreCase
@@ -69,6 +69,7 @@ public class CompareToIgnoreCase extends CompactString {
                 new Object[] { STRING_M11, "a\uFF42", -1 },
                 new Object[] { STRING_SUPPLEMENTARY, STRING_SUPPLEMENTARY_LOWERCASE, 0 },
                 new Object[] { STRING_SUPPLEMENTARY, "\uD801\uDC28\uD801\uDC27\uFF41a", -38 },
+                new Object[] { STRING_SUPPLEMENTARY, "\uD802\uDC00\uD801\uDC01\uFF21A", -984 },
         };
     }
 

--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import static org.testng.Assert.assertEquals;
 
 /*
  * @test
- * @bug 8077559 8248655
+ * @bug 8077559 8248655 8264544
  * @summary Tests Compact String. This one is for String.regionMatches.
  * @run testng/othervm -XX:+CompactStrings RegionMatches
  * @run testng/othervm -XX:-CompactStrings RegionMatches
@@ -75,6 +75,7 @@ public class RegionMatches extends CompactString {
                 new Object[] { STRING_SUPPLEMENTARY, true, 4, "\uFF21", 0, 1,
                         true },
                 new Object[] { STRING_SUPPLEMENTARY, true, 5, "A", 0, 1, true },
+                new Object[] { STRING_SUPPLEMENTARY, true, 0, "\uD802\uDC00\uD801\uDC01\uFF21A", 0, 2, false },
                 new Object[] { STRING_SUPPLEMENTARY_LOWERCASE, false, 0,
                         "\uD801\uDC28\uD801\uDC29", 0, 4, true },
                 new Object[] { STRING_SUPPLEMENTARY_LOWERCASE, true, 0,
@@ -90,7 +91,8 @@ public class RegionMatches extends CompactString {
                 new Object[] { STRING_SUPPLEMENTARY_LOWERCASE, false, 4,
                         "\uFF21", 0, 1, false },
                 new Object[] { STRING_SUPPLEMENTARY_LOWERCASE, false, 4,
-                        "\uFF41", 0, 1, true }, };
+                        "\uFF41", 0, 1, true },
+        };
     }
 
     @Test(dataProvider = "provider")


### PR DESCRIPTION
Please review the fix to the subject issue. Thanks to the contribution by Chris Johnson.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264544](https://bugs.openjdk.java.net/browse/JDK-8264544): Case-insensitive comparison issue with supplementary characters.


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Contributors
 * Chris Johnson `<chriswjohnson.jdk@gmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3300/head:pull/3300` \
`$ git checkout pull/3300`

Update a local copy of the PR: \
`$ git checkout pull/3300` \
`$ git pull https://git.openjdk.java.net/jdk pull/3300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3300`

View PR using the GUI difftool: \
`$ git pr show -t 3300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3300.diff">https://git.openjdk.java.net/jdk/pull/3300.diff</a>

</details>
