### PR TITLE
8264957: Cleanup unused array Type::dual_type

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -993,48 +993,6 @@ const Type *Type::filter_helper(const Type *kills, bool include_speculative) con
 }
 
 //------------------------------xdual------------------------------------------
-// Compute dual right now.
-const Type::TYPES Type::dual_type[Type::lastype] = {
-  Bad,          // Bad
-  Control,      // Control
-  Bottom,       // Top
-  Bad,          // Int - handled in v-call
-  Bad,          // Long - handled in v-call
-  Half,         // Half
-  Bad,          // NarrowOop - handled in v-call
-  Bad,          // NarrowKlass - handled in v-call
-
-  Bad,          // Tuple - handled in v-call
-  Bad,          // Array - handled in v-call
-  Bad,          // VectorMask - handled in v-call
-  Bad,          // VectorA - handled in v-call
-  Bad,          // VectorS - handled in v-call
-  Bad,          // VectorD - handled in v-call
-  Bad,          // VectorX - handled in v-call
-  Bad,          // VectorY - handled in v-call
-  Bad,          // VectorZ - handled in v-call
-
-  Bad,          // AnyPtr - handled in v-call
-  Bad,          // RawPtr - handled in v-call
-  Bad,          // OopPtr - handled in v-call
-  Bad,          // InstPtr - handled in v-call
-  Bad,          // AryPtr - handled in v-call
-
-  Bad,          //  MetadataPtr - handled in v-call
-  Bad,          // KlassPtr - handled in v-call
-
-  Bad,          // Function - handled in v-call
-  Abio,         // Abio
-  Return_Address,// Return_Address
-  Memory,       // Memory
-  FloatBot,     // FloatTop
-  FloatCon,     // FloatCon
-  FloatTop,     // FloatBot
-  DoubleBot,    // DoubleTop
-  DoubleCon,    // DoubleCon
-  DoubleTop,    // DoubleBot
-  Top           // Bottom
-};
 
 const Type *Type::xdual() const {
   // Note: the base() accessor asserts the sanity of _base.

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1006,6 +1006,7 @@ const Type::TYPES Type::dual_type[Type::lastype] = {
 
   Bad,          // Tuple - handled in v-call
   Bad,          // Array - handled in v-call
+  Bad,          // VectorMask - handled in v-call
   Bad,          // VectorA - handled in v-call
   Bad,          // VectorS - handled in v-call
   Bad,          // VectorD - handled in v-call

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -163,8 +163,6 @@ private:
   // join to ensure my lattice is symmetric up and down.  Dual is computed
   // lazily, on demand, and cached in _dual.
   const Type *_dual;            // Cached dual value
-  // Table for efficient dualing of base types
-  static const TYPES dual_type[lastype];
 
 #ifdef ASSERT
   // One type is interface, the other is oop


### PR DESCRIPTION
This is a bug fix for [1] which adds a new vector mask type. The new added TYPE `"VectorMask"` is inserted into `enum TYPES`, while the array `"Type::dual_type"` is not updated. This makes the array elements are not aligned with TYPES.

I met the following crash due to this issue when I was working on the masking feature support on panama-vector:
```
 Internal Error (/home/xiagon01/code/panama-vector/src/hotspot/share/opto/type.hpp:1727), pid=104432, tid=104449
 # assert(_base >= AnyPtr && _base <= KlassPtr) failed: Not a pointer
```
Adding a value like other vector types for the `"VectorMask"` in the array `"dual_type"` can fix it.

[1] https://bugs.openjdk.java.net/browse/JDK-8262355

Tested with tier1 and jdk:tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264957](https://bugs.openjdk.java.net/browse/JDK-8264957): Cleanup unused array Type::dual_type


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3410/head:pull/3410` \
`$ git checkout pull/3410`

Update a local copy of the PR: \
`$ git checkout pull/3410` \
`$ git pull https://git.openjdk.java.net/jdk pull/3410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3410`

View PR using the GUI difftool: \
`$ git pr show -t 3410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3410.diff">https://git.openjdk.java.net/jdk/pull/3410.diff</a>

</details>
