### PR TITLE
8264791: java/util/Random/RandomTestBsi1999.java failed "java.security.SecureRandom nextFloat consecutive"

### DIFF
--- a/test/jdk/java/util/Random/RandomTestBsi1999.java
+++ b/test/jdk/java/util/Random/RandomTestBsi1999.java
@@ -440,6 +440,7 @@ public class RandomTestBsi1999 {
             setRNG(factory.name());
 
             if (currentRNG.equals("SecureRandom")) {
+                // Bug: 8264791
                 // skip because stochastic
             } else if (currentRNG.equals("Random")) {
                 // testOneRng(factory.create(59), 1);

--- a/test/jdk/java/util/Random/RandomTestBsi1999.java
+++ b/test/jdk/java/util/Random/RandomTestBsi1999.java
@@ -440,7 +440,6 @@ public class RandomTestBsi1999 {
             setRNG(factory.name());
 
             if (currentRNG.equals("SecureRandom")) {
-                // Bug: 8264791
                 // skip because stochastic
             } else if (currentRNG.equals("Random")) {
                 // testOneRng(factory.create(59), 1);

--- a/test/jdk/java/util/Random/RandomTestBsi1999.java
+++ b/test/jdk/java/util/Random/RandomTestBsi1999.java
@@ -439,7 +439,9 @@ public class RandomTestBsi1999 {
         RandomGeneratorFactory.all().forEach(factory -> {
             setRNG(factory.name());
 
-            if (factory.name().equals("Random")) {
+            if (currentRNG.equals("SecureRandom")) {
+                // skip because stochastic
+            } else if (currentRNG.equals("Random")) {
                 // testOneRng(factory.create(59), 1);
                 // autocorrelation failure for java.util.Random longs bit 0: count=2207 (should be in [2267,2733]), tau=2819
 


### PR DESCRIPTION
SecureRandom is stochastic and will become unpredictable over time (hence the intermittent nature).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264791](https://bugs.openjdk.java.net/browse/JDK-8264791): java/util/Random/RandomTestBsi1999.java failed "java.security.SecureRandom nextFloat consecutive"


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 5f39180eb961f03c87b895085ee56afeb4d54ad5
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 5f39180eb961f03c87b895085ee56afeb4d54ad5
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 5f39180eb961f03c87b895085ee56afeb4d54ad5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3359/head:pull/3359` \
`$ git checkout pull/3359`

Update a local copy of the PR: \
`$ git checkout pull/3359` \
`$ git pull https://git.openjdk.java.net/jdk pull/3359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3359`

View PR using the GUI difftool: \
`$ git pr show -t 3359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3359.diff">https://git.openjdk.java.net/jdk/pull/3359.diff</a>

</details>
