### PR TITLE
8264997: Remove SystemDictionary::cache_get

### DIFF
--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -128,7 +128,7 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
   // Tells whether a protection is in the approved set.
   bool contains_protection_domain(oop protection_domain) const;
   // Adds a protection domain to the approved set.
-  void add_protection_domain(Dictionary* dict, Handle protection_domain);
+  void add_protection_domain(ClassLoaderData* loader_data, Handle protection_domain);
 
   InstanceKlass* instance_klass() const { return literal(); }
   InstanceKlass** klass_addr() { return (InstanceKlass**)literal_addr(); }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2428,11 +2428,6 @@ void SystemDictionary::invoke_bootstrap_method(BootstrapInfo& bootstrap_specifie
           bootstrap_specifier.resolved_method().not_null()), "bootstrap method call failed");
 }
 
-// Protection domain cache table handling
-
-ProtectionDomainCacheEntry* SystemDictionary::cache_get(Handle protection_domain) {
-  return _pd_cache_table->get(protection_domain);
-}
 
 ClassLoaderData* SystemDictionary::class_loader_data(Handle class_loader) {
   return ClassLoaderData::class_loader_data(class_loader());

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -293,8 +293,6 @@ public:
                                   const char* message);
   static const char* find_nest_host_error(const constantPoolHandle& pool, int which);
 
-  static ProtectionDomainCacheEntry* cache_get(Handle protection_domain);
-
  private:
   // Static tables owned by the SystemDictionary
 


### PR DESCRIPTION
This is a trivial change to remove an unneeded function in SystemDictionary.  The pd_cache_table() that is owned by SystemDictionary is already available to callers of SystemDictionary, ie. the ServiceThread, so there's no need to hide access inside of a function with a backwards name.

I also fixed add_protection_domain logging to be useful and fixed an assert.

Tested with mach5 tier1-3 in progress and manually.