### PR TITLE
8263087: Add a MethodHandle combinator that switches over a set of MethodHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -864,6 +864,12 @@ class InvokerBytecodeGenerator {
                     onStack = emitTryFinally(i);
                     i += 2; // jump to the end of the TF idiom
                     continue;
+                case TABLE_SWITCH:
+                    assert lambdaForm.isTableSwitch(i);
+                    int numCases = (Integer) name.function.intrinsicData();
+                    onStack = emitTableSwitch(i, numCases);
+                    i += 2; // jump to the end of the TS idiom
+                    continue;
                 case LOOP:
                     assert lambdaForm.isLoop(i);
                     onStack = emitLoop(i);
@@ -1387,6 +1393,58 @@ class InvokerBytecodeGenerator {
             default:
                 throw new InternalError("unknown type: " + type);
         }
+    }
+
+    private Name emitTableSwitch(int pos, int numCases) {
+        Name args    = lambdaForm.names[pos];
+        Name invoker = lambdaForm.names[pos+1];
+        Name result  = lambdaForm.names[pos+2];
+
+        Class<?> returnType = result.function.resolvedHandle().type().returnType();
+        MethodType caseType = args.function.resolvedHandle().type()
+            .dropParameterTypes(0,1) // drop collector
+            .changeReturnType(returnType);
+        String caseDescriptor = caseType.basicType().toMethodDescriptorString();
+
+        emitPushArgument(invoker, 2); // push cases
+        mv.visitFieldInsn(Opcodes.GETFIELD, "java/lang/invoke/MethodHandleImpl$CasesHolder", "cases",
+            "[Ljava/lang/invoke/MethodHandle;");
+        int casesLocal = extendLocalsMap(new Class<?>[] { MethodHandle[].class });
+        emitStoreInsn(L_TYPE, casesLocal);
+
+        Label endLabel = new Label();
+        Label defaultLabel = new Label();
+        Label[] caseLabels = new Label[numCases];
+        for (int i = 0; i < caseLabels.length; i++) {
+            caseLabels[i] = new Label();
+        }
+
+        emitPushArgument(invoker, 0); // push switch input
+        mv.visitTableSwitchInsn(0, numCases - 1, defaultLabel, caseLabels);
+
+        mv.visitLabel(defaultLabel);
+        emitPushArgument(invoker, 1); // push default handle
+        emitPushArguments(args, 1); // again, skip collector
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, MH, "invokeBasic", caseDescriptor, false);
+        mv.visitJumpInsn(Opcodes.GOTO, endLabel);
+
+        for (int i = 0; i < numCases; i++) {
+            mv.visitLabel(caseLabels[i]);
+            // Load the particular case:
+            emitLoadInsn(L_TYPE, casesLocal);
+            emitIconstInsn(i);
+            mv.visitInsn(Opcodes.AALOAD);
+
+            // invoke it:
+            emitPushArguments(args, 1); // again, skip collector
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, MH, "invokeBasic", caseDescriptor, false);
+
+            mv.visitJumpInsn(Opcodes.GOTO, endLabel);
+        }
+
+        mv.visitLabel(endLabel);
+
+        return result;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1397,12 +1397,12 @@ class InvokerBytecodeGenerator {
 
     private Name emitTableSwitch(int pos, int numCases) {
         Name args    = lambdaForm.names[pos];
-        Name invoker = lambdaForm.names[pos+1];
-        Name result  = lambdaForm.names[pos+2];
+        Name invoker = lambdaForm.names[pos + 1];
+        Name result  = lambdaForm.names[pos + 2];
 
         Class<?> returnType = result.function.resolvedHandle().type().returnType();
         MethodType caseType = args.function.resolvedHandle().type()
-            .dropParameterTypes(0,1) // drop collector
+            .dropParameterTypes(0, 1) // drop collector
             .changeReturnType(returnType);
         String caseDescriptor = caseType.basicType().toMethodDescriptorString();
 

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -314,6 +314,7 @@ class LambdaForm {
         GET_DOUBLE_VOLATILE("getDoubleVolatile"),
         PUT_DOUBLE_VOLATILE("putDoubleVolatile"),
         TRY_FINALLY("tryFinally"),
+        TABLE_SWITCH("tableSwitch"),
         COLLECT("collect"),
         COLLECTOR("collector"),
         CONVERT("convert"),
@@ -708,6 +709,32 @@ class LambdaForm {
     }
 
     /**
+     * Check if i-th name is a start of the tableSwitch idiom.
+     */
+    boolean isTableSwitch(int pos) {
+        // tableSwitch idiom:
+        //   t_{n}:L=MethodHandle.invokeBasic(...)     // args
+        //   t_{n+1}:L=MethodHandleImpl.tableSwitch(*, *, *, t_{n})
+        //   t_{n+2}:?=MethodHandle.invokeBasic(*, t_{n+1})
+        if (pos + 2 >= names.length)  return false;
+
+        final int POS_COLLECT_ARGS  = pos;
+        final int POS_TABLE_SWITCH  = pos + 1;
+        final int POS_UNBOX_RESULT  = pos + 2;
+
+        Name collectArgs  = names[POS_COLLECT_ARGS];
+        Name tableSwitch  = names[POS_TABLE_SWITCH];
+        Name unboxResult  = names[POS_UNBOX_RESULT];
+        return tableSwitch.refersTo(MethodHandleImpl.class, "tableSwitch") &&
+                collectArgs.isInvokeBasic() &&
+                unboxResult.isInvokeBasic() &&
+                tableSwitch.lastUseIndex(collectArgs)  == 3 &&    // t_{n+1}:L=MethodHandleImpl.<invoker>(*, *, *, t_{n});
+                lastUseIndex(collectArgs)  == POS_TABLE_SWITCH && // t_{n} is local: used only in t_{n+1}
+                unboxResult.lastUseIndex(tableSwitch) == 1 &&     // t_{n+2}:?=MethodHandle.invokeBasic(*, t_{n+1})
+                lastUseIndex(tableSwitch) == POS_UNBOX_RESULT;    // t_{n+1} is local: used only in t_{n+2}
+    }
+
+    /**
      * Check if i-th name is a start of the loop idiom.
      */
     boolean isLoop(int pos) {
@@ -1068,20 +1095,28 @@ class LambdaForm {
         private @Stable MethodHandle resolvedHandle;
         @Stable MethodHandle invoker;
         private final MethodHandleImpl.Intrinsic intrinsicName;
+        private final Object intrinsicData;
 
         NamedFunction(MethodHandle resolvedHandle) {
-            this(resolvedHandle.internalMemberName(), resolvedHandle, MethodHandleImpl.Intrinsic.NONE);
+            this(resolvedHandle.internalMemberName(), resolvedHandle, MethodHandleImpl.Intrinsic.NONE, null);
         }
         NamedFunction(MethodHandle resolvedHandle, MethodHandleImpl.Intrinsic intrinsic) {
-            this(resolvedHandle.internalMemberName(), resolvedHandle, intrinsic);
+            this(resolvedHandle.internalMemberName(), resolvedHandle, intrinsic, null);
+        }
+        NamedFunction(MethodHandle resolvedHandle, MethodHandleImpl.Intrinsic intrinsic, Object intrinsicData) {
+            this(resolvedHandle.internalMemberName(), resolvedHandle, intrinsic, intrinsicData);
         }
         NamedFunction(MemberName member, MethodHandle resolvedHandle) {
-            this(member, resolvedHandle, MethodHandleImpl.Intrinsic.NONE);
+            this(member, resolvedHandle, MethodHandleImpl.Intrinsic.NONE, null);
         }
         NamedFunction(MemberName member, MethodHandle resolvedHandle, MethodHandleImpl.Intrinsic intrinsic) {
+            this(member, resolvedHandle, intrinsic, null);
+        }
+        NamedFunction(MemberName member, MethodHandle resolvedHandle, MethodHandleImpl.Intrinsic intrinsic, Object intrinsicData) {
             this.member = member;
             this.resolvedHandle = resolvedHandle;
             this.intrinsicName = intrinsic;
+            this.intrinsicData = intrinsicData;
             assert(resolvedHandle == null ||
                    resolvedHandle.intrinsicName() == MethodHandleImpl.Intrinsic.NONE ||
                    resolvedHandle.intrinsicName() == intrinsic) : resolvedHandle.intrinsicName() + " != " + intrinsic;
@@ -1098,6 +1133,7 @@ class LambdaForm {
                 this.member = Invokers.invokeBasicMethod(basicInvokerType);
             }
             this.intrinsicName = MethodHandleImpl.Intrinsic.NONE;
+            this.intrinsicData = null;
             assert(isInvokeBasic(member));
         }
 
@@ -1251,6 +1287,10 @@ class LambdaForm {
 
         public MethodHandleImpl.Intrinsic intrinsicName() {
             return intrinsicName;
+        }
+
+        public Object intrinsicData() {
+            return intrinsicData;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -38,6 +38,7 @@ import static java.lang.invoke.LambdaForm.*;
 import static java.lang.invoke.LambdaForm.BasicType.*;
 import static java.lang.invoke.MethodHandleImpl.Intrinsic;
 import static java.lang.invoke.MethodHandleImpl.NF_loop;
+import static java.lang.invoke.MethodHandleImpl.makeIntrinsic;
 
 /** Transforms on LFs.
  *  A lambda-form editor can derive new LFs from its base LF.
@@ -619,7 +620,7 @@ class LambdaFormEditor {
         // adjust the arguments
         MethodHandle aload = MethodHandles.arrayElementGetter(erasedArrayType);
         for (int i = 0; i < arrayLength; i++) {
-            Name loadArgument = new Name(new NamedFunction(aload, Intrinsic.ARRAY_LOAD), spreadParam, i);
+            Name loadArgument = new Name(new NamedFunction(makeIntrinsic(aload, Intrinsic.ARRAY_LOAD)), spreadParam, i);
             buf.insertExpression(exprPos + i, loadArgument);
             buf.replaceParameterByCopy(pos + i, exprPos + i);
         }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1680,6 +1680,11 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
     }
 
     /*non-public*/
+    Object intrinsicData() {
+        return null;
+    }
+
+    /*non-public*/
     MethodHandle withInternalMemberName(MemberName member, boolean isInvokeSpecial) {
         if (member != null) {
             return MethodHandleImpl.makeWrappedMember(this, member, isInvokeSpecial);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -1226,6 +1228,7 @@ abstract class MethodHandleImpl {
         SELECT_ALTERNATIVE,
         GUARD_WITH_CATCH,
         TRY_FINALLY,
+        TABLE_SWITCH,
         LOOP,
         ARRAY_LOAD,
         ARRAY_STORE,
@@ -1360,7 +1363,8 @@ abstract class MethodHandleImpl {
             NF_tryFinally = 3,
             NF_loop = 4,
             NF_profileBoolean = 5,
-            NF_LIMIT = 6;
+            NF_tableSwitch = 6,
+            NF_LIMIT = 7;
 
     private static final @Stable NamedFunction[] NFS = new NamedFunction[NF_LIMIT];
 
@@ -1394,6 +1398,9 @@ abstract class MethodHandleImpl {
                 case NF_profileBoolean:
                     return new NamedFunction(MethodHandleImpl.class
                             .getDeclaredMethod("profileBoolean", boolean.class, int[].class));
+                case NF_tableSwitch:
+                    return new NamedFunction(MethodHandleImpl.class
+                            .getDeclaredMethod("tableSwitch", int.class, MethodHandle.class, CasesHolder.class, Object[].class));
                 default:
                     throw new InternalError("Undefined function: " + func);
             }
@@ -1950,6 +1957,142 @@ abstract class MethodHandleImpl {
             lform = basicType.form().setCachedLambdaForm(MethodTypeForm.LF_COLLECTOR, lform);
         }
         return lform;
+    }
+
+    // use a wrapper because we need this array to be @Stable
+    static class CasesHolder {
+        @Stable
+        final MethodHandle[] cases;
+
+        public CasesHolder(MethodHandle[] cases) {
+            this.cases = cases;
+        }
+    }
+
+    static MethodHandle makeTableSwitch(MethodType type, MethodHandle defaultCase, MethodHandle[] caseActions) {
+        MethodType varargsType = type.changeReturnType(Object[].class);
+        MethodHandle collectArgs = varargsArray(type.parameterCount()).asType(varargsType);
+
+        MethodHandle unboxResult = unboxResultHandle(type.returnType());
+
+        BoundMethodHandle.SpeciesData data = BoundMethodHandle.speciesData_LLLL();
+        LambdaForm form = makeTableSwitchForm(type.basicType(), data, caseActions.length);
+        BoundMethodHandle mh;
+        CasesHolder caseHolder =  new CasesHolder(caseActions);
+        try {
+            mh = (BoundMethodHandle) data.factory().invokeBasic(type, form, (Object) defaultCase, (Object) collectArgs,
+                                                                (Object) unboxResult, (Object) caseHolder);
+        } catch (Throwable ex) {
+            throw uncaughtException(ex);
+        }
+        assert(mh.type() == type);
+        return mh;
+    }
+
+    private static class TableSwitchCacheKey {
+        private final MethodType basicType;
+        private final int numberOfCases;
+
+        public TableSwitchCacheKey(MethodType basicType, int numberOfCases) {
+            this.basicType = basicType;
+            this.numberOfCases = numberOfCases;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TableSwitchCacheKey that = (TableSwitchCacheKey) o;
+            return numberOfCases == that.numberOfCases && Objects.equals(basicType, that.basicType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(basicType, numberOfCases);
+        }
+    }
+
+    private static final Map<TableSwitchCacheKey, LambdaForm> TABLE_SWITCH_LAMBDA_FORM_CACHE = new ConcurrentHashMap<>();
+
+    private static LambdaForm makeTableSwitchForm(MethodType basicType, BoundMethodHandle.SpeciesData data,
+                                                  int numCases) {
+        MethodType lambdaType = basicType.invokerType();
+
+        // We need to cache based on the basic type X number of cases,
+        // since the number of cases is used when generating bytecode.
+        // This also means that we can't use the cache in MethodTypeForm,
+        // which only uses the basic type as a key.
+        TableSwitchCacheKey key = new TableSwitchCacheKey(basicType, numCases);
+        LambdaForm lform = TABLE_SWITCH_LAMBDA_FORM_CACHE.get(key);
+        if (lform != null) {
+            return lform;
+        }
+
+        final int THIS_MH       = 0;
+        final int ARG_BASE      = 1;  // start of incoming arguments
+        final int ARG_LIMIT     = ARG_BASE + basicType.parameterCount();
+        final int ARG_SWITCH_ON = ARG_BASE;
+        assert ARG_SWITCH_ON < ARG_LIMIT;
+
+        int nameCursor = ARG_LIMIT;
+        final int GET_COLLECT_ARGS  = nameCursor++;
+        final int GET_DEFAULT_CASE  = nameCursor++;
+        final int GET_UNBOX_RESULT  = nameCursor++;
+        final int GET_CASES         = nameCursor++;
+        final int BOXED_ARGS        = nameCursor++;
+        final int TABLE_SWITCH      = nameCursor++;
+        final int UNBOXED_RESULT    = nameCursor++;
+
+        int fieldCursor = 0;
+        final int FIELD_DEFAULT_CASE  = fieldCursor++;
+        final int FIELD_COLLECT_ARGS  = fieldCursor++;
+        final int FIELD_UNBOX_RESULT  = fieldCursor++;
+        final int FIELD_CASES         = fieldCursor++;
+
+        Name[] names = arguments(nameCursor - ARG_LIMIT, lambdaType);
+
+        names[THIS_MH] = names[THIS_MH].withConstraint(data);
+        names[GET_DEFAULT_CASE] = new Name(data.getterFunction(FIELD_DEFAULT_CASE), names[THIS_MH]);
+        names[GET_COLLECT_ARGS]  = new Name(data.getterFunction(FIELD_COLLECT_ARGS), names[THIS_MH]);
+        names[GET_UNBOX_RESULT]  = new Name(data.getterFunction(FIELD_UNBOX_RESULT), names[THIS_MH]);
+        names[GET_CASES] = new Name(data.getterFunction(FIELD_CASES), names[THIS_MH]);
+
+        {
+            MethodType collectArgsType = basicType.changeReturnType(Object.class);
+            MethodHandle invokeBasic = MethodHandles.basicInvoker(collectArgsType);
+            Object[] args = new Object[invokeBasic.type().parameterCount()];
+            args[0] = names[GET_COLLECT_ARGS];
+            System.arraycopy(names, ARG_BASE, args, 1, ARG_LIMIT - ARG_BASE);
+            names[BOXED_ARGS] = new Name(new NamedFunction(invokeBasic, Intrinsic.TABLE_SWITCH, numCases), args);
+        }
+
+        {
+            Object[] tfArgs = new Object[]{
+                names[ARG_SWITCH_ON], names[GET_DEFAULT_CASE], names[GET_CASES], names[BOXED_ARGS]};
+            names[TABLE_SWITCH] = new Name(getFunction(NF_tableSwitch), tfArgs);
+        }
+
+        {
+            MethodHandle invokeBasic = MethodHandles.basicInvoker(MethodType.methodType(basicType.rtype(), Object.class));
+            Object[] unboxArgs = new Object[]{names[GET_UNBOX_RESULT], names[TABLE_SWITCH]};
+            names[UNBOXED_RESULT] = new Name(invokeBasic, unboxArgs);
+        }
+
+        lform = new LambdaForm(lambdaType.parameterCount(), names, Kind.TABLE_SWITCH);
+        LambdaForm prev = TABLE_SWITCH_LAMBDA_FORM_CACHE.putIfAbsent(key, lform);
+        return prev != null ? prev : lform;
+    }
+
+    @Hidden
+    static Object tableSwitch(int input, MethodHandle defaultCase, CasesHolder holder, Object[] args) throws Throwable {
+        MethodHandle[] caseActions = holder.cases;
+        MethodHandle selectedCase;
+        if (input < 0 || input >= caseActions.length) {
+            selectedCase = defaultCase;
+        } else {
+            selectedCase = caseActions[input];
+        }
+        return selectedCase.invokeWithArguments(args);
     }
 
     // Indexes into constant method handles:

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7778,6 +7778,32 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * method handle as well. Any arguments assigned to these parameters will be forwarded,
      * together with the selector value, to the selected method handle when invoking it.
      *
+     * @apiNote Example:
+     * The cases each drop the {@code selector} value they are given, and take an additional
+     * {@code String} argument, which is concatenated (using {@link String#concat(String)})
+     * to a specific constant label string for each case:
+     * <blockquote><pre>{@code
+     * MethodHandles.Lookup lookup = MethodHandles.lookup();
+     * MethodHandle caseMh = lookup.findVirtual(String.class, "concat",
+     *         MethodType.methodType(String.class, String.class));
+     * caseMh = MethodHandles.dropArguments(caseMh, 0, int.class);
+     *
+     * MethodHandle caseDefault = MethodHandles.insertArguments(caseMh, 1, "default: ");
+     * MethodHandle case0 = MethodHandles.insertArguments(caseMh, 1, "case 0: ");
+     * MethodHandle case1 = MethodHandles.insertArguments(caseMh, 1, "case 1: ");
+     *
+     * MethodHandle mhSwitch = MethodHandles.tableSwitch(
+     *     caseDefault,
+     *     case0,
+     *     case1
+     * );
+     *
+     * assertEquals("default: data", (String) mhSwitch.invokeExact(-1, "data"));
+     * assertEquals("case 0: data", (String) mhSwitch.invokeExact(0, "data"));
+     * assertEquals("case 1: data", (String) mhSwitch.invokeExact(1, "data"));
+     * assertEquals("default: data", (String) mhSwitch.invokeExact(2, "data"));
+     * }</pre></blockquote>
+     *
      * @param fallback the fallback method handle that is called when the selector is not
      *                 within the range {@code [0, N)}.
      * @param targets array of target method handles.

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7759,4 +7759,64 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         }
     }
 
+    /**
+     * Creates a table switch method handle, which can be used to switch over a set of target
+     * method handles, based on a given target index, called selector.
+     * <p>
+     * For a selector value of {@code n}, where {@code n} falls in the range {@code [0, N)},
+     * and where {@code N} is the number of target method handles, the table switch method
+     * handle will invoke the n-th target method handle from the list of target method handles.
+     * <p>
+     * For a selector value that does not fall in the range {@code [0, N)}, the table switch
+     * method handle will invoke the given fallback method handle.
+     * <p>
+     * All method handles passed to this method must have the same type, with the additional
+     * requirement that the leading parameter be of type {@code int}. The leading parameter
+     * represents the selector.
+     * <p>
+     * Any trailing parameters present in the type will appear on the returned table switch
+     * method handle as well. Any arguments assigned to these parameters will be forwarded,
+     * together with the selector value, to the selected method handle when invoking it.
+     *
+     * @param fallback the fallback method handle that is called when the selector is not
+     *                 within the range {@code [0, N)}.
+     * @param targets array of target method handles.
+     * @return the table switch method handle.
+     * @throws NullPointerException if {@code fallback}, the {@code targets} array, or any
+     *                              any of the elements of the {@code targets} array are
+     *                              {@code null}.
+     * @throws IllegalArgumentException if the {@code targets} array is empty, if the leading
+     *                                  parameter of the fallback handle or any of the target
+     *                                  handles is not {@code int}, or if the types of
+     *                                  the fallback handle and all of target handles are
+     *                                  not the same.
+     */
+    public static MethodHandle tableSwitch(MethodHandle fallback, MethodHandle... targets) {
+        Objects.requireNonNull(fallback);
+        Objects.requireNonNull(targets);
+        targets = targets.clone();
+        MethodType type = tableSwitchChecks(fallback, targets);
+        return MethodHandleImpl.makeTableSwitch(type, fallback, targets);
+    }
+
+    private static MethodType tableSwitchChecks(MethodHandle defaultCase, MethodHandle[] caseActions) {
+        if (caseActions.length == 0)
+            throw new IllegalArgumentException("Not enough cases: " + Arrays.toString(caseActions));
+
+        MethodType expectedType = defaultCase.type();
+
+        if (!(expectedType.parameterCount() >= 1) || expectedType.parameterType(0) != int.class)
+            throw new IllegalArgumentException(
+                "Case actions must have int as leading parameter: " + Arrays.toString(caseActions));
+
+        for (MethodHandle mh : caseActions) {
+            Objects.requireNonNull(mh);
+            if (mh.type() != expectedType)
+                throw new IllegalArgumentException(
+                    "Case actions must have the same type: " + Arrays.toString(caseActions));
+        }
+
+        return expectedType;
+    }
+
 }

--- a/test/jdk/java/lang/invoke/MethodHandles/TestTableSwitch.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/TestTableSwitch.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng/othervm -Xverify:all TestTableSwitch
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.management.ObjectName;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestTableSwitch {
+
+    static final MethodHandle MH_IntConsumer_accept;
+    static final MethodHandle MH_check;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_IntConsumer_accept = lookup.findVirtual(IntConsumer.class, "accept",
+                    MethodType.methodType(void.class, int.class));
+            MH_check = lookup.findStatic(TestTableSwitch.class, "check",
+                    MethodType.methodType(void.class, List.class, Object[].class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static MethodHandle simpleTestCase(String value) {
+        return simpleTestCase(String.class, value);
+    }
+
+    public static MethodHandle simpleTestCase(Class<?> type, Object value) {
+        return MethodHandles.dropArguments(MethodHandles.constant(type, value), 0, int.class);
+    }
+
+    public static Object testValue(Class<?> type) {
+        if (type == String.class) {
+            return "X";
+        } else if (type == byte.class) {
+            return (byte) 42;
+        } else if (type == short.class) {
+            return (short) 84;
+        } else if (type == char.class) {
+            return 'Y';
+        } else if (type == int.class) {
+            return 168;
+        } else if (type == long.class) {
+            return 336L;
+        } else if (type == float.class) {
+            return 42F;
+        } else if (type == double.class) {
+            return 84D;
+        } else if (type == boolean.class) {
+            return true;
+        }
+        return null;
+    }
+
+    static final Class<?>[] TEST_TYPES = {
+        Object.class,
+        String.class,
+        byte.class,
+        short.class,
+        char.class,
+        int.class,
+        long.class,
+        float.class,
+        double.class,
+        boolean.class
+    };
+
+    public static Object[] testArguments(int caseNum, List<Object> testValues) {
+        Object[] args = new Object[testValues.size() + 1];
+        args[0] = caseNum;
+        int insertPos = 1;
+        for (Object testValue : testValues) {
+            args[insertPos++] = testValue;
+        }
+        return args;
+    }
+
+    @DataProvider
+    public static Object[][] nonVoidCases() {
+        List<Object[]> tests = new ArrayList<>();
+
+        for (Class<?> returnType : TEST_TYPES) {
+            for (int numCases = 1; numCases < 5; numCases++) {
+                tests.add(new Object[] { returnType, numCases, List.of() });
+                tests.add(new Object[] { returnType, numCases, List.of(TEST_TYPES) });
+            }
+        }
+
+        return tests.toArray(Object[][]::new);
+    }
+
+    private static void check(List<Object> testValues, Object[] collectedValues) {
+        assertEquals(collectedValues, testValues.toArray());
+    }
+
+    @Test(dataProvider = "nonVoidCases")
+    public void testNonVoidHandles(Class<?> type, int numCases, List<Class<?>> additionalTypes) throws Throwable {
+        MethodHandle collector = MH_check;
+        List<Object> testArguments = new ArrayList<>();
+        collector = MethodHandles.insertArguments(collector, 0, testArguments);
+        collector = collector.asCollector(Object[].class, additionalTypes.size());
+
+        Object defaultReturnValue = testValue(type);
+        MethodHandle defaultCase = simpleTestCase(type, defaultReturnValue);
+        defaultCase = MethodHandles.collectArguments(defaultCase, 1, collector);
+        Object[] returnValues = new Object[numCases];
+        MethodHandle[] cases = new MethodHandle[numCases];
+        for (int i = 0; i < cases.length; i++) {
+            Object returnValue = testValue(type);
+            returnValues[i] = returnValue;
+            MethodHandle theCase = simpleTestCase(type, returnValue);
+            theCase = MethodHandles.collectArguments(theCase, 1, collector);
+            cases[i] = theCase;
+        }
+
+        MethodHandle mhSwitch = MethodHandles.tableSwitch(
+            defaultCase,
+            cases
+        );
+
+        for (Class<?> additionalType : additionalTypes) {
+            testArguments.add(testValue(additionalType));
+        }
+
+        assertEquals(mhSwitch.invokeWithArguments(testArguments(-1, testArguments)), defaultReturnValue);
+
+        for (int i = 0; i < numCases; i++) {
+            assertEquals(mhSwitch.invokeWithArguments(testArguments(i, testArguments)), returnValues[i]);
+        }
+
+        assertEquals(mhSwitch.invokeWithArguments(testArguments(numCases, testArguments)), defaultReturnValue);
+    }
+
+    @Test
+    public void testVoidHandles() throws Throwable {
+        IntFunction<MethodHandle> makeTestCase = expectedIndex -> {
+            IntConsumer test = actualIndex -> assertEquals(actualIndex, expectedIndex);
+            return MH_IntConsumer_accept.bindTo(test);
+        };
+
+        MethodHandle mhSwitch = MethodHandles.tableSwitch(
+            /* default: */ makeTestCase.apply(-1),
+            /* case 0: */  makeTestCase.apply(0),
+            /* case 1: */  makeTestCase.apply(1),
+            /* case 2: */  makeTestCase.apply(2)
+        );
+
+        mhSwitch.invokeExact((int) -1);
+        mhSwitch.invokeExact((int) 0);
+        mhSwitch.invokeExact((int) 1);
+        mhSwitch.invokeExact((int) 2);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullDefaultHandle() {
+        MethodHandles.tableSwitch(null, simpleTestCase("test"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullCases() {
+        MethodHandle[] cases = null;
+        MethodHandles.tableSwitch(simpleTestCase("default"), cases);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullCase() {
+        MethodHandles.tableSwitch(simpleTestCase("default"), simpleTestCase("case"), null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Not enough cases.*")
+    public void testNotEnoughCases() {
+        MethodHandles.tableSwitch(simpleTestCase("default"));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Case actions must have int as leading parameter.*")
+    public void testNotEnoughParameters() {
+        MethodHandle empty = MethodHandles.empty(MethodType.methodType(void.class));
+        MethodHandles.tableSwitch(empty, empty, empty);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Case actions must have int as leading parameter.*")
+    public void testNoLeadingIntParameter() {
+        MethodHandle empty = MethodHandles.empty(MethodType.methodType(void.class, double.class));
+        MethodHandles.tableSwitch(empty, empty, empty);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Case actions must have the same type.*")
+    public void testWrongCaseType() {
+        // doesn't return a String
+        MethodHandle wrongType = MethodHandles.empty(MethodType.methodType(void.class, int.class));
+        MethodHandles.tableSwitch(simpleTestCase("default"), simpleTestCase("case"), wrongType);
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchConstant.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class MethodHandlesTableSwitchConstant {
+
+    // Switch combinator test for a single constant input index
+
+    private static final MethodType callType = MethodType.methodType(int.class, int.class);
+
+    private static final MutableCallSite cs = new MutableCallSite(callType);
+    private static final MethodHandle target = cs.dynamicInvoker();
+
+    private static final MutableCallSite csInput = new MutableCallSite(MethodType.methodType(int.class));
+    private static final MethodHandle targetInput = csInput.dynamicInvoker();
+
+    private static final MethodHandle MH_SUBTRACT;
+    private static final MethodHandle MH_DEFAULT;
+    private static final MethodHandle MH_PAYLOAD;
+
+    static {
+        try {
+            MH_SUBTRACT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchConstant.class, "subtract",
+                    MethodType.methodType(int.class, int.class, int.class));
+            MH_DEFAULT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchConstant.class, "defaultCase",
+                    MethodType.methodType(int.class, int.class));
+            MH_PAYLOAD = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchConstant.class, "payload",
+                    MethodType.methodType(int.class, int.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    // Using batch size since we really need a per-invocation setup
+    // but the measured code is too fast. Using JMH batch size doesn't work
+    // since there is no way to do a batch-level setup as well.
+    private static final int BATCH_SIZE = 1_000_000;
+
+    @Param({
+        "5",
+        "10",
+        "25",
+        "50",
+        "100"
+    })
+    public int numCases;
+
+
+    @Param({
+        "0",
+        "150"
+    })
+    public int offset;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Throwable {
+        MethodHandle[] cases = IntStream.range(0, numCases)
+                .mapToObj(i -> MethodHandles.insertArguments(MH_PAYLOAD, 1, i))
+                .toArray(MethodHandle[]::new);
+        MethodHandle switcher = MethodHandles.tableSwitch(MH_DEFAULT, cases);
+        if (offset != 0) {
+            switcher = MethodHandles.filterArguments(switcher, 0, MethodHandles.insertArguments(MH_SUBTRACT, 1, offset));
+        }
+        cs.setTarget(switcher);
+
+        int input = ThreadLocalRandom.current().nextInt(numCases) + offset;
+        csInput.setTarget(MethodHandles.constant(int.class, input));
+    }
+
+    private static int payload(int dropped, int constant) {
+        return constant;
+    }
+
+    private static int subtract(int a, int b) {
+        return a - b;
+    }
+
+    private static int defaultCase(int x) {
+        throw new IllegalStateException();
+    }
+
+    @Benchmark
+    public void testSwitch(Blackhole bh) throws Throwable {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume((int) target.invokeExact((int) targetInput.invokeExact()));
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchConstant.java
@@ -87,9 +87,7 @@ public class MethodHandlesTableSwitchConstant {
     @Param({
         "5",
         "10",
-        "25",
-        "50",
-        "100"
+        "25"
     })
     public int numCases;
 

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchOpaqueSingle.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchOpaqueSingle.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class MethodHandlesTableSwitchOpaqueSingle {
+
+    // Switch combinator test for a single input index, but opaquely fed in, so the JIT
+    // does not see it as a constant.
+
+    private static final MethodType callType = MethodType.methodType(int.class, int.class);
+
+    private static final MutableCallSite cs = new MutableCallSite(callType);
+    private static final MethodHandle target = cs.dynamicInvoker();
+
+    private static final MethodHandle MH_SUBTRACT;
+    private static final MethodHandle MH_DEFAULT;
+    private static final MethodHandle MH_PAYLOAD;
+
+    static {
+        try {
+            MH_SUBTRACT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "subtract",
+                    MethodType.methodType(int.class, int.class, int.class));
+            MH_DEFAULT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "defaultCase",
+                    MethodType.methodType(int.class, int.class));
+            MH_PAYLOAD = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "payload",
+                    MethodType.methodType(int.class, int.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    // Using batch size since we really need a per-invocation setup
+    // but the measured code is too fast. Using JMH batch size doesn't work
+    // since there is no way to do a batch-level setup as well.
+    private static final int BATCH_SIZE = 1_000_000;
+
+    @Param({
+        "5",
+        "10",
+        "25",
+        "50",
+        "100"
+    })
+    public int numCases;
+
+    @Param({
+        "0",
+        "150"
+    })
+    public int offset;
+
+    public int input;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Throwable {
+        MethodHandle[] cases = IntStream.range(0, numCases)
+                .mapToObj(i -> MethodHandles.insertArguments(MH_PAYLOAD, 1, i))
+                .toArray(MethodHandle[]::new);
+        MethodHandle switcher = MethodHandles.tableSwitch(MH_DEFAULT, cases);
+        if (offset != 0) {
+            switcher = MethodHandles.filterArguments(switcher, 0, MethodHandles.insertArguments(MH_SUBTRACT, 1, offset));
+        }
+        cs.setTarget(switcher);
+
+        input = ThreadLocalRandom.current().nextInt(numCases) + offset;
+    }
+
+    private static int payload(int dropped, int constant) {
+        return constant;
+    }
+
+    private static int subtract(int a, int b) {
+        return a - b;
+    }
+
+    private static int defaultCase(int x) {
+        throw new IllegalStateException();
+    }
+
+    @Benchmark
+    public void testSwitch(Blackhole bh) throws Throwable {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume((int) target.invokeExact(input));
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchOpaqueSingle.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchOpaqueSingle.java
@@ -59,14 +59,11 @@ public class MethodHandlesTableSwitchOpaqueSingle {
     private static final MutableCallSite cs = new MutableCallSite(callType);
     private static final MethodHandle target = cs.dynamicInvoker();
 
-    private static final MethodHandle MH_SUBTRACT;
     private static final MethodHandle MH_DEFAULT;
     private static final MethodHandle MH_PAYLOAD;
 
     static {
         try {
-            MH_SUBTRACT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "subtract",
-                    MethodType.methodType(int.class, int.class, int.class));
             MH_DEFAULT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "defaultCase",
                     MethodType.methodType(int.class, int.class));
             MH_PAYLOAD = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchOpaqueSingle.class, "payload",
@@ -84,17 +81,9 @@ public class MethodHandlesTableSwitchOpaqueSingle {
     @Param({
         "5",
         "10",
-        "25",
-        "50",
-        "100"
+        "25"
     })
     public int numCases;
-
-    @Param({
-        "0",
-        "150"
-    })
-    public int offset;
 
     public int input;
 
@@ -104,20 +93,13 @@ public class MethodHandlesTableSwitchOpaqueSingle {
                 .mapToObj(i -> MethodHandles.insertArguments(MH_PAYLOAD, 1, i))
                 .toArray(MethodHandle[]::new);
         MethodHandle switcher = MethodHandles.tableSwitch(MH_DEFAULT, cases);
-        if (offset != 0) {
-            switcher = MethodHandles.filterArguments(switcher, 0, MethodHandles.insertArguments(MH_SUBTRACT, 1, offset));
-        }
         cs.setTarget(switcher);
 
-        input = ThreadLocalRandom.current().nextInt(numCases) + offset;
+        input = ThreadLocalRandom.current().nextInt(numCases);
     }
 
     private static int payload(int dropped, int constant) {
         return constant;
-    }
-
-    private static int subtract(int a, int b) {
-        return a - b;
     }
 
     private static int defaultCase(int x) {

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchRandom.java
@@ -59,14 +59,11 @@ public class MethodHandlesTableSwitchRandom {
     private static final MutableCallSite cs = new MutableCallSite(callType);
     private static final MethodHandle target = cs.dynamicInvoker();
 
-    private static final MethodHandle MH_SUBTRACT;
     private static final MethodHandle MH_DEFAULT;
     private static final MethodHandle MH_PAYLOAD;
 
     static {
         try {
-            MH_SUBTRACT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "subtract",
-                    MethodType.methodType(int.class, int.class, int.class));
             MH_DEFAULT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "defaultCase",
                     MethodType.methodType(int.class, int.class));
             MH_PAYLOAD = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "payload",
@@ -84,17 +81,9 @@ public class MethodHandlesTableSwitchRandom {
     @Param({
         "5",
         "10",
-        "25",
-        "50",
-        "100"
+        "25"
     })
     public int numCases;
-
-    @Param({
-        "0",
-        "150"
-    })
-    public int offset;
 
     @Param({
         "true",
@@ -110,16 +99,13 @@ public class MethodHandlesTableSwitchRandom {
                         .mapToObj(i -> MethodHandles.insertArguments(MH_PAYLOAD, 1, i))
                         .toArray(MethodHandle[]::new);
         MethodHandle switcher = MethodHandles.tableSwitch(MH_DEFAULT, cases);
-        if (offset != 0) {
-            switcher = MethodHandles.filterArguments(switcher, 0, MethodHandles.insertArguments(MH_SUBTRACT, 1, offset));
-        }
 
         cs.setTarget(switcher);
 
         inputs = new int[BATCH_SIZE];
         Random rand = new Random(0);
         for (int i = 0; i < BATCH_SIZE; i++) {
-            inputs[i] = rand.nextInt(numCases) + offset;
+            inputs[i] = rand.nextInt(numCases);
         }
 
         if (sorted) {
@@ -129,10 +115,6 @@ public class MethodHandlesTableSwitchRandom {
 
     private static int payload(int dropped, int constant) {
         return constant;
-    }
-
-    private static int subtract(int a, int b) {
-        return a - b;
     }
 
     private static int defaultCase(int x) {

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesTableSwitchRandom.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class MethodHandlesTableSwitchRandom {
+
+    // Switch combinator test for a random input index, testing several switch sizes
+
+    private static final MethodType callType = MethodType.methodType(int.class, int.class);
+
+    private static final MutableCallSite cs = new MutableCallSite(callType);
+    private static final MethodHandle target = cs.dynamicInvoker();
+
+    private static final MethodHandle MH_SUBTRACT;
+    private static final MethodHandle MH_DEFAULT;
+    private static final MethodHandle MH_PAYLOAD;
+
+    static {
+        try {
+            MH_SUBTRACT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "subtract",
+                    MethodType.methodType(int.class, int.class, int.class));
+            MH_DEFAULT = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "defaultCase",
+                    MethodType.methodType(int.class, int.class));
+            MH_PAYLOAD = MethodHandles.lookup().findStatic(MethodHandlesTableSwitchRandom.class, "payload",
+                    MethodType.methodType(int.class, int.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    // Using batch size since we really need a per-invocation setup
+    // but the measured code is too fast. Using JMH batch size doesn't work
+    // since there is no way to do a batch-level setup as well.
+    private static final int BATCH_SIZE = 1_000_000;
+
+    @Param({
+        "5",
+        "10",
+        "25",
+        "50",
+        "100"
+    })
+    public int numCases;
+
+    @Param({
+        "0",
+        "150"
+    })
+    public int offset;
+
+    @Param({
+        "true",
+        "false"
+    })
+    public boolean sorted;
+
+    public int[] inputs;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws Throwable {
+        MethodHandle[] cases = IntStream.range(0, numCases)
+                        .mapToObj(i -> MethodHandles.insertArguments(MH_PAYLOAD, 1, i))
+                        .toArray(MethodHandle[]::new);
+        MethodHandle switcher = MethodHandles.tableSwitch(MH_DEFAULT, cases);
+        if (offset != 0) {
+            switcher = MethodHandles.filterArguments(switcher, 0, MethodHandles.insertArguments(MH_SUBTRACT, 1, offset));
+        }
+
+        cs.setTarget(switcher);
+
+        inputs = new int[BATCH_SIZE];
+        Random rand = new Random(0);
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            inputs[i] = rand.nextInt(numCases) + offset;
+        }
+
+        if (sorted) {
+            Arrays.sort(inputs);
+        }
+    }
+
+    private static int payload(int dropped, int constant) {
+        return constant;
+    }
+
+    private static int subtract(int a, int b) {
+        return a - b;
+    }
+
+    private static int defaultCase(int x) {
+        throw new IllegalStateException();
+    }
+
+    @Benchmark
+    public void testSwitch(Blackhole bh) throws Throwable {
+        for (int i = 0; i < inputs.length; i++) {
+            bh.consume((int) target.invokeExact(inputs[i]));
+        }
+    }
+
+}


### PR DESCRIPTION
This patch adds a `tableSwitch` combinator that can be used to switch over a set of method handles given an index, with a fallback in case the index is out of bounds, much like the `tableswitch` bytecode. Here is a description of how it works (copied from the javadoc):

     Creates a table switch method handle, which can be used to switch over a set of target
     method handles, based on a given target index, called selector.

     For a selector value of {@code n}, where {@code n} falls in the range {@code [0, N)},
     and where {@code N} is the number of target method handles, the table switch method
     handle will invoke the n-th target method handle from the list of target method handles.

     For a selector value that does not fall in the range {@code [0, N)}, the table switch
     method handle will invoke the given fallback method handle.

     All method handles passed to this method must have the same type, with the additional
     requirement that the leading parameter be of type {@code int}. The leading parameter
     represents the selector.

     Any trailing parameters present in the type will appear on the returned table switch
     method handle as well. Any arguments assigned to these parameters will be forwarded,
     together with the selector value, to the selected method handle when invoking it.

The combinator does not support specifying the starting index, so the switch cases always run from 0 to however many target handles are specified. A starting index can be added manually with another combination step that filters the input index by adding or subtracting a constant from it, which does not affect performance. One of the reasons for not supporting a starting index is that it allows for more lambda form sharing, but also simplifies the implementation somewhat. I guess an open question is if a convenience overload should be added for that case?

Lookup switch can also be simulated by filtering the input through an injection function that translates it into a case index, which has also proven to have the ability to have comparable performance to, or even better performance than, a bytecode-native `lookupswitch` instruction. I plan to add such an injection function to the runtime libraries in the future as well. Maybe at that point it could be evaluated if it's worth it to add a lookup switch combinator as well, but I don't see an immediate need to include it in this patch.

The current bytecode intrinsification generates a call for each switch case, which guarantees full inlining of the target method handles. Alternatively we could only have 1 callsite at the end of the switch, where each case just loads the target method handle, but currently this does not allow for inlining of the handles, since they are not constant.

Maybe a future C2 optimization could look at the receiver input for invokeBasic call sites, and if the input is a phi node, clone the call for each constant input of the phi. I believe that would allow simplifying the bytecode without giving up on inlining.

Some numbers from the added benchmarks:
```
Benchmark                                        (numCases)  (offset)  (sorted)  Mode  Cnt   Score   Error  Units
MethodHandlesTableSwitchConstant.testSwitch               5         0       N/A  avgt   30   4.186 � 0.054  ms/op
MethodHandlesTableSwitchConstant.testSwitch               5       150       N/A  avgt   30   4.164 � 0.057  ms/op
MethodHandlesTableSwitchConstant.testSwitch              10         0       N/A  avgt   30   4.124 � 0.023  ms/op
MethodHandlesTableSwitchConstant.testSwitch              10       150       N/A  avgt   30   4.126 � 0.025  ms/op
MethodHandlesTableSwitchConstant.testSwitch              25         0       N/A  avgt   30   4.137 � 0.042  ms/op
MethodHandlesTableSwitchConstant.testSwitch              25       150       N/A  avgt   30   4.113 � 0.016  ms/op
MethodHandlesTableSwitchConstant.testSwitch              50         0       N/A  avgt   30   4.118 � 0.028  ms/op
MethodHandlesTableSwitchConstant.testSwitch              50       150       N/A  avgt   30   4.127 � 0.019  ms/op
MethodHandlesTableSwitchConstant.testSwitch             100         0       N/A  avgt   30   4.116 � 0.013  ms/op
MethodHandlesTableSwitchConstant.testSwitch             100       150       N/A  avgt   30   4.121 � 0.020  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch           5         0       N/A  avgt   30   4.113 � 0.009  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch           5       150       N/A  avgt   30   4.149 � 0.041  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          10         0       N/A  avgt   30   4.121 � 0.026  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          10       150       N/A  avgt   30   4.113 � 0.021  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          25         0       N/A  avgt   30   4.129 � 0.028  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          25       150       N/A  avgt   30   4.105 � 0.019  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          50         0       N/A  avgt   30   4.097 � 0.021  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch          50       150       N/A  avgt   30   4.131 � 0.037  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch         100         0       N/A  avgt   30   4.135 � 0.025  ms/op
MethodHandlesTableSwitchOpaqueSingle.testSwitch         100       150       N/A  avgt   30   4.139 � 0.145  ms/op
MethodHandlesTableSwitchRandom.testSwitch                 5         0      true  avgt   30   4.894 � 0.028  ms/op
MethodHandlesTableSwitchRandom.testSwitch                 5         0     false  avgt   30  11.526 � 0.194  ms/op
MethodHandlesTableSwitchRandom.testSwitch                 5       150      true  avgt   30   4.882 � 0.025  ms/op
MethodHandlesTableSwitchRandom.testSwitch                 5       150     false  avgt   30  11.532 � 0.034  ms/op
MethodHandlesTableSwitchRandom.testSwitch                10         0      true  avgt   30   5.065 � 0.076  ms/op
MethodHandlesTableSwitchRandom.testSwitch                10         0     false  avgt   30  13.016 � 0.020  ms/op
MethodHandlesTableSwitchRandom.testSwitch                10       150      true  avgt   30   5.103 � 0.051  ms/op
MethodHandlesTableSwitchRandom.testSwitch                10       150     false  avgt   30  12.984 � 0.102  ms/op
MethodHandlesTableSwitchRandom.testSwitch                25         0      true  avgt   30   8.441 � 0.165  ms/op
MethodHandlesTableSwitchRandom.testSwitch                25         0     false  avgt   30  13.371 � 0.060  ms/op
MethodHandlesTableSwitchRandom.testSwitch                25       150      true  avgt   30   8.628 � 0.032  ms/op
MethodHandlesTableSwitchRandom.testSwitch                25       150     false  avgt   30  13.542 � 0.020  ms/op
MethodHandlesTableSwitchRandom.testSwitch                50         0      true  avgt   30   4.701 � 0.015  ms/op
MethodHandlesTableSwitchRandom.testSwitch                50         0     false  avgt   30  13.562 � 0.063  ms/op
MethodHandlesTableSwitchRandom.testSwitch                50       150      true  avgt   30   7.991 � 3.111  ms/op
MethodHandlesTableSwitchRandom.testSwitch                50       150     false  avgt   30  13.543 � 0.088  ms/op
MethodHandlesTableSwitchRandom.testSwitch               100         0      true  avgt   30   4.712 � 0.020  ms/op
MethodHandlesTableSwitchRandom.testSwitch               100         0     false  avgt   30  13.600 � 0.085  ms/op
MethodHandlesTableSwitchRandom.testSwitch               100       150      true  avgt   30   4.676 � 0.011  ms/op
MethodHandlesTableSwitchRandom.testSwitch               100       150     false  avgt   30  13.476 � 0.043  ms/op
```

Testing:
- [x] Running of included benchmarks
- [x] Inspecting inlining trace and verifying method handle targets are inlined
- [x] Running TestTableSwitch test (currently the only user of the new code)
- [x] Running java/lang/invoke tests (just in case)
- [x] Some manual testing

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263087](https://bugs.openjdk.java.net/browse/JDK-8263087): Add a MethodHandle combinator that switches over a set of MethodHandles


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 80a706f1db7aef09830ae82b8bea0652c940fc55


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3401/head:pull/3401` \
`$ git checkout pull/3401`

Update a local copy of the PR: \
`$ git checkout pull/3401` \
`$ git pull https://git.openjdk.java.net/jdk pull/3401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3401`

View PR using the GUI difftool: \
`$ git pr show -t 3401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3401.diff">https://git.openjdk.java.net/jdk/pull/3401.diff</a>

</details>
