### PR TITLE
8265035: Remove unneeded exception check from refill_ic_stubs()

### DIFF
--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -161,13 +161,6 @@ void InlineCacheBuffer::refill_ic_stubs() {
 
   VM_ICBufferFull ibf;
   VMThread::execute(&ibf);
-  // We could potential get an async. exception at this point.
-  // In that case we will rethrow it to ourselvs.
-  if (HAS_PENDING_EXCEPTION) {
-    oop exception = PENDING_EXCEPTION;
-    CLEAR_PENDING_EXCEPTION;
-    JavaThread::current()->set_pending_async_exception(exception);
-  }
 }
 
 void InlineCacheBuffer::update_inline_caches() {

--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -157,8 +157,6 @@ void InlineCacheBuffer::refill_ic_stubs() {
 #endif
   // we ran out of inline cache buffer space; must enter safepoint.
   // We do this by forcing a safepoint
-  EXCEPTION_MARK;
-
   VM_ICBufferFull ibf;
   VMThread::execute(&ibf);
 }


### PR DESCRIPTION
Hi,

Please review this small fix. The HAS_PENDING_EXCEPTION check will always return false since EXCEPTION_MARK will check that there are no pending exceptions upon entering and VMThread::execute() doesn't throw exceptions.
The comment says that we could get a potential async exception, which is true, since the JT will be blocked waiting on VMOperation_lock. However delivering an async exception doesn't set the _pending_exception field, only additional fields (see JavaThread::send_thread_stop() -> set_pending_async_exception()) that will be later check in check_and_handle_async_exceptions() and only then _pending_exception will be set.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265035](https://bugs.openjdk.java.net/browse/JDK-8265035): Remove unneeded exception check from refill_ic_stubs()


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to 76dbae7328e61f753ab8a1b7acdd26ce4512e19e
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3436/head:pull/3436` \
`$ git checkout pull/3436`

Update a local copy of the PR: \
`$ git checkout pull/3436` \
`$ git pull https://git.openjdk.java.net/jdk pull/3436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3436`

View PR using the GUI difftool: \
`$ git pr show -t 3436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3436.diff">https://git.openjdk.java.net/jdk/pull/3436.diff</a>

</details>
