### PR TITLE
8262744: Formatter '%g' conversion uses wrong format for BigDecimal rounding up to limits

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -3823,6 +3823,7 @@ public final class Formatter implements Closeable, Flushable {
 
                 BigDecimal tenToTheNegFour = BigDecimal.valueOf(1, 4);
                 BigDecimal tenToThePrec = BigDecimal.valueOf(1, -prec);
+                value = value.round(new MathContext(prec));
                 if ((value.equals(BigDecimal.ZERO))
                     || ((value.compareTo(tenToTheNegFour) != -1)
                         && (value.compareTo(tenToThePrec) == -1))) {

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -3821,12 +3821,10 @@ public final class Formatter implements Closeable, Flushable {
                 else if (precision == 0)
                     prec = 1;
 
-                BigDecimal tenToTheNegFour = BigDecimal.valueOf(1, 4);
-                BigDecimal tenToThePrec = BigDecimal.valueOf(1, -prec);
                 value = value.round(new MathContext(prec));
                 if ((value.equals(BigDecimal.ZERO))
-                    || ((value.compareTo(tenToTheNegFour) != -1)
-                        && (value.compareTo(tenToThePrec) == -1))) {
+                    || ((value.compareTo(BigDecimal.valueOf(1, 4)) != -1)
+                        && (value.compareTo(BigDecimal.valueOf(1, -prec)) == -1))) {
 
                     int e = - value.scale()
                         + (value.unscaledValue().toString().length() - 1);

--- a/test/jdk/java/util/Formatter/BigDecimalRounding.java
+++ b/test/jdk/java/util/Formatter/BigDecimalRounding.java
@@ -42,17 +42,21 @@ public class BigDecimalRounding {
     public static void testBigDecimalRounding() {
         var res1 = String.format("%g", 0.00009999999999999995);
         var res2 = String.format("%g", 0.00009999999f);
-        var res3 = String.format("%g", new BigDecimal("0.00009999999999999999995"));
+        var res3 = String.format("%g", new BigDecimal(0.0001));
+        var res4 = String.format("%g", new BigDecimal("0.00009999999999999999995"));
 
         assertEquals(res1, res2);
         assertEquals(res2, res3);
+        assertEquals(res3, res4);
 
-        var res4 = String.format("%.9g", 999999.999999432168754e+3);
-        var res5 = String.format("%.9g", 999999999.999432168754f);
-        var res6 = String.format("%.9g", new BigDecimal("999999.999999432168754e+3")); // !!
+        var res5 = String.format("%.9g", 999999.999999432168754e+3);
+        var res6 = String.format("%.9g", 999999999.999432168754f);
+        var res7 = String.format("%.9g", new BigDecimal("999999.999999432168754e+3")); // !!
+        var res8 = String.format("%.9g", new BigDecimal("1000000000")); // !!
 
-        assertEquals(res4, res5);
         assertEquals(res5, res6);
+        assertEquals(res6, res7);
+        assertEquals(res7, res8);
 
     }
 }

--- a/test/jdk/java/util/Formatter/BigDecimalRounding.java
+++ b/test/jdk/java/util/Formatter/BigDecimalRounding.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8262744
+ * @summary BigDecimal does not always display formatting correctly because
+ * rounding is done after formatting check. Fix moves rounding to before the
+ * range-based formatting check for %g formatting flag.
+ * @run testng BigDecimalRounding
+ */
+
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+import static org.testng.Assert.*;
+
+@Test
+public class BigDecimalRounding {
+
+    public static void testBigDecimalRounding() {
+        var res1 = String.format("%g", 0.00009999999999999995);
+        var res2 = String.format("%g", 0.00009999999f);
+        var res3 = String.format("%g", new BigDecimal("0.00009999999999999999995"));
+
+        assertEquals(res1, res2);
+        assertEquals(res2, res3);
+
+        var res4 = String.format("%.9g", 999999.999999432168754e+3);
+        var res5 = String.format("%.9g", 999999999.999432168754f);
+        var res6 = String.format("%.9g", new BigDecimal("999999.999999432168754e+3")); // !!
+
+        assertEquals(res4, res5);
+        assertEquals(res5, res6);
+
+    }
+}


### PR DESCRIPTION
This fixes a bug where the formatting code for `%g` flags incorrectly tries to round `BigDecimal` after determining whether it should be a decimal numeric format or a scientific numeric format. The solution rounds before determining the correct format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262744](https://bugs.openjdk.java.net/browse/JDK-8262744): Formatter '%g' conversion uses wrong format for BigDecimal rounding up to limits


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to cf40421e94bfe71371d79e579c52de54d8d48e42
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3363/head:pull/3363` \
`$ git checkout pull/3363`

Update a local copy of the PR: \
`$ git checkout pull/3363` \
`$ git pull https://git.openjdk.java.net/jdk pull/3363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3363`

View PR using the GUI difftool: \
`$ git pr show -t 3363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3363.diff">https://git.openjdk.java.net/jdk/pull/3363.diff</a>

</details>
