### PR TITLE
8259242: Remove ProtectionDomainSet_lock

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -89,7 +89,7 @@ void Dictionary::free_entry(DictionaryEntry* entry) {
   // pd_set is accessed during a safepoint.
   // This doesn't require a lock because nothing is reading this
   // entry anymore.  The ClassLoader is dead.
-  if (entry->pd_set_acquire() != NULL) {
+  while (entry->pd_set_acquire() != NULL) {
     ProtectionDomainEntry* to_delete = entry->pd_set_acquire();
     entry->release_set_pd_set(to_delete->next_acquire());
     delete to_delete;

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -141,8 +141,8 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
     return (DictionaryEntry**)HashtableEntry<InstanceKlass*, mtClass>::next_addr();
   }
 
-  ProtectionDomainEntry* pd_set() const            { return Atomic::load(&_pd_set); }
-  void set_pd_set(ProtectionDomainEntry* entry)    { Atomic::store(&_pd_set, entry); }
+  ProtectionDomainEntry* pd_set_acquire() const            { return Atomic::load_acquire(&_pd_set); }
+  void release_set_pd_set(ProtectionDomainEntry* entry)    { Atomic::release_store(&_pd_set, entry); }
 
   // Tells whether the initiating class' protection domain can access the klass in this entry
   inline bool is_valid_protection_domain(Handle protection_domain);

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -34,6 +34,8 @@
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
+#include "runtime/atomic.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/hashtable.inline.hpp"
 
 unsigned int ProtectionDomainCacheTable::compute_hash(Handle protection_domain) {
@@ -58,18 +60,53 @@ void ProtectionDomainCacheTable::trigger_cleanup() {
 }
 
 class CleanProtectionDomainEntries : public CLDClosure {
+  GrowableArray<ProtectionDomainEntry*>* _delete_list;
+ public:
+  CleanProtectionDomainEntries(GrowableArray<ProtectionDomainEntry*>* delete_list) :
+                               _delete_list(delete_list) {}
+
   void do_cld(ClassLoaderData* data) {
     Dictionary* dictionary = data->dictionary();
     if (dictionary != NULL) {
-      dictionary->clean_cached_protection_domains();
+      dictionary->clean_cached_protection_domains(_delete_list);
     }
   }
 };
+
+class HandshakeForPD : public HandshakeClosure {
+ public:
+  HandshakeForPD() : HandshakeClosure("HandshakeForPD") {}
+
+  void do_thread(Thread* thread) {
+    log_trace(protectiondomain)("HandshakeForPD::do_thread: thread="
+                                INTPTR_FORMAT, p2i(thread));
+  }
+};
+
+static void purge_deleted_entries(GrowableArray<ProtectionDomainEntry*>* delete_list) {
+  // If there are any deleted entries, Handshake-all then they'll be
+  // safe to remove since traversing the pd_set list does not stop for
+  // safepoints and only JavaThreads will read the pd_set.
+  // This is actually quite rare because the protection domain is generally associated
+  // with the caller class and class loader, which if still alive will keep this
+  // protection domain entry alive.
+  if (delete_list->length() != 0) {
+    HandshakeForPD hs_pd;
+    Handshake::execute(&hs_pd);
+
+    for (int i = 0; i < delete_list->length(); i++) {
+      ProtectionDomainEntry* entry = delete_list->at(i);
+      delete entry;
+    }
+  }
+}
 
 void ProtectionDomainCacheTable::unlink() {
   // The dictionary entries _pd_set field should be null also, so nothing to do.
   assert(java_lang_System::allow_security_manager(), "should not be called otherwise");
 
+  ResourceMark rm;
+  GrowableArray<ProtectionDomainEntry*> delete_list;
   {
     // First clean cached pd lists in loaded CLDs
     // It's unlikely, but some loaded classes in a dictionary might
@@ -77,9 +114,12 @@ void ProtectionDomainCacheTable::unlink() {
     // The dictionary pd_set points at entries in the ProtectionDomainCacheTable.
     MutexLocker ml(ClassLoaderDataGraph_lock);
     MutexLocker mldict(SystemDictionary_lock);  // need both.
-    CleanProtectionDomainEntries clean;
+    CleanProtectionDomainEntries clean(&delete_list);
     ClassLoaderDataGraph::loaded_cld_do(&clean);
   }
+
+  // Purge any deleted entries outside of the SystemDictionary_lock.
+  purge_deleted_entries(&delete_list);
 
   MutexLocker ml(SystemDictionary_lock);
   int oops_removed = 0;
@@ -129,10 +169,6 @@ oop ProtectionDomainCacheEntry::object() {
   return literal().resolve();
 }
 
-oop ProtectionDomainEntry::object() {
-  return _pd_cache->object();
-}
-
 // The object_no_keepalive() call peeks at the phantomly reachable oop without
 // keeping it alive. This is okay to do in the VM thread state if it is not
 // leaked out to become strongly reachable.
@@ -171,6 +207,7 @@ ProtectionDomainCacheEntry* ProtectionDomainCacheTable::find_entry(int index, Ha
 
   return NULL;
 }
+
 
 ProtectionDomainCacheEntry* ProtectionDomainCacheTable::add_entry(int index, unsigned int hash, Handle protection_domain) {
   assert_locked_or_safepoint(SystemDictionary_lock);

--- a/src/hotspot/share/classfile/protectionDomainCache.hpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 
 #include "oops/oop.hpp"
 #include "oops/weakHandle.hpp"
-#include "memory/iterator.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/hashtable.hpp"
 
 // This class caches the approved protection domains that can access loaded classes.
@@ -62,8 +62,6 @@ class ProtectionDomainCacheEntry : public HashtableEntry<WeakHandle, mtClass> {
 // The amount of different protection domains used is typically magnitudes smaller
 // than the number of system dictionary entries (loaded classes).
 class ProtectionDomainCacheTable : public Hashtable<WeakHandle, mtClass> {
-  friend class VMStructs;
-private:
   ProtectionDomainCacheEntry* bucket(int i) const {
     return (ProtectionDomainCacheEntry*) Hashtable<WeakHandle, mtClass>::bucket(i);
   }
@@ -104,20 +102,17 @@ public:
 };
 
 
+// This describes the linked list protection domain for each DictionaryEntry in pd_set.
 class ProtectionDomainEntry :public CHeapObj<mtClass> {
-  friend class VMStructs;
- public:
-  ProtectionDomainEntry* _next;
   ProtectionDomainCacheEntry* _pd_cache;
+  ProtectionDomainEntry* volatile _next;
+ public:
 
-  ProtectionDomainEntry(ProtectionDomainCacheEntry* pd_cache, ProtectionDomainEntry* next) {
-    _pd_cache = pd_cache;
-    _next     = next;
-  }
+  ProtectionDomainEntry(ProtectionDomainCacheEntry* pd_cache,
+                        ProtectionDomainEntry* head) : _pd_cache(pd_cache), _next(head) {}
 
-  ProtectionDomainEntry* next() { return _next; }
-  void set_next(ProtectionDomainEntry* entry) { _next = entry; }
-  oop object();
+  ProtectionDomainEntry* next() { return Atomic::load(&_next); }
+  void set_next(ProtectionDomainEntry* entry) { Atomic::store(&_next, entry); }
   oop object_no_keepalive();
 };
 #endif // SHARE_CLASSFILE_PROTECTIONDOMAINCACHE_HPP

--- a/src/hotspot/share/classfile/protectionDomainCache.hpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.hpp
@@ -111,8 +111,8 @@ class ProtectionDomainEntry :public CHeapObj<mtClass> {
   ProtectionDomainEntry(ProtectionDomainCacheEntry* pd_cache,
                         ProtectionDomainEntry* head) : _pd_cache(pd_cache), _next(head) {}
 
-  ProtectionDomainEntry* next() { return Atomic::load(&_next); }
-  void set_next(ProtectionDomainEntry* entry) { Atomic::store(&_next, entry); }
+  ProtectionDomainEntry* next_acquire() { return Atomic::load_acquire(&_next); }
+  void release_set_next(ProtectionDomainEntry* entry) { Atomic::release_store(&_next, entry); }
   oop object_no_keepalive();
 };
 #endif // SHARE_CLASSFILE_PROTECTIONDOMAINCACHE_HPP

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -42,7 +42,6 @@
 Mutex*   Patching_lock                = NULL;
 Mutex*   CompiledMethod_lock          = NULL;
 Monitor* SystemDictionary_lock        = NULL;
-Mutex*   ProtectionDomainSet_lock     = NULL;
 Mutex*   SharedDictionary_lock        = NULL;
 Mutex*   Module_lock                  = NULL;
 Mutex*   CompiledIC_lock              = NULL;
@@ -261,7 +260,6 @@ void mutex_init() {
   def(JmethodIdCreation_lock       , PaddedMutex  , special-2,   true,  _safepoint_check_never); // used for creating jmethodIDs.
 
   def(SystemDictionary_lock        , PaddedMonitor, leaf,        true,  _safepoint_check_always);
-  def(ProtectionDomainSet_lock     , PaddedMutex  , leaf-1,      true,  _safepoint_check_never);
   def(SharedDictionary_lock        , PaddedMutex  , leaf,        true,  _safepoint_check_always);
   def(Module_lock                  , PaddedMutex  , leaf+2,      false, _safepoint_check_always);
   def(InlineCacheBuffer_lock       , PaddedMutex  , leaf,        true,  _safepoint_check_never);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -34,7 +34,6 @@
 extern Mutex*   Patching_lock;                   // a lock used to guard code patching of compiled code
 extern Mutex*   CompiledMethod_lock;             // a lock used to guard a compiled method and OSR queues
 extern Monitor* SystemDictionary_lock;           // a lock on the system dictionary
-extern Mutex*   ProtectionDomainSet_lock;        // a lock on the pd_set list in the system dictionary
 extern Mutex*   SharedDictionary_lock;           // a lock on the CDS shared dictionary
 extern Mutex*   Module_lock;                     // a lock on module and package related data structures
 extern Mutex*   CompiledIC_lock;                 // a lock used to guard compiled IC patching and access

--- a/test/hotspot/jtreg/runtime/Dictionary/ClassForName.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ClassForName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class ClassForName {
 
     public ClassForName() {
         try {
-            // class_loader = URLClassLoader, protection_domain = ClassForName.getProtectionDomain()
+            // class_loader = App$ClassLoader, protection_domain = ClassForName.getProtectionDomain()
             Class.forName(java.util.List.class.getName(), false,
                           ClassLoader.getSystemClassLoader());
         } catch (Throwable e) {

--- a/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,9 @@ public class ProtectionDomainCacheTest {
                                                               CLASSFILENAME);
             Files.delete(classFile);
 
-            loadAndRun(jarFilePath);
+            for (int i = 0; i < 20; i++) {
+                loadAndRun(jarFilePath);
+            }
 
             // Give the GC a chance to unload protection domains
             for (int i = 0; i < 100; i++) {
@@ -101,11 +103,12 @@ public class ProtectionDomainCacheTest {
                                       "-XX:+UnlockDiagnosticVMOptions",
                                       "-XX:VerifySubSet=dictionary",
                                       "-XX:+VerifyAfterGC",
-                                      "-Xlog:gc+verify,protectiondomain=debug",
+                                      "-Xlog:gc+verify,protectiondomain=trace",
                                       "-Djava.security.manager",
                                       Test.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("PD in set is not alive");
+        output.shouldContain("HandshakeForPD::do_thread");
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,14 @@
  * @comment build test class and indify classes
  * @build vm.mlvm.mixed.stress.java.findDeadlock.INDIFY_Test
  * @run driver vm.mlvm.share.IndifiedClassesBuilder
- *
  * @run main/othervm -Xlog:gc,safepoint vm.mlvm.mixed.stress.java.findDeadlock.INDIFY_Test
+ *
+ * To see code that takes more time to safepoint run with:
+ * main/othervm -XX:+SafepointTimeout -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AbortVMOnSafepointTimeout
+ *                   -XX:SafepointTimeoutDelay=500
+ *                   -XX:+PrintSystemDictionaryAtExit
+ *                   -Xlog:gc,safepoint
+ *                   vm.mlvm.mixed.stress.java.findDeadlock.INDIFY_Test
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/tools/Indify.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/tools/Indify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ public class Indify {
     public boolean keepgoing = false;
     public boolean expandProperties = false;
     public boolean overwrite = false;
-    public boolean quiet = false;
+    public boolean quiet = true;
     public boolean verbose = false;
     public boolean transitionalJSR292 = true;  // default to false later
     public boolean all = false;


### PR DESCRIPTION
This change makes the DictionaryEntry pd_set reads lock free, because when I set a low SafepointTimeout on the findDeadlock test, these threads were waiting on the ProtectionDomainSet_lock.  This lock is a singleton that's taken for every dictionary entry.

I don't know if this change will make the test never timeout again, because removing this lock caused us to hit a low SafepointTimeout on another _no_safepoint_check lock that is not so easy to eradictate.

Tested with tiers 1-3.  There's a test that exercises this code in runtime/Dictionary/ProtectionDomainCacheTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259242](https://bugs.openjdk.java.net/browse/JDK-8259242): Remove ProtectionDomainSet_lock


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3362/head:pull/3362` \
`$ git checkout pull/3362`

Update a local copy of the PR: \
`$ git checkout pull/3362` \
`$ git pull https://git.openjdk.java.net/jdk pull/3362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3362`

View PR using the GUI difftool: \
`$ git pr show -t 3362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3362.diff">https://git.openjdk.java.net/jdk/pull/3362.diff</a>

</details>
