### PR TITLE
8205502: Make exception message from AnnotationInvocationHandler more informative

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -53,7 +53,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
             superInterfaces.length != 1 ||
             superInterfaces[0] != java.lang.annotation.Annotation.class)
             throw new AnnotationFormatError("Attempt to create proxy for a non-annotation type: " +
-					    type.getName());
+                                            type.getName());
         this.type = type;
         this.memberValues = memberValues;
     }
@@ -579,7 +579,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
             return;
         else
             throw new AnnotationFormatError("Malformed method on an annotation type: " +
-					    currentMethod.toString());
+                                            currentMethod.toString());
     }
 
     /**

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -52,7 +52,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
         if (!type.isAnnotation() ||
             superInterfaces.length != 1 ||
             superInterfaces[0] != java.lang.annotation.Annotation.class)
-            throw new AnnotationFormatError("Attempt to create proxy for a non-annotation type.");
+            throw new AnnotationFormatError("Attempt to create proxy for a non-annotation type: " +
+					    type.getName());
         this.type = type;
         this.memberValues = memberValues;
     }
@@ -492,7 +493,9 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
          * 9.6.1. Annotation Type Elements
          */
         boolean valid = true;
+        Method currentMethod = null;
         for(Method method : memberMethods) {
+            currentMethod = method;
             int modifiers = method.getModifiers();
             // Skip over methods that may be a static initializer or
             // similar construct. A static initializer may be used for
@@ -575,7 +578,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
         if (valid)
             return;
         else
-            throw new AnnotationFormatError("Malformed method on an annotation type");
+            throw new AnnotationFormatError("Malformed method on an annotation type: " +
+					    currentMethod.toString());
     }
 
     /**


### PR DESCRIPTION
Simple change to make the exception/error messages more informative for various malformed annotation situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8205502](https://bugs.openjdk.java.net/browse/JDK-8205502): Make exception message from AnnotationInvocationHandler more informative


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3317/head:pull/3317` \
`$ git checkout pull/3317`

Update a local copy of the PR: \
`$ git checkout pull/3317` \
`$ git pull https://git.openjdk.java.net/jdk pull/3317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3317`

View PR using the GUI difftool: \
`$ git pr show -t 3317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3317.diff">https://git.openjdk.java.net/jdk/pull/3317.diff</a>

</details>
