### PR TITLE
8265082: test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java fails validate-source

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
@@ -4,19 +4,21 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Alibaba designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 /*


### PR DESCRIPTION
A trivial fix to fix the "validate-source" failure in Tier1 due to the bad copyright
header in test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265082](https://bugs.openjdk.java.net/browse/JDK-8265082): test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java fails validate-source


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3438/head:pull/3438` \
`$ git checkout pull/3438`

Update a local copy of the PR: \
`$ git checkout pull/3438` \
`$ git pull https://git.openjdk.java.net/jdk pull/3438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3438`

View PR using the GUI difftool: \
`$ git pr show -t 3438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3438.diff">https://git.openjdk.java.net/jdk/pull/3438.diff</a>

</details>
