### PR TITLE
8264551: Unexpected warning when jpackage creates an exe

### DIFF
--- a/src/jdk.jpackage/windows/native/common/MsiDb.h
+++ b/src/jdk.jpackage/windows/native/common/MsiDb.h
@@ -126,7 +126,7 @@ public:
 
     explicit DatabaseRecord(unsigned fieldCount);
 
-    explicit DatabaseRecord(DatabaseView& view) {
+    explicit DatabaseRecord(DatabaseView& view) : handle(MSIHANDLE(0)) {
         fetch(view);
     }
 


### PR DESCRIPTION
Since fix to [JDK-8263135](https://bugs.openjdk.java.net/browse/JDK-8263135), we've seen following warning message on the console when we run jpackage to create exe.

```
WARNING: MsiCloseHandle(3174034504) failed with error=6 
```

It is caused by lack of initializer in `DatabaseRecord(DatabaseView& view)`. We need to add it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264551](https://bugs.openjdk.java.net/browse/JDK-8264551): Unexpected warning when jpackage creates an exe


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3364/head:pull/3364` \
`$ git checkout pull/3364`

Update a local copy of the PR: \
`$ git checkout pull/3364` \
`$ git pull https://git.openjdk.java.net/jdk pull/3364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3364`

View PR using the GUI difftool: \
`$ git pr show -t 3364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3364.diff">https://git.openjdk.java.net/jdk/pull/3364.diff</a>

</details>
