### PR TITLE
8262900: ToolBasicTest fails to access HTTP server it starts

### DIFF
--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -526,7 +526,7 @@ public class ToolBasicTest extends ReplToolTesting {
     public void testOpenFileOverHttp() throws IOException {
         var script = "int a = 10;int b = 20;int c = a + b;";
 
-        var localhostAddress = new InetSocketAddress(InetAddress.getLocalHost().getHostAddress(), 0);
+        var localhostAddress = new InetSocketAddress(InetAddress.getLoopbackAddress().getHostAddress(), 0);
         var httpServer = HttpServer.create(localhostAddress, 0);
         try {
             httpServer.createContext("/script", exchange -> {


### PR DESCRIPTION
Trying to use `getLoopbackAddress()` instead of `getLocalHost()`, to start the HTTP server. It will hopefully be better accessible. Inspired by:
https://github.com/openjdk/jdk/pull/3137

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262900](https://bugs.openjdk.java.net/browse/JDK-8262900): ToolBasicTest fails to access HTTP server it starts


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3301/head:pull/3301` \
`$ git checkout pull/3301`

Update a local copy of the PR: \
`$ git checkout pull/3301` \
`$ git pull https://git.openjdk.java.net/jdk pull/3301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3301`

View PR using the GUI difftool: \
`$ git pr show -t 3301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3301.diff">https://git.openjdk.java.net/jdk/pull/3301.diff</a>

</details>
