### PR TITLE
8264983: Add gtest for JDK-8264008

### DIFF
--- a/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
@@ -73,7 +73,7 @@ TEST_VM(MetaspaceUtils, committed_compressed_class_pointers) {
   EXPECT_LE(committed_class, committed);
 }
 
-TEST_VM(MetaspaceUtils, none_compressed_class_pointers) {
+TEST_VM(MetaspaceUtils, non_compressed_class_pointers) {
   if (UseCompressedClassPointers) {
     return;
   }

--- a/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspaceUtils.cpp
@@ -73,3 +73,18 @@ TEST_VM(MetaspaceUtils, committed_compressed_class_pointers) {
   EXPECT_LE(committed_class, committed);
 }
 
+TEST_VM(MetaspaceUtils, none_compressed_class_pointers) {
+  if (UseCompressedClassPointers) {
+    return;
+  }
+
+  size_t committed_class = MetaspaceUtils::committed_bytes(Metaspace::ClassType);
+  EXPECT_EQ(committed_class, 0UL);
+
+  size_t used_class = MetaspaceUtils::used_bytes(Metaspace::ClassType);
+  EXPECT_EQ(used_class, 0UL);
+
+  size_t reserved_class = MetaspaceUtils::reserved_bytes(Metaspace::ClassType);
+  EXPECT_EQ(reserved_class, 0UL);
+}
+

--- a/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * Note: This runs the metaspace utils related parts of gtest in configurations which
+ *  are not tested explicitly in the standard gtests.
+ *
+ */
+
+/* @test
+ * @bug 8264008
+ * @summary Run metaspace utils related gtests with compressed class pointers off
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @requires vm.flagless
+ * @run main/native GTestWrapper --gtest_filter=MetaspaceUtils* -XX:-UseCompressedClassPointers
+ */


### PR DESCRIPTION
Hi all,

Here is the gtest for JDK-8264008 as discussed here: https://github.com/openjdk/jdk/pull/3142#pullrequestreview-618244082 .
Any comments?

Testing: 
 - test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java on Linux/{x64,x86_32} and macOSX

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264983](https://bugs.openjdk.java.net/browse/JDK-8264983): Add gtest for JDK-8264008


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 314664a7267ff6f876b45fbad01c6a49910f1108


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3414/head:pull/3414` \
`$ git checkout pull/3414`

Update a local copy of the PR: \
`$ git checkout pull/3414` \
`$ git pull https://git.openjdk.java.net/jdk pull/3414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3414`

View PR using the GUI difftool: \
`$ git pr show -t 3414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3414.diff">https://git.openjdk.java.net/jdk/pull/3414.diff</a>

</details>
