### PR TITLE
8264063: Outer Safepoint poll load should not reference the head of inner strip mined loop.

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1782,20 +1782,6 @@ int MachCallNativeNode::ret_addr_offset() {
   }
 }
 
-// Indicate if the safepoint node needs the polling page as an input
-
-// the shared code plants the oop data at the start of the generated
-// code for the safepoint node and that needs ot be at the load
-// instruction itself. so we cannot plant a mov of the safepoint poll
-// address followed by a load. setting this to true means the mov is
-// scheduled as a prior instruction. that's better for scheduling
-// anyway.
-
-bool SafePointNode::needs_polling_address_input()
-{
-  return true;
-}
-
 //=============================================================================
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -146,12 +146,6 @@ int MachNode::compute_padding(int current_offset) const {
 
 // REQUIRED FUNCTIONALITY
 
-// Indicate if the safepoint node needs the polling page as an input.
-// Since ARM does not have absolute addressing, it does.
-bool SafePointNode::needs_polling_address_input() {
-  return true;
-}
-
 // emit an interrupt that is caught by the debugger (for debugging compiler)
 void emit_break(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1159,14 +1159,6 @@ static int cc_to_biint(int cc, int flags_reg) {
 
 //=============================================================================
 
-// Indicate if the safepoint node needs the polling page as an input.
-bool SafePointNode::needs_polling_address_input() {
-  // The address is loaded from thread by a seperate node.
-  return true;
-}
-
-//=============================================================================
-
 // Emit an interrupt that is caught by the debugger (for debugging compiler).
 void emit_break(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -671,12 +671,6 @@ int CallLeafNoFPDirectNode::compute_padding(int current_offset) const {
   return (12 - current_offset) & 2;
 }
 
-// Indicate if the safepoint node needs the polling page as an input.
-// Since z/Architecture does not have absolute addressing, it does.
-bool SafePointNode::needs_polling_address_input() {
-  return true;
-}
-
 void emit_nop(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);
   __ z_nop();

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -484,8 +484,6 @@ public:
   virtual const RegMask &out_RegMask() const;
   virtual uint           match_edge(uint idx) const;
 
-  static  bool           needs_polling_address_input();
-
 #ifndef PRODUCT
   virtual void           dump_spec(outputStream *st) const;
   virtual void           related(GrowableArray<Node*> *in_rel, GrowableArray<Node*> *out_rel, bool compact) const;

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3701,16 +3701,6 @@ bool PhaseIdealLoop::match_fill_loop(IdealLoopTree* lpt, Node*& store, Node*& st
     for (SimpleDUIterator iter(n); iter.has_next(); iter.next()) {
       Node* use = iter.get();
       if (!lpt->_body.contains(use)) {
-        if (n->is_CountedLoop() && n->as_CountedLoop()->is_strip_mined()) {
-          // In strip-mined counted loops, the CountedLoopNode may be
-          // used by the address polling node of the outer safepoint.
-          // Skip this use because it's safe.
-          Node* sfpt = n->as_CountedLoop()->outer_safepoint();
-          Node* polladr = sfpt->in(TypeFunc::Parms+0);
-          if (use == polladr) {
-            continue;
-          }
-        }
         msg = "node is used outside loop";
         msg_node = n;
         break;


### PR DESCRIPTION
When loop is "strip mined" polling address load ([parse1.cpp#L2280](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/parse1.cpp#L2280)) should be cloned together with safepoint node and pinned outside inner loop. Otherwise we have issues like [8263352](https://bugs.openjdk.java.net/browse/JDK-8263352)

I also remove leftover (unused needs_polling_address_input() method) from  [8220051](https://bugs.openjdk.java.net/browse/JDK-8220051) changes.

Tested hs-tier1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264063](https://bugs.openjdk.java.net/browse/JDK-8264063): Outer Safepoint poll load should not reference the head of inner strip mined loop.


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3365/head:pull/3365` \
`$ git checkout pull/3365`

Update a local copy of the PR: \
`$ git checkout pull/3365` \
`$ git pull https://git.openjdk.java.net/jdk pull/3365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3365`

View PR using the GUI difftool: \
`$ git pr show -t 3365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3365.diff">https://git.openjdk.java.net/jdk/pull/3365.diff</a>

</details>
