### PR TITLE
8166727: javac crashed: [jimage.dll+0x1942] ImageStrings::find+0x28

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -212,6 +212,11 @@ ImageFileReaderTable::ImageFileReaderTable() : _count(0), _max(_growth) {
 }
 
 ImageFileReaderTable::~ImageFileReaderTable() {
+// Bug 8166727
+//
+// WARNING: Should never close the jimage file.
+//          Threads may still be running at shutdown.
+#if 0
     for (u4 i = 0; i < _count; i++) {
         ImageFileReader* image = _table[i];
 
@@ -220,6 +225,7 @@ ImageFileReaderTable::~ImageFileReaderTable() {
         }
     }
     free(_table);
+#endif
 }
 
 // Add a new image entry to the table.

--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -211,23 +211,6 @@ ImageFileReaderTable::ImageFileReaderTable() : _count(0), _max(_growth) {
     assert(_table != NULL && "allocation failed");
 }
 
-ImageFileReaderTable::~ImageFileReaderTable() {
-// Bug 8166727
-//
-// WARNING: Should never close the jimage file.
-//          Threads may still be running at shutdown.
-#if 0
-    for (u4 i = 0; i < _count; i++) {
-        ImageFileReader* image = _table[i];
-
-        if (image != NULL) {
-            delete image;
-        }
-    }
-    free(_table);
-#endif
-}
-
 // Add a new image entry to the table.
 void ImageFileReaderTable::add(ImageFileReader* image) {
     if (_count == _max) {

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -371,7 +371,12 @@ private:
 
 public:
     ImageFileReaderTable();
-    ~ImageFileReaderTable();
+// ~ImageFileReaderTable()
+// Bug 8166727
+//
+// WARNING: Should never close jimage files.
+//          Threads may still be running during shutdown.
+//
 
     // Return the number of entries.
     inline u4 count() { return _count; }


### PR DESCRIPTION
We should never close the jimage since java threads can still be running after a hard exit().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8166727](https://bugs.openjdk.java.net/browse/JDK-8166727): javac crashed: [jimage.dll+0x1942]  ImageStrings::find+0x28


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 515bba9dcc9ce6718e7905038333b092fdf14484
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 515bba9dcc9ce6718e7905038333b092fdf14484


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3304/head:pull/3304` \
`$ git checkout pull/3304`

Update a local copy of the PR: \
`$ git checkout pull/3304` \
`$ git pull https://git.openjdk.java.net/jdk pull/3304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3304`

View PR using the GUI difftool: \
`$ git pr show -t 3304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3304.diff">https://git.openjdk.java.net/jdk/pull/3304.diff</a>

</details>
