### PR TITLE
8265061: Simplify MethodHandleNatives::canBeCalledVirtual

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -667,11 +667,8 @@ class MethodHandleNatives {
 
     static boolean canBeCalledVirtual(MemberName mem) {
         assert(mem.isInvocable());
-        switch (mem.getName()) {
-        case "getContextClassLoader":
-            return canBeCalledVirtual(mem, java.lang.Thread.class);
-        }
-        return false;
+        return mem.getName().equals("getContextClassLoader") &&
+            canBeCalledVirtual(mem, java.lang.Thread.class);
     }
 
     static boolean canBeCalledVirtual(MemberName symbolicRef, Class<?> definingClass) {


### PR DESCRIPTION
Desugaring the single-case switch in MethodHandleNatives::canBeCalledVirtual is a cleanup and minimal startup improvement on apps spinning up MethodHandles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265061](https://bugs.openjdk.java.net/browse/JDK-8265061): Simplify MethodHandleNatives::canBeCalledVirtual


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3433/head:pull/3433` \
`$ git checkout pull/3433`

Update a local copy of the PR: \
`$ git checkout pull/3433` \
`$ git pull https://git.openjdk.java.net/jdk pull/3433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3433`

View PR using the GUI difftool: \
`$ git pr show -t 3433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3433.diff">https://git.openjdk.java.net/jdk/pull/3433.diff</a>

</details>
