### PR TITLE
8232861: (fc) FileChannel.force fails on WebDAV file systems (macOS)

### DIFF
--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -177,9 +177,15 @@ Java_sun_nio_ch_FileDispatcherImpl_force0(JNIEnv *env, jobject this,
             result = fsync(fd);
         } else {
             struct statfs fbuf;
-            if (fstatfs(fd, &fbuf) == 0 && (fbuf.f_flags & MNT_LOCAL) == 0) {
-                /* Try fsync() in case file is not local. */
-                result = fsync(fd);
+            int errno_fcntl = errno;
+            if (fstatfs(fd, &fbuf) == 0) {
+                if ((fbuf.f_flags & MNT_LOCAL) == 0) {
+                    /* Try fsync() in case file is not local. */
+                    result = fsync(fd);
+                }
+            } else {
+                /* fstatfs() failed so reinstate errno from fcntl(). */
+                errno = errno_fcntl;
             }
         }
     }

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,8 +167,10 @@ Java_sun_nio_ch_FileDispatcherImpl_force0(JNIEnv *env, jobject this,
 
 #ifdef MACOSX
     result = fcntl(fd, F_FULLFSYNC);
-    if (result == -1 && errno == ENOTSUP) {
-        /* Try fsync() in case F_FULLSYUNC is not implemented on the file system. */
+    if (result == -1 && (errno == ENOTSUP || errno == ENOTTY)) {
+        /* Try fsync() in case F_FULLSYUNC is not implemented on the file system
+         * or is unsupported by the device.
+         */
         result = fsync(fd);
     }
 #else /* end MACOSX, begin not-MACOSX */


### PR DESCRIPTION
Apparently `fcntl(fd, F_FULLFSYNC)` can fail with `ENOTTY` in addition to `ENOTSUP` although it is not so documented. The `ioctl()` case is documented as
```
[ENOTTY]       fildes is not associated with a character special
               device.
[ENOTTY]       The specified request does not apply to the kind of
               object that the descriptor fildes references.
```

This request proposes to catch `ENOTTY` as well and fall back to `fsync(fd)`. The change was verified manually using a WebDAV server and no failures in CI test tiers 1-3 were observed. An alternative would be to fall back to `fsync(fd)` for **all** errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8232861](https://bugs.openjdk.java.net/browse/JDK-8232861): (fc) FileChannel.force fails on WebDAV file systems (macOS)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3366/head:pull/3366` \
`$ git checkout pull/3366`

Update a local copy of the PR: \
`$ git checkout pull/3366` \
`$ git pull https://git.openjdk.java.net/jdk pull/3366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3366`

View PR using the GUI difftool: \
`$ git pr show -t 3366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3366.diff">https://git.openjdk.java.net/jdk/pull/3366.diff</a>

</details>
