### PR TITLE
8265100: (fs) WindowsFileStore.hashCode() should read cached hash code once

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -52,7 +52,7 @@ class WindowsFileStore
     private final int volType;
     private final String displayName;   // returned by toString
 
-    private volatile int hashCode;
+    private int hashCode;
 
     private WindowsFileStore(String root) throws WindowsException {
         assert root.charAt(root.length()-1) == '\\';

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileStore.java
@@ -52,7 +52,7 @@ class WindowsFileStore
     private final int volType;
     private final String displayName;   // returned by toString
 
-    private int hashCode;
+    private volatile int hashCode;
 
     private WindowsFileStore(String root) throws WindowsException {
         assert root.charAt(root.length()-1) == '\\';
@@ -250,11 +250,13 @@ class WindowsFileStore
 
     @Override
     public int hashCode() {
-        if (hashCode == 0) { // Don't care about race
-            hashCode = (volType == DRIVE_FIXED) ?
+        int hc = hashCode;
+        if (hc == 0) {
+            hc = (volType == DRIVE_FIXED) ?
                 root.toLowerCase(Locale.ROOT).hashCode() : root.hashCode();
+            hashCode = hc;
         }
-        return hashCode;
+        return hc;
     }
 
     @Override


### PR DESCRIPTION
Please review this small request to clean up `WindowsFileStore.hashCode()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265100](https://bugs.openjdk.java.net/browse/JDK-8265100): (fs) WindowsFileStore.hashCode() should read cached hash code once


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3445/head:pull/3445` \
`$ git checkout pull/3445`

Update a local copy of the PR: \
`$ git checkout pull/3445` \
`$ git pull https://git.openjdk.java.net/jdk pull/3445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3445`

View PR using the GUI difftool: \
`$ git pr show -t 3445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3445.diff">https://git.openjdk.java.net/jdk/pull/3445.diff</a>

</details>
