### PR TITLE
8264848: [macos] libjvm.dylib linker warning due to macOS version mismatch

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -79,7 +79,7 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer -mstack-alignment=16"
 
-    # Fix linker warning "... built for newer version than linked for..."
+    # Fix linker warning.
     # Code taken from make/autoconf/flags-cflags.m4 and adapted.
     JVM_BASIC_ASFLAGS+="-DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
         -mmacosx-version-min=$MACOSX_VERSION_MIN"

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -78,6 +78,16 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
 [
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     JVM_BASIC_ASFLAGS="-x assembler-with-cpp -mno-omit-leaf-frame-pointer -mstack-alignment=16"
+
+    # Fix linker warning "... built for newer version than linked for..."
+    # Code taken from make/autoconf/flags-cflags.m4 and adapted.
+    JVM_BASIC_ASFLAGS+="-DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
+        -mmacosx-version-min=$MACOSX_VERSION_MIN"
+
+    if test -n "$MACOSX_VERSION_MAX"; then
+        JVM_BASIC_ASFLAGS+="$OS_CFLAGS \
+            -DMAC_OS_X_VERSION_MAX_ALLOWED=$MACOSX_VERSION_MAX_NODOTS"
+    fi
   fi
 ])
 


### PR DESCRIPTION
May I please request reviews for this small build fix. It removes a linker warning by adding a assembly-time parameter which was previously missing. The same parameter is used at c++ compile time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264848](https://bugs.openjdk.java.net/browse/JDK-8264848): [macos] libjvm.dylib linker warning due to macOS version mismatch


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3379/head:pull/3379` \
`$ git checkout pull/3379`

Update a local copy of the PR: \
`$ git checkout pull/3379` \
`$ git pull https://git.openjdk.java.net/jdk pull/3379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3379`

View PR using the GUI difftool: \
`$ git pr show -t 3379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3379.diff">https://git.openjdk.java.net/jdk/pull/3379.diff</a>

</details>
