### PR TITLE
8264554: X509KeyManagerImpl calls getProtectionParameter with incorrect alias

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
@@ -269,8 +269,8 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
             String keyStoreAlias = alias.substring(secondDot + 1);
             Builder builder = builders.get(builderIndex);
             KeyStore ks = builder.getKeyStore();
-            Entry newEntry = ks.getEntry
-                    (keyStoreAlias, builder.getProtectionParameter(alias));
+            Entry newEntry = ks.getEntry(keyStoreAlias,
+                    builder.getProtectionParameter(keyStoreAlias));
             if (!(newEntry instanceof PrivateKeyEntry)) {
                 // unexpected type of entry
                 return null;


### PR DESCRIPTION
In X509KeyManagerImpl.java, a composited  entry alias consists three parts: an UID counter, a builder index and the real entry alias (See the makeAlias() method).  While calling the KeyStore.Builder.getProtectionParameter(String alias) method, the real entry alias should be used instead, rather than the composited entry alias.

Simple and straightforward update, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264554](https://bugs.openjdk.java.net/browse/JDK-8264554): X509KeyManagerImpl calls getProtectionParameter with incorrect alias


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3326/head:pull/3326` \
`$ git checkout pull/3326`

Update a local copy of the PR: \
`$ git checkout pull/3326` \
`$ git pull https://git.openjdk.java.net/jdk pull/3326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3326`

View PR using the GUI difftool: \
`$ git pr show -t 3326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3326.diff">https://git.openjdk.java.net/jdk/pull/3326.diff</a>

</details>
