### PR TITLE
8264976: Minor numeric bug in AbstractSplittableWithBrineGenerator.makeSplitsSpliterator

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2436,7 +2436,7 @@ public class RandomSupport {
             // designed to work even if SALT_SHIFT does not evenly divide 64
             // (the number of bits in a long value).
             long bits = nextLong();
-            long multiplier = (1 << SALT_SHIFT) - 1;
+            long multiplier = (1L << SALT_SHIFT) - 1;
             long salt = multiplier << (64 - SALT_SHIFT);
             while ((salt & multiplier) != 0) {
                 long digit = Math.multiplyHigh(bits, multiplier);


### PR DESCRIPTION
SonarCloud reports:
  Cast one of the operands of this subtraction operation to a "long".

Here:
```
        Spliterator<SplittableGenerator> makeSplitsSpliterator(long index, long fence, SplittableGenerator source) {
            ...
            long multiplier = (1 << SALT_SHIFT) - 1; // <---- here
```

The shift is integer, and the implicit cast to `long` happens too late. `SALT_SHIFT` is currently 4, so this is not the problem yet. But it would become a problem if `SALT_SHIFT` ever becomes 32 or larger. The shift operand should be `1L` for safety. Observe:

```
jshell> Long.toHexString((1 << 31) - 1)
$2 ==> "7fffffff"

jshell> Long.toHexString((1 << 32) - 1)
$3 ==> "0"

jshell> Long.toHexString((1L << 32) - 1)
$4 ==> "ffffffff"
```

Additional testing: 
 - [x] Linux x86_64 fastdebug, `jdk/utils/Random`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264976](https://bugs.openjdk.java.net/browse/JDK-8264976): Minor numeric bug in AbstractSplittableWithBrineGenerator.makeSplitsSpliterator


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3409/head:pull/3409` \
`$ git checkout pull/3409`

Update a local copy of the PR: \
`$ git checkout pull/3409` \
`$ git pull https://git.openjdk.java.net/jdk pull/3409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3409`

View PR using the GUI difftool: \
`$ git pr show -t 3409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3409.diff">https://git.openjdk.java.net/jdk/pull/3409.diff</a>

</details>
