### PR TITLE
8264923: PNGImageWriter.write_zTXt throws Exception with a typo

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
@@ -824,7 +824,7 @@ public final class PNGImageWriter extends ImageWriter {
             ChunkStream cs = new ChunkStream(PNGImageReader.zTXt_TYPE, stream);
             String keyword = keywordIter.next();
             if (keyword.length() > 79) {
-                throw new IIOException("tEXt keyword is longer than 79");
+                throw new IIOException("zTXt keyword is longer than 79");
             }
             cs.writeBytes(keyword);
             cs.writeByte(0);


### PR DESCRIPTION
Noticed this when backporting JDK-8242557: there is a trivial copy-paste error in exception message. See:
 https://hg.openjdk.java.net/jdk/jdk/rev/645c71334acd#l1.58

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264923](https://bugs.openjdk.java.net/browse/JDK-8264923): PNGImageWriter.write_zTXt throws Exception with a typo


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3397/head:pull/3397` \
`$ git checkout pull/3397`

Update a local copy of the PR: \
`$ git checkout pull/3397` \
`$ git pull https://git.openjdk.java.net/jdk pull/3397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3397`

View PR using the GUI difftool: \
`$ git pr show -t 3397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3397.diff">https://git.openjdk.java.net/jdk/pull/3397.diff</a>

</details>
