### PR TITLE
8264827: Large mapped buffer/segment crash the VM when calling isLoaded

### DIFF
--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,8 @@ class Bits {                            // package-private
         return PAGE_SIZE;
     }
 
-    static int pageCount(long size) {
-        return (int)(size + (long)pageSize() - 1L) / pageSize();
+    static long pageCount(long size) {
+        return (size + (long)pageSize() - 1L) / pageSize();
     }
 
     private static boolean UNALIGNED = UNSAFE.unalignedAccess();

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,10 +61,10 @@ import java.io.UncheckedIOException;
         // considering the loop as dead code.
         Unsafe unsafe = Unsafe.getUnsafe();
         int ps = Bits.pageSize();
-        int count = Bits.pageCount(length);
+        long count = Bits.pageCount(length);
         long a = mappingAddress(address, offset);
         byte x = 0;
-        for (int i=0; i<count; i++) {
+        for (long i=0; i<count; i++) {
             // TODO consider changing to getByteOpaque thus avoiding
             // dead code elimination and the need to calculate a checksum
             x ^= unsafe.getByte(a);
@@ -106,7 +106,7 @@ import java.io.UncheckedIOException;
 
     // native methods
 
-    private static native boolean isLoaded0(long address, long length, int pageCount);
+    private static native boolean isLoaded0(long address, long length, long pageCount);
     private static native void load0(long address, long length);
     private static native void unload0(long address, long length);
     private static native void force0(FileDescriptor fd, long address, long length) throws IOException;

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,11 +56,11 @@ static long calculate_number_of_pages_in_range(void* address, size_t len, size_t
 
 JNIEXPORT jboolean JNICALL
 Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong address,
-                                         jlong len, jint numPages)
+                                         jlong len, jlong numPages)
 {
     jboolean loaded = JNI_TRUE;
     int result = 0;
-    int i = 0;
+    long i = 0;
     void *a = (void *) jlong_to_ptr(address);
     mincore_vec_t* vec = NULL;
 
@@ -70,7 +70,7 @@ Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong addres
     if ((long)pagesize == -1) {
         return JNI_FALSE;
     }
-    numPages = (jint) calculate_number_of_pages_in_range(a, len, pagesize);
+    numPages = (jlong) calculate_number_of_pages_in_range(a, len, pagesize);
 #endif
 
     /* Include space for one sentinel byte at the end of the buffer

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -32,7 +32,7 @@
 
 JNIEXPORT jboolean JNICALL
 Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong address,
-                                         jlong len, jint numPages)
+                                         jlong len, jlong numPages)
 {
     jboolean loaded = JNI_FALSE;
     /* Information not available?

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -297,19 +297,22 @@ public class TestByteBuffer {
         }
     }
 
-    static final long LARGE_SIZE = 4L * 1024L * 1024L * 1024L; // 4GB
+    static final long LARGE_SIZE = 3L * 1024L * 1024L * 1024L; // 3GB
 
-    @Test(dataProvider = "mappedOps")
-    public void testLargeMappedSegment(MappedSegmentOp mappedBufferOp) throws Throwable {
-        File f = new File("test3.out");
+    @Test
+    public void testLargeMappedSegment() throws Throwable {
+        File f = new File("testLargeMappedSegment.out");
         f.createNewFile();
         f.deleteOnExit();
 
         try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0, LARGE_SIZE, FileChannel.MapMode.READ_WRITE)) {
+            MappedMemorySegments.isLoaded(segment);
             MappedMemorySegments.load(segment);
             MappedMemorySegments.isLoaded(segment);
             MappedMemorySegments.force(segment);
+            MappedMemorySegments.isLoaded(segment);
             MappedMemorySegments.unload(segment);
+            MappedMemorySegments.isLoaded(segment);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -301,6 +301,10 @@ public class TestByteBuffer {
 
     @Test
     public void testLargeMappedSegment() throws Throwable {
+        if (System.getProperty("sun.arch.data.model").equals("32")) {
+            throw new SkipException("large mapped files not supported on 32-bit systems");
+        }
+
         File f = new File("testLargeMappedSegment.out");
         f.createNewFile();
         f.deleteOnExit();

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,6 +294,22 @@ public class TestByteBuffer {
             try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
                 checkTuples(segment, segment.asByteBuffer(), 1);
             }
+        }
+    }
+
+    static final long LARGE_SIZE = 4L * 1024L * 1024L * 1024L; // 4GB
+
+    @Test(dataProvider = "mappedOps")
+    public void testLargeMappedSegment(MappedSegmentOp mappedBufferOp) throws Throwable {
+        File f = new File("test3.out");
+        f.createNewFile();
+        f.deleteOnExit();
+
+        try (MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0, LARGE_SIZE, FileChannel.MapMode.READ_WRITE)) {
+            MappedMemorySegments.load(segment);
+            MappedMemorySegments.isLoaded(segment);
+            MappedMemorySegments.force(segment);
+            MappedMemorySegments.unload(segment);
         }
     }
 


### PR DESCRIPTION
Avoid overflow when calculating the number of pages for large mapped segment sizes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264827](https://bugs.openjdk.java.net/browse/JDK-8264827): Large mapped buffer/segment crash the VM when calling isLoaded


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 1816b200a9da028df6a64e2f625d6ca053dfb328
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3378/head:pull/3378` \
`$ git checkout pull/3378`

Update a local copy of the PR: \
`$ git checkout pull/3378` \
`$ git pull https://git.openjdk.java.net/jdk pull/3378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3378`

View PR using the GUI difftool: \
`$ git pr show -t 3378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3378.diff">https://git.openjdk.java.net/jdk/pull/3378.diff</a>

</details>
