### PR TITLE
8264657: ProblemList java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -870,6 +870,7 @@ java/awt/TextArea/TextAreaCursorTest/HoveringAndDraggingTest.java 8024986 macosx
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macosx-all
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
+java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 
 
 ############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264657](https://bugs.openjdk.java.net/browse/JDK-8264657): ProblemList java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java on linux-x64


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3329/head:pull/3329` \
`$ git checkout pull/3329`

Update a local copy of the PR: \
`$ git checkout pull/3329` \
`$ git pull https://git.openjdk.java.net/jdk pull/3329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3329`

View PR using the GUI difftool: \
`$ git pr show -t 3329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3329.diff">https://git.openjdk.java.net/jdk/pull/3329.diff</a>

</details>
