### PR TITLE
8264609 : Number.{byteValue, shortValue} spec should use @implSpec

### DIFF
--- a/src/java.base/share/classes/java/lang/Number.java
+++ b/src/java.base/share/classes/java/lang/Number.java
@@ -107,7 +107,8 @@ public abstract class Number implements java.io.Serializable {
     /**
      * Returns the value of the specified number as a {@code short}.
      *
-     * <p>This implementation returns the result of {@link #intValue} cast
+     * @implSpec
+     * The default implementation returns the result of {@link #intValue} cast
      * to a {@code short}.
      *
      * @return  the numeric value represented by this object after conversion

--- a/src/java.base/share/classes/java/lang/Number.java
+++ b/src/java.base/share/classes/java/lang/Number.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,8 @@ public abstract class Number implements java.io.Serializable {
     /**
      * Returns the value of the specified number as a {@code byte}.
      *
-     * <p>This implementation returns the result of {@link #intValue} cast
+     * @implSpec
+     * The default implementation returns the result of {@link #intValue} cast
      * to a {@code byte}.
      *
      * @return  the numeric value represented by this object after conversion


### PR DESCRIPTION
Please review this small code change and its accompanying CSR:

 https://bugs.openjdk.java.net/browse/JDK-8264610

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264609](https://bugs.openjdk.java.net/browse/JDK-8264609): Number.{byteValue, shortValue} spec should use @implSpec


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3314/head:pull/3314` \
`$ git checkout pull/3314`

Update a local copy of the PR: \
`$ git checkout pull/3314` \
`$ git pull https://git.openjdk.java.net/jdk pull/3314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3314`

View PR using the GUI difftool: \
`$ git pr show -t 3314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3314.diff">https://git.openjdk.java.net/jdk/pull/3314.diff</a>

</details>
