### PR TITLE
8265039: Adjust javadoc for ByteArray*Stream and InputStream

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -39,6 +39,9 @@ import java.util.Objects;
  * this class can be called after the stream has been closed without
  * generating an {@code IOException}.
  *
+ * An instance of this class does not need
+ * wrapping with {@code BufferedInputStream}.
+ *
  * @author  Arthur van Hoff
  * @see     java.io.StringBufferInputStream
  * @since   1.0
@@ -53,7 +56,7 @@ public class ByteArrayInputStream extends InputStream {
      * stream;  element {@code buf[pos]} is
      * the next byte to be read.
      */
-    protected byte buf[];
+    protected byte[] buf;
 
     /**
      * The index of the next character to read from the input stream buffer.
@@ -77,7 +80,7 @@ public class ByteArrayInputStream extends InputStream {
      *
      * @since   1.1
      */
-    protected int mark = 0;
+    protected int mark;
 
     /**
      * The index one greater than the last valid character in the input
@@ -102,7 +105,7 @@ public class ByteArrayInputStream extends InputStream {
      *
      * @param   buf   the input buffer.
      */
-    public ByteArrayInputStream(byte buf[]) {
+    public ByteArrayInputStream(byte[] buf) {
         this.buf = buf;
         this.pos = 0;
         this.count = buf.length;
@@ -122,7 +125,7 @@ public class ByteArrayInputStream extends InputStream {
      * @param   offset   the offset in the buffer of the first byte to read.
      * @param   length   the maximum number of bytes to read from the buffer.
      */
-    public ByteArrayInputStream(byte buf[], int offset, int length) {
+    public ByteArrayInputStream(byte[] buf, int offset, int length) {
         this.buf = buf;
         this.pos = offset;
         this.count = Math.min(offset + length, buf.length);
@@ -169,7 +172,7 @@ public class ByteArrayInputStream extends InputStream {
      * {@code len} is negative, or {@code len} is greater than
      * {@code b.length - off}
      */
-    public synchronized int read(byte b[], int off, int len) {
+    public synchronized int read(byte[] b, int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
 
         if (pos >= count) {

--- a/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
@@ -42,6 +42,9 @@ import jdk.internal.util.ArraysSupport;
  * this class can be called after the stream has been closed without
  * generating an {@code IOException}.
  *
+ * An instance of this class does not need
+ * wrapping with {@code BufferedOutputStream}.
+ *
  * @author  Arthur van Hoff
  * @since   1.0
  */
@@ -51,7 +54,7 @@ public class ByteArrayOutputStream extends OutputStream {
     /**
      * The buffer where data is stored.
      */
-    protected byte buf[];
+    protected byte[] buf;
 
     /**
      * The number of valid bytes in the buffer.
@@ -125,7 +128,7 @@ public class ByteArrayOutputStream extends OutputStream {
      * {@code len} is negative, or {@code len} is greater than
      * {@code b.length - off}
      */
-    public synchronized void write(byte b[], int off, int len) {
+    public synchronized void write(byte[] b, int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
         ensureCapacity(count + len);
         System.arraycopy(b, off, buf, count, len);
@@ -144,7 +147,7 @@ public class ByteArrayOutputStream extends OutputStream {
      * @throws  NullPointerException if {@code b} is {@code null}.
      * @since   11
      */
-    public void writeBytes(byte b[]) {
+    public void writeBytes(byte[] b) {
         write(b, 0, b.length);
     }
 

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -214,7 +214,7 @@ public abstract class InputStream implements Closeable {
      * @throws     NullPointerException  if {@code b} is {@code null}.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -275,7 +275,7 @@ public abstract class InputStream implements Closeable {
      *             {@code b.length - off}
      * @see        java.io.InputStream#read()
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         if (len == 0) {
             return 0;
@@ -623,9 +623,10 @@ public abstract class InputStream implements Closeable {
      * another thread.  A single read or skip of this many bytes will not block,
      * but may read or skip fewer bytes.
      *
-     * <p> Note that while some implementations of {@code InputStream} will
-     * return the total number of bytes in the stream, many will not.  It is
-     * never correct to use the return value of this method to allocate
+     * <p> Note that while some implementations of {@code InputStream}
+     * (e.g. {@code ByteArrayInputStream}) will return
+     * the total number of bytes in the stream, many will not. It is
+     * usually not correct to use the return value of this method to allocate
      * a buffer intended to hold all data in this stream.
      *
      * <p> A subclass's implementation of this method may choose to throw an


### PR DESCRIPTION
Hello,

to avoid cases detected in [https://github.com/openjdk/jdk/pull/2992](https://github.com/openjdk/jdk/pull/2992) I propose to modify JavaDoc of  `ByteArray*Stream` to explicitly mention redundancy of wrapping with `BufferedInputStream`.

As of `InputStream` I think in notation `It is never correct to use the return value of this method to allocate a buffer intended to hold all data in this stream.` the word 'never' should be replaced with 'usually': apart from `ByteArrayInputStream` e.g. `FileInputStream.available()` often returns the count of remaining bytes (the only exclusion I'm aware of is the files located under `/proc/`) and indeed this count can be used to allocate a buffer to read all the bytes in one call.

Consider benchmark

```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
public class ByteArrayInputStreamBenchmark {

  @Benchmark
  public void read(Data data, Blackhole bh) {
    int value;
    var in = data.bais;
    while ((value = in.read()) != -1) {
      bh.consume(value);
    }
  }

  @Benchmark
  public void readBuffered(Data data, Blackhole bh) throws IOException {
    int value;
    var in = new BufferedInputStream(data.bais);
    while ((value = in.read()) != -1) {
      bh.consume(value);
    }
  }

  @Benchmark
  public Object readAllBytes(Data data) {
    var in = data.bais;
    return in.readAllBytes();
  }

  @Benchmark
  public Object readAllBytesBuffered(Data data) throws IOException {
    var in = data.bais;
    return new BufferedInputStream(in).readAllBytes();
  }

  @State(Scope.Thread)
  public static class Data {

    @Param({"8", "128", "512", "1024"})
    private int length;

    private byte[] bytes;
    private ByteArrayInputStream bais;

    @Setup(Level.Iteration)
    public void setUp() {
      bytes = new byte[length];
      ThreadLocalRandom.current().nextBytes(bytes);
    }

    @Setup(Level.Invocation)
    public void setUpBais() {
      bais = new ByteArrayInputStream(bytes);
    }
  }
}
```

giving

```
                                         (length)       Score     Error   Units
read                                            8      55.737 ±   0.431   ns/op
read                                          128     533.172 ±   1.613   ns/op
read                                          512    2066.238 ±  23.989   ns/op
read                                         1024    4335.570 ±  20.137   ns/op

readBuffered                                    8     521.936 ±   2.454   ns/op
readBuffered                                  128     971.617 ± 100.469   ns/op
readBuffered                                  512    2284.472 ± 251.390   ns/op
readBuffered                                 1024    4168.598 ±  77.980   ns/op

readAllBytes                                    8      34.850 ±   0.072   ns/op
readAllBytes                                  128      36.751 ±   0.133   ns/op
readAllBytes                                  512      45.304 ±   0.699   ns/op
readAllBytes                                 1024      61.790 ±   0.386   ns/op

readAllBytesBuffered                            8     870.454 ±   4.406   ns/op
readAllBytesBuffered                          128     910.176 ±  32.258   ns/op
readAllBytesBuffered                          512     896.155 ±   6.005   ns/op
readAllBytesBuffered                         1024     965.596 ±  29.225   ns/op

read:·gc.alloc.rate.norm                        8      32.006 ±   0.001    B/op
read:·gc.alloc.rate.norm                      128      32.007 ±   0.004    B/op
read:·gc.alloc.rate.norm                      512      32.010 ±   0.010    B/op
read:·gc.alloc.rate.norm                     1024      32.011 ±   0.008    B/op

readBuffered:·gc.alloc.rate.norm                8    8280.354 ±   0.016    B/op
readBuffered:·gc.alloc.rate.norm              128    8240.484 ±   0.015    B/op
readBuffered:·gc.alloc.rate.norm              512    8240.599 ±   0.056    B/op
readBuffered:·gc.alloc.rate.norm             1024    8280.978 ±   0.024    B/op

readAllBytes:·gc.alloc.rate.norm                8      56.008 ±   0.001    B/op
readAllBytes:·gc.alloc.rate.norm              128     176.017 ±   0.001    B/op
readAllBytes:·gc.alloc.rate.norm              512     560.035 ±   0.002    B/op
readAllBytes:·gc.alloc.rate.norm             1024    1072.057 ±   0.002    B/op

readAllBytesBuffered:·gc.alloc.rate.norm        8   16512.660 ±   0.026    B/op
readAllBytesBuffered:·gc.alloc.rate.norm      128   16632.684 ±   0.008    B/op
readAllBytesBuffered:·gc.alloc.rate.norm      512   17016.694 ±   0.017    B/op
readAllBytesBuffered:·gc.alloc.rate.norm     1024   17528.748 ±   0.012    B/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265039](https://bugs.openjdk.java.net/browse/JDK-8265039): Adjust javadoc for ByteArray*Stream and InputStream


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3341/head:pull/3341` \
`$ git checkout pull/3341`

Update a local copy of the PR: \
`$ git checkout pull/3341` \
`$ git pull https://git.openjdk.java.net/jdk pull/3341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3341`

View PR using the GUI difftool: \
`$ git pr show -t 3341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3341.diff">https://git.openjdk.java.net/jdk/pull/3341.diff</a>

</details>
