### PR TITLE
8264564: AArch64: use MOVI instead of FMOV to zero FP register

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -2184,13 +2184,13 @@ public:
     if (value)
       fmov_imm(Vn, value, 0b00);
     else
-      fmovs(Vn, zr);
+      movi(Vn, T2S, 0);
   }
   void fmovd(FloatRegister Vn, double value) {
     if (value)
       fmov_imm(Vn, value, 0b01);
     else
-      fmovd(Vn, zr);
+      movi(Vn, T1D, 0);
   }
 
    // Floating-point rounding

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5153,7 +5153,7 @@ address MacroAssembler::byte_array_inflate(Register src, Register dst, Register 
 
   assert_different_registers(src, dst, len, tmp4, rscratch1);
 
-  fmovd(vtmp1, zr);
+  fmovd(vtmp1, 0.0);
   lsrw(tmp4, len, 3);
   bind(after_init);
   cbnzw(tmp4, big);

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -261,7 +261,7 @@ void TemplateTable::fconst(int value)
   transition(vtos, ftos);
   switch (value) {
   case 0:
-    __ fmovs(v0, zr);
+    __ fmovs(v0, 0.0);
     break;
   case 1:
     __ fmovs(v0, 1.0);
@@ -280,7 +280,7 @@ void TemplateTable::dconst(int value)
   transition(vtos, dtos);
   switch (value) {
   case 0:
-    __ fmovd(v0, zr);
+    __ fmovd(v0, 0.0);
     break;
   case 1:
     __ fmovd(v0, 1.0);


### PR DESCRIPTION
HotSpot generates an FMOV from ZR to zero a floating point register:

   fmov d0, xzr

This used to be recommended by the Arm ARM, but that advice was removed
in revision A.j and subsequent revisions (section C.5.3).

Integer->FP moves may be slow on some cores. Instead the preferred
instruction is MOVI with immediate zero:

   movi d0, #0x0

Some micro-architectures special-case FMOV from ZR, and on those cores
this change will have no effect, but in any case FMOV won't be faster
than MOVI.

GCC made this change back in 2016:
  https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=523d72071960

Tested tier1 on AArch64. I don't expect this to have any visible effect
on benchmarks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264564](https://bugs.openjdk.java.net/browse/JDK-8264564): AArch64: use MOVI instead of FMOV to zero FP register


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3322/head:pull/3322` \
`$ git checkout pull/3322`

Update a local copy of the PR: \
`$ git checkout pull/3322` \
`$ git pull https://git.openjdk.java.net/jdk pull/3322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3322`

View PR using the GUI difftool: \
`$ git pr show -t 3322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3322.diff">https://git.openjdk.java.net/jdk/pull/3322.diff</a>

</details>
