### PR TITLE
8264686: ClhsdbTestConnectArgument.java should use SATestUtils::validateSADebugDPrivileges

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbTestConnectArgument.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbTestConnectArgument.java
@@ -44,18 +44,7 @@ public class ClhsdbTestConnectArgument {
 
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
-
-        if (SATestUtils.needsPrivileges()) {
-            // This tests has issues if you try adding privileges on OSX. The debugd process cannot
-            // be killed if you do this (because it is a root process and the test is not), so the destroy()
-            // call fails to do anything, and then waitFor() will time out. If you try to manually kill it with
-            // a "sudo kill" command, that seems to work, but then leaves the LingeredApp it was
-            // attached to in a stuck state for some unknown reason, causing the stopApp() call
-            // to timeout. For that reason we don't run this test when privileges are needed. Note
-            // it does appear to run fine as root, so we still allow it to run on OSX when privileges
-            // are not required.
-            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
-        }
+        SATestUtils.validateSADebugDPrivileges();
 
         System.out.println("Starting ClhsdbTestConnectArgument test");
 


### PR DESCRIPTION
[JDK-8263670](https://bugs.openjdk.java.net/browse/JDK-8263670) has introduced `SATestUtils::validateSADebugDPrivileges` to check privileges for on OS X.

https://github.com/openjdk/jdk/blob/a209ed01bafb7721d6b733d1c4bd3f1776463b5e/test/lib/jdk/test/lib/SA/SATestUtils.java#L211-L225

Most of testcases in serviceability/sa/sadebugd use it, however ClhsdbTestConnectArgument.java isn't so yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264686](https://bugs.openjdk.java.net/browse/JDK-8264686): ClhsdbTestConnectArgument.java should use SATestUtils::validateSADebugDPrivileges


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3339/head:pull/3339` \
`$ git checkout pull/3339`

Update a local copy of the PR: \
`$ git checkout pull/3339` \
`$ git pull https://git.openjdk.java.net/jdk pull/3339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3339`

View PR using the GUI difftool: \
`$ git pr show -t 3339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3339.diff">https://git.openjdk.java.net/jdk/pull/3339.diff</a>

</details>
