### PR TITLE
8262896: [macos_aarch64] Crash in jni_fast_GetLongField

### DIFF
--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -32,6 +32,7 @@
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/safepoint.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 #define __ masm->
 
@@ -51,6 +52,48 @@ static const Register rcounter      = r4;
 static const Register roffset       = r5;
 static const Register rcounter_addr = r6;
 static const Register result        = r7;
+
+// On macos/aarch64 we need to ensure WXExec mode when running generated
+// FastGetXXXField, as these functions can be called from WXWrite context
+// (8262896).  So each FastGetXXXField is wrapped into a C++ statically
+// compiled template function that optionally switches to WXExec if necessary.
+
+#ifdef __APPLE__
+
+static address generated_fast_get_field[T_LONG + 1 - T_BOOLEAN];
+
+template<int BType> struct BasicTypeToJni {};
+template<> struct BasicTypeToJni<T_BOOLEAN> { static const jboolean jni_type; };
+template<> struct BasicTypeToJni<T_BYTE>    { static const jbyte    jni_type; };
+template<> struct BasicTypeToJni<T_CHAR>    { static const jchar    jni_type; };
+template<> struct BasicTypeToJni<T_SHORT>   { static const jshort   jni_type; };
+template<> struct BasicTypeToJni<T_INT>     { static const jint     jni_type; };
+template<> struct BasicTypeToJni<T_LONG>    { static const jlong    jni_type; };
+template<> struct BasicTypeToJni<T_FLOAT>   { static const jfloat   jni_type; };
+template<> struct BasicTypeToJni<T_DOUBLE>  { static const jdouble  jni_type; };
+
+template<int BType, typename JniType = decltype(BasicTypeToJni<BType>::jni_type)>
+JniType static_fast_get_field_wrapper(JNIEnv *env, jobject obj, jfieldID fieldID) {
+  JavaThread* thread = JavaThread::thread_from_jni_environment(env);
+  ThreadWXEnable wx(WXExec, thread);
+  address get_field_addr = generated_fast_get_field[BType - T_BOOLEAN];
+  return ((JniType(*)(JNIEnv *env, jobject obj, jfieldID fieldID))get_field_addr)(env, obj, fieldID);
+}
+
+template<int BType>
+address JNI_FastGetField::generate_fast_get_int_field1() {
+  generated_fast_get_field[BType - T_BOOLEAN] = generate_fast_get_int_field0((BasicType)BType);
+  return (address)static_fast_get_field_wrapper<BType>;
+}
+
+#else // __APPLE__
+
+template<int BType>
+address JNI_FastGetField::generate_fast_get_int_field1() {
+  return generate_fast_get_int_field0((BasicType)BType);
+}
+
+#endif // __APPLE__
 
 address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   const char *name;
@@ -168,33 +211,33 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
 }
 
 address JNI_FastGetField::generate_fast_get_boolean_field() {
-  return generate_fast_get_int_field0(T_BOOLEAN);
+  return generate_fast_get_int_field1<T_BOOLEAN>();
 }
 
 address JNI_FastGetField::generate_fast_get_byte_field() {
-  return generate_fast_get_int_field0(T_BYTE);
+  return generate_fast_get_int_field1<T_BYTE>();
 }
 
 address JNI_FastGetField::generate_fast_get_char_field() {
-  return generate_fast_get_int_field0(T_CHAR);
+  return generate_fast_get_int_field1<T_CHAR>();
 }
 
 address JNI_FastGetField::generate_fast_get_short_field() {
-  return generate_fast_get_int_field0(T_SHORT);
+  return generate_fast_get_int_field1<T_SHORT>();
 }
 
 address JNI_FastGetField::generate_fast_get_int_field() {
-  return generate_fast_get_int_field0(T_INT);
+  return generate_fast_get_int_field1<T_INT>();
 }
 
 address JNI_FastGetField::generate_fast_get_long_field() {
-  return generate_fast_get_int_field0(T_LONG);
+  return generate_fast_get_int_field1<T_LONG>();
 }
 
 address JNI_FastGetField::generate_fast_get_float_field() {
-  return generate_fast_get_int_field0(T_FLOAT);
+  return generate_fast_get_int_field1<T_FLOAT>();
 }
 
 address JNI_FastGetField::generate_fast_get_double_field() {
-  return generate_fast_get_int_field0(T_DOUBLE);
+  return generate_fast_get_int_field1<T_DOUBLE>();
 }

