### PR TITLE
8265079: Implement VarHandle invoker caching

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -103,18 +103,20 @@ class Invokers {
 
     /*non-public*/
     MethodHandle varHandleMethodInvoker(VarHandle.AccessMode ak) {
-        MethodHandle invoker = cachedVHInvoker(VH_INV_GENERIC, ak);
+        boolean isExact = false;
+        MethodHandle invoker = cachedVHInvoker(isExact, ak);
         if (invoker != null)  return invoker;
-        invoker = makeVarHandleMethodInvoker(ak, false);
-        return setCachedVHInvoker(VH_INV_GENERIC, ak, invoker);
+        invoker = makeVarHandleMethodInvoker(ak, isExact);
+        return setCachedVHInvoker(isExact, ak, invoker);
     }
 
     /*non-public*/
     MethodHandle varHandleMethodExactInvoker(VarHandle.AccessMode ak) {
-        MethodHandle invoker = cachedVHInvoker(VH_INV_EXACT, ak);
+        boolean isExact = true;
+        MethodHandle invoker = cachedVHInvoker(isExact, ak);
         if (invoker != null)  return invoker;
-        invoker = makeVarHandleMethodInvoker(ak, true);
-        return setCachedVHInvoker(VH_INV_EXACT, ak, invoker);
+        invoker = makeVarHandleMethodInvoker(ak, isExact);
+        return setCachedVHInvoker(isExact, ak, invoker);
     }
 
     private MethodHandle cachedInvoker(int idx) {
@@ -128,12 +130,14 @@ class Invokers {
         return invokers[idx] = invoker;
     }
 
-    private MethodHandle cachedVHInvoker(int idx, VarHandle.AccessMode ak) {
-        return cachedInvoker(idx + ak.ordinal());
+    private MethodHandle cachedVHInvoker(boolean isExact, VarHandle.AccessMode ak) {
+        int baseIndex = (isExact ? VH_INV_EXACT : VH_INV_GENERIC);
+        return cachedInvoker(baseIndex + ak.ordinal());
     }
 
-    private MethodHandle setCachedVHInvoker(int idx, VarHandle.AccessMode ak, final MethodHandle invoker) {
-        return setCachedInvoker(idx + ak.ordinal(), invoker);
+    private MethodHandle setCachedVHInvoker(boolean isExact, VarHandle.AccessMode ak, final MethodHandle invoker) {
+        int baseIndex = (isExact ? VH_INV_EXACT : VH_INV_GENERIC);
+        return setCachedInvoker(baseIndex + ak.ordinal(), invoker);
     }
 
     private MethodHandle makeExactOrGeneralInvoker(boolean isExact) {

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -54,7 +54,9 @@ class Invokers {
             INV_EXACT          =  0,  // MethodHandles.exactInvoker
             INV_GENERIC        =  1,  // MethodHandles.invoker (generic invocation)
             INV_BASIC          =  2,  // MethodHandles.basicInvoker
-            INV_LIMIT          =  3;
+            VH_INV_EXACT       =  3,  // MethodHandles.varHandleExactInvoker
+            VH_INV_GENERIC     =  VH_INV_EXACT   + VarHandle.AccessMode.values().length,  // MethodHandles.varHandleInvoker
+            INV_LIMIT          =  VH_INV_GENERIC + VarHandle.AccessMode.values().length;
 
     /** Compute and cache information common to all collecting adapters
      *  that implement members of the erasure-family of the given erased type.
@@ -101,14 +103,18 @@ class Invokers {
 
     /*non-public*/
     MethodHandle varHandleMethodInvoker(VarHandle.AccessMode ak) {
-        // TODO cache invoker
-        return makeVarHandleMethodInvoker(ak, false);
+        MethodHandle invoker = cachedVHInvoker(VH_INV_GENERIC, ak);
+        if (invoker != null)  return invoker;
+        invoker = makeVarHandleMethodInvoker(ak, false);
+        return setCachedVHInvoker(VH_INV_GENERIC, ak, invoker);
     }
 
     /*non-public*/
     MethodHandle varHandleMethodExactInvoker(VarHandle.AccessMode ak) {
-        // TODO cache invoker
-        return makeVarHandleMethodInvoker(ak, true);
+        MethodHandle invoker = cachedVHInvoker(VH_INV_EXACT, ak);
+        if (invoker != null)  return invoker;
+        invoker = makeVarHandleMethodInvoker(ak, true);
+        return setCachedVHInvoker(VH_INV_EXACT, ak, invoker);
     }
 
     private MethodHandle cachedInvoker(int idx) {
@@ -120,6 +126,14 @@ class Invokers {
         MethodHandle prev = invokers[idx];
         if (prev != null)  return prev;
         return invokers[idx] = invoker;
+    }
+
+    private MethodHandle cachedVHInvoker(int idx, VarHandle.AccessMode ak) {
+        return cachedInvoker(idx + ak.ordinal());
+    }
+
+    private MethodHandle setCachedVHInvoker(int idx, VarHandle.AccessMode ak, final MethodHandle invoker) {
+        return setCachedInvoker(idx + ak.ordinal(), invoker);
     }
 
     private MethodHandle makeExactOrGeneralInvoker(boolean isExact) {

--- a/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
+++ b/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8265079
+ * @run testng/othervm -Xverify:all -ea -esa TestVHInvokerCaching
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.testng.Assert.assertSame;
+
+public class TestVHInvokerCaching {
+
+    @Test(dataProvider = "testHandles")
+    public static void testVHIInvokerCaching(VarHandle testHandle) throws Throwable {
+        for (VarHandle.AccessMode mode : VarHandle.AccessMode.values()) {
+            MethodHandle handle1 = MethodHandles.varHandleInvoker(mode, testHandle.accessModeType(mode));
+            MethodHandle handle2 = MethodHandles.varHandleInvoker(mode, testHandle.accessModeType(mode));
+            assertSame(handle1, handle2);
+        }
+
+        for (VarHandle.AccessMode mode : VarHandle.AccessMode.values()) {
+            MethodHandle handle1 = MethodHandles.varHandleExactInvoker(mode, testHandle.accessModeType(mode));
+            MethodHandle handle2 = MethodHandles.varHandleExactInvoker(mode, testHandle.accessModeType(mode));
+            assertSame(handle1, handle2);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] testHandles() throws NoSuchFieldException, IllegalAccessException {
+        List<VarHandle> testHandles = new ArrayList<>();
+
+        Class<?>[] TEST_TYPES = {
+            byte.class,
+            short.class,
+            char.class,
+            int.class,
+            long.class,
+            float.class,
+            double.class,
+            Object.class,
+            String.class
+        };
+
+        class Holder {
+            byte f_byte;
+            short f_short;
+            char f_char;
+            int f_int;
+            long f_long;
+            float f_float;
+            double f_double;
+            Object f_Object;
+            String f_String;
+        }
+
+        MethodHandles.Lookup lookup = lookup();
+
+        for (Class<?> type : TEST_TYPES) {
+            testHandles.add(MethodHandles.arrayElementVarHandle(type.arrayType()));
+            testHandles.add(lookup.findVarHandle(Holder.class, "f_" + type.getSimpleName(), type));
+        }
+
+        return testHandles.stream().map(vh -> new Object[]{ vh }).toArray(Object[][]::new);
+    }
+}
+

--- a/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
+++ b/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,18 +60,6 @@ public class TestVHInvokerCaching {
     public static Object[][] testHandles() throws NoSuchFieldException, IllegalAccessException {
         List<VarHandle> testHandles = new ArrayList<>();
 
-        Class<?>[] TEST_TYPES = {
-            byte.class,
-            short.class,
-            char.class,
-            int.class,
-            long.class,
-            float.class,
-            double.class,
-            Object.class,
-            String.class
-        };
-
         class Holder {
             byte f_byte;
             short f_short;
@@ -85,9 +74,12 @@ public class TestVHInvokerCaching {
 
         MethodHandles.Lookup lookup = lookup();
 
-        for (Class<?> type : TEST_TYPES) {
-            testHandles.add(MethodHandles.arrayElementVarHandle(type.arrayType()));
-            testHandles.add(lookup.findVarHandle(Holder.class, "f_" + type.getSimpleName(), type));
+        for (Field field : Holder.class.getFields()) {
+            String fieldName = field.getName();
+            Class<?> fieldType = field.getType();
+
+            testHandles.add(MethodHandles.arrayElementVarHandle(fieldType.arrayType()));
+            testHandles.add(lookup.findVarHandle(Holder.class, fieldName, fieldType));
         }
 
         return testHandles.stream().map(vh -> new Object[]{ vh }).toArray(Object[][]::new);

--- a/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
+++ b/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 8265079
- * @run testng/othervm -Xverify:all -ea -esa TestVHInvokerCaching
+ * @run testng/othervm -Xverify:all TestVHInvokerCaching
  */
 
 import org.testng.annotations.DataProvider;


### PR DESCRIPTION
This patch implements 2 leftover TODOs for implementing var handle invoker MH caching (lambda forms for those were already shared/cached).

This piggybacks on the existing mechanism for method handle invoker caching.

Testing: Local testing `java/lang/invoke` tests. Tier 1-3

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265079](https://bugs.openjdk.java.net/browse/JDK-8265079): Implement VarHandle invoker caching


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to fa5a721f6daacd81ce50dd878ca162fa3da0f373
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to df10dbddb57ae706cbcc3c43873ae736f2c86dff
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to fa5a721f6daacd81ce50dd878ca162fa3da0f373
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to fa5a721f6daacd81ce50dd878ca162fa3da0f373


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3439/head:pull/3439` \
`$ git checkout pull/3439`

Update a local copy of the PR: \
`$ git checkout pull/3439` \
`$ git pull https://git.openjdk.java.net/jdk pull/3439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3439`

View PR using the GUI difftool: \
`$ git pr show -t 3439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3439.diff">https://git.openjdk.java.net/jdk/pull/3439.diff</a>

</details>
