### PR TITLE
8048199: Replace anonymous inner classes with lambdas, where applicable, in JNDI

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
@@ -59,9 +59,8 @@ final class LdapBindingEnumeration
         if (attrs.get(Obj.JAVA_ATTRIBUTES[Obj.CLASSNAME]) != null) {
             // serialized object or object reference
             try {
-                obj = AccessController.doPrivileged(
-                        (PrivilegedExceptionAction<Object>) () -> Obj.decodeObject(attrs), acc
-                );
+                PrivilegedExceptionAction<Object> pa = () -> Obj.decodeObject(attrs);
+                obj = AccessController.doPrivileged(pa, acc);
             } catch (PrivilegedActionException e) {
                 throw (NamingException)e.getException();
             }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java
@@ -59,12 +59,9 @@ final class LdapBindingEnumeration
         if (attrs.get(Obj.JAVA_ATTRIBUTES[Obj.CLASSNAME]) != null) {
             // serialized object or object reference
             try {
-                obj = AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws NamingException {
-                        return Obj.decodeObject(attrs);
-                    }
-                }, acc);
+                obj = AccessController.doPrivileged(
+                        (PrivilegedExceptionAction<Object>) () -> Obj.decodeObject(attrs), acc
+                );
             } catch (PrivilegedActionException e) {
                 throw (NamingException)e.getException();
             }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
@@ -395,47 +395,21 @@ public final class LdapPoolManager {
         }
     }
 
-    private static final String getProperty(final String propName,
-        final String defVal) {
+    private static final String getProperty(final String propName, final String defVal) {
         return AccessController.doPrivileged(
-            new PrivilegedAction<String>() {
-            public String run() {
-                try {
-                    return System.getProperty(propName, defVal);
-                } catch (SecurityException e) {
-                    return defVal;
-                }
-            }
-        });
+                (PrivilegedAction<String>) () -> System.getProperty(propName, defVal)
+        );
     }
 
-    private static final int getInteger(final String propName,
-        final int defVal) {
-        Integer val = AccessController.doPrivileged(
-            new PrivilegedAction<Integer>() {
-            public Integer run() {
-                try {
-                    return Integer.getInteger(propName, defVal);
-                } catch (SecurityException e) {
-                    return defVal;
-                }
-            }
-        });
-        return val.intValue();
+    private static final int getInteger(final String propName, final int defVal) {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<Integer>) () -> Integer.getInteger(propName, defVal).intValue()
+        );
     }
 
-    private static final long getLong(final String propName,
-        final long defVal) {
-        Long val = AccessController.doPrivileged(
-            new PrivilegedAction<Long>() {
-            public Long run() {
-                try {
-                    return Long.getLong(propName, defVal);
-                } catch (SecurityException e) {
-                    return defVal;
-                }
-            }
-        });
-        return val.longValue();
+    private static final long getLong(final String propName, final long defVal) {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<Long>) () -> Long.getLong(propName, defVal).longValue()
+        );
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
@@ -396,20 +396,17 @@ public final class LdapPoolManager {
     }
 
     private static final String getProperty(final String propName, final String defVal) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<String>) () -> System.getProperty(propName, defVal)
-        );
+        PrivilegedAction<String> pa = () -> System.getProperty(propName, defVal);
+        return AccessController.doPrivileged(pa);
     }
 
     private static final int getInteger(final String propName, final int defVal) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Integer>) () -> Integer.getInteger(propName, defVal).intValue()
-        );
+        PrivilegedAction<Integer> pa = () -> Integer.getInteger(propName, defVal);
+        return AccessController.doPrivileged(pa);
     }
 
     private static final long getLong(final String propName, final long defVal) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Long>) () -> Long.getLong(propName, defVal).longValue()
-        );
+        PrivilegedAction<Long> pa = () -> Long.getLong(propName, defVal);
+        return AccessController.doPrivileged(pa);
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
@@ -119,9 +119,8 @@ final class LdapSearchEnumeration
                 // Entry contains Java-object attributes (ser/ref object)
                 // serialized object or object reference
                 try {
-                    obj = AccessController.doPrivileged(
-                            (PrivilegedExceptionAction<Object>) () -> Obj.decodeObject(attrs), acc
-                    );
+                    PrivilegedExceptionAction<Object> pea = () -> Obj.decodeObject(attrs);
+                    obj = AccessController.doPrivileged(pea, acc);
                 } catch (PrivilegedActionException e) {
                     throw (NamingException)e.getException();
                 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java
@@ -119,12 +119,9 @@ final class LdapSearchEnumeration
                 // Entry contains Java-object attributes (ser/ref object)
                 // serialized object or object reference
                 try {
-                    obj = AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                        @Override
-                        public Object run() throws NamingException {
-                            return Obj.decodeObject(attrs);
-                        }
-                    }, acc);
+                    obj = AccessController.doPrivileged(
+                            (PrivilegedExceptionAction<Object>) () -> Obj.decodeObject(attrs), acc
+                    );
                 } catch (PrivilegedActionException e) {
                     throw (NamingException)e.getException();
                 }

