### PR TITLE
8262280: Incorrect exception handling for VMThread in class redefinition

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -236,7 +236,7 @@ bool VM_RedefineClasses::doit_prologue() {
 }
 
 void VM_RedefineClasses::doit() {
-  Thread *thread = Thread::current();
+  Thread* current = Thread::current();
 
 #if INCLUDE_CDS
   if (UseSharedSpaces) {
@@ -255,11 +255,11 @@ void VM_RedefineClasses::doit() {
   // Mark methods seen on stack and everywhere else so old methods are not
   // cleaned up if they're on the stack.
   MetadataOnStackMark md_on_stack(/*walk_all_metadata*/true, /*redefinition_walk*/true);
-  HandleMark hm(thread);   // make sure any handles created are deleted
-                           // before the stack walk again.
+  HandleMark hm(current);   // make sure any handles created are deleted
+                            // before the stack walk again.
 
   for (int i = 0; i < _class_count; i++) {
-    redefine_single_class(_class_defs[i].klass, _scratch_classes[i], thread);
+    redefine_single_class(current, _class_defs[i].klass, _scratch_classes[i]);
   }
 
   // Flush all compiled code that depends on the classes redefined.
@@ -269,7 +269,7 @@ void VM_RedefineClasses::doit() {
   // that reference methods of the evolved classes.
   // Have to do this after all classes are redefined and all methods that
   // are redefined are marked as old.
-  AdjustAndCleanMetadata adjust_and_clean_metadata(thread);
+  AdjustAndCleanMetadata adjust_and_clean_metadata(current);
   ClassLoaderDataGraph::classes_do(&adjust_and_clean_metadata);
 
   // JSR-292 support
@@ -288,7 +288,7 @@ void VM_RedefineClasses::doit() {
   if (log_is_enabled(Trace, redefine, class, obsolete, metadata)) {
 #endif
     log_trace(redefine, class, obsolete, metadata)("calling check_class");
-    CheckClass check_class(thread);
+    CheckClass check_class(current);
     ClassLoaderDataGraph::classes_do(&check_class);
 #ifdef PRODUCT
   }
@@ -3784,14 +3784,14 @@ void VM_RedefineClasses::AdjustAndCleanMetadata::do_klass(Klass* k) {
   }
 }
 
-void VM_RedefineClasses::update_jmethod_ids(Thread* thread) {
+void VM_RedefineClasses::update_jmethod_ids() {
   for (int j = 0; j < _matching_methods_length; ++j) {
     Method* old_method = _matching_old_methods[j];
     jmethodID jmid = old_method->find_jmethod_id_or_null();
     if (jmid != NULL) {
       // There is a jmethodID, change it to point to the new method
-      methodHandle new_method_h(thread, _matching_new_methods[j]);
-      Method::change_method_associated_with_jmethod_id(jmid, new_method_h());
+      Method* new_method = _matching_new_methods[j];
+      Method::change_method_associated_with_jmethod_id(jmid, new_method);
       assert(Method::resolve_jmethod_id(jmid) == _matching_new_methods[j],
              "should be replaced");
     }
@@ -4203,10 +4203,10 @@ void VM_RedefineClasses::swap_annotations(InstanceKlass* the_class,
 //      a helper method to be specified. The interesting parameters
 //      that we would like to pass to the helper method are saved in
 //      static global fields in the VM operation.
-void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
-       InstanceKlass* scratch_class, TRAPS) {
+void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclass,
+                                               InstanceKlass* scratch_class) {
 
-  HandleMark hm(THREAD);   // make sure handles from this call are freed
+  HandleMark hm(current);   // make sure handles from this call are freed
 
   if (log_is_enabled(Info, redefine, class, timer)) {
     _timer_rsc_phase1.start();
@@ -4228,7 +4228,7 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
   _new_methods = scratch_class->methods();
   _the_class = the_class;
   compute_added_deleted_matching_methods();
-  update_jmethod_ids(THREAD);
+  update_jmethod_ids();
 
   _any_class_has_resolved_methods = the_class->has_resolved_methods() || _any_class_has_resolved_methods;
 
@@ -4416,7 +4416,7 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
   if (!the_class->should_be_initialized()) {
     // Class was already initialized, so AOT has only seen the original version.
     // We need to let AOT look at it again.
-    AOTLoader::load_for_klass(the_class, THREAD);
+    AOTLoader::load_for_klass(the_class, current);
   }
 
   // keep track of previous versions of this class
@@ -4444,13 +4444,13 @@ void VM_RedefineClasses::redefine_single_class(jclass the_jclass,
   }
 
   {
-    ResourceMark rm(THREAD);
+    ResourceMark rm(current);
     // increment the classRedefinedCount field in the_class and in any
     // direct and indirect subclasses of the_class
     log_info(redefine, class, load)
       ("redefined name=%s, count=%d (avail_mem=" UINT64_FORMAT "K)",
        the_class->external_name(), java_lang_Class::classRedefinedCount(the_class->java_mirror()), os::available_memory() >> 10);
-    Events::log_redefinition(THREAD, "redefined class name=%s, count=%d",
+    Events::log_redefinition(current, "redefined class name=%s, count=%d",
                              the_class->external_name(),
                              java_lang_Class::classRedefinedCount(the_class->java_mirror()));
 

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -407,7 +407,7 @@ class VM_RedefineClasses: public VM_Operation {
   void compute_added_deleted_matching_methods();
 
   // Change jmethodIDs to point to the new methods
-  void update_jmethod_ids(Thread* thread);
+  void update_jmethod_ids();
 
   // In addition to marking methods as old and/or obsolete, this routine
   // counts the number of methods that are EMCP (Equivalent Module Constant Pool).
@@ -415,8 +415,8 @@ class VM_RedefineClasses: public VM_Operation {
   void transfer_old_native_function_registrations(InstanceKlass* the_class);
 
   // Install the redefinition of a class
-  void redefine_single_class(jclass the_jclass,
-    InstanceKlass* scratch_class_oop, TRAPS);
+  void redefine_single_class(Thread* current, jclass the_jclass,
+                             InstanceKlass* scratch_class_oop);
 
   void swap_annotations(InstanceKlass* new_class,
                         InstanceKlass* scratch_class);


### PR DESCRIPTION
This is a trivial change to remove the last TRAPS from redefine_single_class which is called by the VM thread during a safepoint.
Tested with serviceability/jvmti/RedefineClasses, vmTestbase/nsk/jvmti,jdi and jdk/java/lang/instrument tests.  And tier1 sanity in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262280](https://bugs.openjdk.java.net/browse/JDK-8262280): Incorrect exception handling for VMThread in class redefinition


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3310/head:pull/3310` \
`$ git checkout pull/3310`

Update a local copy of the PR: \
`$ git checkout pull/3310` \
`$ git pull https://git.openjdk.java.net/jdk pull/3310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3310`

View PR using the GUI difftool: \
`$ git pr show -t 3310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3310.diff">https://git.openjdk.java.net/jdk/pull/3310.diff</a>

</details>
