### PR TITLE
8264398: BevelBorderUIResource​(int, Color, Color) and BevelBoder(int, Color, Color) spec should clarify about usage of highlight and shadow color

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
@@ -86,11 +86,9 @@ public class BevelBorder extends AbstractBorder
     /**
      * Creates a bevel border with the specified type, highlight and
      * shadow colors.
-     * The bevel outer highlight color and
-     * bevel inner highlight color will be derived from
-     * specified highlight color and
-     * bevel outer shadow color
-     * and bevel inner shadow color
+     * The bevel outer highlight color and bevel inner highlight color
+     * will be derived from specified highlight color and
+     * bevel outer shadow color and bevel inner shadow color
      * will be derived from specified shadow color.
      * @param bevelType the type of bevel for the border
      * @param highlight the color to use for the bevel highlight

--- a/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
@@ -86,6 +86,10 @@ public class BevelBorder extends AbstractBorder
     /**
      * Creates a bevel border with the specified type, highlight and
      * shadow colors.
+     * highlightOuterColor and highlightInnerColor will be derived from
+     * specified highlight color and
+     * shadowOuterColor and shadowInnerColor  will be derived from
+     * specified shadow color.
      * @param bevelType the type of bevel for the border
      * @param highlight the color to use for the bevel highlight
      * @param shadow the color to use for the bevel shadow

--- a/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,10 +86,16 @@ public class BevelBorder extends AbstractBorder
     /**
      * Creates a bevel border with the specified type, highlight and
      * shadow colors.
-     * highlightOuterColor and highlightInnerColor will be derived from
+     * highlightOuterColor which is the color to use for the
+     * bevel outer highlight
+     * and highlightInnerColor which is the color to use for the
+     * bevel inner highlight will be derived from
      * specified highlight color and
-     * shadowOuterColor and shadowInnerColor  will be derived from
-     * specified shadow color.
+     * shadowOuterColor which is the color to use for the
+     * bevel outer shadow
+     * and shadowInnerColor which is the color to use for the
+     * bevel inner shadow
+     * will be derived from specified shadow color.
      * @param bevelType the type of bevel for the border
      * @param highlight the color to use for the bevel highlight
      * @param shadow the color to use for the bevel shadow

--- a/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/BevelBorder.java
@@ -86,15 +86,11 @@ public class BevelBorder extends AbstractBorder
     /**
      * Creates a bevel border with the specified type, highlight and
      * shadow colors.
-     * highlightOuterColor which is the color to use for the
-     * bevel outer highlight
-     * and highlightInnerColor which is the color to use for the
-     * bevel inner highlight will be derived from
+     * The bevel outer highlight color and
+     * bevel inner highlight color will be derived from
      * specified highlight color and
-     * shadowOuterColor which is the color to use for the
-     * bevel outer shadow
-     * and shadowInnerColor which is the color to use for the
-     * bevel inner shadow
+     * bevel outer shadow color
+     * and bevel inner shadow color
      * will be derived from specified shadow color.
      * @param bevelType the type of bevel for the border
      * @param highlight the color to use for the bevel highlight

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -219,10 +219,10 @@ public class BorderUIResource implements Border, UIResource, Serializable
 
         /**
          * Constructs a {@code BevelBorderUIResource}.
-         * The shadow color is used for both inner and outer shadow and
-         * highlight color is used for both inner and outer highlight
-         * but brighter version of highlight color is used for outer highlight and
-         * brighter versoin of shadow color is used for inner shadow.
+         * highlightOuterColor and highlightInnerColor will be derived from
+         * specified highlight color and
+         * shadowOuterColor and shadowInnerColor  will be derived from
+         * specified shadow color.
          * @param bevelType the type of bevel for the border
          * @param highlight the color to use for the bevel highlight
          * @param shadow the color to use for the bevel shadow

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,10 +219,16 @@ public class BorderUIResource implements Border, UIResource, Serializable
 
         /**
          * Constructs a {@code BevelBorderUIResource}.
-         * highlightOuterColor and highlightInnerColor will be derived from
+         * highlightOuterColor which is the color to use for the
+         * bevel outer highlight
+         * and highlightInnerColor which is the color to use for the
+         * bevel inner highlight will be derived from
          * specified highlight color and
-         * shadowOuterColor and shadowInnerColor  will be derived from
-         * specified shadow color.
+         * shadowOuterColor which is the color to use for the
+         * bevel outer shadow
+         * and shadowInnerColor which is the color to use for the
+         * bevel inner shadow
+         * will be derived from specified shadow color.
          * @param bevelType the type of bevel for the border
          * @param highlight the color to use for the bevel highlight
          * @param shadow the color to use for the bevel shadow

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -219,6 +219,10 @@ public class BorderUIResource implements Border, UIResource, Serializable
 
         /**
          * Constructs a {@code BevelBorderUIResource}.
+         * The shadow color is used for both inner and outer shadow and
+         * highlight color is used for both inner and outer highlight
+         * but brighter version of highlight color is used for outer highlight and
+         * brighter versoin of shadow color is used for inner shadow.
          * @param bevelType the type of bevel for the border
          * @param highlight the color to use for the bevel highlight
          * @param shadow the color to use for the bevel shadow

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -219,15 +219,11 @@ public class BorderUIResource implements Border, UIResource, Serializable
 
         /**
          * Constructs a {@code BevelBorderUIResource}.
-         * highlightOuterColor which is the color to use for the
-         * bevel outer highlight
-         * and highlightInnerColor which is the color to use for the
-         * bevel inner highlight will be derived from
+         * The bevel outer highlight color and
+         * bevel inner highlight color will be derived from
          * specified highlight color and
-         * shadowOuterColor which is the color to use for the
-         * bevel outer shadow
-         * and shadowInnerColor which is the color to use for the
-         * bevel inner shadow
+         * bevel outer shadow color
+         * and bevel inner shadow color
          * will be derived from specified shadow color.
          * @param bevelType the type of bevel for the border
          * @param highlight the color to use for the bevel highlight

--- a/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/BorderUIResource.java
@@ -219,11 +219,9 @@ public class BorderUIResource implements Border, UIResource, Serializable
 
         /**
          * Constructs a {@code BevelBorderUIResource}.
-         * The bevel outer highlight color and
-         * bevel inner highlight color will be derived from
-         * specified highlight color and
-         * bevel outer shadow color
-         * and bevel inner shadow color
+         * The bevel outer highlight color and bevel inner highlight color
+         * will be derived from specified highlight color and
+         * bevel outer shadow color and bevel inner shadow color
          * will be derived from specified shadow color.
          * @param bevelType the type of bevel for the border
          * @param highlight the color to use for the bevel highlight


### PR DESCRIPTION
The current spec for javax/swing/plaf/BorderUIResource.BevelBorderUIResource.html(int,java.awt.Color,java.awt.Color) does not clearly specify the usage of color for hightlight and shadow as there are outer/inner hightlight and outer/inner shadow.
Updated spec to clarify the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264398](https://bugs.openjdk.java.net/browse/JDK-8264398): BevelBorderUIResource​(int, Color, Color) and BevelBoder(int, Color, Color) spec should clarify about usage of highlight and shadow color


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3305/head:pull/3305` \
`$ git checkout pull/3305`

Update a local copy of the PR: \
`$ git checkout pull/3305` \
`$ git pull https://git.openjdk.java.net/jdk pull/3305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3305`

View PR using the GUI difftool: \
`$ git pr show -t 3305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3305.diff">https://git.openjdk.java.net/jdk/pull/3305.diff</a>

</details>
