### PR TITLE
8264359: Compiler directives should enable DebugNonSafepoints when PrintAssembly is requested

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -30,6 +30,7 @@
 #include "compiler/compilerOracle.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/globals_extension.hpp"
 
 CompilerDirectives::CompilerDirectives() : _next(NULL), _match(NULL), _ref_count(0) {
   _c1_store = new DirectiveSet(this);
@@ -103,6 +104,10 @@ void DirectiveSet::finalize(outputStream* st) {
   // Check LogOption and warn
   if (LogOption && !LogCompilation) {
     st->print_cr("Warning:  +LogCompilation must be set to enable compilation logging from directives");
+  }
+  if (PrintAssemblyOption && FLAG_IS_DEFAULT(DebugNonSafepoints)) {
+    warning("printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output");
+    DebugNonSafepoints = true;
   }
 
   // if any flag has been modified - set directive as enabled

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -911,9 +911,6 @@ void compilerOracle_init() {
   if (has_command(CompileCommand::Print)) {
     if (PrintAssembly) {
       warning("CompileCommand and/or %s file contains 'print' commands, but PrintAssembly is also enabled", default_cc_file);
-    } else if (FLAG_IS_DEFAULT(DebugNonSafepoints)) {
-      warning("printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output");
-      DebugNonSafepoints = true;
     }
   }
 }


### PR DESCRIPTION
DebugNonSafepoints should be set when PrintAssembly is requested. This only happened for compile commands but not for compiler directives. This PR moves the check to compiler directives - that code path is used for both directives and commands. I am leaving the check and update in arguments.cpp - there might be some need for using flag PrintAssembly for stubs or wrappers, in a code path that doesn't use commands or directives.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264359](https://bugs.openjdk.java.net/browse/JDK-8264359): Compiler directives should enable DebugNonSafepoints when PrintAssembly is requested


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3316/head:pull/3316` \
`$ git checkout pull/3316`

Update a local copy of the PR: \
`$ git checkout pull/3316` \
`$ git pull https://git.openjdk.java.net/jdk pull/3316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3316`

View PR using the GUI difftool: \
`$ git pr show -t 3316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3316.diff">https://git.openjdk.java.net/jdk/pull/3316.diff</a>

</details>
