### PR TITLE
8264779: Fix doclint warnings in java/nio

### DIFF
--- a/make/scripts/genExceptions.sh
+++ b/make/scripts/genExceptions.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,9 @@ __END__
 
     cat >>$out <<__END__
 
+    /**
+     * The $ARG_PHRASE.
+     */
     private $ARG_TYPE $ARG_ID;
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
+++ b/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class MalformedInputException
     private static final long serialVersionUID = -3438823399834806194L;
 
     /**
-     * The length of the input byte sequence
+     * The length of the input byte sequence.
      */
     private int inputLength;
 

--- a/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
+++ b/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
@@ -42,7 +42,7 @@ public class MalformedInputException
     private static final long serialVersionUID = -3438823399834806194L;
 
     /**
-     * The length of the input byte sequence.
+     * The length of the input.
      */
     private int inputLength;
 

--- a/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
+++ b/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
@@ -41,6 +41,9 @@ public class MalformedInputException
     @java.io.Serial
     private static final long serialVersionUID = -3438823399834806194L;
 
+    /**
+     * The length of the input byte sequence
+     */
     private int inputLength;
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
+++ b/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
@@ -41,6 +41,9 @@ public class UnmappableCharacterException
     @java.io.Serial
     private static final long serialVersionUID = -7026962371537706123L;
 
+    /**
+     * The length of the input character (or byte) sequence
+     */
     private int inputLength;
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
+++ b/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class UnmappableCharacterException
     private static final long serialVersionUID = -7026962371537706123L;
 
     /**
-     * The length of the input character (or byte) sequence
+     * The length of the input character (or byte) sequence.
      */
     private int inputLength;
 

--- a/src/java.base/share/classes/java/nio/charset/exceptions
+++ b/src/java.base/share/classes/java/nio/charset/exceptions
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2007, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 SINCE=1.4
 PACKAGE=java.nio.charset
 # This year should only change if the generated source is modified.
-COPYRIGHT_YEARS="2000, 2007,"
+COPYRIGHT_YEARS="2000, 2021,"
 
 SUPER=java.io.IOException
 

--- a/src/java.base/share/classes/java/nio/exceptions
+++ b/src/java.base/share/classes/java/nio/exceptions
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2007, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 SINCE=1.4
 PACKAGE=java.nio
 # This year should only change if the generated source is modified.
-COPYRIGHT_YEARS="2000, 2007,"
+COPYRIGHT_YEARS="2000, 2021,"
 
 
 SUPER=RuntimeException

--- a/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java
+++ b/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,9 @@ public final class DirectoryIteratorException
      * @throws  InvalidObjectException
      *          if the object is invalid or has a cause that is not
      *          an {@code IOException}
+     *
+     * @throws  IOException
+     *          if an I/O error occurs
      *
      * @throws  ClassNotFoundException
      *          if the class of a serialized object could not be

--- a/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java
+++ b/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java
@@ -73,9 +73,16 @@ public final class DirectoryIteratorException
     /**
      * Called to read the object from a stream.
      *
+     * @param   s
+     *          the {@code ObjectInputStream} to read
+     *
      * @throws  InvalidObjectException
      *          if the object is invalid or has a cause that is not
      *          an {@code IOException}
+     *
+     * @throws  ClassNotFoundException
+     *          if the class of a serialized object could not be
+     *          found
      */
     @java.io.Serial
     private void readObject(ObjectInputStream s)

--- a/src/java.base/share/classes/java/nio/file/FileSystemException.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystemException.java
@@ -40,7 +40,15 @@ public class FileSystemException
     @java.io.Serial
     static final long serialVersionUID = -3055425747967319812L;
 
+    /**
+     *  String identifying the file or {@code null} if not known
+     */
     private final String file;
+
+    /**
+     *  String identifying the other file or {@code null} if there isn't
+     *  another file or if not known
+     */
     private final String other;
 
     /**

--- a/src/java.base/share/classes/java/nio/file/FileSystemException.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,13 +41,13 @@ public class FileSystemException
     static final long serialVersionUID = -3055425747967319812L;
 
     /**
-     *  String identifying the file or {@code null} if not known
+     *  String identifying the file or {@code null} if not known.
      */
     private final String file;
 
     /**
      *  String identifying the other file or {@code null} if there isn't
-     *  another file or if not known
+     *  another file or if not known.
      */
     private final String other;
 

--- a/src/java.base/share/classes/java/nio/file/InvalidPathException.java
+++ b/src/java.base/share/classes/java/nio/file/InvalidPathException.java
@@ -39,7 +39,15 @@ public class InvalidPathException
     @java.io.Serial
     static final long serialVersionUID = 4355821422286746137L;
 
+    /**
+     * The invalid input path string
+     */
     private String input;
