### PR TITLE
8264864: Multiple byte tag not supported by ASN.1 encoding

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -222,7 +222,7 @@ public class DerValue {
      */
     DerValue(byte tag, byte[] buffer, int start, int end, boolean allowBER) {
         if ((tag & 0x1f) == 0x1f) {
-            throw new IllegalArgumentException("Tag number cannot be 31");
+            throw new IllegalArgumentException("Tag number 31 is not supported");
         }
         this.tag = tag;
         this.buffer = buffer;
@@ -319,7 +319,7 @@ public class DerValue {
         int pos = offset;
         tag = buf[pos++];
         if ((tag & 0x1f) == 0x1f) {
-            throw new IOException("Tag number cannot exceed 30");
+            throw new IOException("Tag number over 30 is not supported");
         }
         int lenByte = buf[pos++];
 
@@ -395,7 +395,7 @@ public class DerValue {
     DerValue(InputStream in, boolean allowBER) throws IOException {
         this.tag = (byte)in.read();
         if ((tag & 0x1f) == 0x1f) {
-            throw new IOException("Tag number cannot exceed 30");
+            throw new IOException("Tag number over 30 is not supported");
         }
         int length = DerInputStream.getLength(in);
         if (length == -1) { // indefinite length encoding found
@@ -1150,7 +1150,7 @@ public class DerValue {
      */
     public static byte createTag(byte tagClass, boolean form, byte val) {
         if (val < 0 || val > 30) {
-            throw new IllegalArgumentException("Tag number cannot exceed 30");
+            throw new IllegalArgumentException("Tag number over 30 is not supported");
         }
         byte tag = (byte)(tagClass | val);
         if (form) {

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,6 +221,9 @@ public class DerValue {
      * Creates a new DerValue by specifying all its fields.
      */
     DerValue(byte tag, byte[] buffer, int start, int end, boolean allowBER) {
+        if ((tag & 0x1f) == 0x1f) {
+            throw new IllegalArgumentException("Tag number cannot be 31");
+        }
         this.tag = tag;
         this.buffer = buffer;
         this.start = start;
@@ -315,6 +318,9 @@ public class DerValue {
         }
         int pos = offset;
         tag = buf[pos++];
+        if ((tag & 0x1f) == 0x1f) {
+            throw new IOException("Tag number cannot exceed 30");
+        }
         int lenByte = buf[pos++];
 
         int length;
@@ -388,6 +394,9 @@ public class DerValue {
     // arg to control whether DER checks are enforced.
     DerValue(InputStream in, boolean allowBER) throws IOException {
         this.tag = (byte)in.read();
+        if ((tag & 0x1f) == 0x1f) {
+            throw new IOException("Tag number cannot exceed 30");
+        }
         int length = DerInputStream.getLength(in);
         if (length == -1) { // indefinite length encoding found
             if (!allowBER) {
@@ -1140,6 +1149,9 @@ public class DerValue {
      * @param val the tag value
      */
     public static byte createTag(byte tagClass, boolean form, byte val) {
+        if (val < 0 || val > 30) {
+            throw new IllegalArgumentException("Tag number cannot exceed 30");
+        }
         byte tag = (byte)(tagClass | val);
         if (form) {
             tag |= (byte)0x20;

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -222,7 +222,7 @@ public class DerValue {
      */
     DerValue(byte tag, byte[] buffer, int start, int end, boolean allowBER) {
         if ((tag & 0x1f) == 0x1f) {
-            throw new IllegalArgumentException("Tag number 31 is not supported");
+            throw new IllegalArgumentException("Tag number over 30 is not supported");
         }
         this.tag = tag;
         this.buffer = buffer;

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -319,7 +319,7 @@ public class DerValue {
         int pos = offset;
         tag = buf[pos++];
         if ((tag & 0x1f) == 0x1f) {
-            throw new IOException("Tag number over 30 is not supported");
+            throw new IOException("Tag number over 30 at " + offset + " is not supported");
         }
         int lenByte = buf[pos++];
 

--- a/test/jdk/sun/security/util/DerValue/WideTag.java
+++ b/test/jdk/sun/security/util/DerValue/WideTag.java
@@ -34,7 +34,6 @@ import sun.security.util.DerInputStream;
 import sun.security.util.DerValue;
 
 import java.io.IOException;
-import java.util.HexFormat;
 
 public class WideTag {
 
@@ -45,17 +44,23 @@ public class WideTag {
         DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0);
 
         // Big ones
-        Utils.runAndCheckException(() -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)31),
+        Utils.runAndCheckException(
+                () -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)31),
                 IllegalArgumentException.class);
-        Utils.runAndCheckException(() -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)222),
+        Utils.runAndCheckException(
+                () -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)222),
                 IllegalArgumentException.class);
 
         // We don't accept number 31
         Utils.runAndCheckException(() -> new DerValue((byte)0xbf, new byte[10]),
                 IllegalArgumentException.class);
 
-        // A CONTEXT [48] with 2 zeroes. Not supported
-        byte[] wideDER = HexFormat.of().parseHex("BF30020000");
+        // CONTEXT [98] size 97. Not supported. Should fail.
+        // Before this fix, it was interpreted as CONTEXT [31] size 98.
+        byte[] wideDER = new byte[100];
+        wideDER[0] = (byte)0xBF;
+        wideDER[1] = (byte)98;
+        wideDER[2] = (byte)97;
 
         Utils.runAndCheckException(() -> new DerValue(wideDER),
                 IOException.class);

--- a/test/jdk/sun/security/util/DerValue/WideTag.java
+++ b/test/jdk/sun/security/util/DerValue/WideTag.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8264864
+ * @summary Multiple byte tag not supported by ASN.1 encoding
+ * @modules java.base/sun.security.util
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Utils;
+import sun.security.util.DerInputStream;
+import sun.security.util.DerValue;
+
+import java.io.IOException;
+import java.util.HexFormat;
+
+public class WideTag {
+
+    public static void main(String[] args) throws Exception {
+
+        // Small ones
+        DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)30);
+        DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0);
+
+        // Big ones
+        Utils.runAndCheckException(() -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)31),
+                IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)222),
+                IllegalArgumentException.class);
+
+        // We don't accept number 31
+        Utils.runAndCheckException(() -> new DerValue((byte)0xbf, new byte[10]),
+                IllegalArgumentException.class);
+
+        // A CONTEXT [48] with 2 zeroes. Not supported
+        byte[] wideDER = HexFormat.of().parseHex("BF30020000");
+
+        Utils.runAndCheckException(() -> new DerValue(wideDER),
+                IOException.class);
+        Utils.runAndCheckException(() -> new DerInputStream(wideDER).getDerValue(),
+                IOException.class);
+    }
+}


### PR DESCRIPTION
This code change does not intend to support multiple byte tags. Instead, it aims to fail more gracefully when such a tag is encountered. For `DerValue` constructors from an encoding (type I), an `IOException` will be thrown since it's already in the throws clause. For constructors from tag and value (type II), an `IllegalArgumentException` will be thrown. All existing type II callers inside JDK use tag numbers smaller than 31.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264864](https://bugs.openjdk.java.net/browse/JDK-8264864): Multiple byte tag not supported by ASN.1 encoding


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 9b0f9db9ff6ac915f865d08fe2657a63d57fbb91


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3391/head:pull/3391` \
`$ git checkout pull/3391`

Update a local copy of the PR: \
`$ git checkout pull/3391` \
`$ git pull https://git.openjdk.java.net/jdk pull/3391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3391`

View PR using the GUI difftool: \
`$ git pr show -t 3391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3391.diff">https://git.openjdk.java.net/jdk/pull/3391.diff</a>

</details>
