### PR TITLE
8264696: Multi-catch clause causes compiler exception because it uses the package-private supertype

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -385,9 +385,17 @@ public class Resolve {
     }
 
     boolean isAccessible(Env<AttrContext> env, Type t, boolean checkInner) {
-        return (t.hasTag(ARRAY))
-            ? isAccessible(env, types.cvarUpperBound(types.elemtype(t)))
-            : isAccessible(env, t.tsym, checkInner);
+        if (t.hasTag(ARRAY)) {
+            return isAccessible(env, types.cvarUpperBound(types.elemtype(t)));
+        } else if (!t.isUnion()) {
+            return isAccessible(env, t.tsym, checkInner);
+        } else {
+            boolean canAccessible = true;
+            for (Type alternativeType : ((UnionClassType) t).getAlternativeTypes()) {
+                canAccessible = canAccessible && isAccessible(env, alternativeType.tsym, checkInner);
+            }
+            return canAccessible;
+        }
     }
 
     /** Is symbol accessible as a member of given type in given environment?

--- a/test/langtools/tools/javac/resolve/PackagePrivateSupertypeAtMultiCatch.java
+++ b/test/langtools/tools/javac/resolve/PackagePrivateSupertypeAtMultiCatch.java
@@ -101,7 +101,6 @@ public class PackagePrivateSupertypeAtMultiCatch extends TestRunner {
         new JavacTask(tb)
                 .files(tb.findJavaFiles(src))
                 .outdir(out)
-                .run()
-                .writeAll();
+                .run();
     }
 }

--- a/test/langtools/tools/javac/resolve/PackagePrivateSupertypeAtMultiCatch.java
+++ b/test/langtools/tools/javac/resolve/PackagePrivateSupertypeAtMultiCatch.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8264696
+ * @summary Multi-catch clause causes compiler exception because it uses the package-private supertype
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main PackagePrivateSupertypeAtMultiCatch
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+
+public class PackagePrivateSupertypeAtMultiCatch extends TestRunner {
+    ToolBox tb;
+
+    private static String testCode = """
+            package pkg1;
+            import pkg2.Child1Exception;
+            import pkg2.Child2Exception;
+            class Test {
+                void success() {
+                    try {
+                        foo();
+                    } catch (Child1Exception e) {
+                        e.getMessage();
+                    } catch (Child2Exception e) {
+                        e.getMessage();
+                    }
+                }
+                void fail() {
+                    try {
+                        foo();
+                    } catch (Child1Exception | Child2Exception e) {
+                        e.getMessage();
+                    }
+                }
+                void foo() throws Child1Exception, Child2Exception {
+                }
+            }""";
+
+    private static String parentExceptionCode = """
+            package pkg2;
+            class ParentException extends Exception {
+            }""";
+
+    private static String child1ExceptionCode = """
+            package pkg2;
+            public class Child1Exception extends ParentException {
+            }""";
+
+    private static String child2ExceptionCode = """
+            package pkg2;
+            public class Child2Exception extends ParentException {
+            }""";
+
+    public PackagePrivateSupertypeAtMultiCatch() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new PackagePrivateSupertypeAtMultiCatch().runTests();
+    }
+
+    @Test
+    public void testPackagePrivateSupertypeAtMultiCatch() throws Exception {
+        Path src = Paths.get("src");
+        tb.writeJavaFiles(src, testCode, parentExceptionCode, child1ExceptionCode, child2ExceptionCode);
+        Path out = Paths.get("out");
+        Files.createDirectories(out);
+        new JavacTask(tb)
+                .files(tb.findJavaFiles(src))
+                .outdir(out)
+                .run()
+                .writeAll();
+    }
+}


### PR DESCRIPTION
Hi all,

The method `isAccessible(Env<AttrContext> env, Type t, boolean checkInner)` should take `UnionClassType` as a special type to do some corresponding work. If not, the problem will occur. This patch fixes it and adds a test case.

Thank you for taking the time to review.

Best Regards.
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264696](https://bugs.openjdk.java.net/browse/JDK-8264696): Multi-catch clause causes compiler exception because it uses the package-private supertype


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3374/head:pull/3374` \
`$ git checkout pull/3374`

Update a local copy of the PR: \
`$ git checkout pull/3374` \
`$ git pull https://git.openjdk.java.net/jdk pull/3374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3374`

View PR using the GUI difftool: \
`$ git pr show -t 3374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3374.diff">https://git.openjdk.java.net/jdk/pull/3374.diff</a>

</details>