+
+    /**
+     * The index of the input string at which the error occurred or
+     * {@code -1} if not known
+     */
     private int index;
 
     /**

--- a/src/java.base/share/classes/java/nio/file/InvalidPathException.java
+++ b/src/java.base/share/classes/java/nio/file/InvalidPathException.java
@@ -40,7 +40,7 @@ public class InvalidPathException
     static final long serialVersionUID = 4355821422286746137L;
 
     /**
-     * The invalid input path string.
+     * The input string.
      */
     private String input;
 

--- a/src/java.base/share/classes/java/nio/file/InvalidPathException.java
+++ b/src/java.base/share/classes/java/nio/file/InvalidPathException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,13 @@ public class InvalidPathException
     static final long serialVersionUID = 4355821422286746137L;
 
     /**
-     * The invalid input path string
+     * The invalid input path string.
      */
     private String input;
 
     /**
      * The index of the input string at which the error occurred or
-     * {@code -1} if not known
+     * {@code -1} if not known.
      */
     private int index;
 

--- a/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
@@ -41,7 +41,7 @@ public class UserPrincipalNotFoundException
     static final long serialVersionUID = -5369283889045833024L;
 
     /**
-     * The name of the {@code UserPrincipal} that does not exist
+     * The name of the {@code UserPrincipal} that does not exist.
      */
     private final String name;
 

--- a/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
@@ -41,7 +41,7 @@ public class UserPrincipalNotFoundException
     static final long serialVersionUID = -5369283889045833024L;
 
     /**
-     * The name of the {@code UserPrincipal} that does not exist.
+     * The user principal name.
      */
     private final String name;
 

--- a/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
@@ -40,6 +40,9 @@ public class UserPrincipalNotFoundException
     @java.io.Serial
     static final long serialVersionUID = -5369283889045833024L;
 
+    /**
+     * The name of the {@code UserPrincipal} that does not exist
+     */
     private final String name;
 
     /**


### PR DESCRIPTION
This fix addresses the following warnings which were generated by building JDK API documentation with the `-Xdoclint:all` option enabled:

```
./build/linux-x64/support/gensrc/java.base/java/nio/charset/IllegalCharsetNameException.java:47: warning: no comment
    private String charsetName;
                   ^
./open/src/java.base/share/classes/java/nio/charset/MalformedInputException.java:44: warning: no comment
    private int inputLength;
                ^
./open/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java:44: warning: no comment
    private int inputLength;
                ^
./build/linux-x64/support/gensrc/java.base/java/nio/charset/UnsupportedCharsetException.java:47: warning: no comment
    private String charsetName;
                   ^
./open/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java:81: warning: no @param for s
    private void readObject(ObjectInputStream s)
                 ^
./open/src/java.base/share/classes/java/nio/file/DirectoryIteratorException.java:81: warning: no @throws for java.lang.ClassNotFoundException
    private void readObject(ObjectInputStream s)
                 ^
./open/src/java.base/share/classes/java/nio/file/FileSystemException.java:43: warning: no comment
    private final String file;
                         ^
./open/src/java.base/share/classes/java/nio/file/FileSystemException.java:44: warning: no comment
    private final String other;
                         ^
./open/src/java.base/share/classes/java/nio/file/InvalidPathException.java:43: warning: no comment
    private int index;
                ^
./open/src/java.base/share/classes/java/nio/file/InvalidPathException.java:42: warning: no comment
    private String input;
                   ^
./open/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java:43: warning: no comment
    private final String name;
                         ^
```
Changes to [`genExceptions.sh`](https://github.com/openjdk/jdk/commit/b729d8ed7970737a8a2d4e8aa788df33789faea2) and the two [`exceptions`](https://github.com/openjdk/jdk/commit/b729d8ed7970737a8a2d4e8aa788df33789faea2) templates are to address the warnings concerned with `UnsupportedCharsetException.java` and `IllegalCharsetNameException.java` which are generated when `make jdk-image` is run.

CSR: https://bugs.openjdk.java.net/browse/JDK-8264844

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264779](https://bugs.openjdk.java.net/browse/JDK-8264779): Fix doclint warnings in java/nio


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to b729d8ed7970737a8a2d4e8aa788df33789faea2
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 0b879f1588d9e5047b1396bba0576653d333160a
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 0b879f1588d9e5047b1396bba0576653d333160a
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3376/head:pull/3376` \
`$ git checkout pull/3376`

Update a local copy of the PR: \
`$ git checkout pull/3376` \
`$ git pull https://git.openjdk.java.net/jdk pull/3376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3376`

View PR using the GUI difftool: \
`$ git pr show -t 3376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3376.diff">https://git.openjdk.java.net/jdk/pull/3376.diff</a>

</details>
