### PR TITLE
8264809: test-lib fails to build due to some warnings in ASN1Formatter and jfr

### DIFF
--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -151,6 +151,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
      * @param prefix a string to prefix each line of output, used for indentation
      * @throws IOException if an I/O error occurs
      */
+    @SuppressWarnings("fallthrough")
     private int annotate(DataInputStream in, Appendable out, int available, String prefix) throws IOException {
         int origAvailable = available;
         while (available != 0 || origAvailable < 0) {

--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,7 +333,7 @@ public class GCHelper {
                         // No existing batch. Create new.
                         currBatch = new GcBatch();
                         batches.add(currBatch);
-                        openGcIds.push(new Integer(gcId));
+                        openGcIds.push(Integer.valueOf(gcId));
                     }
                 }
                 boolean isEndEvent = currBatch.addEvent(event);

--- a/test/lib/jdk/test/lib/jfr/SimpleEventHelper.java
+++ b/test/lib/jdk/test/lib/jfr/SimpleEventHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class SimpleEventHelper {
         for (RecordedEvent event : getSimpleEvents(events)) {
             int id = Events.assertField(event, "id").getValue();
             System.out.printf("event.id=%d%n", id);
-            missingIds.remove(new Integer(id));
+            missingIds.remove(Integer.valueOf(id));
         }
         if (!missingIds.isEmpty()) {
             missingIds.forEach(id -> System.out.println("Missing MyEvent with id " + id));


### PR DESCRIPTION
Hi all,

test-lib fails to build due to three javac warnings:
```
/jdk/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java:250: warning: [fallthrough] possible fall-through into case
                case TAG_PrintableString:
                ^
error: warnings found and -Werror specified
/jdk/test/lib/jdk/test/lib/jfr/GCHelper.java:336: warning: [removal] Integer(int) in Integer has been deprecated and marked for removal
                        openGcIds.push(new Integer(gcId));
                                       ^
/jdk/test/lib/jdk/test/lib/jfr/SimpleEventHelper.java:80: warning: [removal] Integer(int) in Integer has been deprecated and marked for removal
            missingIds.remove(new Integer(id));
```

It would be better to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264809](https://bugs.openjdk.java.net/browse/JDK-8264809): test-lib fails to build due to some warnings in ASN1Formatter and jfr


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3367/head:pull/3367` \
`$ git checkout pull/3367`

Update a local copy of the PR: \
`$ git checkout pull/3367` \
`$ git pull https://git.openjdk.java.net/jdk pull/3367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3367`

View PR using the GUI difftool: \
`$ git pr show -t 3367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3367.diff">https://git.openjdk.java.net/jdk/pull/3367.diff</a>

</details>
