### PR TITLE
8264874: Build interim-langtools for HotSpot only if Graal is enabled

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -92,9 +92,11 @@ $(eval $(call SetupTarget, buildtools-modules, \
     MAKEFILE := CompileModuleTools, \
 ))
 
+# interim-langtools is needed by hotspot only when $(INCLUDE_GRAAL) is true
+GRAAL_INTERIM_LANGTOOLS_true = interim-langtools
 $(eval $(call SetupTarget, buildtools-hotspot, \
     MAKEFILE := CompileToolsHotspot, \
-    DEPS := interim-langtools, \
+    DEPS := $(GRAAL_INTERIM_LANGTOOLS_$(INCLUDE_GRAAL)), \
 ))
 
 ################################################################################


### PR DESCRIPTION
Many HotSpot developers make only the `hotspot` target, and copy the resulting `libjvm.so` into an already-build JDK image.

HotSpot requires `interim-langtools` only when Graal is enabled. When Graal is disabled, we can avoid building `interim-langtools`. This improves the build time of `make hotspot` by about 20 seconds, or about 15%:

```
Old:
$ make clean
$ time make hotspot
....
real 1m57.905s
user 42m22.524s
sys 3m7.372s

New:
$ make clean
$ time make hotspot
....
real 1m39.916s
user 41m59.984s
sys 3m3.188s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264874](https://bugs.openjdk.java.net/browse/JDK-8264874): Build interim-langtools for HotSpot only if Graal is enabled


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3389/head:pull/3389` \
`$ git checkout pull/3389`

Update a local copy of the PR: \
`$ git checkout pull/3389` \
`$ git pull https://git.openjdk.java.net/jdk pull/3389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3389`

View PR using the GUI difftool: \
`$ git pr show -t 3389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3389.diff">https://git.openjdk.java.net/jdk/pull/3389.diff</a>

</details>
