### PR TITLE
8263157: [macos]: java.library.path is being set incorrectly

### DIFF
--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,7 +116,10 @@ Jvm* AppLauncher::createJvmLauncher() const {
 
     (*jvm)
         .setPath(findJvmLib(cfgFile, defaultRuntimePath, jvmLibNames))
-        .addArgument(launcherPath);
+        .addArgument(launcherPath)
+        .addArgument(_T("-Djava.library.path=")
+            + appDirPath + FileUtils::pathSeparator
+            + FileUtils::dirname(launcherPath));
 
     if (initJvmFromCmdlineOnly) {
         tstring_array::const_iterator argIt = args.begin();


### PR DESCRIPTION
This is regression from JDK-8242302. Fixed by setting java.library.path to same values as it was before JDK-8242302.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263157](https://bugs.openjdk.java.net/browse/JDK-8263157): [macos]: java.library.path is being set incorrectly


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3443/head:pull/3443` \
`$ git checkout pull/3443`

Update a local copy of the PR: \
`$ git checkout pull/3443` \
`$ git pull https://git.openjdk.java.net/jdk pull/3443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3443`

View PR using the GUI difftool: \
`$ git pr show -t 3443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3443.diff">https://git.openjdk.java.net/jdk/pull/3443.diff</a>

</details>
