### PR TITLE
8264649: runtime/InternalApi/ThreadCpuTimesDeadlock.java crash in fastdebug C2 with -XX:-UseTLAB

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1481,6 +1481,9 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
   temp->init_req(0,nn);     // Add a use to nn to prevent him from dying
   remove_dead_node( old );
   temp->del_req(0);         // Yank bogus edge
+  if (nn != NULL && nn->outcnt() == 0) {
+    _worklist.push(nn);
+  }
 #ifndef PRODUCT
   if( VerifyIterativeGVN ) {
     for ( int i = 0; i < _verify_window_size; i++ ) {

--- a/test/hotspot/jtreg/runtime/InternalApi/ThreadCpuTimesDeadlock.java
+++ b/test/hotspot/jtreg/runtime/InternalApi/ThreadCpuTimesDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,15 @@
  * @summary Possible JVM deadlock in ThreadTimesClosure when using HotspotInternal non-public API.
  * @modules java.management/sun.management
  * @run main/othervm -XX:+UsePerfData -Xmx128m ThreadCpuTimesDeadlock
+ */
+
+/*
+ * @test
+ * @bug 8264649
+ * @summary OSR compiled metthod crash when UseTLAB is off
+ * @requires vm.debug
+ * @modules java.management/sun.management
+ * @run main/othervm -XX:-UseTLAB -XX:+UsePerfData -Xmx128m ThreadCpuTimesDeadlock
  */
 
 import java.lang.management.ManagementFactory;

--- a/test/hotspot/jtreg/runtime/InternalApi/ThreadCpuTimesDeadlock.java
+++ b/test/hotspot/jtreg/runtime/InternalApi/ThreadCpuTimesDeadlock.java
@@ -33,7 +33,7 @@
 /*
  * @test
  * @bug 8264649
- * @summary OSR compiled metthod crash when UseTLAB is off
+ * @summary OSR compiled method crash when UseTLAB is off
  * @requires vm.debug
  * @modules java.management/sun.management
  * @run main/othervm -XX:-UseTLAB -XX:+UsePerfData -Xmx128m ThreadCpuTimesDeadlock


### PR DESCRIPTION
Please help review this fix. Detailed analysis in https://bugs.openjdk.java.net/browse/JDK-8264649

Tier1/2 release /fastdebug passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264649](https://bugs.openjdk.java.net/browse/JDK-8264649): runtime/InternalApi/ThreadCpuTimesDeadlock.java crash in fastdebug C2 with -XX:-UseTLAB


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3336/head:pull/3336` \
`$ git checkout pull/3336`

Update a local copy of the PR: \
`$ git checkout pull/3336` \
`$ git pull https://git.openjdk.java.net/jdk pull/3336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3336`

View PR using the GUI difftool: \
`$ git pr show -t 3336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3336.diff">https://git.openjdk.java.net/jdk/pull/3336.diff</a>

</details>
