### PR TITLE
8264318 Lanai: DrawHugeImageTest.java fails on apple M1

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -156,10 +156,11 @@ static void
 replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRasInfo *srcInfo,
                      const MTLRasterFormatInfo *rfi,
                      int dx1, int dy1, int dx2, int dy2) {
-    const int sw = srcInfo->bounds.x2 - srcInfo->bounds.x1;
-    const int sh = srcInfo->bounds.y2 - srcInfo->bounds.y1;
-    const int dw = dx2 - dx1;
-    const int dh = dy2 - dy1;
+    const int sw = MIN(srcInfo->bounds.x2 - srcInfo->bounds.x1, MTL_GPU_FAMILY_MAC_TXT_SIZE);
+    const int sh = MIN(srcInfo->bounds.y2 - srcInfo->bounds.y1, MTL_GPU_FAMILY_MAC_TXT_SIZE);
+    const int dw = MIN(dx2 - dx1, MTL_GPU_FAMILY_MAC_TXT_SIZE);
+    const int dh = MIN(dy2 - dy1, MTL_GPU_FAMILY_MAC_TXT_SIZE);
+
     if (dw < sw || dh < sh) {
         J2dTraceLn4(J2D_TRACE_ERROR, "replaceTextureRegion: dest size: (%d, %d) less than source size: (%d, %d)", dw, dh, sw, sh);
         return;


### PR DESCRIPTION
Check if blit sizes are less than MTL_GPU_FAMILY_MAC_TXT_SIZE.

It's safe since we copy tile from the image with memcpy. 
```
// copy src pixels inside src bounds to buff
for (int row = 0; row < sh; row++) {
    memcpy(buff.contents + (row * sw * srcInfo->pixelStride), raster, sw * srcInfo->pixelStride);
    raster += (NSUInteger)srcInfo->scanStride;
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264318](https://bugs.openjdk.java.net/browse/JDK-8264318): Lanai: DrawHugeImageTest.java fails on apple M1


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3369/head:pull/3369` \
`$ git checkout pull/3369`

Update a local copy of the PR: \
`$ git checkout pull/3369` \
`$ git pull https://git.openjdk.java.net/jdk pull/3369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3369`

View PR using the GUI difftool: \
`$ git pr show -t 3369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3369.diff">https://git.openjdk.java.net/jdk/pull/3369.diff</a>

</details>
