### PR TITLE
8264948: Check for TLS extensions total length

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
@@ -54,7 +54,19 @@ final class SSLExtensions {
             ByteBuffer m, SSLExtension[] extensions) throws IOException {
         this.handshakeMessage = hm;
 
+        if (m.remaining() < 2) {
+            throw hm.handshakeContext.conContext.fatal(
+                    Alert.ILLEGAL_PARAMETER,
+                    "Incorrect extensions: no length field");
+        }
+
         int len = Record.getInt16(m);
+        if (len > m.remaining()) {
+            throw hm.handshakeContext.conContext.fatal(
+                    Alert.ILLEGAL_PARAMETER,
+                    "Insufficient extensions data");
+        }
+
         encodedLength = len + 2;        // 2: the length of the extensions.
         while (len > 0) {
             int extId = Record.getInt16(m);

--- a/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
@@ -56,14 +56,14 @@ final class SSLExtensions {
 
         if (m.remaining() < 2) {
             throw hm.handshakeContext.conContext.fatal(
-                    Alert.ILLEGAL_PARAMETER,
+                    Alert.DECODE_ERROR,
                     "Incorrect extensions: no length field");
         }
 
         int len = Record.getInt16(m);
         if (len > m.remaining()) {
             throw hm.handshakeContext.conContext.fatal(
-                    Alert.ILLEGAL_PARAMETER,
+                    Alert.DECODE_ERROR,
                     "Insufficient extensions data");
         }
 
@@ -73,7 +73,7 @@ final class SSLExtensions {
             int extLen = Record.getInt16(m);
             if (extLen > m.remaining()) {
                 throw hm.handshakeContext.conContext.fatal(
-                        Alert.ILLEGAL_PARAMETER,
+                        Alert.DECODE_ERROR,
                         "Error parsing extension (" + extId +
                         "): no sufficient data");
             }


### PR DESCRIPTION
To improve the readability, it would be nice to check the TLS extensions total length while parsing.

No new regression test,  trial update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264948](https://bugs.openjdk.java.net/browse/JDK-8264948): Check for TLS extensions total length


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3405/head:pull/3405` \
`$ git checkout pull/3405`

Update a local copy of the PR: \
`$ git checkout pull/3405` \
`$ git pull https://git.openjdk.java.net/jdk pull/3405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3405`

View PR using the GUI difftool: \
`$ git pr show -t 3405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3405.diff">https://git.openjdk.java.net/jdk/pull/3405.diff</a>

</details>
