### PR TITLE
8264731: Introduce InstanceKlass::method_at_itable_or_null()

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3150,41 +3150,45 @@ jint InstanceKlass::jvmti_class_status() const {
   return result;
 }
 
-Method* InstanceKlass::method_at_itable(Klass* holder, int index, TRAPS) {
-  itableOffsetEntry* ioe = (itableOffsetEntry*)start_of_itable();
-  int method_table_offset_in_words = ioe->offset()/wordSize;
-  int nof_interfaces = (method_table_offset_in_words - itable_offset_in_words())
-                       / itableOffsetEntry::size();
-
-  for (int cnt = 0 ; ; cnt ++, ioe ++) {
+Method* InstanceKlass::method_at_itable(InstanceKlass* holder, int index, TRAPS) {
+  bool itable_entry_found; // out parameter
+  Method* m = method_at_itable_or_null(holder, index, itable_entry_found);
+  if (m != NULL) {
+    assert(itable_entry_found, "sanity");
+    return m;
+  } else if (itable_entry_found) {
+    THROW_NULL(vmSymbols::java_lang_AbstractMethodError());
+  } else {
     // If the interface isn't implemented by the receiver class,
     // the VM should throw IncompatibleClassChangeError.
-    if (cnt >= nof_interfaces) {
-      ResourceMark rm(THREAD);
-      stringStream ss;
-      bool same_module = (module() == holder->module());
-      ss.print("Receiver class %s does not implement "
-               "the interface %s defining the method to be called "
-               "(%s%s%s)",
-               external_name(), holder->external_name(),
-               (same_module) ? joint_in_module_of_loader(holder) : class_in_module_of_loader(),
-               (same_module) ? "" : "; ",
-               (same_module) ? "" : holder->class_in_module_of_loader());
-      THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
-    }
-
-    Klass* ik = ioe->interface_klass();
-    if (ik == holder) break;
+    ResourceMark rm(THREAD);
+    stringStream ss;
+    bool same_module = (module() == holder->module());
+    ss.print("Receiver class %s does not implement "
+             "the interface %s defining the method to be called "
+             "(%s%s%s)",
+             external_name(), holder->external_name(),
+             (same_module) ? joint_in_module_of_loader(holder) : class_in_module_of_loader(),
+             (same_module) ? "" : "; ",
+             (same_module) ? "" : holder->class_in_module_of_loader());
+    THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
   }
-
-  itableMethodEntry* ime = ioe->first_method_entry(this);
-  Method* m = ime[index].method();
-  if (m == NULL) {
-    THROW_NULL(vmSymbols::java_lang_AbstractMethodError());
-  }
-  return m;
 }
 
+Method* InstanceKlass::method_at_itable_or_null(InstanceKlass* holder, int index, bool& itable_entry_found) {
+  klassItable itable(this);
+  for (int i = 0; i < itable.size_offset_table(); i++) {
+    itableOffsetEntry* offset_entry = itable.offset_entry(i);
+    if (offset_entry->interface_klass() == holder) {
+      itable_entry_found = true;
+      itableMethodEntry* ime = offset_entry->first_method_entry(this);
+      Method* m = ime[index].method();
+      return m;
+    }
+  }
+  itable_entry_found = false;
+  return NULL; // offset entry not found
+}
 
 #if INCLUDE_JVMTI
 // update default_methods for redefineclasses for methods that are

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3177,18 +3177,18 @@ Method* InstanceKlass::method_at_itable(InstanceKlass* holder, int index, TRAPS)
   }
 }
 
-Method* InstanceKlass::method_at_itable_or_null(InstanceKlass* holder, int index, bool& itable_entry_found) {
+Method* InstanceKlass::method_at_itable_or_null(InstanceKlass* holder, int index, bool& implements_interface) {
   klassItable itable(this);
   for (int i = 0; i < itable.size_offset_table(); i++) {
     itableOffsetEntry* offset_entry = itable.offset_entry(i);
     if (offset_entry->interface_klass() == holder) {
-      itable_entry_found = true;
+      implements_interface = true;
       itableMethodEntry* ime = offset_entry->first_method_entry(this);
       Method* m = ime[index].method();
       return m;
     }
   }
-  itable_entry_found = false;
+  implements_interface = false;
   return NULL; // offset entry not found
 }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3151,12 +3151,14 @@ jint InstanceKlass::jvmti_class_status() const {
 }
 
 Method* InstanceKlass::method_at_itable(InstanceKlass* holder, int index, TRAPS) {
-  bool itable_entry_found; // out parameter
-  Method* m = method_at_itable_or_null(holder, index, itable_entry_found);
+  bool implements_interface; // initialized by method_at_itable_or_null
+  Method* m = method_at_itable_or_null(holder, index,
+                                       implements_interface); // out parameter
   if (m != NULL) {
-    assert(itable_entry_found, "sanity");
+    assert(implements_interface, "sanity");
     return m;
-  } else if (itable_entry_found) {
+  } else if (implements_interface) {
+    // Throw AbstractMethodError since corresponding itable slot is empty.
     THROW_NULL(vmSymbols::java_lang_AbstractMethodError());
   } else {
     // If the interface isn't implemented by the receiver class,

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1108,7 +1108,8 @@ public:
 
   // Java itable
   klassItable itable() const;        // return klassItable wrapper
-  Method* method_at_itable(Klass* holder, int index, TRAPS);
+  Method* method_at_itable(InstanceKlass* holder, int index, TRAPS);
+  Method* method_at_itable_or_null(InstanceKlass* holder, int index, bool& itable_entry_found);
 
 #if INCLUDE_JVMTI
   void adjust_default_methods(bool* trace_name_printed);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -906,7 +906,7 @@ static void jni_invoke_nonstatic(JNIEnv *env, JavaValue* result, jobject receive
   {
     Method* m = Method::resolve_jmethod_id(method_id);
     number_of_parameters = m->size_of_parameters();
-    Klass* holder = m->method_holder();
+    InstanceKlass* holder = m->method_holder();
     if (call_type != JNI_VIRTUAL) {
         selected_method = m;
     } else if (!m->has_itable_index()) {


### PR DESCRIPTION
Introduce `InstanceKlass::method_at_itable_or_null()` - a non-throwing variant of `InstanceKlass::method_at_itable()` that implements interface method selection. 

As a cleanup, rewrite `InstanceKlass::method_at_itable()` on top of `InstanceKlass::method_at_itable_or_null()`.

Testing: 
* [x] hs-tier1 - hs-tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264731](https://bugs.openjdk.java.net/browse/JDK-8264731): Introduce InstanceKlass::method_at_itable_or_null()


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 2755b4831427ad5f9f1e16e2f52a35d90de66bde
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 91b977c0b04c42ca7b17c101e0e0a8ccb72929a5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3344/head:pull/3344` \
`$ git checkout pull/3344`

Update a local copy of the PR: \
`$ git checkout pull/3344` \
`$ git pull https://git.openjdk.java.net/jdk pull/3344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3344`

View PR using the GUI difftool: \
`$ git pr show -t 3344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3344.diff">https://git.openjdk.java.net/jdk/pull/3344.diff</a>

</details>
