### PR TITLE
8264512: jdk/test/jdk/java/util/prefs/ExportNode.java relies on default platform encoding

### DIFF
--- a/test/jdk/java/util/prefs/ExportNode.java
+++ b/test/jdk/java/util/prefs/ExportNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,25 +30,46 @@
  * @run main/othervm -Djava.util.prefs.userRoot=. ExportNode
  * @author Konstantin Kladko
  */
-import java.util.prefs.*;
-import java.io.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 public class ExportNode {
+    private static final String NODE_NAME_1 = "ExportNodeTestName1";
+    private static final String NODE_NAME_2 = "ExportNodeTestName2";
+
     public static void main(String[] args) throws
-                                            BackingStoreException, IOException {
-            Preferences N1 = Preferences.userRoot().node("ExportNodeTest1");
-            N1.put("ExportNodeTestName1","ExportNodeTestValue1");
-            Preferences N2 = N1.node("ExportNodeTest2");
-            N2.put("ExportNodeTestName2","ExportNodeTestValue2");
-            ByteArrayOutputStream exportStream = new ByteArrayOutputStream();
-            N2.exportNode(exportStream);
+        BackingStoreException, IOException {
+        Preferences N1 = Preferences.userRoot().node("ExportNodeTest1");
+        N1.put(NODE_NAME_1,"ExportNodeTestValue1");
+        Preferences N2 = N1.node("ExportNodeTest2");
+        N2.put(NODE_NAME_2,"ExportNodeTestValue2");
+        ByteArrayOutputStream exportStream = new ByteArrayOutputStream();
+        N2.exportNode(exportStream);
 
-            // Removal of preference node should always succeed on Solaris/Linux
-            // by successfully acquiring the appropriate file lock (4947349)
-            N1.removeNode();
+        // Removal of preference node should always succeed on Solaris/Linux
+        // by successfully acquiring the appropriate file lock (4947349)
+        N1.removeNode();
 
-            if (((exportStream.toString()).lastIndexOf("ExportNodeTestName2")== -1) ||
-               ((exportStream.toString()).lastIndexOf("ExportNodeTestName1")!= -1)) {
-            }
+        String streamAsString = exportStream.toString("UTF-8");
+
+        StringBuilder sb = null;
+        if (streamAsString.lastIndexOf(NODE_NAME_2) == -1) {
+            if (sb == null)
+                sb = new StringBuilder();
+            sb.append(NODE_NAME_2 + " should have been found");
+        }
+        if (streamAsString.lastIndexOf(NODE_NAME_1) != -1) {
+            if (sb == null)
+                sb = new StringBuilder();
+            else
+                sb.append("; ");
+            sb.append(NODE_NAME_1 + " should *not* have been found");
+        }
+
+        if (sb != null)
+            throw new RuntimeException(sb.toString());
    }
 }


### PR DESCRIPTION
This test emits to a `java.io.ByteArrayOutputStream` the contents of a `java.utils.prefs.Preferences` node. The `UTF-8` character encoding is used [1]. The `ByteArrayOutputStream` is then converted to a `String` using `toString()` which uses the platform's default character set [2]. The resulting `String` is then checked for the node names that it should and should not contain.

This change proposes to use `ByteArrayOutputStream.toString(String)` to obtain the string [3] to maintain consistency of the encoding. It also adds throwing a `RuntimeException` if the node string is not as expected. It is unclear why this test was not already throwing such an exception.

[1] https://docs.oracle.com/en/java/javase/16/docs/api/java.prefs/java/util/prefs/Preferences.html#exportNode(java.io.OutputStream)
[2] https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/io/ByteArrayOutputStream.html#toString()
[3] https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/io/ByteArrayOutputStream.html#toString(java.lang.String)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264512](https://bugs.openjdk.java.net/browse/JDK-8264512): jdk/test/jdk/java/util/prefs/ExportNode.java relies on default platform encoding


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3332/head:pull/3332` \
`$ git checkout pull/3332`

Update a local copy of the PR: \
`$ git checkout pull/3332` \
`$ git pull https://git.openjdk.java.net/jdk pull/3332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3332`

View PR using the GUI difftool: \
`$ git pr show -t 3332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3332.diff">https://git.openjdk.java.net/jdk/pull/3332.diff</a>

</details>
