### PR TITLE
8265052: Break circular include dependency in objArrayOop.inline.hpp

### DIFF
--- a/src/hotspot/share/oops/objArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/objArrayOop.inline.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_OOPS_OBJARRAYOOP_INLINE_HPP
 #define SHARE_OOPS_OBJARRAYOOP_INLINE_HPP
 
-#include "oops/access.inline.hpp"
+#include "oops/access.hpp"
 #include "oops/arrayOop.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
There's a circular dependency of the includes in objArrayOop.inline.hpp. This does not show up in the current main line, but caused compilation errors in a JFR enhancement.

The objArrayOop.inline.hpp can't even be compiled by itself:

In file included from /home/stefank/git/alt2/open/src/hotspot/share/oops/access.inline.hpp:28,
                 from /home/stefank/git/alt2/open/src/hotspot/share/oops/objArrayOop.inline.hpp:28:
/home/stefank/git/alt2/open/src/hotspot/share/gc/shared/barrierSet.inline.hpp: In static member function 'static bool BarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy_in_heap(arrayOop, size_t, T*, arrayOop, size_t, T*, size_t)':
/home/stefank/git/alt2/open/src/hotspot/share/gc/shared/barrierSet.inline.hpp:48:48: error: invalid use of incomplete type 'class objArrayOopDesc' [-Werror]
   48 | Klass* const dst_klass = objArrayOop(dst_obj)->element_klass();

objArrayOop.inline.hpp includes access.inline.hpp, which in turn
includes barrierSet.inline.hpp, which includes objArrayOop.inline.hpp. This means oopsHierarchy.hpp, that is supposed to be included by objArrayOop.inline.hpp, isn't included before it is then used by barrierSet.inline.hpp.

The proposed fix is to change the inclusion of access.inline.hpp to access.hpp, in objArrayOop.inline.hpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265052](https://bugs.openjdk.java.net/browse/JDK-8265052): Break circular include dependency in objArrayOop.inline.hpp


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3431/head:pull/3431` \
`$ git checkout pull/3431`

Update a local copy of the PR: \
`$ git checkout pull/3431` \
`$ git pull https://git.openjdk.java.net/jdk pull/3431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3431`

View PR using the GUI difftool: \
`$ git pr show -t 3431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3431.diff">https://git.openjdk.java.net/jdk/pull/3431.diff</a>

</details>
