### PR TITLE
8244190: JFR: When starting a JVM with -XX:StartFlightRecording, output is written to stdout

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -30,7 +30,12 @@
 #include "jfr/jni/jfrJavaSupport.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
+#include "logging/log.hpp"
+#include "logging/logConfiguration.hpp"
+#include "logging/logMessage.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/objArrayOop.hpp"
+#include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "runtime/handles.inline.hpp"
@@ -128,21 +133,52 @@ static bool invalid_state(outputStream* out, TRAPS) {
   return is_disabled(out) || !is_module_available(out, THREAD);
 }
 
-static void print_pending_exception(outputStream* output, oop throwable) {
+static void handle_pending_exception(outputStream* output, bool startup, oop throwable) {
   assert(throwable != NULL, "invariant");
 
   oop msg = java_lang_Throwable::message(throwable);
+  if (msg == NULL) {
+    return;
+  }
+  char* text = java_lang_String::as_utf8_string(msg);
+  if (text != NULL) {
+    if (startup) {
+      log_error(jfr,startup)("%s", text);
+    } else {
+      output->print_raw_cr(text);
+    }
+  }
+}
 
-  if (msg != NULL) {
-    char* text = java_lang_String::as_utf8_string(msg);
+static void print_message(outputStream* output, oop content, TRAPS) {
+  objArrayOop lines = objArrayOop(content);
+  assert(lines != NULL, "invariant");
+  assert(lines->is_array(), "must be array");
+  const int length = lines->length();
+  for (int i = 0; i < length; ++i) {
+    const char* text = JfrJavaSupport::c_str(lines->obj_at(i), THREAD);
+    if (text == NULL) {
+      // An oome has been thrown and is pending.
+      break;
+    }
     output->print_raw_cr(text);
   }
 }
 
-static void print_message(outputStream* output, const char* message) {
-  if (message != NULL) {
-    output->print_raw(message);
-  }
+static void log(oop content, TRAPS) {
+    LogMessage(jfr,startup) msg;
+    objArrayOop lines = objArrayOop(content);
+    assert(lines != NULL, "invariant");
+    assert(lines->is_array(), "must be array");
+    const int length = lines->length();
+    for (int i = 0; i < length; ++i) {
+      const char* text = JfrJavaSupport::c_str(lines->obj_at(i), THREAD);
+      if (text == NULL) {
+        // An oome has been thrown and is pending.
+        break;
+      }
+      msg.info("%s", text);
+    }
 }
 
 static void handle_dcmd_result(outputStream* output,
@@ -151,10 +187,11 @@ static void handle_dcmd_result(outputStream* output,
                                TRAPS) {
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
   assert(output != NULL, "invariant");
+  const bool startup = DCmd_Source_Internal == source;
   if (HAS_PENDING_EXCEPTION) {
-    print_pending_exception(output, PENDING_EXCEPTION);
+    handle_pending_exception(output, startup, PENDING_EXCEPTION);
     // Don't clear excption on startup, JVM should fail initialization.
-    if (DCmd_Source_Internal != source) {
+    if (!startup) {
       CLEAR_PENDING_EXCEPTION;
     }
     return;
@@ -162,9 +199,20 @@ static void handle_dcmd_result(outputStream* output,
 
   assert(!HAS_PENDING_EXCEPTION, "invariant");
 
-  if (result != NULL) {
-    const char* result_chars = java_lang_String::as_utf8_string(result);
-    print_message(output, result_chars);
+  if (startup) {
+    if (log_is_enabled(Warning, jfr, start))  {
+      // if warning is set, assume user hasn't configured log level
+      // Log to Info and reset to Warning. This way user can disable
+      // default output by setting -Xlog:jfr+start=error/off
+      LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
+      log(result, THREAD);
+      LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
+    } else {
+      log(result, THREAD);
+    }
+  } else {
+      // Print output for jcmd or MXBean
+      print_message(output, result, THREAD);
   }
 }
 
@@ -261,7 +309,7 @@ void JfrDumpFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
 
   static const char klass[] = "jdk/jfr/internal/dcmd/DCmdDump";
   static const char method[] = "execute";
-  static const char signature[] = "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Ljava/lang/String;";
+  static const char signature[] = "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);
@@ -327,7 +375,7 @@ void JfrCheckFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
 
   static const char klass[] = "jdk/jfr/internal/dcmd/DCmdCheck";
   static const char method[] = "execute";
-  static const char signature[] = "(Ljava/lang/String;Ljava/lang/Boolean;)Ljava/lang/String;";
+  static const char signature[] = "(Ljava/lang/String;Ljava/lang/Boolean;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);
@@ -471,7 +519,7 @@ void JfrStartFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
   static const char method[] = "execute";
   static const char signature[] = "(Ljava/lang/String;[Ljava/lang/String;Ljava/lang/Long;"
     "Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;"
-    "Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;)Ljava/lang/String;";
+    "Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);
@@ -541,7 +589,7 @@ void JfrStopFlightRecordingDCmd::execute(DCmdSource source, TRAPS) {
 
   static const char klass[] = "jdk/jfr/internal/dcmd/DCmdStop";
   static const char method[] = "execute";
-  static const char signature[] = "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;";
+  static const char signature[] = "(Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);
@@ -654,7 +702,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   static const char method[] = "execute";
   static const char signature[] = "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;"
     "Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;"
-    "Ljava/lang/Long;Ljava/lang/Boolean;)Ljava/lang/String;";
+    "Ljava/lang/Long;Ljava/lang/Boolean;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -144,7 +144,7 @@ static void handle_pending_exception(outputStream* output, bool startup, oop thr
     if (startup) {
       log_error(jfr,startup)("%s", text);
     } else {
-      output->print_raw_cr(text);
+      output->print_cr("%s", text);
     }
   }
 }
@@ -160,7 +160,7 @@ static void print_message(outputStream* output, oop content, TRAPS) {
       // An oome has been thrown and is pending.
       break;
     }
-    output->print_raw_cr(text);
+    output->print_cr("%s", text);
   }
 }
 

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -34,7 +34,6 @@
 #include "logging/logConfiguration.hpp"
 #include "logging/logMessage.hpp"
 #include "memory/resourceArea.hpp"
-#include "oops/objArrayOop.hpp"
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
@@ -200,10 +199,10 @@ static void handle_dcmd_result(outputStream* output,
   assert(!HAS_PENDING_EXCEPTION, "invariant");
 
   if (startup) {
-    if (log_is_enabled(Warning, jfr, start))  {
+    if (log_is_enabled(Warning, jfr, startup))  {
       // if warning is set, assume user hasn't configured log level
       // Log to Info and reset to Warning. This way user can disable
-      // default output by setting -Xlog:jfr+start=error/off
+      // default output by setting -Xlog:jfr+startup=error/off
       LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
       log(result, THREAD);
       LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
@@ -77,6 +77,7 @@ class JfrJavaSupport : public AllStatic {
   static Klass* klass(const jobject handle);
   // caller needs ResourceMark
   static const char* c_str(jstring string, Thread* jt);
+  static const char* c_str(oop string, Thread* t);
 
   // exceptions
   static void throw_illegal_state_exception(const char* message, TRAPS);

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -165,6 +165,7 @@
   LOG_TAG(stacktrace) \
   LOG_TAG(stackwalk) \
   LOG_TAG(start) \
+  LOG_TAG(startup) \
   LOG_TAG(startuptime) \
   LOG_TAG(state) \
   LOG_TAG(stats) \

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -50,20 +50,15 @@ import jdk.jfr.internal.Utils;
  */
 abstract class AbstractDCmd {
 
-    private final StringWriter result;
-    private final PrintWriter log;
-
-    protected AbstractDCmd() {
-        result = new StringWriter();
-        log = new PrintWriter(result);
-    }
+    private final StringBuilder currentLine = new StringBuilder(80);
+    private final List<String> lines = new ArrayList<>();
 
     protected final FlightRecorder getFlightRecorder() {
         return FlightRecorder.getFlightRecorder();
     }
 
-    public final String getResult() {
-        return result.toString();
+    public final String[] getResult() {
+        return lines.toArray(new String[lines.size()]);
     }
 
     public String getPid() {
@@ -136,15 +131,16 @@ abstract class AbstractDCmd {
     }
 
     protected final void println() {
-        log.println();
+        lines.add(currentLine.toString());
+        currentLine.setLength(0);
     }
 
     protected final void print(String s) {
-        log.print(s);
+        currentLine.append(s);
     }
 
     protected final void print(String s, Object... args) {
-        log.printf(s, args);
+        currentLine.append(String.format(s, args));
     }
 
     protected final void println(String s, Object... args) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -25,8 +25,6 @@
 package jdk.jfr.internal.dcmd;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
@@ -58,7 +58,7 @@ final class DCmdCheck extends AbstractDCmd {
      *
      * @throws DCmdException if the check could not be completed.
      */
-    public String execute(String recordingText, Boolean verbose) throws DCmdException {
+    public String[] execute(String recordingText, Boolean verbose) throws DCmdException {
         executeInternal(recordingText, verbose);
         return getResult();
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
@@ -59,7 +59,7 @@ final class DCmdConfigure extends AbstractDCmd {
      * @throws DCmdException
      *             if the dump could not be completed
      */
-    public String execute
+    public String[] execute
     (
             boolean verbose,
             String repositoryPath,
@@ -177,7 +177,7 @@ final class DCmdConfigure extends AbstractDCmd {
             updated = true;
         }
         if (!verbose) {
-            return "";
+            return new String[0];
         }
         if (!updated) {
             println("Current configuration:");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -69,7 +69,7 @@ final class DCmdDump extends AbstractDCmd {
      *
      * @throws DCmdException if the dump could not be completed
      */
-    public String execute(String name, String filename, Long maxAge, Long maxSize, String begin, String end, Boolean pathToGcRoots) throws DCmdException {
+    public String[] execute(String name, String filename, Long maxAge, Long maxSize, String begin, String end, Boolean pathToGcRoots) throws DCmdException {
         if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
             Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG,
                     "Executing DCmdDump: name=" + name +

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -82,7 +82,7 @@ final class DCmdStart extends AbstractDCmd {
      * @throws DCmdException if recording could not be started
      */
     @SuppressWarnings("resource")
-    public String execute(String name, String[] settings, Long delay, Long duration, Boolean disk, String path, Long maxAge, Long maxSize, Long flush, Boolean dumpOnExit, Boolean pathToGcRoots) throws DCmdException {
+    public String[] execute(String name, String[] settings, Long delay, Long duration, Boolean disk, String path, Long maxAge, Long maxSize, Long flush, Boolean dumpOnExit, Boolean pathToGcRoots) throws DCmdException {
         if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
             Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "Executing DCmdStart: name=" + name +
                     ", settings=" + Arrays.asList(settings) +

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -55,7 +55,7 @@ final class DCmdStop extends AbstractDCmd {
      *
      * @throws DCmdException if recording could not be stopped
      */
-    public String execute(String name, String filename) throws DCmdException {
+    public String[] execute(String name, String filename) throws DCmdException {
         if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
             Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "Executing DCmdStart: name=" + name + ", filename=" + filename);
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java
@@ -34,7 +34,7 @@
 
 public class ModulePathAndCP_JFR {
     public static void main(String... args) throws Exception {
-        ModulePathAndCP.run("-XX:StartFlightRecording=dumponexit=true", "-Xlog:cds+jvmti=debug");
+        ModulePathAndCP.run("-XX:StartFlightRecording=dumponexit=true", "-Xlog:cds+jvmti=debug,jfr+startup=off");
     }
 }
 

--- a/test/jdk/jdk/jfr/jcmd/JcmdAsserts.java
+++ b/test/jdk/jdk/jfr/jcmd/JcmdAsserts.java
@@ -35,7 +35,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class JcmdAsserts {
 
-    private static final String NEW_LINE = System.getProperty("line.separator");
+    private static final String NEW_LINE = "\n";
 
     public static void assertJfrNotUsed(OutputAnalyzer output) {
         output.shouldMatch("Flight Recorder has not been used");

--- a/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.startupargs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main jdk.jfr.startupargs.TestStartupMessage
+ */
+public class TestStartupMessage {
+
+    public static class TestMessage {
+        public static void main(String[] args) throws Exception {
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+         startWith("-Xlog:jfr+startup=off")
+             .shouldNotContain("[jfr,startup")
+             .shouldNotContain("Started recording")
+             .shouldNotContain("Use jcmd");
+
+         startWith("-Xlog:jfr+startup=error")
+             .shouldNotContain("[jfr,startup")
+             .shouldNotContain("Started recording")
+             .shouldNotContain("Use jcmd");
+
+         // Known limitation.
+         // Can't turn off log with -Xlog:jfr+startup=warning
+
+         startWith(null)
+             .shouldContain("[info][jfr,startup")
+             .shouldContain("Started recording")
+             .shouldContain("Use jcmd");
+
+         startWith("-Xlog:jfr+startup=info")
+             .shouldContain("[info][jfr,startup")
+             .shouldContain("Started recording")
+             .shouldContain("Use jcmd");
+    }
+
+    private static OutputAnalyzer startWith(String command) throws Exception {
+        List<String> commands = new ArrayList<>();
+        if (command != null) {
+            commands.add(command);
+        }
+        commands.add("-XX:StartFlightRecording");
+        commands.add(TestMessage.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(commands);
+        OutputAnalyzer out = ProcessTools.executeProcess(pb);
+        out.shouldHaveExitValue(0);
+        return out;
+    }
+}

--- a/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
@@ -24,6 +24,7 @@
 package jdk.jfr.startupargs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -44,12 +45,12 @@ public class TestStartupMessage {
     }
 
     public static void main(String[] args) throws Exception {
-         startWith("-Xlog:jfr+startup=off")
+         startJfrJvm("-Xlog:jfr+startup=off")
              .shouldNotContain("[jfr,startup")
              .shouldNotContain("Started recording")
              .shouldNotContain("Use jcmd");
 
-         startWith("-Xlog:jfr+startup=error")
+         startJfrJvm("-Xlog:jfr+startup=error")
              .shouldNotContain("[jfr,startup")
              .shouldNotContain("Started recording")
              .shouldNotContain("Use jcmd");
@@ -57,22 +58,19 @@ public class TestStartupMessage {
          // Known limitation.
          // Can't turn off log with -Xlog:jfr+startup=warning
 
-         startWith(null)
+         startJfrJvm()
              .shouldContain("[info][jfr,startup")
              .shouldContain("Started recording")
              .shouldContain("Use jcmd");
 
-         startWith("-Xlog:jfr+startup=info")
+         startJfrJvm("-Xlog:jfr+startup=info")
              .shouldContain("[info][jfr,startup")
              .shouldContain("Started recording")
              .shouldContain("Use jcmd");
     }
 
-    private static OutputAnalyzer startWith(String command) throws Exception {
-        List<String> commands = new ArrayList<>();
-        if (command != null) {
-            commands.add(command);
-        }
+    private static OutputAnalyzer startJfrJvm(String... args) throws Exception {
+        List<String> commands = new ArrayList<>(Arrays.asList(args));
         commands.add("-XX:StartFlightRecording");
         commands.add(TestMessage.class.getName());
         ProcessBuilder pb = ProcessTools.createTestJvm(commands);


### PR DESCRIPTION
Hi,

Could I have review of a change that makes it possible to silence the output of JFR during startup. That is:

"Started recording 1. No limit specified, using maxsize=250MB as default.

Use jcmd 38045 JFR.dump name=1 filename=FILEPATH to copy recording data to file"

There are severals ways to approach this:

1) Remove the output completely
- Con: Users will think JFR is not working since they are used to see the output
- Con: The PID must be found by other means
- Con: No hint about jcmd, or disk space being used

2) Introduce a flag to silence the output, i.e. -XX:StartFlightRecording:silent=true
- Con: Users must read documentation to find out about the option
- Con: It introduces a second mechanism to control logging
- Pro: Easy to backport. No behavioral change.

3) Write to unified logging with level Info
- Con: Users will think JFR is not working since they are used to see the output
- Con: The PID must be found by other means
- Con: No hint about jcmd, or disk space being used
- Con: Users must read documentation to find out about -Xlog:jfr+startup=info

4) Write to unified logging with level Warning
- Con: Confusing since it is not a warning.
- Pro: Users can see the tag set and turn it off easily using -Xlog:jfr+startup=off/error

5) If -XX:StartFlightRecording has been specified, set jfr+startup=Info temporarily and write with level Info.
- Con: If user has specified -Xlog:jfr+startup=warning it will not take effect.
- Pro: Users can see the tag set and turn it off easily using -Xlog:jfr+startup=off/error

One could try to detect if the user has set the level to  jfr+startup=warning and not change the level to Info in those cases. Unfortunately there is no mechanism in UL to see if a tag set has been touched and one would need to take into account there could be several types of output, i.e. files, that can be touched. It becomes complicated.

I have chosen to implement 5. It's not perfect, but perhaps sufficient for now? Detection of -Xlog:jfr+startup=warning could be added in the future if there is a need.

$ java -XX:StartFlightRecording -version
[0.385s][info][jfr,startup] Started recording 1. No limit specified, using maxsize=250MB as default.
[0.385s][info][jfr,startup] 
[0.385s][info][jfr,startup] Use jcmd 7469 JFR.dump name=1 filename=FILEPATH to copy recording data to file.

$ java -XX:StartFlightRecording:settings=foo.bar -version
[0.174s][error][jfr,startup] Could not parse settings file 'foo.bar'

Testing: jdk/jdk/jfr, tier1-tier4

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244190](https://bugs.openjdk.java.net/browse/JDK-8244190): JFR: When starting a JVM with -XX:StartFlightRecording, output is written to stdout


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3417/head:pull/3417` \
`$ git checkout pull/3417`

Update a local copy of the PR: \
`$ git checkout pull/3417` \
`$ git pull https://git.openjdk.java.net/jdk pull/3417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3417`

View PR using the GUI difftool: \
`$ git pr show -t 3417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3417.diff">https://git.openjdk.java.net/jdk/pull/3417.diff</a>

</details>
