### PR TITLE
8264626: C1 should be able to inline excluded methods

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3461,7 +3461,6 @@ const char* GraphBuilder::check_can_parse(ciMethod* callee) const {
   // Certain methods cannot be parsed at all:
   if ( callee->is_native())            return "native method";
   if ( callee->is_abstract())          return "abstract method";
-  if (!callee->can_be_compiled())      return "not compilable (disabled)";
   if (!callee->can_be_parsed())        return "cannot be parsed";
   return NULL;
 }


### PR DESCRIPTION
I noticed a behavioral between c1 and c2. In c2 excluded methods can still be inlined, which is the desired behaviour. Inlining is controlled separately. I propose a small change to c1 inlining that make it work in the same way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264626](https://bugs.openjdk.java.net/browse/JDK-8264626): C1 should be able to inline excluded methods


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3315/head:pull/3315` \
`$ git checkout pull/3315`

Update a local copy of the PR: \
`$ git checkout pull/3315` \
`$ git pull https://git.openjdk.java.net/jdk pull/3315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3315`

View PR using the GUI difftool: \
`$ git pr show -t 3315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3315.diff">https://git.openjdk.java.net/jdk/pull/3315.diff</a>

</details>
