### PR TITLE
8264885: Fix the code style of macro in aarch64_neon_ad.m4

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -1057,7 +1057,7 @@ instruct vand_not$1$2`'(vec$3 dst, vec$3 src1, vec$3 src2, imm$2_M1 m1)
   %}
   ins_pipe(pipe_class_default);
 %}')dnl
-dnl        $1 $2 $3 $4  $5
+dnl            $1 $2 $3 $4  $5
 VECTOR_AND_NOT(2, I, D, 8,  8B)
 VECTOR_AND_NOT(4, I, X, 16, 16B)
 VECTOR_AND_NOT(2, L, X, 16, 16B)
@@ -1116,7 +1116,7 @@ instruct v$1`'2L`'(vecX dst, vecX src1, vecX src2)
   %}
   ins_pipe(vdop128);
 %}')dnl
-dnl                $1   $2   $3    $4
+dnl                 $1   $2   $3    $4
 VECTOR_MAX_MIN_LONG(max, Max, src1, src2)
 VECTOR_MAX_MIN_LONG(min, Min, src2, src1)
 dnl
@@ -1897,7 +1897,7 @@ instruct vsqrt$2$3`'(vec$4 dst, vec$4 src)
   %}
   ins_pipe(v`'ifelse($2$3, 2F, unop, sqrt)_fp`'ifelse($4, D, 64, 128));
 %}')dnl
-dnl  $1      $2  $3 $4 $5
+dnl   $1     $2  $3 $4 $5
 VSQRT(fsqrt, 2,  F, D, S)
 VSQRT(fsqrt, 4,  F, X, S)
 VSQRT(fsqrt, 2,  D, X, D)
@@ -1938,7 +1938,7 @@ instruct v$3$5$6`'(vec$7 dst, vec$7 src1, vec$7 src2)
 %}')dnl
 
 // --------------------------------- AND --------------------------------------
-dnl     $1    $2    $3   $4   $5  $6 $7
+dnl      $1   $2    $3   $4   $5  $6 $7
 VLOGICAL(and, andr, and, And, 8,  B, D)
 VLOGICAL(and, andr, and, And, 16, B, X)
 


### PR DESCRIPTION
* trivial fix
* align the comment of macros

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264885](https://bugs.openjdk.java.net/browse/JDK-8264885): Fix the code style of macro in aarch64_neon_ad.m4


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3395/head:pull/3395` \
`$ git checkout pull/3395`

Update a local copy of the PR: \
`$ git checkout pull/3395` \
`$ git pull https://git.openjdk.java.net/jdk pull/3395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3395`

View PR using the GUI difftool: \
`$ git pr show -t 3395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3395.diff">https://git.openjdk.java.net/jdk/pull/3395.diff</a>

</details>