--- a/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
@@ -220,7 +220,7 @@ public class StartTlsRequest implements ExtendedRequest {
      * Acquire the class loader associated with this thread.
      */
     private final ClassLoader getContextClassLoader() {
-        PrivilegedAction<ClassLoader> pa = () -> Thread.currentThread().getContextClassLoader();
+        PrivilegedAction<ClassLoader> pa = Thread.currentThread()::getContextClassLoader;
         return AccessController.doPrivileged(pa);
     }
 

--- a/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
@@ -221,22 +221,14 @@ public class StartTlsRequest implements ExtendedRequest {
      */
     private final ClassLoader getContextClassLoader() {
         return AccessController.doPrivileged(
-            new PrivilegedAction<ClassLoader>() {
-                public ClassLoader run() {
-                    return Thread.currentThread().getContextClassLoader();
-                }
-            }
+                (PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader()
         );
     }
 
     private static final boolean privilegedHasNext(final Iterator<StartTlsResponse> iter) {
-        Boolean answer = AccessController.doPrivileged(
-            new PrivilegedAction<Boolean>() {
-            public Boolean run() {
-                return Boolean.valueOf(iter.hasNext());
-            }
-        });
-        return answer.booleanValue();
+        return AccessController.doPrivileged(
+                (PrivilegedAction<Boolean>) iter::hasNext
+        );
     }
 
     private static final long serialVersionUID = 4441679576360753397L;

--- a/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/StartTlsRequest.java
@@ -220,15 +220,13 @@ public class StartTlsRequest implements ExtendedRequest {
      * Acquire the class loader associated with this thread.
      */
     private final ClassLoader getContextClassLoader() {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader()
-        );
+        PrivilegedAction<ClassLoader> pa = () -> Thread.currentThread().getContextClassLoader();
+        return AccessController.doPrivileged(pa);
     }
 
     private static final boolean privilegedHasNext(final Iterator<StartTlsResponse> iter) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) iter::hasNext
-        );
+        PrivilegedAction<Boolean> pa = iter::hasNext;
+        return AccessController.doPrivileged(pa);
     }
 
     private static final long serialVersionUID = 4441679576360753397L;

--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
@@ -73,21 +73,19 @@ public final class JdkLDAP extends Provider {
         super("JdkLDAP", PROVIDER_VER, "JdkLDAP Provider (implements LDAP CertStore)");
 
         final Provider p = this;
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                HashMap<String, String> attrs = new HashMap<>(2);
-                attrs.put("LDAPSchema", "RFC2587");
-                attrs.put("ImplementedIn", "Software");
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            HashMap<String, String> attrs = new HashMap<>(2);
+            attrs.put("LDAPSchema", "RFC2587");
+            attrs.put("ImplementedIn", "Software");
 
-                /*
-                 * CertStore
-                 * attrs: LDAPSchema, ImplementedIn
-                 */
-                putService(new ProviderService(p, "CertStore",
-                           "LDAP", "sun.security.provider.certpath.ldap.LDAPCertStore",
-                           null, attrs));
-                return null;
-            }
+            /*
+             * CertStore
+             * attrs: LDAPSchema, ImplementedIn
+             */
+            putService(new ProviderService(p, "CertStore",
+                       "LDAP", "sun.security.provider.certpath.ldap.LDAPCertStore",
+                       null, attrs));
+            return null;
         });
     }
 }

--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/JdkLDAP.java
@@ -73,7 +73,7 @@ public final class JdkLDAP extends Provider {
         super("JdkLDAP", PROVIDER_VER, "JdkLDAP Provider (implements LDAP CertStore)");
 
         final Provider p = this;
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        PrivilegedAction<Void> pa = () -> {
             HashMap<String, String> attrs = new HashMap<>(2);
             attrs.put("LDAPSchema", "RFC2587");
             attrs.put("ImplementedIn", "Software");
@@ -86,6 +86,7 @@ public final class JdkLDAP extends Provider {
                        "LDAP", "sun.security.provider.certpath.ldap.LDAPCertStore",
                        null, attrs));
             return null;
-        });
+        };
+        AccessController.doPrivileged(pa);
     }
 }


### PR DESCRIPTION
### Description
This fix is part of a previous effort to both cleanup/modernise JNDI code, the details of which can be seen in [JDK-8048091](https://bugs.openjdk.java.net/browse/JDK-8048091). A number JNDI methods under `java.naming` use Anonymous Inner Classes in cases where only a single object unique to the requirements of the method is used. The issues these occurrences of AICs cause are highlighted below.

### Issue
- AICs, in the cases concerned with this fix, are used where only one operation is required. While AICs can be useful for more complex implementations (using interfaces, multiple methods needed, local fields etc.), Lambdas are better suited here as they result in a more readable and concise solution.

### Fixes
- Where applicable, occurrences of AICs were replaced with lambdas to address the issues above resulting primarily in more readable/concise code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8048199](https://bugs.openjdk.java.net/browse/JDK-8048199): Replace anonymous inner classes with lambdas, where applicable, in JNDI


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 840ea35c067fde1eaa24288fe3684b0f86850b30
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 840ea35c067fde1eaa24288fe3684b0f86850b30


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3416/head:pull/3416` \
`$ git checkout pull/3416`

Update a local copy of the PR: \
`$ git checkout pull/3416` \
`$ git pull https://git.openjdk.java.net/jdk pull/3416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3416`

View PR using the GUI difftool: \
`$ git pr show -t 3416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3416.diff">https://git.openjdk.java.net/jdk/pull/3416.diff</a>

</details>
