### PR TITLE
JDK-8264572: ForkJoinPool.getCommonPoolParallelism() reports always 1

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2572,7 +2572,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         this.saturate = null;
         this.workerNamePrefix = null;
         int p = Math.min(Math.max(parallelism, 0), MAX_CAP), size;
-        this.mode = 0;
+        this.mode = p;
         if (p > 0) {
             size = 1 << (33 - Integer.numberOfLeadingZeros(p - 1));
             this.bounds = ((1 - p) & SMASK) | (COMMON_MAX_SPARES << SWIDTH);

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2572,6 +2572,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         this.saturate = null;
         this.workerNamePrefix = null;
         int p = Math.min(Math.max(parallelism, 0), MAX_CAP), size;
+        this.mode = 0;
         if (p > 0) {
             size = 1 << (33 - Integer.numberOfLeadingZeros(p - 1));
             this.bounds = ((1 - p) & SMASK) | (COMMON_MAX_SPARES << SWIDTH);


### PR DESCRIPTION
This reinserts setting common pool parallelism inadvertently clobbered in JDK-8259800

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264572](https://bugs.openjdk.java.net/browse/JDK-8264572): ForkJoinPool.getCommonPoolParallelism() reports always 1


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3324/head:pull/3324` \
`$ git checkout pull/3324`

Update a local copy of the PR: \
`$ git checkout pull/3324` \
`$ git pull https://git.openjdk.java.net/jdk pull/3324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3324`

View PR using the GUI difftool: \
`$ git pr show -t 3324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3324.diff">https://git.openjdk.java.net/jdk/pull/3324.diff</a>

</details>
