### PR TITLE
8264682: MemProfiling does not own Heap_lock when using G1

### DIFF
--- a/src/hotspot/share/runtime/memprofiler.cpp
+++ b/src/hotspot/share/runtime/memprofiler.cpp
@@ -115,6 +115,9 @@ void MemProfiler::do_trace() {
       resource_memory_usage += cur->resource_area()->size_in_bytes();
     }
 
+    // used() calls G1Allocator::used_in_alloc_regions() when G1 enabled,
+    // it checks whether Heap_lock was owned on this thread's behalf.
+    G1GC_ONLY(MutexLocker ml(Heap_lock);)
     // Print trace line in log
     fprintf(_log_fp, "%6.1f,%5d," SIZE_FORMAT_W(5) "," UINTX_FORMAT_W(6) "," UINTX_FORMAT_W(6) ",",
             os::elapsedTime(),

--- a/test/hotspot/jtreg/runtime/MemProfiler/MemProfilingWithGC.java
+++ b/test/hotspot/jtreg/runtime/MemProfiler/MemProfilingWithGC.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test MemProfilingWithGC
+ * @bug 8264682
+ * @summary test combinations of various GC and -XX:+MemProfiling
+ * @library /test/lib
+ * @run driver MemProfilingWithGC
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class MemProfilingWithGC {
+    public static void main(String... args) throws Exception {
+        final String GCs[] = new String[] {
+            "UseG1GC",
+            "UseSerialGC",
+            "UseParallelGC",
+            "UseShenandoahGC",
+            "UseZGC",
+            "UseEpsilonGC",
+        };
+        for (int i = 0; i < GCs.length; i++) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+" + GCs[i],
+                "-XX:+MemProfiling",
+                "-version");
+            OutputAnalyzer out = new OutputAnalyzer(pb.start());
+            out.shouldHaveExitValue(0);
+        }
+    }
+}


### PR DESCRIPTION
Trivial fix for JDK-8264682.

`Universe::heap()->used()` calls G1Allocator::used_in_alloc_regions() when G1 enabled,  it checks whether Heap_lock was owned on this thread's behalf.

/label add hotspot-gc
/label add hotspot-runtime

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264682](https://bugs.openjdk.java.net/browse/JDK-8264682): MemProfiling does not own Heap_lock when using G1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3340/head:pull/3340` \
`$ git checkout pull/3340`

Update a local copy of the PR: \
`$ git checkout pull/3340` \
`$ git pull https://git.openjdk.java.net/jdk pull/3340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3340`

View PR using the GUI difftool: \
`$ git pr show -t 3340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3340.diff">https://git.openjdk.java.net/jdk/pull/3340.diff</a>

</details>
