### PR TITLE
JDK-8264655: Minor internal doc comment cleanup

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
  * or {@link javax.lang.model.element.Element "language model elements"}.
  * The usage is made explicit when it is not clear from the surrounding context.
  *
- * @see <a href="https://html.spec.whatwg.org/#classes>WhatWG: {@code class} attribute</a>
+ * @see <a href="https://html.spec.whatwg.org/#classes">WhatWG: {@code class} attribute</a>
  */
 public enum HtmlStyle {
     block,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TagName.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TagName.java
@@ -35,7 +35,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
  *  This code and its internal interfaces are subject to change or
  *  deletion without notice.</b>
  *
- * @see <a href=""https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-name>WhatWG: Tag Name</a>
+ * @see <a href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-name">WhatWG: Tag Name</a>
  * @see <a href="https://www.w3.org/TR/html51/syntax.html#tag-name">HTML 5.1: Tag Name</a>
  */
 public enum TagName {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -84,7 +84,7 @@ import jdk.javadoc.internal.doclint.DocLint;
  * Configure the output based on the options. Doclets should sub-class
  * BaseConfiguration, to configure and add their own options. This class contains
  * all user options which are supported by the standard doclet.
- * <p>
+ *
  * <p><b>This is NOT part of any supported API.
  * If you write code that depends on this, you do so at your own risk.
  * This code and its internal interfaces are subject to change or

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,20 +40,18 @@ import static jdk.javadoc.internal.doclint.HtmlTag.Attr.*;
 /**
  * Enum representing HTML tags.
  *
- * The intent of this class is to embody the semantics of W3C HTML 4.01
+ * The intent of this class is to embody the semantics of the current HTML standard,
  * to the extent supported/used by javadoc.
- * In time, we may wish to transition javadoc and doclint to using HTML 5.
  *
- * This is derivative of com.sun.tools.doclets.formats.html.markup.HtmlTag.
+ * This class is derivative of {@link jdk.javadoc.internal.doclets.formats.html.markup.TagName}.
  * Eventually, these two should be merged back together, and possibly made
  * public.
  *
- * @see <a href="http://www.w3.org/TR/REC-html40/">HTML 4.01 Specification</a>
+ * @see <a href="https://html.spec.whatwg.org/multipage/">HTML Living Standard</a>
  * @see <a href="http://www.w3.org/TR/html5/">HTML 5 Specification</a>
- * @see <a href="http://www.w3.org/TR/wai-aria/ ">WAI-ARIA Specification</a>
+ * @see <a href="http://www.w3.org/TR/REC-html40/">HTML 4.01 Specification</a>
+ * @see <a href="http://www.w3.org/TR/wai-aria/">WAI-ARIA Specification</a>
  * @see <a href="http://www.w3.org/TR/aria-in-html/#recommendations-table">WAI-ARIA Recommendations Table</a>
- * @author Bhavesh Patel
- * @author Jonathan Gibbons (revised)
  */
 public enum HtmlTag {
     A(BlockType.INLINE, EndKind.REQUIRED,
@@ -401,7 +399,7 @@ public enum HtmlTag {
     /**
      * Enum representing the supportability of HTML element.
      */
-    public static enum ElemKind {
+    public enum ElemKind {
         OK,
         INVALID,
         OBSOLETE,
@@ -411,7 +409,7 @@ public enum HtmlTag {
     /**
      * Enum representing the type of HTML element.
      */
-    public static enum BlockType {
+    public enum BlockType {
         BLOCK,
         INLINE,
         LIST_ITEM,
@@ -422,20 +420,20 @@ public enum HtmlTag {
     /**
      * Enum representing HTML end tag requirement.
      */
-    public static enum EndKind {
+    public enum EndKind {
         NONE,
         OPTIONAL,
         REQUIRED
     }
 
-    public static enum Flag {
+    public enum Flag {
         ACCEPTS_BLOCK,
         ACCEPTS_INLINE,
         EXPECT_CONTENT,
         NO_NEST
     }
 
-    public static enum Attr {
+    public enum Attr {
         ABBR,
         ALIGN,
         ALINK,
@@ -532,7 +530,7 @@ public enum HtmlTag {
         }
     }
 
-    public static enum AttrKind {
+    public enum AttrKind {
         OK,
         INVALID,
         OBSOLETE,


### PR DESCRIPTION
Please review some minor updates to internal doc comments on javadoc code. 

In addition, since this is just a cleanup PR, some redundant modifiers noted by an IDE have been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264655](https://bugs.openjdk.java.net/browse/JDK-8264655): Minor internal doc comment cleanup


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3327/head:pull/3327` \
`$ git checkout pull/3327`

Update a local copy of the PR: \
`$ git checkout pull/3327` \
`$ git pull https://git.openjdk.java.net/jdk pull/3327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3327`

View PR using the GUI difftool: \
`$ git pr show -t 3327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3327.diff">https://git.openjdk.java.net/jdk/pull/3327.diff</a>

</details>
