### PR TITLE
8264765: BreakIterator sees bogus sentence boundary in parenthesized “i.e.” phrase

### DIFF
--- a/src/java.base/share/classes/sun/text/resources/BreakIteratorRules.java
+++ b/src/java.base/share/classes/sun/text/resources/BreakIteratorRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,7 +310,7 @@ public class BreakIteratorRules extends ListResourceBundle {
               // punctuation" and quotation marks
               + "<start-punctuation>=[:Ps::Pi:\\\"\\\'];"
 
-              // punctuation with may occur at the end of a sentence: "ending punctuation"
+              // punctuation which may occur at the end of a sentence: "ending punctuation"
               // and quotation marks
               + "<end>=[:Pe::Pf:\\\"\\\'];"
 
@@ -323,9 +323,12 @@ public class BreakIteratorRules extends ListResourceBundle {
               // periods, which MAY signal the end of a sentence
               + "<period>=[\\.\uff0e];"
 
+              // comma, which may not occur at the start of a sentence
+              + "<comma>=[\\,];"
+
               // characters that may occur at the beginning of a sentence: basically anything
               // not mentioned above (letters and digits are specifically excluded)
-              + "<sent-start>=[^[:L:<space><start-punctuation><end><digit><term><period>\u2029<ignore>]];"
+              + "<sent-start>=[^[:L:<space><start-punctuation><end><digit><term><period><comma>\u2029<ignore>]];"
 
               // Hindi phrase separator
               + "<danda>=[\u0964\u0965];"

--- a/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
+++ b/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 4035266 4052418 4068133 4068137 4068139 4086052 4095322 4097779
  *      4097920 4098467 4111338 4113835 4117554 4143071 4146175 4152117
- *      4152416 4153072 4158381 4214367 4217703 4638433
+ *      4152416 4153072 4158381 4214367 4217703 4638433 8264765
  * @library /java/text/testlib
  * @run main/timeout=2000 BreakIteratorTest
  * @summary test BreakIterator
@@ -742,6 +742,17 @@ public class BreakIteratorTest extends IntlTest
                 + "<tt>rnd</tt>.  ");
         sentenceSelectionData.addElement("Note that this constructor always "
                 + "constructs a non-negative BigInteger.\u2029");
+
+        generalIteratorTest(sentenceBreak, sentenceSelectionData);
+    }
+
+    public void TestBug8264765() {
+        Vector<String> sentenceSelectionData = new Vector<String>();
+
+        // Comma should not be regarded as the start of a sentence,
+        // otherwise the backwards rule would break the following sentence.
+        sentenceSelectionData.addElement(
+            "Due to a problem (e.g., software bug), the server is down. ");
 
         generalIteratorTest(sentenceBreak, sentenceSelectionData);
     }


### PR DESCRIPTION
Please review the fix to the subject issue. It is not actually related to "parenthesized", but period-comma sequence was regarded as a break on a backward traverse.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264765](https://bugs.openjdk.java.net/browse/JDK-8264765): BreakIterator sees bogus sentence boundary in parenthesized “i.e.” phrase


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3400/head:pull/3400` \
`$ git checkout pull/3400`

Update a local copy of the PR: \
`$ git checkout pull/3400` \
`$ git pull https://git.openjdk.java.net/jdk pull/3400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3400`

View PR using the GUI difftool: \
`$ git pr show -t 3400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3400.diff">https://git.openjdk.java.net/jdk/pull/3400.diff</a>

</details>
