### PR TITLE
8264623: Change to Xcode 12.4 for building on Macos at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -974,8 +974,11 @@ var getJibProfilesProfiles = function (input, common, data) {
     // This gives us a guaranteed working version of lldb for the jtreg failure handler.
     if (input.build_os == "macosx") {
         macosxRunTestExtra = {
-            environment_path: input.get("devkit", "install_path")
-                + "/Xcode.app/Contents/Developer/usr/bin"
+            dependencies: [ "lldb" ],
+            environment_path: [
+                input.get("gnumake", "install_path") + "/bin",
+                input.get("lldb", "install_path") + "/Xcode.app/Contents/Developer/usr/bin",
+            ],
         };
         profiles["run-test"] = concatObjects(profiles["run-test"], macosxRunTestExtra);
         profiles["run-test-prebuilt"] = concatObjects(profiles["run-test-prebuilt"], macosxRunTestExtra);
@@ -1030,7 +1033,7 @@ var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
         linux_x64: "gcc10.2.0-OL6.4+1.0",
-        macosx_x64: "Xcode11.3.1-MacOSX10.15+1.1",
+        macosx: "Xcode12.4+1.0",
         windows_x64: "VS2019-16.7.2+1.1",
         linux_aarch64: "gcc10.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
@@ -1043,6 +1046,8 @@ var getJibProfilesDependencies = function (input, common) {
         : input.target_platform);
     if (input.target_platform == "windows_aarch64") {
         devkit_platform = "windows_x64";
+    } else if (input.target_os == "macosx") {
+        devkit_platform = "macosx";
     }
     var devkit_cross_prefix = "";
     if (!(input.target_os == "windows")) {
@@ -1093,6 +1098,13 @@ var getJibProfilesDependencies = function (input, common) {
             ext: "tar.gz",
             module: "devkit-" + input.build_platform,
             revision: devkit_platform_revisions[input.build_platform]
+        },
+
+        lldb: {
+            organization: common.organization,
+            ext: "tar.gz",
+            module: "devkit-macosx_x64",
+            revision: "Xcode11.3.1-MacOSX10.15+1.1",
         },
 
         cups: {


### PR DESCRIPTION
Switch to Xcode 12.4 for building macosx-x64 at Oracle. The new lldb dependency is needed to ensure that we can collect information when testing on older versions of macOS which do not support Xcode 12.4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264623](https://bugs.openjdk.java.net/browse/JDK-8264623): Change to Xcode 12.4 for building on Macos at Oracle


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3388/head:pull/3388` \
`$ git checkout pull/3388`

Update a local copy of the PR: \
`$ git checkout pull/3388` \
`$ git pull https://git.openjdk.java.net/jdk pull/3388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3388`

View PR using the GUI difftool: \
`$ git pr show -t 3388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3388.diff">https://git.openjdk.java.net/jdk/pull/3388.diff</a>

</details>
