### PR TITLE
JDK-8264664: use text blocks in javac module tests

### DIFF
--- a/test/langtools/tools/javac/modules/AddLimitMods.java
+++ b/test/langtools/tools/javac/modules/AddLimitMods.java
@@ -361,22 +361,24 @@ public class AddLimitMods extends ModuleTestBase {
 
                 StringBuilder testClassNamed = new StringBuilder();
 
-                testClassNamed.append("package test;\n" +
-                                      "public class Test {\n" +
-                                      "    public static void main(String... args) throws Exception {\n");
+                testClassNamed.append("""
+                        package test;
+                        public class Test {
+                            public static void main(String... args) throws Exception {
+                        """);
 
                 for (Entry<String, String> e : MODULES_TO_CHECK_TO_SAMPLE_CLASS.entrySet()) {
                     testClassNamed.append("        System.err.println(\"visible:" + e.getKey() + ":\" + ModuleLayer.boot().findModule(\"" + e.getKey() + "\").isPresent());\n");
                 }
 
-                testClassNamed.append("        Class<?> cp = Class.forName(Test.class.getClassLoader().getUnnamedModule(), \"cp.CP\");\n");
-                testClassNamed.append("        cp.getDeclaredMethod(\"runMe\").invoke(null);\n");
-
-                testClassNamed.append("        Class<?> automatic = Class.forName(ModuleLayer.boot().findModule(\"automatic\").get(), \"automatic.Automatic\");\n");
-                testClassNamed.append("        automatic.getDeclaredMethod(\"runMe\").invoke(null);\n");
-
-                testClassNamed.append("    }\n" +
-                                      "}");
+                testClassNamed.append("""
+                                Class<?> cp = Class.forName(Test.class.getClassLoader().getUnnamedModule(), "cp.CP");
+                                cp.getDeclaredMethod("runMe").invoke(null);
+                                Class<?> automatic = Class.forName(ModuleLayer.boot().findModule("automatic").get(), "automatic.Automatic");
+                                automatic.getDeclaredMethod("runMe").invoke(null);
+                            }
+                        }
+                        """);
 
                 tb.writeJavaFiles(m2Runtime, moduleInfo, testClassNamed.toString());
 
@@ -415,8 +417,10 @@ public class AddLimitMods extends ModuleTestBase {
 
                 tb.writeJavaFiles(m2,
                                   moduleInfo,
-                                  "package test;\n" +
-                                  "public class Test {}\n");
+                                  """
+                                      package test;
+                                      public class Test {}
+                                      """);
 
                 List<String> auxOptions = success ? Arrays.asList(
                     "--processor-path", System.getProperty("test.class.path"),
@@ -448,12 +452,13 @@ public class AddLimitMods extends ModuleTestBase {
                                       "public class " + simpleName + " {" +
                                       "    public static void runMe() throws Exception {");
         for (Entry<String, String> e : MODULES_TO_CHECK_TO_SAMPLE_CLASS.entrySet()) {
-            checkClassesAccessible.append("try {");
-            checkClassesAccessible.append("Class.forName(\"" + e.getValue() + "\").newInstance();");
-            checkClassesAccessible.append("System.err.println(\"" + fqn + ":" + e.getKey() + ":true\");");
-            checkClassesAccessible.append("} catch (Exception ex) {");
-            checkClassesAccessible.append("System.err.println(\"" + fqn + ":" + e.getKey() + ":false\");");
-            checkClassesAccessible.append("}");
+            checkClassesAccessible
+                    .append("try {")
+                    .append("Class.forName(\"" + e.getValue() + "\").newInstance();")
+                    .append("System.err.println(\"" + fqn + ":" + e.getKey() + ":true\");")
+                    .append("} catch (Exception ex) {")
+                    .append("System.err.println(\"" + fqn + ":" + e.getKey() + ":false\");")
+                    .append("}");
         }
 
         checkClassesAccessible.append("    }\n" +

--- a/test/langtools/tools/javac/modules/AnachronisticModuleInfo/module-info.jcod
+++ b/test/langtools/tools/javac/modules/AnachronisticModuleInfo/module-info.jcod
@@ -4,12 +4,12 @@ class foo/module-info {
   52; // version
   [] { // Constant Pool
     ; // first element is empty
-    class #6; // #1    
-    Utf8 "SourceFile"; // #2    
-    Utf8 "module-info.java"; // #3    
-    Utf8 "Module"; // #4    
-    Utf8 "java.base"; // #5    
-    Utf8 "foo/module-info"; // #6    
+    class #6; // #1
+    Utf8 "SourceFile"; // #2
+    Utf8 "module-info.java"; // #3
+    Utf8 "Module"; // #4
+    Utf8 "java.base"; // #5
+    Utf8 "foo/module-info"; // #6
   } // Constant Pool
 
   0x8000; // access

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -906,7 +906,8 @@ public class AnnotationProcessing extends ModuleTestBase {
                     runCompiler(base,
                                 m1,
                                 classes,
-                                "createSource(() -> filer.createResource(StandardLocation.CLASS_OUTPUT, \"impl\", \"impl\"" + originating + "), \"impl\", \"impl\")",
+                                """
+                                    createSource(() -> filer.createResource(StandardLocation.CLASS_OUTPUT, "impl", "impl\"""" + originating + "), \"impl\", \"impl\")",
                                 options);
                     assertFileExists(classes, modulePath, "impl", "impl");
                 }
@@ -1044,28 +1045,31 @@ public class AnnotationProcessing extends ModuleTestBase {
 
     private void compileAP(Path target, String code) {
         String processorCode =
-            "import java.util.*;\n" +
-            "import javax.annotation.processing.*;\n" +
-            "import javax.lang.model.*;\n" +
-            "import javax.lang.model.element.*;\n" +
-            "import javax.lang.model.type.*;\n" +
-            "import javax.lang.model.util.*;\n" +
-            "import javax.tools.*;\n" +
-            "@SupportedAnnotationTypes(\"*\")\n" +
-            "public final class AP extends AnnotationProcessing.GeneratingAP {\n" +
-            "\n" +
-            "        int round;\n" +
-            "\n" +
-            "        @Override\n" +
-            "        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {\n" +
-            "            if (round++ != 0)\n" +
-            "                return false;\n" +
-            "            Filer filer = processingEnv.getFiler();\n" +
-            "            TypeElement jlObject = processingEnv.getElementUtils().getTypeElement(\"java.lang.Object\");\n" +
-            code + ";\n" +
-            "            return false;\n" +
-            "        }\n" +
-            "    }\n";
+            """
+                import java.util.*;
+                import javax.annotation.processing.*;
+                import javax.lang.model.*;
+                import javax.lang.model.element.*;
+                import javax.lang.model.type.*;
+                import javax.lang.model.util.*;
+                import javax.tools.*;
+                @SupportedAnnotationTypes("*")
+                public final class AP extends AnnotationProcessing.GeneratingAP {
+                
+                        int round;
+                
+                        @Override
+                        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                            if (round++ != 0)
+                                return false;
+                            Filer filer = processingEnv.getFiler();
+                            TypeElement jlObject = processingEnv.getElementUtils().getTypeElement("java.lang.Object");
+                """ + code + """
+                ;
+                            return false;
+                        }
+                    }
+                """;
         new JavacTask(tb)
           .options("-classpath", System.getProperty("test.class.path"))
           .sources(processorCode)

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1055,9 +1055,9 @@ public class AnnotationProcessing extends ModuleTestBase {
                 import javax.tools.*;
                 @SupportedAnnotationTypes("*")
                 public final class AP extends AnnotationProcessing.GeneratingAP {
-                
+
                         int round;
-                
+
                         @Override
                         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
                             if (round++ != 0)

--- a/test/langtools/tools/javac/modules/AnnotationProcessorsInModulesTest.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessorsInModulesTest.java
@@ -49,7 +49,7 @@ public class AnnotationProcessorsInModulesTest extends ModuleTestBase {
             """
                 module anno_proc1x {
                     requires java.compiler;
-                
+
                     provides javax.annotation.processing.Processor
                       with mypkg1.MyProcessor1;
                 }""";
@@ -58,7 +58,7 @@ public class AnnotationProcessorsInModulesTest extends ModuleTestBase {
             """
                 module anno_proc2x {
                     requires java.compiler;
-                
+
                     provides javax.annotation.processing.Processor
                       with mypkg2.MyProcessor2;
                 }""";
@@ -66,23 +66,23 @@ public class AnnotationProcessorsInModulesTest extends ModuleTestBase {
     private static final String annotationProcessor1 =
             """
                 package mypkg1;
-                
+
                 import javax.annotation.processing.AbstractProcessor;
                 import javax.annotation.processing.RoundEnvironment;
                 import javax.annotation.processing.SupportedAnnotationTypes;
                 import javax.lang.model.SourceVersion;
                 import javax.lang.model.element.*;
-                
+
                 import java.util.*;
-                
+
                 @SupportedAnnotationTypes("*")
                 public final class MyProcessor1 extends AbstractProcessor {
-                
+
                     @Override
                     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
                         return false;
                     }
-                
+
                     @Override
                     public SourceVersion getSupportedSourceVersion() {
                         System.out.println("the annotation processor 1 is working!");
@@ -93,23 +93,23 @@ public class AnnotationProcessorsInModulesTest extends ModuleTestBase {
     private static final String annotationProcessor2 =
             """
                 package mypkg2;
-                
+
                 import javax.annotation.processing.AbstractProcessor;
                 import javax.annotation.processing.RoundEnvironment;
                 import javax.annotation.processing.SupportedAnnotationTypes;
                 import javax.lang.model.SourceVersion;
                 import javax.lang.model.element.*;
-                
+
                 import java.util.*;
-                
+
                 @SupportedAnnotationTypes("*")
                 public final class MyProcessor2 extends AbstractProcessor {
-                
+
                     @Override
                     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
                         return false;
                     }
-                
+
                     @Override
                     public SourceVersion getSupportedSourceVersion() {
                         System.out.println("the annotation processor 2 is working!");

--- a/test/langtools/tools/javac/modules/AnnotationProcessorsInModulesTest.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessorsInModulesTest.java
@@ -46,72 +46,76 @@ public class AnnotationProcessorsInModulesTest extends ModuleTestBase {
     }
 
     private static final String annotationProcessorModule1 =
-            "module anno_proc1x {\n" +
-            "    requires java.compiler;\n" +
-            "\n" +
-            "    provides javax.annotation.processing.Processor\n" +
-            "      with mypkg1.MyProcessor1;\n" +
-            "}";
+            """
+                module anno_proc1x {
+                    requires java.compiler;
+                
+                    provides javax.annotation.processing.Processor
+                      with mypkg1.MyProcessor1;
+                }""";
 
     private static final String annotationProcessorModule2 =
-            "module anno_proc2x {\n" +
-            "    requires java.compiler;\n" +
-            "\n" +
-            "    provides javax.annotation.processing.Processor\n" +
-            "      with mypkg2.MyProcessor2;\n" +
-            "}";
+            """
+                module anno_proc2x {
+                    requires java.compiler;
+                
+                    provides javax.annotation.processing.Processor
+                      with mypkg2.MyProcessor2;
+                }""";
 
     private static final String annotationProcessor1 =
-            "package mypkg1;\n" +
-            "\n" +
-            "import javax.annotation.processing.AbstractProcessor;\n" +
-            "import javax.annotation.processing.RoundEnvironment;\n" +
-            "import javax.annotation.processing.SupportedAnnotationTypes;\n" +
-            "import javax.lang.model.SourceVersion;\n" +
-            "import javax.lang.model.element.*;\n" +
-            "\n" +
-            "import java.util.*;\n" +
-            "\n" +
-            "@SupportedAnnotationTypes(\"*\")\n" +
-            "public final class MyProcessor1 extends AbstractProcessor {\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {\n" +
-            "        return false;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public SourceVersion getSupportedSourceVersion() {\n" +
-            "        System.out.println(\"the annotation processor 1 is working!\");\n" +
-            "        return SourceVersion.latest();\n" +
-            "    }\n" +
-            "}";
+            """
+                package mypkg1;
+                
+                import javax.annotation.processing.AbstractProcessor;
+                import javax.annotation.processing.RoundEnvironment;
+                import javax.annotation.processing.SupportedAnnotationTypes;
+                import javax.lang.model.SourceVersion;
+                import javax.lang.model.element.*;
+                
+                import java.util.*;
+                
+                @SupportedAnnotationTypes("*")
+                public final class MyProcessor1 extends AbstractProcessor {
+                
+                    @Override
+                    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                        return false;
+                    }
+                
+                    @Override
+                    public SourceVersion getSupportedSourceVersion() {
+                        System.out.println("the annotation processor 1 is working!");
+                        return SourceVersion.latest();
+                    }
+                }""";
 
     private static final String annotationProcessor2 =
-            "package mypkg2;\n" +
-            "\n" +
-            "import javax.annotation.processing.AbstractProcessor;\n" +
-            "import javax.annotation.processing.RoundEnvironment;\n" +
-            "import javax.annotation.processing.SupportedAnnotationTypes;\n" +
-            "import javax.lang.model.SourceVersion;\n" +
-            "import javax.lang.model.element.*;\n" +
-            "\n" +
-            "import java.util.*;\n" +
-            "\n" +
-            "@SupportedAnnotationTypes(\"*\")\n" +
-            "public final class MyProcessor2 extends AbstractProcessor {\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {\n" +
-            "        return false;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public SourceVersion getSupportedSourceVersion() {\n" +
-            "        System.out.println(\"the annotation processor 2 is working!\");\n" +
-            "        return SourceVersion.latest();\n" +
-            "    }\n" +
-            "}";
+            """
+                package mypkg2;
+                
+                import javax.annotation.processing.AbstractProcessor;
+                import javax.annotation.processing.RoundEnvironment;
+                import javax.annotation.processing.SupportedAnnotationTypes;
+                import javax.lang.model.SourceVersion;
+                import javax.lang.model.element.*;
+                
+                import java.util.*;
+                
+                @SupportedAnnotationTypes("*")
+                public final class MyProcessor2 extends AbstractProcessor {
+                
+                    @Override
+                    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                        return false;
+                    }
+                
+                    @Override
+                    public SourceVersion getSupportedSourceVersion() {
+                        System.out.println("the annotation processor 2 is working!");
+                        return SourceVersion.latest();
+                    }
+                }""";
 
     private static final String testClass = "class Test{}";
 

--- a/test/langtools/tools/javac/modules/AnnotationsOnModules.java
+++ b/test/langtools/tools/javac/modules/AnnotationsOnModules.java
@@ -270,11 +270,12 @@ public class AnnotationsOnModules extends ModuleTestBase {
         Path m1 = base.resolve("src1/A");
 
         tb.writeJavaFiles(m1,
-                "module A { " +
-                        "exports p1 to B; opens p1 to B;" +
-                        "exports p2 to C; opens p2 to C;" +
-                        "exports p3 to B,C; opens p3 to B,C;" +
-                        "}",
+                """
+                    module A {
+                        exports p1 to B; opens p1 to B;
+                        exports p2 to C; opens p2 to C;
+                        exports p3 to B,C; opens p3 to B,C;
+                    }""",
                 "package p1; public class A { }",
                 "package p2; public class A { }",
                 "package p3; public class A { }");
@@ -547,10 +548,11 @@ public class AnnotationsOnModules extends ModuleTestBase {
         String DEPRECATED_JAVADOC = "/** @deprecated */";
         for (String suppress : new String[] {"", DEPRECATED_JAVADOC, "@Deprecated ", "@SuppressWarnings(\"deprecation\") "}) {
             tb.writeJavaFiles(m3,
-                              suppress + "module m3x {\n" +
-                              "    requires m1x;\n" +
-                              "    exports api to m1x, m2x;\n" +
-                              "}",
+                              suppress + """
+                                  module m3x {
+                                      requires m1x;
+                                      exports api to m1x, m2x;
+                                  }""",
                               "package api; public class Api { }");
             System.err.println("compile m3x");
             actual = new JavacTask(tb)

--- a/test/langtools/tools/javac/modules/AutomaticModules.java
+++ b/test/langtools/tools/javac/modules/AutomaticModules.java
@@ -461,10 +461,11 @@ public class AutomaticModules extends ModuleTestBase {
         Path src = base.resolve("src");
 
         tb.writeJavaFiles(src,
-                          "module m1x {\n" +
-                          "    requires transitive automaticA;\n" +
-                          "    requires automaticB;\n" +
-                          "}");
+                          """
+                              module m1x {
+                                  requires transitive automaticA;
+                                  requires automaticB;
+                              }""");
 
         Path classes = base.resolve("classes");
 
@@ -550,11 +551,12 @@ public class AutomaticModules extends ModuleTestBase {
             .getOutputLines(Task.OutputKind.DIRECT);
 
         tb.writeJavaFiles(src,
-                          "@SuppressWarnings(\"requires-transitive-automatic\")\n" +
-                          "module m1x {\n" +
-                          "    requires transitive automaticA;\n" +
-                          "    requires automaticB;\n" +
-                          "}");
+                          """
+                              @SuppressWarnings("requires-transitive-automatic")
+                              module m1x {
+                                  requires transitive automaticA;
+                                  requires automaticB;
+                              }""");
 
         new JavacTask(tb)
             .options("--source-path", src.toString(),
@@ -590,11 +592,12 @@ public class AutomaticModules extends ModuleTestBase {
         }
 
         tb.writeJavaFiles(src,
-                          "@SuppressWarnings(\"requires-automatic\")\n" +
-                          "module m1x {\n" +
-                          "    requires transitive automaticA;\n" +
-                          "    requires automaticB;\n" +
-                          "}");
+                          """
+                              @SuppressWarnings("requires-automatic")
+                              module m1x {
+                                  requires transitive automaticA;
+                                  requires automaticB;
+                              }""");
 
         log = new JavacTask(tb)
             .options("--source-path", src.toString(),

--- a/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
+++ b/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
@@ -577,13 +577,15 @@ public class ConvenientAccessErrorsTest extends ModuleTestBase {
         Path src_m2 = src.resolve("m2x");
         tb.writeJavaFiles(src_m2,
                           "module m2x { requires m1x; }",
-                          "package test;\n" +
-                          "import api.Sub;\n" +
-                          "import api.Base;\n" +
-                          "public class Test {\n" +
-                          "    Sub a2;\n" +
-                          "    Base a;\n" +
-                          "}\n");
+                          """
+                              package test;
+                              import api.Sub;
+                              import api.Base;
+                              public class Test {
+                                  Sub a2;
+                                  Base a;
+                              }
+                              """);
         Path m2xClasses = classes.resolve("m2x");
         tb.createDirectories(m2xClasses);
         List<String> log = new JavacTask(tb)

--- a/test/langtools/tools/javac/modules/EdgeCases.java
+++ b/test/langtools/tools/javac/modules/EdgeCases.java
@@ -302,13 +302,17 @@ public class EdgeCases extends ModuleTestBase {
         Path src_m1 = src.resolve("m1x");
         tb.writeJavaFiles(src_m1,
                           "module m1x { exports test.m1x; }",
-                          "package test.m1x;\n" +
-                          "public class Test {}\n");
+                          """
+                              package test.m1x;
+                              public class Test {}
+                              """);
         Path src_m2 = src.resolve("m2x");
         tb.writeJavaFiles(src_m2,
                           "module m2x { requires m1x; }",
-                          "package test;\n" +
-                          "public class m1x {}\n");
+                          """
+                              package test;
+                              public class m1x {}
+                              """);
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
@@ -515,15 +519,21 @@ public class EdgeCases extends ModuleTestBase {
         Path src_m1 = src.resolve("m1x");
         tb.writeJavaFiles(src_m1,
                           "module m1x { }",
-                          "package m1x;\n" +
-                          "import m1x.a.*; public class Test { A a; }\n",
-                          "package m1x.a;\n" +
-                          "public class A { }\n");
+                          """
+                              package m1x;
+                              import m1x.a.*; public class Test { A a; }
+                              """,
+                          """
+                              package m1x.a;
+                              public class A { }
+                              """);
         Path src_m2 = src.resolve("m2x");
         tb.writeJavaFiles(src_m2,
                           "module m2x { }",
-                          "package m1x;\n" +
-                          "public class a { public static class A { } }\n");
+                          """
+                              package m1x;
+                              public class a { public static class A { } }
+                              """);
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 

--- a/test/langtools/tools/javac/modules/ExportsUnexported.java
+++ b/test/langtools/tools/javac/modules/ExportsUnexported.java
@@ -53,27 +53,37 @@ public class ExportsUnexported extends ModuleTestBase {
 
     @Test
     public void testLocations(Path base) throws Exception {
-        String warningsTest = "package api;\n" +
-                      "import impl.impl.*;\n" +
-                      "@impl.impl^.DocAnn\n" +
-                      "public abstract class Api<T extends impl.impl^.Cls&impl.impl^.Intf> extends impl.impl^.Cls implements impl.impl^.Intf, impl.impl^.NonDocAnn, impl.impl^.DocAnn {\n" +
-                      "    public static <E extends impl.impl^.Cls&impl.impl^.Intf> impl.impl^.Cls m(impl.impl^.Intf i, impl.impl^.Cls c) throws impl.impl^.Exc { return null; }\n" +
-                      "    public static impl.impl^.Cls f;\n" +
-                      "}";
-        String noWarningsTest = "package api;\n" +
-                      "import impl.impl.*;\n" +
-                      "@impl.impl.NonDocAnn\n" +
-                      "public abstract class Api {\n" +
-                      "    private static abstract class I <T extends impl.impl.Cls&impl.impl.Intf> extends impl.impl.Cls implements impl.impl.Intf, impl.impl.NonDocAnn, impl.impl.DocAnn {\n" +
-                      "        public static abstract class II <T extends impl.impl.Cls&impl.impl.Intf> extends impl.impl.Cls implements impl.impl.Intf, impl.impl.NonDocAnn, impl.impl.DocAnn { }\n" +
-                      "        public static <E extends impl.impl.Cls&impl.impl.Intf> impl.impl.Cls m(impl.impl.Intf i, impl.impl.Cls c) throws impl.impl.Exc { return null; }\n" +
-                      "        public static impl.impl.Cls f;\n" +
-                      "    }\n" +
-                      "    private static <E extends impl.impl.Cls&impl.impl.Intf> impl.impl.Cls m(impl.impl.Intf i, impl.impl.Cls c) throws impl.impl.Exc { return null; }\n" +
-                      "    private static impl.impl.Cls f1;\n" +
-                      "    public static void m() { new impl.impl.Cls(); }\n" +
-                      "    public static Object f2 = new impl.impl.Cls();\n" +
-                      "}";
+        String warningsTest = """
+            package api;
+            import impl.impl.*;
+            @impl.impl^.DocAnn
+            public abstract class Api<T extends impl.impl^.Cls&impl.impl^.Intf> extends impl\
+            .impl^.Cls implements impl.impl^.Intf, impl.impl^.NonDocAnn, impl.impl^.DocAnn {
+                public static <E extends impl.impl^.Cls&impl.impl^.Intf> impl.impl^.Cls m(im\
+            pl.impl^.Intf i, impl.impl^.Cls c) throws impl.impl^.Exc { return null; }
+                public static impl.impl^.Cls f;
+            }""";
+        String noWarningsTest = """
+            package api;
+            import impl.impl.*;
+            @impl.impl.NonDocAnn
+            public abstract class Api {
+                private static abstract class I <T extends impl.impl.Cls&impl.impl.Intf> ext\
+            ends impl.impl.Cls implements impl.impl.Intf, impl.impl.NonDocAnn, impl.impl.Doc\
+            Ann {
+                    public static abstract class II <T extends impl.impl.Cls&impl.impl.Intf>\
+             extends impl.impl.Cls implements impl.impl.Intf, impl.impl.NonDocAnn, impl.impl\
+            .DocAnn { }
+                    public static <E extends impl.impl.Cls&impl.impl.Intf> impl.impl.Cls m(i\
+            mpl.impl.Intf i, impl.impl.Cls c) throws impl.impl.Exc { return null; }
+                    public static impl.impl.Cls f;
+                }
+                private static <E extends impl.impl.Cls&impl.impl.Intf> impl.impl.Cls m(impl\
+            .impl.Intf i, impl.impl.Cls c) throws impl.impl.Exc { return null; }
+                private static impl.impl.Cls f1;
+                public static void m() { new impl.impl.Cls(); }
+                public static Object f2 = new impl.impl.Cls();
+            }""";
         for (String genericTest : new String[] {warningsTest, noWarningsTest}) {
             for (String test : new String[] {genericTest, genericTest.replaceAll("impl\\.impl\\^.([A-Za-z])", "^$1").replaceAll("impl\\.impl\\.([A-Za-z])", "$1")}) {
                 System.err.println("testing: " + test);
@@ -171,31 +181,37 @@ public class ExportsUnexported extends ModuleTestBase {
                           "package lib2; public class Lib2 {}");
         Path src_api = src.resolve("api");
         tb.writeJavaFiles(src_api,
-                          "module api {\n" +
-                          "    exports api;\n" +
-                          "    exports qapi1 to qual1x;\n" +
-                          "    exports qapi2 to qual1x, qual2x;\n" +
-                          "    requires transitive lib1x;\n" +
-                          "    requires lib2x;\n" +
-                          "}\n",
-                          "package api;\n" +
-                          "public class Api {\n" +
-                          "    public lib1.Lib1 lib1;\n" +
-                          "    public lib2.Lib2 lib2;\n" +
-                          "    public qapi1.QApi1 qapi1;\n" +
-                          "    public impl.Impl impl;\n" +
-                          "}",
-                          "package qapi1;\n" +
-                          "public class QApi1 {\n" +
-                          "    public qapi2.QApi2 qapi2;\n" +
-                          "}",
-                          "package qapi2;\n" +
-                          "public class QApi2 {\n" +
-                          "    public qapi1.QApi1 qapi1;\n" +
-                          "}",
-                          "package impl;\n" +
-                          "public class Impl {\n" +
-                          "}");
+                          """
+                              module api {
+                                  exports api;
+                                  exports qapi1 to qual1x;
+                                  exports qapi2 to qual1x, qual2x;
+                                  requires transitive lib1x;
+                                  requires lib2x;
+                              }
+                              """,
+                          """
+                              package api;
+                              public class Api {
+                                  public lib1.Lib1 lib1;
+                                  public lib2.Lib2 lib2;
+                                  public qapi1.QApi1 qapi1;
+                                  public impl.Impl impl;
+                              }""",
+                          """
+                              package qapi1;
+                              public class QApi1 {
+                                  public qapi2.QApi2 qapi2;
+                              }""",
+                          """
+                              package qapi2;
+                              public class QApi2 {
+                                  public qapi1.QApi1 qapi1;
+                              }""",
+                          """
+                              package impl;
+                              public class Impl {
+                              }""");
         Path src_qual1 = src.resolve("qual1x");
         tb.writeJavaFiles(src_qual1, "module qual1x { }");
         Path src_qual2 = src.resolve("qual2x");
@@ -232,21 +248,24 @@ public class ExportsUnexported extends ModuleTestBase {
         Path src = base.resolve("src");
         Path src_api = src.resolve("api");
         tb.writeJavaFiles(src_api,
-                          "module api {\n" +
-                          "    exports api;\n" +
-                          "}\n",
-                          "package api;\n" +
-                          "import impl.Impl.Nested;\n" +
-                          "public class Api {\n" +
-                          "    public impl.Impl impl1;\n" +
-                          "    public impl.Impl.Nested impl2;\n" +
-                          "    public Nested impl3;\n" +
-                          "}",
-                          "package impl;\n" +
-                          "public class Impl {\n" +
-                          "    public static class Nested {\n" +
-                          "    }\n" +
-                          "}");
+                          """
+                              module api {
+                                  exports api;
+                              }""",
+                          """
+                              package api;
+                              import impl.Impl.Nested;
+                              public class Api {
+                                  public impl.Impl impl1;
+                                  public impl.Impl.Nested impl2;
+                                  public Nested impl3;
+                              }""",
+                          """
+                              package impl;
+                              public class Impl {
+                                  public static class Nested {
+                                  }
+                              }""");
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
@@ -279,25 +298,29 @@ public class ExportsUnexported extends ModuleTestBase {
         Path src = base.resolve("src");
         Path src_api = src.resolve("api");
         tb.writeJavaFiles(src_api,
-                          "module api {\n" +
-                          "    exports api;\n" +
-                          "}\n",
-                          "package api;\n" +
-                          "public class Api extends PackagePrivateClass<PackagePrivateInterface> implements PackagePrivateInterface<PackagePrivateClass> {\n" +
-                          "    protected PackagePrivateClass<?> f1;\n" +
-                          "    protected PackagePrivateInterface<?> f2;\n" +
-                          "    protected Inner f3;\n" +
-                          "    protected PrivateInner f4;\n" +
-                          "    protected impl.Impl f5;\n" +
-                          "    public static class InnerClass extends PrivateInner {}\n" +
-                          "    protected static class Inner {}\n" +
-                          "    private static class PrivateInner {}\n" +
-                          "}\n" +
-                          "class PackagePrivateClass<T> {}\n" +
-                          "interface PackagePrivateInterface<T> {}",
-                          "package impl;\n" +
-                          "public class Impl {\n" +
-                          "}");
+                          """
+                              module api {
+                                  exports api;
+                              }""",
+                          """
+                              package api;
+                              public class Api extends PackagePrivateClass<PackagePrivateInterface> implements\
+                               PackagePrivateInterface<PackagePrivateClass> {
+                                  protected PackagePrivateClass<?> f1;
+                                  protected PackagePrivateInterface<?> f2;
+                                  protected Inner f3;
+                                  protected PrivateInner f4;
+                                  protected impl.Impl f5;
+                                  public static class InnerClass extends PrivateInner {}
+                                  protected static class Inner {}
+                                  private static class PrivateInner {}
+                              }
+                              class PackagePrivateClass<T> {}
+                              interface PackagePrivateInterface<T> {}""",
+                          """
+                              package impl;
+                              public class Impl {
+                              }""");
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
@@ -333,24 +356,27 @@ public class ExportsUnexported extends ModuleTestBase {
         Path src = base.resolve("src");
         Path src_api = src.resolve("api");
         tb.writeJavaFiles(src_api,
-                          "module api {\n" +
-                          "    exports api;\n" +
-                          "}\n",
-                          "package api;\n" +
-                          "public class Api {\n" +
-                          "    @SuppressWarnings(\"exports\")\n" +
-                          "    public PackagePrivateClass f1;\n" +
-                          "    public PackagePrivateClass f2;\n" +
-                          "    @SuppressWarnings(\"exports\")\n" +
-                          "    public void t() {}\n" +
-                          "    public PackagePrivateClass f3;\n" +
-                          "    @SuppressWarnings(\"exports\")\n" +
-                          "    public static class C {\n" +
-                          "        public PackagePrivateClass f4;\n" +
-                          "    }\n" +
-                          "    public PackagePrivateClass f5;\n" +
-                          "}\n" +
-                          "class PackagePrivateClass<T> {}\n");
+                          """
+                              module api {
+                                  exports api;
+                              }""",
+                          """
+                              package api;
+                              public class Api {
+                                  @SuppressWarnings("exports")
+                                  public PackagePrivateClass f1;
+                                  public PackagePrivateClass f2;
+                                  @SuppressWarnings("exports")
+                                  public void t() {}
+                                  public PackagePrivateClass f3;
+                                  @SuppressWarnings("exports")
+                                  public static class C {
+                                      public PackagePrivateClass f4;
+                                  }
+                                  public PackagePrivateClass f5;
+                              }
+                              class PackagePrivateClass<T> {}
+                              """);
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
@@ -397,21 +423,29 @@ public class ExportsUnexported extends ModuleTestBase {
         Path src = base.resolve("src");
         Path src_api = src.resolve("api");
         tb.writeJavaFiles(src_api,
-                          "module api {\n" +
-                          "    requires transitive dep;\n" +
-                          "    requires transitive api.one;\n" +
-                          "    exports api;\n" +
-                          "}\n",
-                          "package api;\n" +
-                          "public class Api extends dep.Dep implements api2.Api2 {}\n");
+                          """
+                              module api {
+                                  requires transitive dep;
+                                  requires transitive api.one;
+                                  exports api;
+                              }
+                              """,
+                          """
+                              package api;
+                              public class Api extends dep.Dep implements api2.Api2 {}
+                              """);
         Path src_dep = src.resolve("dep");
         tb.writeJavaFiles(src_dep,
-                          "module dep {\n" +
-                          "    requires transitive api.one;\n" +
-                          "    exports dep;\n" +
-                          "}\n",
-                          "package dep;\n" +
-                          "public class Dep {}\n");
+                          """
+                              module dep {
+                                  requires transitive api.one;
+                                  exports dep;
+                              }
+                              """,
+                          """
+                              package dep;
+                              public class Dep {}
+                              """);
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 

--- a/test/langtools/tools/javac/modules/HelloWorldTest.java
+++ b/test/langtools/tools/javac/modules/HelloWorldTest.java
@@ -47,11 +47,12 @@ public class HelloWorldTest extends ModuleTestBase {
     }
 
     public static final String HELLO_WORLD =
-          "class HelloWorld {\n"
-        + "    public static void main(String... args) {\n"
-        + "        System.out.println(\"Hello World!\");\n"
-        + "    }\n"
-        + "}";
+          """
+              class HelloWorld {
+                  public static void main(String... args) {
+                      System.out.println("Hello World!");
+                  }
+              }""";
 
     public static final String PKG_HELLO_WORLD =
           "package p;\n"

--- a/test/langtools/tools/javac/modules/ModuleInfoTest.java
+++ b/test/langtools/tools/javac/modules/ModuleInfoTest.java
@@ -748,27 +748,31 @@ public class ModuleInfoTest extends ModuleTestBase {
     public void testJDK8202832(Path base) throws Exception {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src.resolve("m1a"),
-                          "module m1a {\n" +
-                          "    requires m2a;\n" +
-                          "    requires m2b;\n" +
-                          "}");
+                          """
+                              module m1a {
+                                  requires m2a;
+                                  requires m2b;
+                              }""");
         tb.writeJavaFiles(src.resolve("m1b"),
-                          "module m1b {\n" +
-                          "    requires m2b;\n" +
-                          "    requires m2a;\n" +
-                          "}");
+                          """
+                              module m1b {
+                                  requires m2b;
+                                  requires m2a;
+                              }""");
         tb.writeJavaFiles(src.resolve("m2a"),
-                          "module m2a {\n" +
-                          "    requires m3;\n" +
-                          "    requires m1a;\n" +
-                          "    requires m1b;\n" +
-                          "}");
+                          """
+                              module m2a {
+                                  requires m3;
+                                  requires m1a;
+                                  requires m1b;
+                              }""");
         tb.writeJavaFiles(src.resolve("m2b"),
-                          "module m2b {\n" +
-                          "    requires m3;\n" +
-                          "    requires m1a;\n" +
-                          "    requires m1b;\n" +
-                          "}");
+                          """
+                              module m2b {
+                                  requires m3;
+                                  requires m1a;
+                                  requires m1b;
+                              }""");
         tb.writeJavaFiles(src.resolve("m3"),
                           "module m3 { }");
 

--- a/test/langtools/tools/javac/modules/OpenModulesTest.java
+++ b/test/langtools/tools/javac/modules/OpenModulesTest.java
@@ -90,11 +90,12 @@ public class OpenModulesTest extends ModuleTestBase {
                 .replace(System.getProperty("line.separator"), "\n")
                 .replaceAll("@[^;]*;", ";");
 
-        String expected = "module m1x {\n" +
-                          "  requires java.base;\n" +
-                          "  exports api1;\n" +
-                          "  opens api2;\n" +
-                          "}";
+        String expected = """
+            module m1x {
+              requires java.base;
+              exports api1;
+              opens api2;
+            }""";
 
         if (!decompiled.contains(expected)) {
             throw new Exception("expected output not found: " + decompiled);
@@ -154,10 +155,11 @@ public class OpenModulesTest extends ModuleTestBase {
                 .replace(System.getProperty("line.separator"), "\n")
                 .replaceAll("@[^;]*;", ";");
 
-        String expected = "open module m1x {\n" +
-                          "  requires java.base;\n" +
-                          "  exports api1;\n" +
-                          "}";
+        String expected = """
+                open module m1x {
+                  requires java.base;
+                  exports api1;
+                }""";
 
         if (!decompiled.contains(expected)) {
             throw new Exception("expected output not found: " + decompiled);

--- a/test/langtools/tools/javac/modules/PluginsInModulesTest.java
+++ b/test/langtools/tools/javac/modules/PluginsInModulesTest.java
@@ -47,48 +47,50 @@ public class PluginsInModulesTest extends ModuleTestBase {
     }
 
     private static final String pluginModule1 =
-            "module pluginMod1x {\n" +
-            "    requires jdk.compiler;\n" +
-            "\n" +
-            "    provides com.sun.source.util.Plugin\n" +
-            "      with mypkg1.SimplePlugin1;\n" +
-            "}";
+            """
+                module pluginMod1x {
+                    requires jdk.compiler;
+                
+                    provides com.sun.source.util.Plugin
+                      with mypkg1.SimplePlugin1;
+                }""";
 
     private static final String plugin1 =
-            "package mypkg1;\n" +
-            "import com.sun.source.util.JavacTask;\n" +
-            "import com.sun.source.util.Plugin;\n" +
-            "import com.sun.source.util.TaskEvent;\n" +
-            "import com.sun.source.util.TaskListener;\n" +
-            "\n" +
-            "public class SimplePlugin1 implements Plugin {\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public String getName() {\n" +
-            "        return \"simpleplugin1\";\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public void init(JavacTask task, String... args) {\n" +
-            "        task.addTaskListener(new PostAnalyzeTaskListener());\n" +
-            "    }\n" +
-            "\n" +
-            "    private static class PostAnalyzeTaskListener implements TaskListener {\n" +
-            "        @Override\n" +
-            "        public void started(TaskEvent taskEvent) { \n" +
-            "            if (taskEvent.getKind().equals(TaskEvent.Kind.COMPILATION)) {\n" +
-            "                System.out.println(\"simpleplugin1 started for event \" + taskEvent.getKind());\n" +
-            "            }\n" +
-            "        }\n" +
-            "\n" +
-            "        @Override\n" +
-            "        public void finished(TaskEvent taskEvent) {\n" +
-            "            if (taskEvent.getKind().equals(TaskEvent.Kind.COMPILATION)) {\n" +
-            "                System.out.println(\"simpleplugin1 finished for event \" + taskEvent.getKind());\n" +
-            "            }\n" +
-            "        }\n" +
-            "    }\n" +
-            "}";
+            """
+                package mypkg1;
+                import com.sun.source.util.JavacTask;
+                import com.sun.source.util.Plugin;
+                import com.sun.source.util.TaskEvent;
+                import com.sun.source.util.TaskListener;
+                
+                public class SimplePlugin1 implements Plugin {
+                
+                    @Override
+                    public String getName() {
+                        return "simpleplugin1";
+                    }
+                
+                    @Override
+                    public void init(JavacTask task, String... args) {
+                        task.addTaskListener(new PostAnalyzeTaskListener());
+                    }
+                
+                    private static class PostAnalyzeTaskListener implements TaskListener {
+                        @Override
+                        public void started(TaskEvent taskEvent) {\s
+                            if (taskEvent.getKind().equals(TaskEvent.Kind.COMPILATION)) {
+                                System.out.println("simpleplugin1 started for event " + taskEvent.getKind());
+                            }
+                        }
+                
+                        @Override
+                        public void finished(TaskEvent taskEvent) {
+                            if (taskEvent.getKind().equals(TaskEvent.Kind.COMPILATION)) {
+                                System.out.println("simpleplugin1 finished for event " + taskEvent.getKind());
+                            }
+                        }
+                    }
+                }""";
 
     private static final String testClass = "class Test { }";
 

--- a/test/langtools/tools/javac/modules/PluginsInModulesTest.java
+++ b/test/langtools/tools/javac/modules/PluginsInModulesTest.java
@@ -50,7 +50,7 @@ public class PluginsInModulesTest extends ModuleTestBase {
             """
                 module pluginMod1x {
                     requires jdk.compiler;
-                
+
                     provides com.sun.source.util.Plugin
                       with mypkg1.SimplePlugin1;
                 }""";
@@ -62,19 +62,19 @@ public class PluginsInModulesTest extends ModuleTestBase {
                 import com.sun.source.util.Plugin;
                 import com.sun.source.util.TaskEvent;
                 import com.sun.source.util.TaskListener;
-                
+
                 public class SimplePlugin1 implements Plugin {
-                
+
                     @Override
                     public String getName() {
                         return "simpleplugin1";
                     }
-                
+
                     @Override
                     public void init(JavacTask task, String... args) {
                         task.addTaskListener(new PostAnalyzeTaskListener());
                     }
-                
+
                     private static class PostAnalyzeTaskListener implements TaskListener {
                         @Override
                         public void started(TaskEvent taskEvent) {\s
@@ -82,7 +82,7 @@ public class PluginsInModulesTest extends ModuleTestBase {
                                 System.out.println("simpleplugin1 started for event " + taskEvent.getKind());
                             }
                         }
-                
+
                         @Override
                         public void finished(TaskEvent taskEvent) {
                             if (taskEvent.getKind().equals(TaskEvent.Kind.COMPILATION)) {

--- a/test/langtools/tools/javac/modules/RequiresStaticTest.java
+++ b/test/langtools/tools/javac/modules/RequiresStaticTest.java
@@ -56,11 +56,12 @@ public class RequiresStaticTest extends ModuleTestBase {
     public void testJavaSE_OK(Path base) throws Exception {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
-                "module m { requires static java.se; }",
-                "import java.awt.Frame;\n"  // in java.se
-                + "class Test {\n"
-                + "    Frame f;\n"
-                + "}");
+                // use class in java.se
+                """
+                    import java.awt.Frame;
+                    class Test {
+                        Frame f;
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -76,10 +77,12 @@ public class RequiresStaticTest extends ModuleTestBase {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
                 "module m { requires static java.se; }",
-                "import com.sun.source.tree.Tree;\n" // not in java.se (in jdk.compiler)
-                + "class Test {\n"
-                + "    Tree t;\n"
-                + "}");
+                // use class not in java.se (in jdk.compiler)
+                """
+                    import com.sun.source.tree.Tree;
+                    class Test {
+                        Tree t;
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -154,61 +157,73 @@ public class RequiresStaticTest extends ModuleTestBase {
         Path src_m1 = src.resolve("m1x");
         tb.writeJavaFiles(src_m1,
                 "module m1x { requires m2x; }",
-                "package p1;\n"
-                + "import p2.C2;\n"
-                + "import p3.C3;\n"
-                + "import p4.C4;\n"
+                """
+                    package p1;
+                    import p2.C2;
+                    import p3.C3;
+                    import p4.C4;
+                    """
                 + m1_extraImports
-                + "class C1 {\n"
-                + "  C2 c2; C3 c3; C4 c4;\n"
+                + """
+                    class C1 {
+                      C2 c2; C3 c3; C4 c4;
+                    """
                 + m1_extraUses
                 + "}\n");
 
         Path src_m2 = src.resolve("m2x");
         tb.writeJavaFiles(src_m2,
-                "module m2x {\n"
-                + "  requires transitive m3x;\n"
-                + "  requires static m6x;\n"
-                + "  exports p2;\n"
-                + "}",
-                "package p2;\n"
-                + "public class C2 {p7.C7 c7; p6.C6 c6; p4.C4 c4;}\n");
+                """
+                    module m2x {
+                      requires transitive m3x;
+                      requires static m6x;
+                      exports p2;
+                    }""",
+                """
+                    package p2;
+                    public class C2 {p7.C7 c7; p6.C6 c6; p4.C4 c4;}""");
 
         Path src_m3 = src.resolve("m3x");
         tb.writeJavaFiles(src_m3,
                 "module m3x { requires transitive static m4x; exports p3; }",
-                "package p3;\n"
-                + "public class C3 { }\n");
+                """
+                    package p3;
+                    public class C3 { }""");
 
         Path src_m4 = src.resolve("m4x");
         tb.writeJavaFiles(src_m4,
                 "module m4x { requires m5x; requires static m6x; exports p4; }",
-                "package p4;\n"
-                + "public class C4 { p6.C6 c6; p7.C7 c7;}\n");
+                """
+                    package p4;
+                    public class C4 { p6.C6 c6; p7.C7 c7;}""");
 
         Path src_m5 = src.resolve("m5x");
         tb.writeJavaFiles(src_m5,
                 "module m5x { exports p5; }",
-                "package p5;\n"
-                + "public class C5 { }\n");
+                """
+                    package p5;
+                    public class C5 { }""");
 
         Path src_m6 = src.resolve("m6x");
         tb.writeJavaFiles(src_m6,
                 "module m6x { requires transitive m7x; exports p6; }",
-                "package p6;\n"
-                + "public class C6 { p7.C7 c7; }\n");
+                """
+                    package p6;
+                    public class C6 { p7.C7 c7; }""");
 
         Path src_m7 = src.resolve("m7x");
         tb.writeJavaFiles(src_m7,
                 "module m7x { requires static m8x; exports p7; }",
-                "package p7;\n"
-                + "public class C7 { p8.C8 c8; }\n");
+                """
+                    package p7;
+                    public class C7 { p8.C8 c8; }""");
 
         Path src_m8 = src.resolve("m8x");
         tb.writeJavaFiles(src_m8,
                 "module m8x { exports p8; }",
-                "package p8;\n"
-                        + "public class C8 { }\n");
+                """
+                    package p8;
+                    public class C8 { }""");
 
         return src;
     }
@@ -235,20 +250,22 @@ public class RequiresStaticTest extends ModuleTestBase {
         Path m3 = src.resolve("m3x");
         tb.writeJavaFiles(m3,
                 "module m3x { requires static m1x; }",
-                "package m3x;\n" +
-                "public class Test {\n" +
-                "    public static void main(String... args) {\n" +
-                "        try {\n" +
-                "           Class.forName(\"m1x.Api\");\n" +
-                "        } catch (ClassNotFoundException e) {\n" +
-                "            System.err.println(\"ok\");\n" +
-                "        }\n" +
-                "    }\n" +
-                "}",
-                "package m3x;\n" +
-                "public class ApiUse{\n" +
-                "    m1x.Api api;\n" +
-                "}");
+                """
+                    package m3x;
+                    public class Test {
+                        public static void main(String... args) {
+                            try {
+                               Class.forName("m1x.Api");
+                            } catch (ClassNotFoundException e) {
+                                System.err.println("ok");
+                            }
+                        }
+                    }""",
+                """
+                    package m3x;
+                    public class ApiUse{
+                        m1x.Api api;
+                    }""");
 
         Path m3Classes = classes.resolve("m3x");
         Files.createDirectories(m3Classes);
@@ -307,20 +324,22 @@ public class RequiresStaticTest extends ModuleTestBase {
         Path m3 = src.resolve("m3x");
         tb.writeJavaFiles(m3,
                 "module m3x { requires m2x; }",
-                "package m3x;\n" +
-                "public class Test {\n" +
-                "    public static void main(String... args) {\n" +
-                "        try {\n" +
-                "           Class.forName(\"m1x.Api\");\n" +
-                "        } catch (ClassNotFoundException e) {\n" +
-                "            System.err.println(\"ok\");\n" +
-                "        }\n" +
-                "    }\n" +
-                "}",
-                "package m3x;\n" +
-                "public class ApiUse{\n" +
-                "    m1x.Api api;\n" +
-                "}");
+                """
+                    package m3x;
+                    public class Test {
+                        public static void main(String... args) {
+                            try {
+                               Class.forName("m1x.Api");
+                            } catch (ClassNotFoundException e) {
+                                System.err.println("ok");
+                            }
+                        }
+                    }""",
+                """
+                    package m3x;
+                    public class ApiUse{
+                        m1x.Api api;
+                    }""");
 
         Path m3Classes = classes.resolve("m3x");
         Files.createDirectories(m3Classes);

--- a/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
+++ b/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
@@ -49,12 +49,14 @@ public class RequiresTransitiveTest extends ModuleTestBase {
     @Test
     public void testJavaSE_OK(Path base) throws Exception {
         Path src = base.resolve("src");
-        tb.writeJavaFiles(src,
+        tb.writeJavaFiles(src, 
                 "module m { requires java.se; }",
-                "import java.awt.Frame;\n"  // in java.se
-                + "class Test {\n"
-                + "    Frame f;\n"
-                + "}");
+                // use class in java.se
+                """
+                    import java.awt.Frame;
+                    class Test {
+                        Frame f;
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -70,10 +72,12 @@ public class RequiresTransitiveTest extends ModuleTestBase {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
                 "module m { requires java.se; }",
-                "import com.sun.source.tree.Tree;\n" // not in java.se (in jdk.compiler)
-                + "class Test {\n"
-                + "    Tree t;\n"
-                + "}");
+                // use class not in java.se (in jdk.compiler)
+                """
+                    import com.sun.source.tree.Tree;
+                    class Test {
+                        Tree t;
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -144,55 +148,76 @@ public class RequiresTransitiveTest extends ModuleTestBase {
         Path src_m1 = src.resolve("m1x");
         tb.writeJavaFiles(src_m1,
                 "module m1x { requires m2x; }",
-                "package p1;\n"
-                + "import p2.C2;\n"
-                + "import p3.C3;\n"
-                + "import p4.C4;\n"
+                """
+                    package p1;
+                    import p2.C2;
+                    import p3.C3;
+                    import p4.C4;
+                    """
                 + m1_extraImports
-                + "class C1 {\n"
-                + "  C2 c2; C3 c3; C4 c4;\n"
+                + """
+                    class C1 {
+                      C2 c2; C3 c3; C4 c4;
+                    """
                 + m1_extraUses
                 + "}\n");
 
         Path src_m2 = src.resolve("m2x");
         tb.writeJavaFiles(src_m2,
-                "module m2x {\n"
-                + "  requires transitive m3x;\n"
-                + "  requires        m6x;\n"
-                + "  exports p2;\n"
-                + "}",
-                "package p2;\n"
-                + "public class C2 { }\n");
+                """
+                    module m2x {
+                      requires transitive m3x;
+                      requires        m6x;
+                      exports p2;
+                    }""",
+                """
+                    package p2;
+                    public class C2 { }
+                    """);
 
         Path src_m3 = src.resolve("m3x");
         tb.writeJavaFiles(src_m3,
-                "module m3x { requires transitive m4x; exports p3; }",
-                "package p3;\n"
-                + "public class C3 { }\n");
+                """
+                    module m3x { requires transitive m4x; exports p3; }
+                    """,
+                """
+                    package p3;
+                    public class C3 { }
+                    """);
 
         Path src_m4 = src.resolve("m4x");
         tb.writeJavaFiles(src_m4,
-                "module m4x { requires m5x; exports p4; }",
-                "package p4;\n"
-                + "public class C4 { }\n");
+                """
+                    module m4x { requires m5x; exports p4; }
+                    """,
+                """
+                    package p4;
+                    public class C4 { }
+                    """);
 
         Path src_m5 = src.resolve("m5x");
         tb.writeJavaFiles(src_m5,
-                "module m5x { exports p5; }",
-                "package p5;\n"
-                + "public class C5 { }\n");
+                """
+                    module m5x { exports p5; }
+                    """,
+                """
+                    package p5;
+                    public class C5 { }
+                    """);
 
         Path src_m6 = src.resolve("m6x");
         tb.writeJavaFiles(src_m6,
                 "module m6x { requires transitive m7x; exports p6; }",
-                "package p6;\n"
-                + "public class C6 { }\n");
+                """
+                    package p6;
+                    public class C6 { }""");
 
         Path src_m7 = src.resolve("m7x");
         tb.writeJavaFiles(src_m7,
                 "module m7x { exports p7; }",
-                "package p7;\n"
-                + "public class C7 { }\n");
+                """
+                    package p7;
+                    public class C7 { }""");
 
         return src;
     }

--- a/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
+++ b/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
@@ -49,7 +49,7 @@ public class RequiresTransitiveTest extends ModuleTestBase {
     @Test
     public void testJavaSE_OK(Path base) throws Exception {
         Path src = base.resolve("src");
-        tb.writeJavaFiles(src, 
+        tb.writeJavaFiles(src,
                 "module m { requires java.se; }",
                 // use class in java.se
                 """

--- a/test/langtools/tools/javac/modules/SubpackageTest.java
+++ b/test/langtools/tools/javac/modules/SubpackageTest.java
@@ -66,11 +66,12 @@ public class SubpackageTest extends ModuleTestBase {
 
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
-            "package p.q;\n"
-            + "import p.E;\n"
-            + "class Test {\n"
-            + "  void m() { throw new E(); }\n"
-            + "}");
+            """
+                package p.q;
+                import p.E;
+                class Test {
+                  void m() { throw new E(); }
+                }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -95,17 +96,18 @@ public class SubpackageTest extends ModuleTestBase {
                 "module mpqr { exports p.q.r; }",
                 "package p.q.r; public class C3 { }");
         tb.writeJavaFiles(src.resolve("m"),
-                "module m {"
-                + "  requires mp;\n"
-                + "  requires mpq;\n"
-                + "  requires mpqr;\n"
-                + "}",
-                "package x;\n"
-                + "class C {\n"
-                + "  p.C1 c1;\n"
-                + "  p.q.C2 c2;\n"
-                + "  p.q.r.C3 c3;\n"
-                + "}");
+                """
+                    module m {  requires mp;
+                      requires mpq;
+                      requires mpqr;
+                    }""",
+                """
+                    package x;
+                    class C {
+                      p.C1 c1;
+                      p.q.C2 c2;
+                      p.q.r.C3 c3;
+                    }""");
         Path modules = base.resolve("modules");
         Files.createDirectories(modules);
 

--- a/test/langtools/tools/javac/modules/T8159439/module-info.jcod
+++ b/test/langtools/tools/javac/modules/T8159439/module-info.jcod
@@ -4,15 +4,15 @@ module mod {
   53; // version
   [] { // Constant Pool
     ; // first element is empty
-    Utf8 "mod/module-info"; // #1    
-    class #1; // #2    
-    Utf8 "java/lang/Object"; // #3    
-    class #3; // #4    
-    Utf8 "java.base"; // #5    
-    Utf8 "pkg"; // #6    
-    Utf8 "Module"; // #7    
-    Utf8 "Version"; // #8    
-    Utf8 "6.0"; // #9    
+    Utf8 "mod/module-info"; // #1
+    class #1; // #2
+    Utf8 "java/lang/Object"; // #3
+    class #3; // #4
+    Utf8 "java.base"; // #5
+    Utf8 "pkg"; // #6
+    Utf8 "Module"; // #7
+    Utf8 "Version"; // #8
+    Utf8 "6.0"; // #9
   } // Constant Pool
 
   0x8000; // access

--- a/test/langtools/tools/javac/modules/WrongErrorMessageForNestedServiceProviderTest.java
+++ b/test/langtools/tools/javac/modules/WrongErrorMessageForNestedServiceProviderTest.java
@@ -49,23 +49,26 @@ public class WrongErrorMessageForNestedServiceProviderTest extends ModuleTestBas
     }
 
     private static final String twoServicesModuleDef =
-            "module m {\n" +
-            "    exports example;\n" +
-            "    provides example.SomeService with example.ServiceImpl;\n" +
-            "    provides example.SomeServiceOuter with example.Outer.ServiceImplOuter;\n" +
-            "}";
+            """
+                module m {
+                    exports example;
+                    provides example.SomeService with example.ServiceImpl;
+                    provides example.SomeServiceOuter with example.Outer.ServiceImplOuter;
+                }""";
 
     private static final String someServiceInt =
-            "package example;\n" +
-            "public interface SomeService {\n" +
-            "    public void foo();\n" +
-            "}";
+            """
+                package example;
+                public interface SomeService {
+                    public void foo();
+                }""";
 
     private static final String someServiceIntOuter =
-            "package example;\n" +
-            "public interface SomeServiceOuter {\n" +
-            "    public void foo();\n" +
-            "}";
+            """
+                package example;
+                public interface SomeServiceOuter {
+                    public void foo();
+                }""";
 
     @Test
     public void testPositive(Path base) throws Exception {
@@ -74,19 +77,21 @@ public class WrongErrorMessageForNestedServiceProviderTest extends ModuleTestBas
                 twoServicesModuleDef,
                 someServiceInt,
                 someServiceIntOuter,
-                "package example;\n" +
-                "public class ServiceImpl implements example.SomeService {\n" +
-                "    public ServiceImpl() {}\n" +
-                "    public void foo() {}\n" +
-                "}",
+                """
+                    package example;
+                    public class ServiceImpl implements example.SomeService {
+                        public ServiceImpl() {}
+                        public void foo() {}
+                    }""",
 
-                "package example;\n" +
-                "class Outer {\n" +
-                "    public static class ServiceImplOuter implements example.SomeServiceOuter {\n" +
-                "        public ServiceImplOuter() {}\n" +
-                "        public void foo() {}\n" +
-                "    }\n" +
-                "}");
+                """
+                    package example;
+                    class Outer {
+                        public static class ServiceImplOuter implements example.SomeServiceOuter {
+                            public ServiceImplOuter() {}
+                            public void foo() {}
+                        }
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -110,20 +115,21 @@ public class WrongErrorMessageForNestedServiceProviderTest extends ModuleTestBas
                 twoServicesModuleDef,
                 someServiceInt,
                 someServiceIntOuter,
+                """
+                    package example;
+                    class ServiceImpl implements example.SomeService {
+                        public ServiceImpl() {}
+                        public void foo() {}
+                    }""",
 
-                "package example;\n" +
-                "class ServiceImpl implements example.SomeService {\n" +
-                "    public ServiceImpl() {}\n" +
-                "    public void foo() {}\n" +
-                "}",
-
-                "package example;\n" +
-                "class Outer {\n" +
-                "    static class ServiceImplOuter implements example.SomeServiceOuter {\n" +
-                "        public ServiceImplOuter() {}\n" +
-                "        public void foo() {}\n" +
-                "    }\n" +
-                "}");
+                """
+                    package example;
+                    class Outer {
+                        static class ServiceImplOuter implements example.SomeServiceOuter {
+                            public ServiceImplOuter() {}
+                            public void foo() {}
+                        }
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 
@@ -147,22 +153,24 @@ public class WrongErrorMessageForNestedServiceProviderTest extends ModuleTestBas
     public void testClassWrappedByPrivateClass(Path base) throws Exception {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
-                "module m {\n" +
-                "    exports example;\n" +
-                "    provides example.SomeServiceOuter with example.Outer1.Outer2.ServiceImplOuter;\n" +
-                "}",
+                """
+                    module m {
+                        exports example;
+                        provides example.SomeServiceOuter with example.Outer1.Outer2.ServiceImplOuter;
+                    }""",
 
                 someServiceIntOuter,
 
-                "package example;\n" +
-                "class Outer1 {\n" +
-                "    static private class Outer2 {\n" +
-                "        public static class ServiceImplOuter implements example.SomeServiceOuter {\n" +
-                "            public ServiceImplOuter() {}\n" +
-                "            public void foo() {}\n" +
-                "        }\n" +
-                "    }\n" +
-                "}");
+                """
+                    package example;
+                    class Outer1 {
+                        static private class Outer2 {
+                            public static class ServiceImplOuter implements example.SomeServiceOuter {
+                                public ServiceImplOuter() {}
+                                public void foo() {}
+                            }
+                        }
+                    }""");
         Path classes = base.resolve("classes");
         Files.createDirectories(classes);
 


### PR DESCRIPTION
Please review an update to the javac module tests to use text blocks to represent multi-line strings.

The conversion was done mostly semi-automatically, using a utility used to covert the javadoc tests. Some edits were manual.

In all cases, there are no changes to the semantics of any test. In particular, no diagnostic messages containing line and column information were updated.

All `:tier1` tests pass on all standard platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264664](https://bugs.openjdk.java.net/browse/JDK-8264664): use text blocks in javac module tests


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 064110a09df82ddd361f9fdca198e710149b143e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3335/head:pull/3335` \
`$ git checkout pull/3335`

Update a local copy of the PR: \
`$ git checkout pull/3335` \
`$ git pull https://git.openjdk.java.net/jdk pull/3335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3335`

View PR using the GUI difftool: \
`$ git pr show -t 3335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3335.diff">https://git.openjdk.java.net/jdk/pull/3335.diff</a>

</details>
