### PR TITLE
8080185:  [TESTBUG] Test instructions need to be updated for test java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -850,7 +850,6 @@ java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
-java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html 8080185 macosx-all,linux-all
 javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
 java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java 8163086 macosx-all

--- a/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html
+++ b/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
   @test
   @bug 6242241
   @summary Tests basic DnD functionality in an applet
+  @requires (os.family == "windows")
   @author Your Name: Alexey Utkin area=dnd
   @run applet/manual=yesno DnDFileGroupDescriptor.html
   -->

--- a/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
+++ b/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
@@ -39,7 +39,7 @@ public class DnDFileGroupDescriptor extends Applet {
 
         String[] instructions = {
          "The applet window contains a red field.",
-         "1. Start MS Outlook program. Find and open "
+         "1. Start MS Outlook program. Find and open ",
          "   the mail form with attachments.",
          "2. Select attachments from the mail and drag into a red field of applet.",
          "   When the mouse enters the field during the drag, the application ",

--- a/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
+++ b/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
@@ -1,5 +1,5 @@
  /*
-  * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+  * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
   * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
   *
   * This code is free software; you can redistribute it and/or modify it
@@ -39,9 +39,7 @@ public class DnDFileGroupDescriptor extends Applet {
 
         String[] instructions = {
          "The applet window contains a red field.",
-         "1. Start MS Outlook program. Find and open ",
-         "   the mail form with attachments.",
-         "2. Select attachments from the mail and drag into a red field of applet.",
+         "1. Select any file from File Explorer and drag into a red field of applet.",
          "   When the mouse enters the field during the drag, the application ",
          "   should change the cursor form to OLE-copy and field color to yellow.",
          "3. Release the mouse button (drop attachments) over the field.",

--- a/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
+++ b/test/jdk/java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.java
@@ -39,7 +39,9 @@ public class DnDFileGroupDescriptor extends Applet {
 
         String[] instructions = {
          "The applet window contains a red field.",
-         "1. Select any file from File Explorer and drag into a red field of applet.",
+         "1. Start MS Outlook program. Find and open "
+         "   the mail form with attachments.",
+         "2. Select attachments from the mail and drag into a red field of applet.",
          "   When the mouse enters the field during the drag, the application ",
          "   should change the cursor form to OLE-copy and field color to yellow.",
          "3. Release the mouse button (drop attachments) over the field.",


### PR DESCRIPTION
This testcase was a regression testcase for a windows bug JDK-6242241 whereby dragging an attachment from a Microsoft Outlook message to the application results in blank or semicolons.
The testcase was later made applicable to windows only by JDK-7147083 
http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/d8efcad28072
so we can remove the test from Problemlist which is problemlisted for linux and mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8080185](https://bugs.openjdk.java.net/browse/JDK-8080185): [TESTBUG] Test instructions need to be updated for test java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 1c023abaa6b6644724fe76ce9aa738c2ce86f7c5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3406/head:pull/3406` \
`$ git checkout pull/3406`

Update a local copy of the PR: \
`$ git checkout pull/3406` \
`$ git pull https://git.openjdk.java.net/jdk pull/3406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3406`

View PR using the GUI difftool: \
`$ git pr show -t 3406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3406.diff">https://git.openjdk.java.net/jdk/pull/3406.diff</a>

</details>
