### PR TITLE
8264727: Shenandoah: Remove extraneous whitespace from phase timings report

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -101,8 +101,8 @@ class outputStream;
   f(final_roots_gross,                              "Pause Final Roots (G)")           \
   f(final_roots,                                    "Pause Final Roots (N)")           \
                                                                                        \
-  f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")     \
-  f(init_update_refs,                               "Pause Init  Update Refs (N)")     \
+  f(init_update_refs_gross,                         "Pause Init Update Refs (G)")      \
+  f(init_update_refs,                               "Pause Init Update Refs (N)")      \
   f(init_update_refs_manage_gclabs,                 "  Manage GCLABs")                 \
                                                                                        \
   f(conc_update_refs,                               "Concurrent Update Refs")          \


### PR DESCRIPTION
This extra space doesn't look like it was intended to improve any alignment of text in the report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264727](https://bugs.openjdk.java.net/browse/JDK-8264727): Shenandoah: Remove extraneous whitespace from phase timings report


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3342/head:pull/3342` \
`$ git checkout pull/3342`

Update a local copy of the PR: \
`$ git checkout pull/3342` \
`$ git pull https://git.openjdk.java.net/jdk pull/3342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3342`

View PR using the GUI difftool: \
`$ git pr show -t 3342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3342.diff">https://git.openjdk.java.net/jdk/pull/3342.diff</a>

</details>
