### PR TITLE
8264644: Add PrintClassLoaderDataGraphAtExit to print the detailed CLD graph

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -975,7 +975,7 @@ void ClassLoaderData::print_on(outputStream* out) const {
   out->print_cr(" - dictionary          " PTR_FORMAT, p2i(_dictionary));
   if (_jmethod_ids != NULL) {
     out->print   (" - jmethod count       ");
-    Method::print_jmethod_ids(this, out);
+    Method::print_jmethod_ids_counts(this, out);
     out->print_cr("");
   }
   out->print_cr(" - deallocate list     " PTR_FORMAT, p2i(_deallocate_list));

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -940,6 +940,7 @@ public:
     _out->print("%s,", k->external_name());
   }
 };
+
 void ClassLoaderData::print_on(outputStream* out) const {
   ResourceMark rm;
   out->print_cr("ClassLoaderData(" INTPTR_FORMAT ")", p2i(this));

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -942,15 +942,15 @@ public:
 };
 void ClassLoaderData::print_on(outputStream* out) const {
   ResourceMark rm;
-  out->print_cr("ClassLoaderData(" PTR_FORMAT ")", p2i(this));
+  out->print_cr("ClassLoaderData(" INTPTR_FORMAT ")", p2i(this));
   out->print_cr(" - name                %s", loader_name_and_id());
   if (!_holder.is_null()) {
     out->print   (" - holder              ");
     _holder.print_on(out);
     out->print_cr("");
   }
-  out->print_cr(" - class loader        " PTR_FORMAT, p2i(_class_loader.ptr_raw()));
-  out->print_cr(" - metaspace           " PTR_FORMAT, p2i(_metaspace));
+  out->print_cr(" - class loader        " INTPTR_FORMAT, p2i(_class_loader.ptr_raw()));
+  out->print_cr(" - metaspace           " INTPTR_FORMAT, p2i(_metaspace));
   out->print_cr(" - unloading           %s", _unloading ? "true" : "false");
   out->print_cr(" - class mirror holder %s", _has_class_mirror_holder ? "true" : "false");
   out->print_cr(" - modified oops       %s", _modified_oops ? "true" : "false");
@@ -969,17 +969,17 @@ void ClassLoaderData::print_on(outputStream* out) const {
   PrintKlassClosure closure(out);
   ((ClassLoaderData*)this)->classes_do(&closure);
   out->print_cr(" }");
-  out->print_cr(" - packages            " PTR_FORMAT, p2i(_packages));
-  out->print_cr(" - module              " PTR_FORMAT, p2i(_modules));
-  out->print_cr(" - unnamed module      " PTR_FORMAT, p2i(_unnamed_module));
-  out->print_cr(" - dictionary          " PTR_FORMAT, p2i(_dictionary));
+  out->print_cr(" - packages            " INTPTR_FORMAT, p2i(_packages));
+  out->print_cr(" - module              " INTPTR_FORMAT, p2i(_modules));
+  out->print_cr(" - unnamed module      " INTPTR_FORMAT, p2i(_unnamed_module));
+  out->print_cr(" - dictionary          " INTPTR_FORMAT, p2i(_dictionary));
   if (_jmethod_ids != NULL) {
     out->print   (" - jmethod count       ");
-    Method::print_jmethod_ids_counts(this, out);
+    Method::print_jmethod_ids_count(this, out);
     out->print_cr("");
   }
-  out->print_cr(" - deallocate list     " PTR_FORMAT, p2i(_deallocate_list));
-  out->print_cr(" - next CLD            " PTR_FORMAT, p2i(_next));
+  out->print_cr(" - deallocate list     " INTPTR_FORMAT, p2i(_deallocate_list));
+  out->print_cr(" - next CLD            " INTPTR_FORMAT, p2i(_next));
 }
 #endif // PRODUCT
 

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -949,8 +949,8 @@ void ClassLoaderData::print_on(outputStream* out) const {
     _holder.print_on(out);
     out->print_cr("");
   }
-  out->print_cr(" - class loader        %p", _class_loader.ptr_raw());
-  out->print_cr(" - metaspace           %p", _metaspace);
+  out->print_cr(" - class loader        " PTR_FORMAT, p2i(_class_loader.ptr_raw()));
+  out->print_cr(" - metaspace           " PTR_FORMAT, p2i(_metaspace));
   out->print_cr(" - unloading           %s", _unloading ? "true" : "false");
   out->print_cr(" - class mirror holder %s", _has_class_mirror_holder ? "true" : "false");
   out->print_cr(" - modified oops       %s", _modified_oops ? "true" : "false");
@@ -969,17 +969,17 @@ void ClassLoaderData::print_on(outputStream* out) const {
   PrintKlassClosure closure(out);
   ((ClassLoaderData*)this)->classes_do(&closure);
   out->print_cr(" }");
-  out->print_cr(" - packages            %p", _packages);
-  out->print_cr(" - module              %p", _modules);
-  out->print_cr(" - unnamed module      %p", _unnamed_module);
-  out->print_cr(" - dictionary          %p", _dictionary);
+  out->print_cr(" - packages            " PTR_FORMAT, p2i(_packages));
+  out->print_cr(" - module              " PTR_FORMAT, p2i(_modules));
+  out->print_cr(" - unnamed module      " PTR_FORMAT, p2i(_unnamed_module));
+  out->print_cr(" - dictionary          " PTR_FORMAT, p2i(_dictionary));
   if (_jmethod_ids != NULL) {
     out->print   (" - jmethod count       ");
     Method::print_jmethod_ids(this, out);
     out->print_cr("");
   }
-  out->print_cr(" - deallocate list     %p", _deallocate_list);
-  out->print_cr(" - next CLD            %p", _next);
+  out->print_cr(" - deallocate list     " PTR_FORMAT, p2i(_deallocate_list));
+  out->print_cr(" - next CLD            " PTR_FORMAT, p2i(_next));
 }
 #endif // PRODUCT
 

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -945,9 +945,9 @@ void ClassLoaderData::print_on(outputStream* out) const {
   out->print_cr("ClassLoaderData(" PTR_FORMAT ")", p2i(this));
   out->print_cr(" - name                %s", loader_name_and_id());
   if (!_holder.is_null()) {
-  out->print   (" - holder              ");
-  _holder.print_on(out);
-  out->print_cr("");
+    out->print   (" - holder              ");
+    _holder.print_on(out);
+    out->print_cr("");
   }
   out->print_cr(" - class loader        %p", _class_loader.ptr_raw());
   out->print_cr(" - metaspace           %p", _metaspace);
@@ -974,9 +974,9 @@ void ClassLoaderData::print_on(outputStream* out) const {
   out->print_cr(" - unnamed module      %p", _unnamed_module);
   out->print_cr(" - dictionary          %p", _dictionary);
   if (_jmethod_ids != NULL) {
-  out->print   (" - jmethod count       ");
-  Method::print_jmethod_ids(this, out);
-  out->print_cr("");
+    out->print   (" - jmethod count       ");
+    Method::print_jmethod_ids(this, out);
+    out->print_cr("");
   }
   out->print_cr(" - deallocate list     %p", _deallocate_list);
   out->print_cr(" - next CLD            %p", _next);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -673,6 +673,7 @@ void ClassLoaderDataGraph::verify() {
 // callable from debugger
 extern "C" int print_loader_data_graph() {
   ResourceMark rm;
+  MutexLocker ml(ClassLoaderDataGraph_lock);
   ClassLoaderDataGraph::print_on(tty);
   return 0;
 }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2255,7 +2255,7 @@ bool Method::is_valid_method(const Method* m) {
 }
 
 #ifndef PRODUCT
-void Method::print_jmethod_ids_counts(const ClassLoaderData* loader_data, outputStream* out) {
+void Method::print_jmethod_ids_count(const ClassLoaderData* loader_data, outputStream* out) {
   out->print("%d", loader_data->jmethod_ids()->count_methods());
 }
 #endif // PRODUCT

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2255,7 +2255,7 @@ bool Method::is_valid_method(const Method* m) {
 }
 
 #ifndef PRODUCT
-void Method::print_jmethod_ids(const ClassLoaderData* loader_data, outputStream* out) {
+void Method::print_jmethod_ids_counts(const ClassLoaderData* loader_data, outputStream* out) {
   out->print("%d", loader_data->jmethod_ids()->count_methods());
 }
 #endif // PRODUCT

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2256,7 +2256,7 @@ bool Method::is_valid_method(const Method* m) {
 
 #ifndef PRODUCT
 void Method::print_jmethod_ids(const ClassLoaderData* loader_data, outputStream* out) {
-  out->print(" jni_method_id count = %d", loader_data->jmethod_ids()->count_methods());
+  out->print("%d", loader_data->jmethod_ids()->count_methods());
 }
 #endif // PRODUCT
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -822,7 +822,7 @@ public:
 
   // Clear methods
   static void clear_jmethod_ids(ClassLoaderData* loader_data);
-  static void print_jmethod_ids_counts(const ClassLoaderData* loader_data, outputStream* out) PRODUCT_RETURN;
+  static void print_jmethod_ids_count(const ClassLoaderData* loader_data, outputStream* out) PRODUCT_RETURN;
 
   // Get this method's jmethodID -- allocate if it doesn't exist
   jmethodID jmethod_id();

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -822,7 +822,7 @@ public:
 
   // Clear methods
   static void clear_jmethod_ids(ClassLoaderData* loader_data);
-  static void print_jmethod_ids(const ClassLoaderData* loader_data, outputStream* out) PRODUCT_RETURN;
+  static void print_jmethod_ids_counts(const ClassLoaderData* loader_data, outputStream* out) PRODUCT_RETURN;
 
   // Get this method's jmethodID -- allocate if it doesn't exist
   jmethodID jmethod_id();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -689,6 +689,9 @@ const intx ObjectAlignmentInBytes = 8;
   notproduct(bool, PrintSystemDictionaryAtExit, false,                      \
           "Print the system dictionary at exit")                            \
                                                                             \
+  notproduct(bool, PrintClassLoaderDataGraphAtExit, false,                  \
+          "Print the class loader data graph at exit")                      \
+                                                                            \
   product(bool, DynamicallyResizeSystemDictionaries, true, DIAGNOSTIC,      \
           "Dynamically resize system dictionaries as needed")               \
                                                                             \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -330,6 +330,11 @@ void print_statistics() {
     ResourceMark rm;
     MutexLocker mcld(ClassLoaderDataGraph_lock);
     SystemDictionary::print();
+  }
+
+  if (PrintClassLoaderDataGraphAtExit) {
+    ResourceMark rm;
+    MutexLocker mcld(ClassLoaderDataGraph_lock);
     ClassLoaderDataGraph::print();
   }
 


### PR DESCRIPTION
Trivial chanage to make debugging happy, now cld->print() would be:

```
ClassLoaderData(0x00007ff17432b670)
 - name                'platform'
 - holder              WeakHandle: 0x00000007fef56678
 - class loader        0x7ff17432b828
 - metaspace           0x7ff17468a0b0
 - unloading           false
 - class mirror holder false
 - modified oops       true
 - keep alive          0
 - claim               strong
 - handles             43
 - dependency count    0
 - klasses             {java.sql.SQLFeatureNotSupportedException,java.sql.SQLNonTransientException,java.sql.SQLException,sun.util.resources.provider.NonBaseLocaleDataMetaInfo,org.ietf.jgss.GSSException,javax.sql.DataSource,java.sql.Wrapper,javax.sql.CommonDataSource,java.sql.Time,java.sql.Date,java.sql.Timestamp,sun.util.resources.cldr.provider.CLDRLocaleDataMetaInfo, }
 - packages            0x7ff17432bc20
 - module              0x7ff17432c520
 - unnamed module      0x7ff17432c3d0
 - dictionary          0x7ff17432c470
 - deallocate list     0x7ff0a4023bd0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264644](https://bugs.openjdk.java.net/browse/JDK-8264644): Add PrintClassLoaderDataGraphAtExit to print the detailed CLD graph


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 97db359eda0c19f24f685878a48e99da5404daa1
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 1eb6766bb4965e507da7f7fc8e903a4bbdc37b71
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 1eb6766bb4965e507da7f7fc8e903a4bbdc37b71


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3323/head:pull/3323` \
`$ git checkout pull/3323`

Update a local copy of the PR: \
`$ git checkout pull/3323` \
`$ git pull https://git.openjdk.java.net/jdk pull/3323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3323`

View PR using the GUI difftool: \
`$ git pr show -t 3323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3323.diff">https://git.openjdk.java.net/jdk/pull/3323.diff</a>

</details>