--- a/src/hotspot/share/prims/jniFastGetField.hpp
+++ b/src/hotspot/share/prims/jniFastGetField.hpp
@@ -65,6 +65,11 @@ class JNI_FastGetField : AllStatic {
   static address generate_fast_get_int_field0(BasicType type);
   static address generate_fast_get_float_field0(BasicType type);
 
+#ifdef AARCH64
+  template<int BType>
+  static address generate_fast_get_int_field1();
+#endif // AARCH64
+
  public:
 #if defined(_WINDOWS) && !defined(_WIN64)
   static GetBooleanField_t jni_fast_GetBooleanField_fp;

--- a/test/hotspot/gtest/runtime/test_threads.cpp
+++ b/test/hotspot/gtest/runtime/test_threads.cpp
@@ -176,3 +176,16 @@ TEST_VM(ThreadsTest, claim_overflow) {
   ThreadInVMfromNative invm(JavaThread::current());
   VMThread::execute(&op);
 }
+
+TEST_VM(ThreadsTest, fast_jni_in_vm) {
+  JavaThread* current = JavaThread::current();
+  JNIEnv* env = current->jni_environment();
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+
+  // DirectByteBuffer is an easy way to trigger GetIntField,
+  // see JDK-8262896
+  jlong capacity = 0x10000;
+  jobject buffer = env->NewDirectByteBuffer(NULL, (jlong)capacity);
+  ASSERT_NE((void*)NULL, buffer);
+  ASSERT_EQ(capacity, env->GetDirectBufferCapacity(buffer));
+}


### PR DESCRIPTION
Hi, please review a fix for a random crash on macos/aarch64.

By default, GetXXXField JNI Interface implementation is a generated function (-XX:+UseFastJNIAccessors). Usually the function is called by JNI code running in WXExec mode and everything is fine. But sometime we attempt to call it in WXWrite context, like in the stack trace attached to the bug:

```
v  ~BufferBlob::jni_fast_GetLongField
V  [libjvm.dylib+0x7a6538]  Perf_Detach+0x168
j  jdk.internal.perf.Perf.detach(Ljava/nio/ByteBuffer;)V+0 java.base@17-internal
j  jdk.internal.perf.Perf$CleanerAction.run()V+8 java.base@17-internal
j  jdk.internal.ref.CleanerImpl$PhantomCleanableRef.performCleanup()V+4 java.base@17-internal
j  jdk.internal.ref.PhantomCleanable.clean()V+12 java.base@17-internal
j  jdk.internal.ref.CleanerImpl.run()V+57 java.base@17-internal
j  java.lang.Thread.run()V+11 java.base@17-internal
j  jdk.internal.misc.InnocuousThread.run()V+20 java.base@17-internal
v  ~StubRoutines::call_stub
```

One way to fix the bug is to ensure WXExec mode before calling GetXXXField, but it depends on finding and fixing all such cases. 

This patch instead adds additional actions to GetXXXField implementation to ensure correct W^X mode regardless if it is called from WXWrite or WXExec mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262896](https://bugs.openjdk.java.net/browse/JDK-8262896): [macos_aarch64] Crash in jni_fast_GetLongField


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3422/head:pull/3422` \
`$ git checkout pull/3422`

Update a local copy of the PR: \
`$ git checkout pull/3422` \
`$ git pull https://git.openjdk.java.net/jdk pull/3422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3422`

View PR using the GUI difftool: \
`$ git pr show -t 3422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3422.diff">https://git.openjdk.java.net/jdk/pull/3422.diff</a>

</details>
