### PR TITLE
Clarify what is returned by ByteBuffer.capacity in javadoc

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -282,7 +282,7 @@ public abstract class Buffer {
     /**
      * Returns this buffer's capacity.
      *
-     * @return  The capacity of this buffer
+     * @return  The capacity of this buffer as an amount of bytes
      */
     public final int capacity() {
         return capacity;


### PR DESCRIPTION
This is probably not needed, but it did kind of annoy me that it wasn't clarified in the documentation that the capacity is the amount of bytes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3412/head:pull/3412` \
`$ git checkout pull/3412`

Update a local copy of the PR: \
`$ git checkout pull/3412` \
`$ git pull https://git.openjdk.java.net/jdk pull/3412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3412`

View PR using the GUI difftool: \
`$ git pr show -t 3412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3412.diff">https://git.openjdk.java.net/jdk/pull/3412.diff</a>

</details>
