### PR TITLE
8264650: Cross-compilation to macos/aarch64

### DIFF
--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -265,6 +265,11 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
     fi
   fi
 
+  if test "x$OPENJDK_TARGET_OS" = xmacosx &&
+      test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+    MACHINE_FLAG="-arch arm64"
+  fi
+
   # FIXME: global flags are not used yet...
   # The "global" flags will *always* be set. Without them, it is not possible to
   # get a working compilation.

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -265,9 +265,12 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
     fi
   fi
 
-  if test "x$OPENJDK_TARGET_OS" = xmacosx &&
-      test "x$OPENJDK_TARGET_CPU" = xaarch64; then
-    MACHINE_FLAG="$MACHINE_FLAG -arch arm64"
+  if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      MACHINE_FLAG="$MACHINE_FLAG -arch arm64"
+    elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
+      MACHINE_FLAG="$MACHINE_FLAG -arch x86_64"
+    fi
   fi
 
   # FIXME: global flags are not used yet...

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -267,7 +267,7 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
 
   if test "x$OPENJDK_TARGET_OS" = xmacosx &&
       test "x$OPENJDK_TARGET_CPU" = xaarch64; then
-    MACHINE_FLAG="-arch arm64"
+    MACHINE_FLAG="$MACHINE_FLAG -arch arm64"
   fi
 
   # FIXME: global flags are not used yet...


### PR DESCRIPTION
Please review adding necessary flags for cross-compilation on macos/x86 targeting macos/aarch64.

All CFLAGS, CXXFLAGS, LDFLAGS need target CPU flag `-arch arm64`.
This patch adds the flag along e.g `-m64`.

Tested:
* cross-compilation 
  * macos/x86 -> macos/aarch64: configure --openjdk-target=aarch64-apple-darwin
  * macos/aarch64 -> macos/x86: configure --openjdk-target=x86_64-apple-darwin
* native compilation:
  * macos/aarch64
  * macos/x86

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264650](https://bugs.openjdk.java.net/browse/JDK-8264650): Cross-compilation to macos/aarch64


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3325/head:pull/3325` \
`$ git checkout pull/3325`

Update a local copy of the PR: \
`$ git checkout pull/3325` \
`$ git pull https://git.openjdk.java.net/jdk pull/3325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3325`

View PR using the GUI difftool: \
`$ git pr show -t 3325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3325.diff">https://git.openjdk.java.net/jdk/pull/3325.diff</a>

</details>
