### PR TITLE
8264759: x86_32 Minimal VM build failure after JDK-8262355

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -219,6 +219,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
     }
   }
 
+#ifdef COMPILER2
   if (save_vectors) {
     __ subptr(rsp, ymm_bytes);
     // Save upper half of YMM registers
@@ -239,6 +240,9 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
     }
   }
   __ vzeroupper();
+#else
+  assert(!save_vectors, "vectors are generated only by C2");
+#endif
 
   // Set an oopmap for the call site.  This oopmap will map all
   // oop-registers and debug-info registers as callee-saved.  This

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -239,10 +239,11 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
       }
     }
   }
-  __ vzeroupper();
 #else
   assert(!save_vectors, "vectors are generated only by C2");
 #endif
+
+  __ vzeroupper();
 
   // Set an oopmap for the call site.  This oopmap will map all
   // oop-registers and debug-info registers as callee-saved.  This


### PR DESCRIPTION
```
* For target hotspot_variant-minimal_libjvm_objs_sharedRuntime_x86_32.o:
/home/shade/trunks/jdk/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp: In static member function 'static OopMap* RegisterSaver::save_live_registers(MacroAssembler*, int, int*, bool, bool)':
/home/shade/trunks/jdk/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp:234:22: error: 'opmask_state_bytes' was not declared in this scope
  234 |       __ subptr(rsp, opmask_state_bytes);
      |                      ^~~~~~~~~~~~~~~~~~
```

`opmask_state_bytes` is defined under `COMPILER2` in the same method. Instead of protecting the block that uses `opmask_state_bytes`, I opted to protect the whole `if (save_vectors)` block, in the same way it is protected in the method prolog. The new assert checks the same thing as the assert in prolog.

Additional testing:
 - [x] Linux x86_32 Minimal build
 - [x] Linux x86_32 Server build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264759](https://bugs.openjdk.java.net/browse/JDK-8264759): x86_32 Minimal VM build failure after JDK-8262355


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 86a5d8fd01a94f35c79b413844af2b3d222ea7a8
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3353/head:pull/3353` \
`$ git checkout pull/3353`

Update a local copy of the PR: \
`$ git checkout pull/3353` \
`$ git pull https://git.openjdk.java.net/jdk pull/3353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3353`

View PR using the GUI difftool: \
`$ git pr show -t 3353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3353.diff">https://git.openjdk.java.net/jdk/pull/3353.diff</a>

</details>
