### PR TITLE
8264672: runtime/ParallelLoad/ParallelSuperTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
@@ -61,7 +61,7 @@ class MyLoader extends ClassLoader {
     private static boolean parallel = false;
     private Object sync = new Object();
     private Object thread_sync = new Object();
-    private static volatile boolean ready = false;
+    private static volatile boolean waiting = false;
 
     private void makeThreadWait() {
         if (!parallel) { return; }
@@ -74,7 +74,7 @@ class MyLoader extends ClassLoader {
             synchronized(sync) {
                 try {
                     ThreadPrint.println("t1 waits parallelCapable loader");
-                    ready = true;
+                    waiting = true;
                     sync.wait();  // Give up lock before request to load B
                 } catch (InterruptedException e) {}
              }
@@ -90,7 +90,7 @@ class MyLoader extends ClassLoader {
     // Non-parallelCapable class loader thread will be woken up by the jvm.
     private void wakeUpThread() {
         if (isRegisteredAsParallelCapable()) {
-            while (!ready) {
+            while (!waiting) {
                 try {
                     Thread.sleep(1);
                 } catch (InterruptedException e) {}

--- a/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
@@ -61,6 +61,7 @@ class MyLoader extends ClassLoader {
     private static boolean parallel = false;
     private Object sync = new Object();
     private Object thread_sync = new Object();
+    private static boolean ready = false;
 
     private void makeThreadWait() {
         if (!parallel) { return; }
@@ -73,6 +74,7 @@ class MyLoader extends ClassLoader {
             synchronized(sync) {
                 try {
                     ThreadPrint.println("t1 waits parallelCapable loader");
+                    ready = true;
                     sync.wait();  // Give up lock before request to load B
                 } catch (InterruptedException e) {}
              }
@@ -88,6 +90,11 @@ class MyLoader extends ClassLoader {
     // Non-parallelCapable class loader thread will be woken up by the jvm.
     private void wakeUpThread() {
         if (isRegisteredAsParallelCapable()) {
+            while (!ready) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {}
+            }
             synchronized(sync) {
                 sync.notify();
             }

--- a/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/MyLoader.java
@@ -61,7 +61,7 @@ class MyLoader extends ClassLoader {
     private static boolean parallel = false;
     private Object sync = new Object();
     private Object thread_sync = new Object();
-    private static boolean ready = false;
+    private static volatile boolean ready = false;
 
     private void makeThreadWait() {
         if (!parallel) { return; }


### PR DESCRIPTION
Added a flag so that thread 2 will notify thread 1 after it's waiting, and not before.
Ran 100x on macosx-x64-debug without timeout (actually ran original 100x without timeout also).
The test relies on one thread waiting at a place where another can find the class loading in progress.  Alternate suggestions welcome.
Thanks!
Coleen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264672](https://bugs.openjdk.java.net/browse/JDK-8264672): runtime/ParallelLoad/ParallelSuperTest.java timed out


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to 5958bdcb3923cc671f14f2225fa353ff2c5d4369
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to d5991d9ec5203f68fae9787db37770b051ecda49
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 5958bdcb3923cc671f14f2225fa353ff2c5d4369


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3375/head:pull/3375` \
`$ git checkout pull/3375`

Update a local copy of the PR: \
`$ git checkout pull/3375` \
`$ git pull https://git.openjdk.java.net/jdk pull/3375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3375`

View PR using the GUI difftool: \
`$ git pr show -t 3375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3375.diff">https://git.openjdk.java.net/jdk/pull/3375.diff</a>

</details>
