### PR TITLE
8264954: unified handling for VectorMask object re-materialization during de-optimization

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -267,11 +267,7 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
     // logic for both predicated and non-predicated targets.
     bool is_mask = is_vector_mask(iklass);
     if (is_mask) {
-      if (vec_value->Opcode() == Op_VectorLoadMask) {
-        const Type* in1_ty = vec_value->in(1)->bottom_type();
-        assert(in1_ty->isa_vect() && in1_ty->is_vect()->element_basic_type() == T_BOOLEAN, "");
-        vec_value = vec_value->in(1);
-      } else if (vec_value->Opcode() != Op_VectorStoreMask) {
+      if (vec_value->Opcode() != Op_VectorStoreMask) {
         const TypeVect* vt = vec_value->bottom_type()->is_vect();
         BasicType bt = vt->element_basic_type();
         vec_value = gvn.transform(VectorStoreMaskNode::make(gvn, vec_value, bt, vt->length()));

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -263,15 +263,14 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
     sobj->init_req(0, C->root());
 
     // If a mask is feeding into a safepoint, then its value should be
-    // packed into a byte vector first, this will simplify the re-materialization
-    // logic for both predicated and non-predicated targets.
+    // packed into a boolean/byte vector first, this will simplify the
+    // re-materialization logic for both predicated and non-predicated
+    // targets.
     bool is_mask = is_vector_mask(iklass);
-    if (is_mask) {
-      if (vec_value->Opcode() != Op_VectorStoreMask) {
-        const TypeVect* vt = vec_value->bottom_type()->is_vect();
-        BasicType bt = vt->element_basic_type();
-        vec_value = gvn.transform(VectorStoreMaskNode::make(gvn, vec_value, bt, vt->length()));
-      }
+    if (is_mask && vec_value->Opcode() != Op_VectorStoreMask) {
+      const TypeVect* vt = vec_value->bottom_type()->is_vect();
+      BasicType bt = vt->element_basic_type();
+      vec_value = gvn.transform(VectorStoreMaskNode::make(gvn, vec_value, bt, vt->length()));
     }
     sfpt->add_req(vec_value);
 

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -65,6 +65,8 @@ BasicType VectorSupport::klass2bt(InstanceKlass* ik) {
 
   if (is_vector_shuffle(ik)) {
     return T_BYTE;
+  } else if (is_vector_mask(ik)) {
+    return T_BOOLEAN;
   } else { // vector and mask
     oop value = ik->java_mirror()->obj_field(fd.offset());
     BasicType elem_bt = java_lang_Class::as_BasicType(value);
@@ -86,45 +88,36 @@ jint VectorSupport::klass2length(InstanceKlass* ik) {
   return vlen;
 }
 
-void VectorSupport::init_payload_element(typeArrayOop arr, bool is_mask, BasicType elem_bt, int index, address addr) {
-  if (is_mask) {
-    switch (elem_bt) {
-      case T_BYTE:
-      case T_SHORT:
-      case T_INT:
-      case T_LONG:
-      case T_FLOAT:
-      case T_DOUBLE: arr->bool_at_put(index,  (*(jbyte*)addr) != 0); break;
+// Masks require special handling: when boxed they are packed and stored in boolean
+// arrays, but in scalarized form they have the same size as corresponding vectors.
+// For example, Int512Mask is represented in memory as boolean[16], but
+// occupies the whole 512-bit vector register when scalarized.
+// During scalarization inserting a VectorStoreMask node between mask
+// and safepoint node always ensures the existence of masks in a boolean array.
+//
+// TODO: revisit when predicate registers are fully supported.
+//
+void VectorSupport::init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr) {
+  switch (elem_bt) {
+    case T_BOOLEAN:
+    case T_BYTE:   arr->  byte_at_put(index,   *(jbyte*)addr); break;
+    case T_SHORT:  arr-> short_at_put(index,  *(jshort*)addr); break;
+    case T_INT:    arr->   int_at_put(index,    *(jint*)addr); break;
+    case T_FLOAT:  arr-> float_at_put(index,  *(jfloat*)addr); break;
+    case T_LONG:   arr->  long_at_put(index,   *(jlong*)addr); break;
+    case T_DOUBLE: arr->double_at_put(index, *(jdouble*)addr); break;
 
-      default: fatal("unsupported: %s", type2name(elem_bt));
-    }
-  } else {
-    switch (elem_bt) {
-      case T_BYTE:   arr->  byte_at_put(index,   *(jbyte*)addr); break;
-      case T_SHORT:  arr-> short_at_put(index,  *(jshort*)addr); break;
-      case T_INT:    arr->   int_at_put(index,    *(jint*)addr); break;
-      case T_FLOAT:  arr-> float_at_put(index,  *(jfloat*)addr); break;
-      case T_LONG:   arr->  long_at_put(index,   *(jlong*)addr); break;
-      case T_DOUBLE: arr->double_at_put(index, *(jdouble*)addr); break;
-
-      default: fatal("unsupported: %s", type2name(elem_bt));
-    }
+    default: fatal("unsupported: %s", type2name(elem_bt));
   }
 }
 
 Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, Location location, TRAPS) {
-  bool is_mask = is_vector_mask(ik);
-
   int num_elem = klass2length(ik);
   BasicType elem_bt = klass2bt(ik);
-  // Inserting a VectorStoreMask before stitching the mask
-  // to SafePointNode will ensure packing the mask into a
-  // byte array for masks present in both predicated register
-  // or vector registers.
-  int elem_size = is_mask ? 1 : type2aelembytes(elem_bt);
+  int elem_size = type2aelembytes(elem_bt);
 
   // On-heap vector values are represented as primitive arrays.
-  TypeArrayKlass* tak = TypeArrayKlass::cast(Universe::typeArrayKlassObj(is_mask ? T_BOOLEAN : elem_bt));
+  TypeArrayKlass* tak = TypeArrayKlass::cast(Universe::typeArrayKlassObj(elem_bt));
 
   typeArrayOop arr = tak->allocate(num_elem, CHECK_NH); // safepoint
 
@@ -137,13 +130,13 @@ Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* f
       int off   = (i * elem_size) % VMRegImpl::stack_slot_size;
 
       address elem_addr = reg_map->location(vreg, vslot) + off; // assumes little endian element order
-      init_payload_element(arr, is_mask, elem_bt, i, elem_addr);
+      init_payload_element(arr, elem_bt, i, elem_addr);
     }
   } else {
     // Value was directly saved on the stack.
     address base_addr = ((address)fr->unextended_sp()) + location.stack_offset();
     for (int i = 0; i < num_elem; i++) {
-      init_payload_element(arr, is_mask, elem_bt, i, base_addr + i * elem_size);
+      init_payload_element(arr, elem_bt, i, base_addr + i * elem_size);
     }
   }
   return Handle(THREAD, arr);

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -94,12 +94,10 @@ jint VectorSupport::klass2length(InstanceKlass* ik) {
 // occupies the whole 512-bit vector register when scalarized.
 // During scalarization inserting a VectorStoreMask node between mask
 // and safepoint node always ensures the existence of masks in a boolean array.
-//
-// TODO: revisit when predicate registers are fully supported.
-//
+
 void VectorSupport::init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr) {
   switch (elem_bt) {
-    case T_BOOLEAN:
+    case T_BOOLEAN: arr->  byte_at_put(index,   *(jboolean*)addr); break;
     case T_BYTE:   arr->  byte_at_put(index,   *(jbyte*)addr); break;
     case T_SHORT:  arr-> short_at_put(index,  *(jshort*)addr); break;
     case T_INT:    arr->   int_at_put(index,    *(jint*)addr); break;

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -42,7 +42,7 @@ class VectorSupport : AllStatic {
   static Handle allocate_vector_payload(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ScopeValue* payload, TRAPS);
   static Handle allocate_vector_payload_helper(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, Location location, TRAPS);
 
-  static void init_payload_element(typeArrayOop arr, bool is_mask, BasicType elem_bt, int index, address addr);
+  static void init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr);
 
   static BasicType klass2bt(InstanceKlass* ik);
   static jint klass2length(InstanceKlass* ik);


### PR DESCRIPTION
Following flow describes object reconstruction for de-optimization:-
1)	PhaseVector::scalarize_vbox_node() creates SafePointScalarObjectNode to captures the box type information, also it connects to node holding the boxed value.
2)	During code emit phase (PhaseOutput) C2 process above information to dumps ObjectValue holding the box information and LocationValue to holding the value information into ScopeDescriptor corresponding to Safepoint PC.
3)	De-optimization blobs dump the value held in registers to the stack locations using RegisterSave::save_live_registers() and a mapping b/w register and its stack location is added to RegisterMap.
4)	During de-optimization, compiled frame objects are re-allocated using identity information held in ObjectValue and their fields are initialized using values held in the stack locations accessed through register-stack mappings. 

By inserting a VectorStoreMaskNode before stitching the mask holding node to Safepoint we make sure that value held in opmask/vector register is transferred to a byte vector. Thus rest of the flow works as it is, stack location will hold the value in the form of a byte array irrespective of the box shape.

tier1-tier3 regressions are clean with UseAVX=2/3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264954](https://bugs.openjdk.java.net/browse/JDK-8264954): unified handling for VectorMask object re-materialization during de-optimization


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 239923fd891a84545b7b6a0c71355d2927e7f827


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3408/head:pull/3408` \
`$ git checkout pull/3408`

Update a local copy of the PR: \
`$ git checkout pull/3408` \
`$ git pull https://git.openjdk.java.net/jdk pull/3408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3408`

View PR using the GUI difftool: \
`$ git pr show -t 3408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3408.diff">https://git.openjdk.java.net/jdk/pull/3408.diff</a>

</details>
