### PR TITLE
8264633: Add missing logging to PlatformRecording#stop

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -176,7 +176,9 @@ public final class PlatformRecording implements AutoCloseable {
                 notifyIfStateChanged(newState, oldState);
                 close(); // remove if copied out
             } catch(IOException e) {
-                // throw e; // BUG8925030
+                Logger.log(LogTag.JFR, LogLevel.ERROR,
+                           "Unable to complete I/O operation when dumping recording \"" + getName() + "\" (" + getId() + ") due to: "
+                           + e.getMessage());
             }
         } else {
             notifyIfStateChanged(newState, oldState);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -177,8 +177,7 @@ public final class PlatformRecording implements AutoCloseable {
                 close(); // remove if copied out
             } catch(IOException e) {
                 Logger.log(LogTag.JFR, LogLevel.ERROR,
-                           "Unable to complete I/O operation when dumping recording \"" + getName() + "\" (" + getId() + ") due to: "
-                           + e.getMessage());
+                           "Unable to complete I/O operation when dumping recording \"" + getName() + "\" (" + getId() + ")");
             }
         } else {
             notifyIfStateChanged(newState, oldState);


### PR DESCRIPTION
small fix to add logging to the catch block in PlatformRecording#stop

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264633](https://bugs.openjdk.java.net/browse/JDK-8264633): Add missing logging to PlatformRecording#stop


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3319/head:pull/3319` \
`$ git checkout pull/3319`

Update a local copy of the PR: \
`$ git checkout pull/3319` \
`$ git pull https://git.openjdk.java.net/jdk pull/3319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3319`

View PR using the GUI difftool: \
`$ git pr show -t 3319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3319.diff">https://git.openjdk.java.net/jdk/pull/3319.diff</a>

</details>
