### PR TITLE
8263227: C2: inconsistent spilling due to dead nodes in exception block

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1272,6 +1272,12 @@ void PhaseCFG::verify() const {
           }
         }
       }
+      if (n->is_Proj()) {
+        Node* pred = block->get_node(j - 1);
+        Node* parent = n->in(0);
+        assert(pred == parent || (pred->is_Proj() && pred->in(0) == parent),
+               "projections must follow their parents or other sibling projections");
+      }
     }
 
     j = block->end_idx();

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1245,12 +1245,18 @@ void PhaseCFG::verify() const {
       for (uint k = 0; k < n->req(); k++) {
         Node *def = n->in(k);
         if (def && def != n) {
-          assert(get_block_for_node(def) || def->is_Con(), "must have block; constants for debug info ok");
-          // Verify that instructions in the block is in correct order.
+          Block* def_block = get_block_for_node(def);
+          assert(def_block || def->is_Con(), "must have block; constants for debug info ok");
+          // Verify that all definitions dominate their uses (except for virtual
+          // instructions merging multiple definitions).
+          assert(n->is_Root() || n->is_Region() || n->is_Phi() ||
+                 def_block->dominates(block),
+                 "uses must be dominated by definitions");
+          // Verify that instructions in the block are in correct order.
           // Uses must follow their definition if they are at the same block.
           // Mostly done to check that MachSpillCopy nodes are placed correctly
           // when CreateEx node is moved in build_ifg_physical().
-          if (get_block_for_node(def) == block && !(block->head()->is_Loop() && n->is_Phi()) &&
+          if (def_block == block && !(block->head()->is_Loop() && n->is_Phi()) &&
               // See (+++) comment in reg_split.cpp
               !(n->jvms() != NULL && n->jvms()->is_monitor_use(k))) {
             bool is_loop = false;

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1249,7 +1249,7 @@ void PhaseCFG::verify() const {
           assert(def_block || def->is_Con(), "must have block; constants for debug info ok");
           // Verify that all definitions dominate their uses (except for virtual
           // instructions merging multiple definitions).
-          assert(n->is_Root() || n->is_Region() || n->is_Phi() ||
+          assert(n->is_Root() || n->is_Region() || n->is_Phi() || n->is_MachMerge() ||
                  def_block->dominates(block),
                  "uses must be dominated by definitions");
           // Verify that instructions in the block are in correct order.

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1273,8 +1273,10 @@ void PhaseCFG::verify() const {
         }
       }
       if (n->is_Proj()) {
+        assert(j >= 1, "a projection cannot be the first instruction in a block");
         Node* pred = block->get_node(j - 1);
         Node* parent = n->in(0);
+        assert(parent != NULL, "projections must have a parent");
         assert(pred == parent || (pred->is_Proj() && pred->in(0) == parent),
                "projections must follow their parents or other sibling projections");
       }

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -1390,13 +1390,13 @@ void PhaseCFG::call_catch_cleanup(Block* block) {
   }
 
   // If the successor blocks have a CreateEx node, move it back to the top
-  for(uint i4 = 0; i4 < block->_num_succs; i4++ ) {
+  for (uint i4 = 0; i4 < block->_num_succs; i4++) {
     Block *sb = block->_succs[i4];
     uint new_cnt = end - beg;
     // Remove any newly created, but dead, nodes by traversing their schedule
     // backwards. Here, a dead node is a node whose only outputs (if any) are
     // unused projections.
-    for( uint j = new_cnt; j > 0; j-- ) {
+    for (uint j = new_cnt; j > 0; j--) {
       Node *n = sb->get_node(j);
       // Individual projections are examined together with all siblings when
       // their parent is visited.

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,8 @@ void PhaseChaitin::insert_proj( Block *b, uint i, Node *spill, uint maxlrg ) {
   // Do not insert between a call and his Catch
   if( b->get_node(i)->is_Catch() ) {
     // Put the instruction at the top of the fall-thru block.
+    // This assumes that the instruction is not used in the other exception
+    // blocks. Global code motion is responsible for maintaining this invariant.
     // Find the fall-thru projection
     while( 1 ) {
       const CatchProjNode *cp = b->get_node(++i)->as_CatchProj();

--- a/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
@@ -27,8 +27,8 @@ package compiler.exceptions;
  * @test
  * @bug 8263227
  * @summary Tests that users of return values from exception-throwing method
- *          calls are placed in the call's fall-through path. The second run
- *          with a variable seed is added for test robustness.
+ *          calls are not duplicated in the call's exception path. The second
+ *          run with a variable seed is added for test robustness.
  * @library /test/lib /
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
  *                   -XX:+UnlockDiagnosticVMOptions
@@ -48,10 +48,10 @@ public class TestSpilling {
 
     public static void test() {
         int a = Integer.valueOf(42).intValue();
-        // The logic below should be placed in the fall-through path of
-        // java.lang.Integer::intValue(). Otherwise, it might be cloned in the
-        // exception path and cause live range splitting to create uses without
-        // reaching definitions if 'a' is spilled.
+        // After global code motion, the logic below should only be placed in
+        // the fall-through path of java.lang.Integer::intValue(). Otherwise,
+        // live range splitting might create uses without reaching definitions
+        // if 'a' is spilled.
         int b = (((a & 0x0000F000)) + 1);
         int c = a / b + ((a % b > 0) ? 1 : 0);
     }

--- a/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.exceptions;
+
+/**
+ * @test
+ * @bug 8263227
+ * @summary Tests that users of return values from exception-throwing method
+ *          calls are placed in the call's fall-through path. The second run
+ *          with a variable seed is added for test robustness.
+ * @library /test/lib /
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -Xbatch -XX:+StressGCM -XX:StressSeed=0
+ *                   -XX:+VerifyRegisterAllocator
+ *                   -XX:CompileCommand=dontinline,java.lang.Integer::*
+ *                   compiler.exceptions.TestSpilling
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -Xbatch -XX:+StressGCM
+ *                   -XX:+VerifyRegisterAllocator
+ *                   -XX:CompileCommand=dontinline,java.lang.Integer::*
+ *                   compiler.exceptions.TestSpilling
+ */
+
+public class TestSpilling {
+
+    public static void test() {
+        int a = Integer.valueOf(42).intValue();
+        // The logic below should be placed in the fall-through path of
+        // java.lang.Integer::intValue(). Otherwise, it might be cloned in the
+        // exception path and cause live range splitting to create uses without
+        // reaching definitions if 'a' is spilled.
+        int b = (((a & 0x0000F000)) + 1);
+        int c = a / b + ((a % b > 0) ? 1 : 0);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+
+}


### PR DESCRIPTION
This change eliminates dead multi-nodes created by call-catch cleanup after GCM. Eliminating all dead code created by call-catch cleanup avoids potential issues when splitting the live range of call result values, see the analysis in the [bug report](https://bugs.openjdk.java.net/browse/JDK-8263227) for details. This solution is the least invasive of the three alternatives proposed in the bug report (the other two are constraining global code motion and extending live-range splitting).

The change also extends the control-flow graph verification pass to catch similar live-range splitting issues earlier (with `+VerifyRegisterAllocator`).

Tested on:
- original bug reproducer
- hs-tier1-5 (windows-x64, linux-x64, linux-aarch64, and macosx-x64) with `+VerifyRegisterAllocator`
- hs-tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64) with `+VerifyRegisterAllocator` and `+StressGCM` (5 repetitions)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263227](https://bugs.openjdk.java.net/browse/JDK-8263227): C2: inconsistent spilling due to dead nodes in exception block


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3303/head:pull/3303` \
`$ git checkout pull/3303`

Update a local copy of the PR: \
`$ git checkout pull/3303` \
`$ git pull https://git.openjdk.java.net/jdk pull/3303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3303`

View PR using the GUI difftool: \
`$ git pr show -t 3303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3303.diff">https://git.openjdk.java.net/jdk/pull/3303.diff</a>

</details>
