### PR TITLE
8262898: com/sun/net/httpserver/bugs/8199849/ParamTest.java times out

### DIFF
--- a/test/jdk/com/sun/net/httpserver/bugs/8199849/ParamTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8199849/ParamTest.java
@@ -200,6 +200,7 @@ public class ParamTest {
             URI uri = url.toURI();
             HttpClient client = HttpClient.newBuilder()
                 .authenticator(auth)
+                .proxy(ProxySelector.of(null))
                 .build();
 
             HttpRequest request = HttpRequest


### PR DESCRIPTION
Hi,

Could I get the following small test fix reviewed please? The test is timing out on Mac probably because it is running on a system with a proxy that is not bypassed for loopback connections. The test already sets NO_PROXY explicitly for one part of the test. It needs to do the equivalent for the second part.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262898](https://bugs.openjdk.java.net/browse/JDK-8262898): com/sun/net/httpserver/bugs/8199849/ParamTest.java times out


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3358/head:pull/3358` \
`$ git checkout pull/3358`

Update a local copy of the PR: \
`$ git checkout pull/3358` \
`$ git pull https://git.openjdk.java.net/jdk pull/3358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3358`

View PR using the GUI difftool: \
`$ git pr show -t 3358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3358.diff">https://git.openjdk.java.net/jdk/pull/3358.diff</a>

</details>
