### PR TITLE
8264540: WhiteBox.metaspaceReserveAlignment should return shared region alignment

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1780,8 +1780,8 @@ WB_ENTRY(jlong, WB_MetaspaceCapacityUntilGC(JNIEnv* env, jobject wb))
   return (jlong) MetaspaceGC::capacity_until_GC();
 WB_END
 
-WB_ENTRY(jlong, WB_MetaspaceReserveAlignment(JNIEnv* env, jobject wb))
-  return (jlong)Metaspace::reserve_alignment();
+WB_ENTRY(jlong, WB_MetaspaceSharedRegionAlignment(JNIEnv* env, jobject wb))
+  return (jlong)MetaspaceShared::core_region_alignment();
 WB_END
 
 WB_ENTRY(jboolean, WB_IsMonitorInflated(JNIEnv* env, jobject wb, jobject obj))
@@ -2505,7 +2505,7 @@ static JNINativeMethod methods[] = {
      CC"(Ljava/lang/ClassLoader;J)J",                 (void*)&WB_AllocateMetaspace },
   {CC"incMetaspaceCapacityUntilGC", CC"(J)J",         (void*)&WB_IncMetaspaceCapacityUntilGC },
   {CC"metaspaceCapacityUntilGC", CC"()J",             (void*)&WB_MetaspaceCapacityUntilGC },
-  {CC"metaspaceReserveAlignment", CC"()J",            (void*)&WB_MetaspaceReserveAlignment },
+  {CC"metaspaceSharedRegionAlignment", CC"()J",       (void*)&WB_MetaspaceSharedRegionAlignment },
   {CC"getCPUFeatures",     CC"()Ljava/lang/String;",  (void*)&WB_GetCPUFeatures     },
   {CC"getNMethod0",         CC"(Ljava/lang/reflect/Executable;Z)[Ljava/lang/Object;",
                                                       (void*)&WB_GetNMethod         },

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1780,8 +1780,14 @@ WB_ENTRY(jlong, WB_MetaspaceCapacityUntilGC(JNIEnv* env, jobject wb))
   return (jlong) MetaspaceGC::capacity_until_GC();
 WB_END
 
+// The function is only valid when CDS is available.
 WB_ENTRY(jlong, WB_MetaspaceSharedRegionAlignment(JNIEnv* env, jobject wb))
+#if INCLUDE_CDS
   return (jlong)MetaspaceShared::core_region_alignment();
+#else
+  ShouldNotReachHere();
+  return 0L;
+#endif
 WB_END
 
 WB_ENTRY(jboolean, WB_IsMonitorInflated(JNIEnv* env, jobject wb, jobject obj))

--- a/test/hotspot/jtreg/runtime/cds/SpaceUtilizationCheck.java
+++ b/test/hotspot/jtreg/runtime/cds/SpaceUtilizationCheck.java
@@ -45,7 +45,7 @@ import java.lang.Integer;
 public class SpaceUtilizationCheck {
     // For the RW/RO regions:
     // [1] Each region must have strictly less than
-    //     WhiteBox.metaspaceReserveAlignment() bytes of unused space.
+    //     WhiteBox.metaspaceSharedRegionAlignment() bytes of unused space.
     // [2] There must be no gap between two consecutive regions.
 
     public static void main(String[] args) throws Exception {
@@ -58,8 +58,8 @@ public class SpaceUtilizationCheck {
         OutputAnalyzer output = CDSTestUtils.createArchiveAndCheck(opts);
         Pattern pattern = Pattern.compile("(..)  space: *([0-9]+).* out of *([0-9]+) bytes .* at 0x([0-9a0-f]+)");
         WhiteBox wb = WhiteBox.getWhiteBox();
-        long reserve_alignment = wb.metaspaceReserveAlignment();
-        System.out.println("Metaspace::reserve_alignment() = " + reserve_alignment);
+        long reserve_alignment = wb.metaspaceSharedRegionAlignment();
+        System.out.println("MetaspaceShared::core_region_alignment() = " + reserve_alignment);
 
         // Look for output like this. The pattern will only match the first 2 regions, which is what we need to check
         //
@@ -88,7 +88,7 @@ public class SpaceUtilizationCheck {
                     }
                     if (unused > reserve_alignment) {
                         // [1] Check for unused space
-                        throw new RuntimeException("Unused space (" + unused + ") must be smaller than Metaspace::reserve_alignment() (" +
+                        throw new RuntimeException("Unused space (" + unused + ") must be smaller than MetaspaceShared::core_region_alignment() (" +
                                                    reserve_alignment + ")");
                     }
                     if (last_region >= 0 && address != last_region) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -67,6 +67,7 @@ public class SharedArchiveConsistency {
     public static int sp_used_offset;  // offset of CDSFileMapRegion::_used
     public static int size_t_size;     // size of size_t
     public static int int_size;        // size of int
+    public static long alignment;      // MetaspaceShared::core_region_alignment
 
     // The following should be consistent with the enum in the C++ MetaspaceShared class
     public static String[] shared_region_name = {
@@ -104,6 +105,7 @@ public class SharedArchiveConsistency {
         sp_used_offset = wb.getOffsetForName("CDSFileMapRegion::_used") - sp_offset_crc;
         size_t_size = wb.getOffsetForName("size_t_size");
         CDSFileMapRegion_size  = wb.getOffsetForName("CDSFileMapRegion_size");
+        alignment = wb.metaspaceSharedRegionAlignment();
     }
 
     public static int getFileHeaderSize(FileChannel fc) throws Exception {
@@ -195,7 +197,6 @@ public class SharedArchiveConsistency {
 
     static long get_region_used_size_aligned(FileChannel fc, int region) throws Exception {
         long n = sp_offset + CDSFileMapRegion_size * region + sp_used_offset;
-        long alignment = WhiteBox.getWhiteBox().metaspaceReserveAlignment();
         long used = readInt(fc, n, size_t_size);
         used = (used + alignment - 1) & ~(alignment - 1);
         return used;

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -397,7 +397,7 @@ public class WhiteBox {
   public native long allocateMetaspace(ClassLoader classLoader, long size);
   public native long incMetaspaceCapacityUntilGC(long increment);
   public native long metaspaceCapacityUntilGC();
-  public native long metaspaceReserveAlignment();
+  public native long metaspaceSharedRegionAlignment();
 
   // Metaspace Arena Tests
   public native long createMetaspaceTestContext(long commit_limit, long reserve_limit);


### PR DESCRIPTION
Hi, Please review
  After JDK-8236847, the shared region alignment (new as MetaspaceShared::core_region_alignment) is no longer default to os pagesize, it is a configurable value at build time instead. The WhiteBox api metaspaceReserveAlignment() should reflect the change. 

Tests:tier1,tier2,tier3,tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264540](https://bugs.openjdk.java.net/browse/JDK-8264540): WhiteBox.metaspaceReserveAlignment should return shared region alignment


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3309/head:pull/3309` \
`$ git checkout pull/3309`

Update a local copy of the PR: \
`$ git checkout pull/3309` \
`$ git pull https://git.openjdk.java.net/jdk pull/3309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3309`

View PR using the GUI difftool: \
`$ git pr show -t 3309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3309.diff">https://git.openjdk.java.net/jdk/pull/3309.diff</a>

</details>
