### PR TITLE
8264918: [JVMCI] getVtableIndexForInterfaceMethod doesn't check that type and method are related

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -729,10 +729,11 @@ C2V_END
 C2V_VMENTRY_0(jint, getVtableIndexForInterfaceMethod, (JNIEnv* env, jobject, jobject jvmci_type, jobject jvmci_method))
   Klass* klass = JVMCIENV->asKlass(jvmci_type);
   methodHandle method(THREAD, JVMCIENV->asMethod(jvmci_method));
+  InstanceKlass* holder = method->method_holder();
   if (klass->is_interface()) {
     JVMCI_THROW_MSG_0(InternalError, err_msg("Interface %s should be handled in Java code", klass->external_name()));
   }
-  if (!method->method_holder()->is_interface()) {
+  if (!holder->is_interface()) {
     JVMCI_THROW_MSG_0(InternalError, err_msg("Method %s is not held by an interface, this case should be handled in Java code", method->name_and_sig_as_C_string()));
   }
   if (!klass->is_instance_klass()) {
@@ -740,6 +741,9 @@ C2V_VMENTRY_0(jint, getVtableIndexForInterfaceMethod, (JNIEnv* env, jobject, job
   }
   if (!InstanceKlass::cast(klass)->is_linked()) {
     JVMCI_THROW_MSG_0(InternalError, err_msg("Class %s must be linked", klass->external_name()));
+  }
+  if (!klass->is_subtype_of(holder)) {
+    JVMCI_THROW_MSG_0(InternalError, err_msg("Class %s does not implement interface %s", klass->external_name(), holder->external_name()));
   }
   return LinkResolver::vtable_index_of_interface_method(klass, method);
 C2V_END

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetVtableIndexForInterfaceTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetVtableIndexForInterfaceTest.java
@@ -116,17 +116,19 @@ public class GetVtableIndexForInterfaceTest {
                 InternalError.class));
         // class not implementing iface
         result.add(new TestCase(DoNotExtendClass.class,
-                SingleImplementerInterface.class, "defaultMethod", false));
+                SingleImplementerInterface.class, "defaultMethod", false,
+                InternalError.class));
         // abstract class which doesn't implement iface
         result.add(new TestCase(AbstractClass.class,
-                SingleImplementerInterface.class, "defaultMethod", false));
+                SingleImplementerInterface.class, "defaultMethod", false,
+                InternalError.class));
         // abstract class which implements iface
         result.add(new TestCase(MultipleAbstractImplementer.class,
                 MultipleImplementersInterface.class, "defaultMethod", true));
         // class not initialized
         result.add(new TestCase(AnotherSingleImplementer.class,
-                AnotherSingleImplementerInterface.class, "defaultMethod",
-                false, InternalError.class));
+                AnotherSingleImplementerInterface.class, "defaultMethod", false,
+                InternalError.class));
         return result;
     }
 


### PR DESCRIPTION
getVtableIndexForInterfaceMethod should reject the case when a resolved class doesn't implement the holder interface.

Testing:
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264918](https://bugs.openjdk.java.net/browse/JDK-8264918): [JVMCI] getVtableIndexForInterfaceMethod doesn't check that type and method are related


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3396/head:pull/3396` \
`$ git checkout pull/3396`

Update a local copy of the PR: \
`$ git checkout pull/3396` \
`$ git pull https://git.openjdk.java.net/jdk pull/3396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3396`

View PR using the GUI difftool: \
`$ git pr show -t 3396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3396.diff">https://git.openjdk.java.net/jdk/pull/3396.diff</a>

</details>
