### PR TITLE
8264788:  Make SequentialSubTasksDone use-once

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2055,18 +2055,15 @@ public:
   MarkFromRootsTask(uint active_workers) :
       AbstractGangTask("MarkFromRootsTask"),
       _strong_roots_scope(active_workers),
-      _subtasks(),
+      _subtasks(ParallelRootType::sentinel),
       _terminator(active_workers, ParCompactionManager::oop_task_queues()),
       _active_workers(active_workers) {
-    _subtasks.set_n_threads(active_workers);
-    _subtasks.set_n_tasks(ParallelRootType::sentinel);
   }
 
   virtual void work(uint worker_id) {
     for (uint task = 0; _subtasks.try_claim_task(task); /*empty*/ ) {
       mark_from_roots_work(static_cast<ParallelRootType::Value>(task), worker_id);
     }
-    _subtasks.all_tasks_completed();
 
     PCAddThreadRootsMarkingTaskClosure closure(worker_id);
     Threads::possibly_parallel_threads_do(true /*parallel */, &closure);

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -303,14 +303,12 @@ public:
                     bool is_empty) :
       AbstractGangTask("ScavengeRootsTask"),
       _strong_roots_scope(active_workers),
-      _subtasks(),
+      _subtasks(ParallelRootType::sentinel),
       _old_gen(old_gen),
       _gen_top(gen_top),
       _active_workers(active_workers),
       _is_empty(is_empty),
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
-    _subtasks.set_n_threads(active_workers);
-    _subtasks.set_n_tasks(ParallelRootType::sentinel);
   }
 
   virtual void work(uint worker_id) {
@@ -345,7 +343,6 @@ public:
     for (uint root_type = 0; _subtasks.try_claim_task(root_type); /* empty */ ) {
       scavenge_roots_work(static_cast<ParallelRootType::Value>(root_type), worker_id);
     }
-    _subtasks.all_tasks_completed();
 
     PSThreadRootsTaskClosure closure(worker_id);
     Threads::possibly_parallel_threads_do(true /*parallel */, &closure);

--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -401,12 +401,8 @@ SubTasksDone::~SubTasksDone() {
 
 bool SequentialSubTasksDone::try_claim_task(uint& t) {
   t = _num_claimed;
-  while (t < _num_tasks) {
-    uint res = Atomic::cmpxchg(&_num_claimed, t, t+1);
-    if (res == t) {
-      return true;
-    }
-    t = res;
+  if (t < _num_tasks) {
+    t = Atomic::add(&_num_claimed, 1u) - 1;
   }
-  return false;
+  return t < _num_tasks;
 }

--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -399,39 +399,14 @@ SubTasksDone::~SubTasksDone() {
 
 // *** SequentialSubTasksDone
 
-void SequentialSubTasksDone::clear() {
-  _n_tasks   = _n_claimed   = 0;
-  _n_threads = _n_completed = 0;
-}
-
-bool SequentialSubTasksDone::valid() {
-  return _n_threads > 0;
-}
-
 bool SequentialSubTasksDone::try_claim_task(uint& t) {
-  t = _n_claimed;
-  while (t < _n_tasks) {
-    uint res = Atomic::cmpxchg(&_n_claimed, t, t+1);
+  t = _num_claimed;
+  while (t < _num_tasks) {
+    uint res = Atomic::cmpxchg(&_num_claimed, t, t+1);
     if (res == t) {
       return true;
     }
     t = res;
-  }
-  return false;
-}
-
-bool SequentialSubTasksDone::all_tasks_completed() {
-  uint complete = _n_completed;
-  while (true) {
-    uint res = Atomic::cmpxchg(&_n_completed, complete, complete+1);
-    if (res == complete) {
-      break;
-    }
-    complete = res;
-  }
-  if (complete+1 == _n_threads) {
-    clear();
-    return true;
   }
   return false;
 }

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -358,13 +358,14 @@ class SequentialSubTasksDone : public CHeapObj<mtInternal> {
 public:
   SequentialSubTasksDone(uint num_tasks) : _num_tasks(num_tasks), _num_claimed(0) { }
   ~SequentialSubTasksDone() {
-    assert(_num_claimed == _num_tasks, "Claimed %u tasks of %u", _num_claimed, _num_tasks);
+    // Claiming may try to claim more tasks than there are.
+    assert(_num_claimed >= _num_tasks, "Claimed %u tasks of %u", _num_claimed, _num_tasks);
   }
 
   // Attempt to claim the next unclaimed task in the sequence,
   // returning true if successful, with t set to the index of the
-  // claimed task.  Returns false if there are no more unclaimed tasks
-  // in the sequence.
+  // claimed task. Returns false if there are no more unclaimed tasks
+  // in the sequence. In this case t is undefined.
   bool try_claim_task(uint& t);
 };
 

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -346,57 +346,26 @@ public:
 // sub-tasks from a set (possibly an enumeration), claim sub-tasks
 // in sequential order. This is ideal for claiming dynamically
 // partitioned tasks (like striding in the parallel remembered
-// set scanning). Note that unlike the above class this is
-// a stack object - is there any reason for it not to be?
+// set scanning).
 
-class SequentialSubTasksDone : public StackObj {
-protected:
-  uint _n_tasks;     // Total number of tasks available.
-  volatile uint _n_claimed;   // Number of tasks claimed.
-  // _n_threads is used to determine when a sub task is done.
-  // See comments on SubTasksDone::_n_threads
-  uint _n_threads;   // Total number of parallel threads.
-  volatile uint _n_completed; // Number of completed threads.
+class SequentialSubTasksDone : public CHeapObj<mtInternal> {
 
-  void clear();
+  uint _num_tasks;     // Total number of tasks available.
+  volatile uint _num_claimed;   // Number of tasks claimed.
+
+  NONCOPYABLE(SequentialSubTasksDone);
 
 public:
-  SequentialSubTasksDone() {
-    clear();
+  SequentialSubTasksDone(uint num_tasks) : _num_tasks(num_tasks), _num_claimed(0) { }
+  ~SequentialSubTasksDone() {
+    assert(_num_claimed == _num_tasks, "Claimed %u tasks of %u", _num_claimed, _num_tasks);
   }
-  ~SequentialSubTasksDone() {}
-
-  // True iff the object is in a valid state.
-  bool valid();
-
-  // number of tasks
-  uint n_tasks() const { return _n_tasks; }
-
-  // Get/set the number of parallel threads doing the tasks to t.
-  // Should be called before the task starts but it is safe
-  // to call this once a task is running provided that all
-  // threads agree on the number of threads.
-  uint n_threads() { return _n_threads; }
-  void set_n_threads(uint t) { _n_threads = t; }
-
-  // Set the number of tasks to be claimed to t. As above,
-  // should be called before the tasks start but it is safe
-  // to call this once a task is running provided all threads
-  // agree on the number of tasks.
-  void set_n_tasks(uint t) { _n_tasks = t; }
 
   // Attempt to claim the next unclaimed task in the sequence,
   // returning true if successful, with t set to the index of the
   // claimed task.  Returns false if there are no more unclaimed tasks
   // in the sequence.
   bool try_claim_task(uint& t);
-
-  // The calling thread asserts that it has attempted to claim
-  // all the tasks it possibly can in the sequence. Every thread
-  // claiming tasks must promise call this. Returns true if this
-  // is the last thread to complete so that the thread can perform
-  // cleanup if necessary.
-  bool all_tasks_completed();
 };
 
 #endif // SHARE_GC_SHARED_WORKGROUP_HPP


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that simplifies code ahead?

SequentialSubTasksDone has some machinery to reset itself automatically after all tasks were claimed.

This is not used at all and can/should be removed. 

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264788](https://bugs.openjdk.java.net/browse/JDK-8264788): Make SequentialSubTasksDone use-once


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to 5393097086e354134393523b411c9db02a31c461
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3372/head:pull/3372` \
`$ git checkout pull/3372`

Update a local copy of the PR: \
`$ git checkout pull/3372` \
`$ git pull https://git.openjdk.java.net/jdk pull/3372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3372`

View PR using the GUI difftool: \
`$ git pr show -t 3372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3372.diff">https://git.openjdk.java.net/jdk/pull/3372.diff</a>

</details>
