### PR TITLE
8264742: member variable _monitor of MonitorLocker is redundant

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -198,7 +198,6 @@ void assert_locked_or_safepoint_or_handshake(const Mutex* lock, const JavaThread
 class MutexLocker: public StackObj {
  protected:
   Mutex* _mutex;
- private:
  public:
   MutexLocker(Mutex* mutex, Mutex::SafepointCheckFlag flag = Mutex::_safepoint_check_flag) :
     _mutex(mutex) {
@@ -242,36 +241,41 @@ class MutexLocker: public StackObj {
 
 class MonitorLocker: public MutexLocker {
   Mutex::SafepointCheckFlag _flag;
-  Monitor* _monitor;
+
+ protected:
+  Monitor* as_monitor() const {
+    return static_cast<Monitor*>(_mutex);
+  }
+
  public:
   MonitorLocker(Monitor* monitor, Mutex::SafepointCheckFlag flag = Mutex::_safepoint_check_flag) :
-    MutexLocker(monitor, flag), _flag(flag), _monitor(monitor) {
+    MutexLocker(monitor, flag), _flag(flag) {
     // Superclass constructor did locking
-    assert(_monitor != NULL, "NULL monitor not allowed");
+    assert(monitor != NULL, "NULL monitor not allowed");
   }
 
   MonitorLocker(Thread* thread, Monitor* monitor, Mutex::SafepointCheckFlag flag = Mutex::_safepoint_check_flag) :
-    MutexLocker(thread, monitor, flag), _flag(flag), _monitor(monitor)  {
+    MutexLocker(thread, monitor, flag), _flag(flag) {
     // Superclass constructor did locking
-    assert(_monitor != NULL, "NULL monitor not allowed");
+    assert(monitor != NULL, "NULL monitor not allowed");
   }
 
   bool wait(int64_t timeout = 0,
             bool as_suspend_equivalent = !Mutex::_as_suspend_equivalent_flag) {
     if (_flag == Mutex::_safepoint_check_flag) {
-      return _monitor->wait(timeout, as_suspend_equivalent);
+      return as_monitor()->wait(timeout, as_suspend_equivalent);
     } else {
-      return _monitor->wait_without_safepoint_check(timeout);
+      return as_monitor()->wait_without_safepoint_check(timeout);
     }
     return false;
   }
 
   void notify_all() {
-    _monitor->notify_all();
+    as_monitor()->notify_all();
   }
 
   void notify() {
-    _monitor->notify();
+    as_monitor()->notify();
   }
 };
 


### PR DESCRIPTION
MonitorLocker is a subclass of MutexLocker. The member variable _monitor
has the same value of _mutex in its base class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264742](https://bugs.openjdk.java.net/browse/JDK-8264742): member variable _monitor of MonitorLocker is redundant


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3350/head:pull/3350` \
`$ git checkout pull/3350`

Update a local copy of the PR: \
`$ git checkout pull/3350` \
`$ git pull https://git.openjdk.java.net/jdk pull/3350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3350`

View PR using the GUI difftool: \
`$ git pr show -t 3350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3350.diff">https://git.openjdk.java.net/jdk/pull/3350.diff</a>

</details>
