### PR TITLE
8264752: JFR crash when only specify threadbuffersize=30M

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.cpp
@@ -305,7 +305,12 @@ static void thread_buffer_size(JfrMemoryOptions* options) {
   options->global_buffer_size = div_total_by_units(options->memory_size, options->buffer_count);
   if (options->thread_buffer_size > options->global_buffer_size) {
     options->global_buffer_size = options->thread_buffer_size;
-    options->buffer_count = div_total_by_per_unit(options->memory_size, options->global_buffer_size);
+    if (options->memory_size_configured) {
+      options->buffer_count = div_total_by_per_unit(options->memory_size, options->global_buffer_size);
+    } else {
+      // init memory_size according buffer count and size
+      options->memory_size = options->buffer_count * options->global_buffer_size;
+    }
   }
   assert(options->global_buffer_size >= options->thread_buffer_size, "invariant");
 }

--- a/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.cpp
@@ -308,8 +308,8 @@ static void thread_buffer_size(JfrMemoryOptions* options) {
     if (options->memory_size_configured) {
       options->buffer_count = div_total_by_per_unit(options->memory_size, options->global_buffer_size);
     } else {
-      // init memory_size according buffer count and size
-      options->memory_size = options->buffer_count * options->global_buffer_size;
+      // init memory_size by buffer count and size
+      options->memory_size = multiply(options->global_buffer_size, options->buffer_count);
     }
   }
   assert(options->global_buffer_size >= options->thread_buffer_size, "invariant");

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -541,6 +541,10 @@ static bool valid_memory_relations(const JfrMemoryOptions& options) {
         return false;
       }
     }
+  } else if (options.thread_buffer_size_configured && options.memory_size_configured) {
+    if (!ensure_first_gteq_second(_dcmd_memorysize, _dcmd_threadbuffersize)) {
+      return false;
+    }
   }
   return true;
 }

--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -637,6 +637,11 @@ public class TestMemoryOptions {
         tc = new TestCase("GlobalBufferSizeTimesGlobalBufferCountEqualToMinMemorySizePositive", false);
         tc.setGlobalBufferSizeTestParam(64, 'k');
         tc.setGlobalBufferCountTestParam(16, 'b');
+        testCases.add(tc);
+
+        // threadbuffersize exceeds default memory-size
+        tc = new TestCase("ThreadBufferSizeExceedMemorySize", false);
+        tc.setThreadBufferSizeTestParam(30, 'm');
         testCases.add(tc);
     }
 


### PR DESCRIPTION
SIGFPE crash happens in release build with following JFR crash options. Because div_total_by_per_unit try to divide smaller memorysize with larger threadbuffersize. 
```
div_total_by_per_unit
  const julong units = total_pages / per_unit_pages;    // units is zero
  const julong rem = total_pages % per_unit_pages;

  assert(units > 0, "invariant");

  if (rem > 0) {
    total_pages -= rem % units;
    per_unit_pages += rem / units;     // SIGFPE happen
  }
```

-XX:StartFlightRecording -XX:FlightRecorderOptions:threadbuffersize=30M
-XX:StartFlightRecording -XX:FlightRecorderOptions:threadbuffersize=30M,memorysize=10M

Fix includes
1. if threadbuffersize is larger than memorysize, fail with message
```
[0.019s][error][arguments] Value specified for option "memorysize" is 10M
[0.019s][error][arguments] Value specified for option "threadbuffersize" is 30M
[0.019s][error][arguments] The value for option "threadbuffersize" should not be larger than the value specified for option "memorysize
```
2. In "thread_buffer_size(JfrMemoryOptions* options)", If memor_size is not configured, calculate new memory_size according to buffer_size and buffer_count. Avoid possible SIGFPE in div_total_by_per_unit.


There are other assertions in debug build with JFR options, leave them in other bug fix (https://bugs.openjdk.java.net/browse/JDK-8241773) 
1. -XX:FlightRecorderOptions:threadbuffersize=6M,memorysize=10M    assert(options.buffer_count >= MIN_BUFFER_COUNT) failed: invariant 
2. -XX:FlightRecorderOptions:globalbuffersize=4G   assert(free_size() == size) failed: invariant  
3. -XX:FlightRecorderOptions:threadbuffersize=4G    assert(free_size() == size) failed: invariant

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264752](https://bugs.openjdk.java.net/browse/JDK-8264752): JFR crash when only specify threadbuffersize=30M


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3355/head:pull/3355` \
`$ git checkout pull/3355`

Update a local copy of the PR: \
`$ git checkout pull/3355` \
`$ git pull https://git.openjdk.java.net/jdk pull/3355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3355`

View PR using the GUI difftool: \
`$ git pr show -t 3355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3355.diff">https://git.openjdk.java.net/jdk/pull/3355.diff</a>

</details>
