### PR TITLE
8265012: Shenandoah: Backout JDK-8264718

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -191,13 +191,8 @@ ShenandoahMarkConcurrentRootsTask::ShenandoahMarkConcurrentRootsTask(ShenandoahO
 void ShenandoahMarkConcurrentRootsTask::work(uint worker_id) {
   ShenandoahConcurrentWorkerSession worker_session(worker_id);
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
-  if (ShenandoahStringDedup::is_enabled()) {
-    ShenandoahMarkRefsDedupClosure cl(q, _rp);
-    _root_scanner.roots_do(&cl, worker_id);
-  } else {
-    ShenandoahMarkRefsClosure cl(q, _rp);
-    _root_scanner.roots_do(&cl, worker_id);
-  }
+  ShenandoahMarkRefsClosure cl(q, _rp);
+  _root_scanner.roots_do(&cl, worker_id);
 }
 
 void ShenandoahConcurrentMark::mark_concurrent_roots() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
@@ -41,6 +41,11 @@ ShenandoahMarkRefsSuperClosure::ShenandoahMarkRefsSuperClosure(ShenandoahObjToSc
   _weak(false)
 { }
 
+ShenandoahInitMarkRootsClosure::ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q) :
+  _queue(q),
+  _mark_context(ShenandoahHeap::heap()->marking_context()) {
+}
+
 ShenandoahMark::ShenandoahMark() :
   _task_queues(ShenandoahHeap::heap()->marking_context()->task_queues()) {
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
@@ -31,6 +31,21 @@
 
 class ShenandoahCMDrainMarkingStackClosure;
 
+class ShenandoahInitMarkRootsClosure : public OopClosure {
+private:
+  ShenandoahObjToScanQueue* const _queue;
+  ShenandoahMarkingContext* const _mark_context;
+
+  template <class T>
+  inline void do_oop_work(T* p);
+
+public:
+  ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q);
+
+  void do_oop(narrowOop* p) { do_oop_work(p); }
+  void do_oop(oop* p)       { do_oop_work(p); }
+};
+
 // Base class for mark
 // Mark class does not maintain states. Instead, mark states are
 // maintained by task queues, mark bitmap and SATB buffers (concurrent mark)

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -40,6 +40,11 @@
 #include "utilities/powerOfTwo.hpp"
 
 template <class T>
+void ShenandoahInitMarkRootsClosure::do_oop_work(T* p) {
+  ShenandoahMark::mark_through_ref<T, NO_DEDUP>(p, _queue, _mark_context, false);
+}
+
+template <class T>
 void ShenandoahMark::do_task(ShenandoahObjToScanQueue* q, T* cl, ShenandoahLiveData* live_data, ShenandoahMarkTask* task) {
   oop obj = task->obj();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -33,37 +33,8 @@
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahRootProcessor.inline.hpp"
-#include "gc/shenandoah/shenandoahStringDedup.hpp"
 #include "gc/shenandoah/shenandoahSTWMark.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
-
-template <StringDedupMode STRING_DEDUP>
-class ShenandoahInitMarkRootsClosure : public OopClosure {
-private:
-  ShenandoahObjToScanQueue* const _queue;
-  ShenandoahMarkingContext* const _mark_context;
-
-  template <class T>
-  inline void do_oop_work(T* p);
-
-public:
-  ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q);
-
-  void do_oop(narrowOop* p) { do_oop_work(p); }
-  void do_oop(oop* p)       { do_oop_work(p); }
-};
-
-template <StringDedupMode STRING_DEDUP>
-ShenandoahInitMarkRootsClosure<STRING_DEDUP>::ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q) :
-  _queue(q),
-  _mark_context(ShenandoahHeap::heap()->marking_context()) {
-}
-
-template <StringDedupMode STRING_DEDUP>
-template <class T>
-void ShenandoahInitMarkRootsClosure<STRING_DEDUP>::do_oop_work(T* p) {
-  ShenandoahMark::mark_through_ref<T, STRING_DEDUP>(p, _queue, _mark_context, false);
-}
 
 class ShenandoahSTWMarkTask : public AbstractGangTask {
 private:
@@ -128,13 +99,8 @@ void ShenandoahSTWMark::mark() {
 }
 
 void ShenandoahSTWMark::mark_roots(uint worker_id) {
-  if (ShenandoahStringDedup::is_enabled()) {
-    ShenandoahInitMarkRootsClosure<ENQUEUE_DEDUP> init_mark(task_queues()->queue(worker_id));
-    _root_scanner.roots_do(&init_mark, worker_id);
-  } else {
-    ShenandoahInitMarkRootsClosure<NO_DEDUP> init_mark(task_queues()->queue(worker_id));
-    _root_scanner.roots_do(&init_mark, worker_id);
-  }
+  ShenandoahInitMarkRootsClosure  init_mark(task_queues()->queue(worker_id));
+  _root_scanner.roots_do(&init_mark, worker_id);
 }
 
 void ShenandoahSTWMark::finish_mark(uint worker_id) {
@@ -146,3 +112,4 @@ void ShenandoahSTWMark::finish_mark(uint worker_id) {
             false, // not cancellable
             ShenandoahStringDedup::is_enabled());
 }
+


### PR DESCRIPTION
It turns out that enquening string deduplication candidates during concurrent root scanning may result lock rank inversion between stack watermark lock and string dedup queue lock, if the scanning is triggered by stack watermark and dedup buffer happens to be full.

Backout JDK-8264718 for now, will retry after Kim's string deduplication refactoring.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265012](https://bugs.openjdk.java.net/browse/JDK-8265012): Shenandoah: Backout JDK-8264718


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3423/head:pull/3423` \
`$ git checkout pull/3423`

Update a local copy of the PR: \
`$ git checkout pull/3423` \
`$ git pull https://git.openjdk.java.net/jdk pull/3423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3423`

View PR using the GUI difftool: \
`$ git pr show -t 3423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3423.diff">https://git.openjdk.java.net/jdk/pull/3423.diff</a>

</details>
