### PR TITLE
8261301: StringWriter.flush() is NOOP but documentation does not indicate it

### DIFF
--- a/src/java.base/share/classes/java/io/CharArrayWriter.java
+++ b/src/java.base/share/classes/java/io/CharArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -276,6 +276,8 @@ public class CharArrayWriter extends Writer {
 
     /**
      * Flush the stream.
+     *
+     * <p> The {@code flush} method of {@code CharArrayWriter} does nothing.
      */
     public void flush() { }
 

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,6 +229,8 @@ public class StringWriter extends Writer {
 
     /**
      * Flush the stream.
+     *
+     * <p> The {@code flush} method of {@code StringWriter} does nothing.
      */
     public void flush() {
     }


### PR DESCRIPTION
The specification of the method `flush()` in the `java.io` classes `CharArrayWriter` and `StringWriter` is not explicit about the fact that the method has no effect. This request proposes to add to the specification of each flush() method the sentence
```
The {@code flush} method of {@code <ClassName/>} does nothing.
```
The corresponding CSR is JDK-8264867.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261301](https://bugs.openjdk.java.net/browse/JDK-8261301): StringWriter.flush() is NOOP but documentation does not indicate it


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3383/head:pull/3383` \
`$ git checkout pull/3383`

Update a local copy of the PR: \
`$ git checkout pull/3383` \
`$ git pull https://git.openjdk.java.net/jdk pull/3383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3383`

View PR using the GUI difftool: \
`$ git pr show -t 3383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3383.diff">https://git.openjdk.java.net/jdk/pull/3383.diff</a>

</details>
