### PR TITLE
8264200: java/nio/channels/DatagramChannel/SRTest.java fails intermittently

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -112,10 +112,10 @@ public class SRTest {
 
     public static class ClassicWriter implements Runnable, AutoCloseable {
         final DatagramSocket ds;
-        final int port;
+        final int dstPort;
 
-        ClassicWriter(int port) throws SocketException {
-            this.port = port;
+        ClassicWriter(int dstPort) throws SocketException {
+            this.dstPort = dstPort;
             this.ds = new DatagramSocket();
         }
 
@@ -124,7 +124,7 @@ public class SRTest {
                 byte[] data = DATA_STRING.getBytes(US_ASCII);
                 InetAddress address = InetAddress.getLoopbackAddress();
                 DatagramPacket dp = new DatagramPacket(data, data.length,
-                                                       address, port);
+                                                       address, dstPort);
                 ds.send(dp);
             } catch (Exception e) {
                 log.println("ClassicWriter [" + ds.getLocalAddress() + "]");
@@ -142,11 +142,11 @@ public class SRTest {
 
     public static class NioWriter implements Runnable, AutoCloseable {
         final DatagramChannel dc;
-        final int port;
+        final int dstPort;
 
-        NioWriter(int port) throws IOException {
+        NioWriter(int dstPort) throws IOException {
             this.dc = DatagramChannel.open();
-            this.port = port;
+            this.dstPort = dstPort;
         }
 
         public void run() {
@@ -155,7 +155,7 @@ public class SRTest {
                 bb.put(DATA_STRING.getBytes(US_ASCII));
                 bb.flip();
                 InetAddress address = InetAddress.getLoopbackAddress();
-                InetSocketAddress isa = new InetSocketAddress(address, port);
+                InetSocketAddress isa = new InetSocketAddress(address, dstPort);
                 dc.send(bb, isa);
             } catch (Exception ex) {
                 log.println("NioWriter [" + dc.socket().getLocalAddress() + "]");

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -31,12 +31,12 @@ import java.io.*;
 import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
-import java.nio.charset.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import org.testng.annotations.*;
 
@@ -120,7 +120,7 @@ public class SRTest {
         public void run() {
             try {
                 String dataString = "hello";
-                byte[] data = dataString.getBytes();
+                byte[] data = dataString.getBytes(US_ASCII);
                 InetAddress address = InetAddress.getLoopbackAddress();
                 DatagramPacket dp = new DatagramPacket(data, data.length,
                                                        address, port);
@@ -152,9 +152,9 @@ public class SRTest {
 
         public void run() {
             try {
-                DatagramChannel dc = DatagramChannel.open();
+                String dataString = "hello";
                 ByteBuffer bb = ByteBuffer.allocateDirect(256);
-                bb.put("hello".getBytes());
+                bb.put(dataString.getBytes(US_ASCII));
                 bb.flip();
                 InetAddress address = InetAddress.getLoopbackAddress();
                 InetSocketAddress isa = new InetSocketAddress(address, port);
@@ -162,10 +162,10 @@ public class SRTest {
                 Thread.sleep(50);
                 dc.send(bb, isa);
             } catch (Exception ex) {
-                log.println("ClassicWriter [" + dc.socket().getLocalAddress() + "]");
+                log.println("NioWriter [" + dc.socket().getLocalAddress() + "]");
                 throw new RuntimeException("NioWriter threw exception: " + ex);
             } finally {
-                log.println("NioWriter Finished");
+                log.println("NioWriter finished");
             }
         }
 
@@ -192,10 +192,10 @@ public class SRTest {
                 byte[] buf = new byte[256];
                 DatagramPacket dp = new DatagramPacket(buf, buf.length);
                 ds.receive(dp);
-                String received = new String(dp.getData());
+                String received = new String(dp.getData(), US_ASCII);
                 log.println("ClassicReader received: " + received);
             } catch (Exception ex) {
-                log.println("ClassicWriter [" + ds.getLocalAddress() +"]");
+                log.println("ClassicReader [" + ds.getLocalAddress() +"]");
                 throw new RuntimeException("ClassicReader threw exception: " + ex);
             } finally {
                 log.println("ClassicReader finished");
@@ -223,12 +223,12 @@ public class SRTest {
         public void run() {
             try {
                 ByteBuffer bb = ByteBuffer.allocateDirect(100);
-                SocketAddress sa = dc.receive(bb);
+                dc.receive(bb);
                 bb.flip();
-                CharBuffer cb = StandardCharsets.US_ASCII.newDecoder().decode(bb);
+                CharBuffer cb = US_ASCII.newDecoder().decode(bb);
                 log.println("NioReader received: " + cb);
             } catch (Exception ex) {
-                log.println("ClassicWriter [" + dc.socket().getLocalAddress() +"]");
+                log.println("NioReader [" + dc.socket().getLocalAddress() +"]");
                 throw new RuntimeException("NioReader threw exception: " + ex);
             } finally {
                 log.println("NioReader finished");

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -24,7 +24,7 @@
 /* @test
  * @summary Test DatagramChannel's send and receive methods
  * @author Mike McCloskey
- * @run testng/othervm/timeout=100 SRTest
+ * @run testng/othervm/timeout=20 SRTest
  */
 
 import java.io.*;

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -23,7 +23,6 @@
 
 /* @test
  * @summary Test DatagramChannel's send and receive methods
- * @author Mike McCloskey
  * @run testng/othervm/timeout=20 SRTest
  */
 

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -126,8 +126,6 @@ public class SRTest {
                 DatagramPacket dp = new DatagramPacket(data, data.length,
                                                        address, port);
                 ds.send(dp);
-                Thread.sleep(50);
-                ds.send(dp);
             } catch (Exception e) {
                 log.println("ClassicWriter [" + ds.getLocalAddress() + "]");
                 throw new RuntimeException("ClassicWriter threw exception: " + e);
@@ -158,8 +156,6 @@ public class SRTest {
                 bb.flip();
                 InetAddress address = InetAddress.getLoopbackAddress();
                 InetSocketAddress isa = new InetSocketAddress(address, port);
-                dc.send(bb, isa);
-                Thread.sleep(50);
                 dc.send(bb, isa);
             } catch (Exception ex) {
                 log.println("NioWriter [" + dc.socket().getLocalAddress() + "]");

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -45,6 +45,8 @@ public class SRTest {
     ExecutorService executorService;
     static PrintStream log = System.err;
 
+    static final String DATA_STRING = "hello";
+
     @BeforeClass
     public void beforeClass() {
         executorService = Executors.newCachedThreadPool();
@@ -119,8 +121,7 @@ public class SRTest {
 
         public void run() {
             try {
-                String dataString = "hello";
-                byte[] data = dataString.getBytes(US_ASCII);
+                byte[] data = DATA_STRING.getBytes(US_ASCII);
                 InetAddress address = InetAddress.getLoopbackAddress();
                 DatagramPacket dp = new DatagramPacket(data, data.length,
                                                        address, port);
@@ -152,9 +153,8 @@ public class SRTest {
 
         public void run() {
             try {
-                String dataString = "hello";
                 ByteBuffer bb = ByteBuffer.allocateDirect(256);
-                bb.put(dataString.getBytes(US_ASCII));
+                bb.put(DATA_STRING.getBytes(US_ASCII));
                 bb.flip();
                 InetAddress address = InetAddress.getLoopbackAddress();
                 InetSocketAddress isa = new InetSocketAddress(address, port);
@@ -192,7 +192,7 @@ public class SRTest {
                 byte[] buf = new byte[256];
                 DatagramPacket dp = new DatagramPacket(buf, buf.length);
                 ds.receive(dp);
-                String received = new String(dp.getData(), US_ASCII);
+                String received = new String(dp.getData(), 0, DATA_STRING.length(), US_ASCII);
                 log.println("ClassicReader received: " + received);
             } catch (Exception ex) {
                 log.println("ClassicReader [" + ds.getLocalAddress() +"]");

--- a/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SRTest.java
@@ -188,7 +188,7 @@ public class SRTest {
                 byte[] buf = new byte[256];
                 DatagramPacket dp = new DatagramPacket(buf, buf.length);
                 ds.receive(dp);
-                String received = new String(dp.getData(), 0, DATA_STRING.length(), US_ASCII);
+                String received = new String(dp.getData(), dp.getOffset(), dp.getLength(), US_ASCII);
                 log.println("ClassicReader received: " + received);
             } catch (Exception ex) {
                 log.println("ClassicReader [" + ds.getLocalAddress() +"]");


### PR DESCRIPTION
### Description
SRTest.java has been seen to fail intermittently in a similar manner to other recent failures in [DatagramChannel tests](https://github.com/openjdk/jdk/pull/679). With SRTest.java, these failures are associated with a number of issues listed below. Note that XReader refers to both ClassicReader and NioReader classes. Likewise for XWriter.

### Issues
- Test is run in AgentVM mode.
- Receivers bind to wildcard/localhost which has been a source of instability.
- Sockets are not closed properly if an exception is thrown, even more of an issue due to test running in AgentVM mode.
- An XReader instance will wait forever to receive a `DatagramPacket` if an XSender has not sent one.

### Fixes
To Address these issues, the following was done respective to the order of the Issues above:
- Test now runs with `testng/othervm` and uses its own thread pool. Note that the change to testng was not absolutely essential but means that if one test case fails the others will still be run which could provide useful information on why a failure occured.
- Receivers now bind to loopback address instead of localhost.
- XReader and XWriter classes implement `Autocloseable` and are declared within a try-with-resources block for each test case. As well as this, the test cases are now executed with `CompleteableFuture.allOf(futures)` such that if any Reader or Writer throws an exception during execution, the threads will exit in a safe manner and the exception concerned will be thrown (wrapped in a `CompletionException`).
- Test will now timeout with respect to timeout limit of Jtreg which is set to 20 seconds for this test. Note that this is given in the `@run` as `testng/othervm/timeout=20` tag in seconds. See Action Options in Jtreg docs [here](https://openjdk.java.net/jtreg/tag-spec.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264200](https://bugs.openjdk.java.net/browse/JDK-8264200): java/nio/channels/DatagramChannel/SRTest.java fails intermittently


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 594244555c95f799c1bf83841c2b042749b38b67
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 6ac1b2c345fe90951a13010ad49b6bd967f023a2
 * [Mark Sheppard](https://openjdk.java.net/census#msheppar) (@msheppar - **Reviewer**) ⚠️ Review applies to 594244555c95f799c1bf83841c2b042749b38b67


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3354/head:pull/3354` \
`$ git checkout pull/3354`

Update a local copy of the PR: \
`$ git checkout pull/3354` \
`$ git pull https://git.openjdk.java.net/jdk pull/3354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3354`

View PR using the GUI difftool: \
`$ git pr show -t 3354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3354.diff">https://git.openjdk.java.net/jdk/pull/3354.diff</a>

</details>
