### PR TITLE
8264972: Unused TypeFunc declared in OptoRuntime

### DIFF
--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -302,14 +302,6 @@ private:
   // leaf on stack replacement interpreter accessor types
   static const TypeFunc* osr_end_Type();
 
-  // leaf on stack replacement interpreter accessor types
-  static const TypeFunc* fetch_int_Type();
-  static const TypeFunc* fetch_long_Type();
-  static const TypeFunc* fetch_float_Type();
-  static const TypeFunc* fetch_double_Type();
-  static const TypeFunc* fetch_oop_Type();
-  static const TypeFunc* fetch_monitor_Type();
-
   static const TypeFunc* register_finalizer_Type();
 
   // Dtrace support


### PR DESCRIPTION
When investigating some C2 related stuff, I noticed that some TypeFunc are declared in OptoRuntime since JDK6:

  // leaf on stack replacement interpreter accessor types
  static const TypeFunc* fetch_int_Type();
  static const TypeFunc* fetch_long_Type();
  static const TypeFunc* fetch_float_Type();
  static const TypeFunc* fetch_double_Type();
  static const TypeFunc* fetch_oop_Type();
  static const TypeFunc* fetch_monitor_Type();

They are neither used nor implemented. It looks like we can remove them(I'm curious about their stories/history.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264972](https://bugs.openjdk.java.net/browse/JDK-8264972): Unused TypeFunc declared in OptoRuntime


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3429/head:pull/3429` \
`$ git checkout pull/3429`

Update a local copy of the PR: \
`$ git checkout pull/3429` \
`$ git pull https://git.openjdk.java.net/jdk pull/3429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3429`

View PR using the GUI difftool: \
`$ git pr show -t 3429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3429.diff">https://git.openjdk.java.net/jdk/pull/3429.diff</a>

</details>
