### PR TITLE
8264783: G1 BOT verification should not verify beyond allocation threshold

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -327,7 +327,8 @@ void G1BlockOffsetTablePart::alloc_block_work(HeapWord** threshold_, size_t* ind
 void G1BlockOffsetTablePart::verify() const {
   assert(_hr->bottom() < _hr->top(), "Only non-empty regions should be verified.");
   size_t start_card = _bot->index_for(_hr->bottom());
-  size_t end_card = _bot->index_for(_hr->top() - 1);
+  // Do not verify beyond the BOT allocation threshold.
+  size_t end_card = MIN2(_bot->index_for(_hr->top() - 1), _next_offset_index - 1);
 
   for (size_t current_card = start_card; current_card < end_card; current_card++) {
     u_char entry = _bot->offset_array(current_card);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -721,7 +721,7 @@ void HeapRegion::verify(VerifyOption vo,
     p += obj_size;
   }
 
-  if (!is_young() && !is_empty()) {
+  if (!is_empty()) {
     _bot_part.verify();
   }
 


### PR DESCRIPTION
The G1 BOT contains an allocation threshold which basically acts as a "last known valid entry" index for the per-region BOT (which are views on the global BOT table).

Currently G1 BOT verification actually "verifies" the BOT within a region past that BOT index.

This causes issues with young regions; actually there is already code that prevents their BOT verification. This is perfectly fine, allocations in young regions do not update the BOTs.

With JDK-8262068/PR #2760 this existing filtering of young regions (such that their BOT is not verified) does not work because there may be young regions that are not compacted (so with a BOT that have that last known valid entry at the start of the region) are still labelled as old.

This change proposes to not try to verify the BOT beyond the last known valid index (which is arguably not worth doing), which also covers the existing young filtering.

There are alternatives that may work in particular for JDK-8262068:
a) always compact young regions (which recreates the BOT)
b) create a "dummy" BOT that spans the entire part of the region containing live objects

However they were rejected by me because
option a) takes time and directly counters that optimization for no reason
option b) makes finding the start of an object within these regions slow (they are not refined when there is at least *some* bot)

and finally I do not think there is much point in trying to be clever about areas in the BOT that are known to not contain useful values. 

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264783](https://bugs.openjdk.java.net/browse/JDK-8264783): G1 BOT verification should not verify beyond allocation threshold


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3356/head:pull/3356` \
`$ git checkout pull/3356`

Update a local copy of the PR: \
`$ git checkout pull/3356` \
`$ git pull https://git.openjdk.java.net/jdk pull/3356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3356`

View PR using the GUI difftool: \
`$ git pr show -t 3356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3356.diff">https://git.openjdk.java.net/jdk/pull/3356.diff</a>

</details>
