### PR TITLE
8265104: CpuLoad and SystemCpuLoad in OperatingSystem MXBean returns -1.0

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         if (containerMetrics != null && containerMetrics.getCpuSetCpus() != null) {
             return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
         }
-        return false;
+        // cpuset.cpus is not available, so we can assume the VM is run on the host CPUs.
+        return true;
     }
 
     /* native methods */

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -161,7 +161,11 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
                     if (cpuSet == null || cpuSet.length <= 0) {
                         cpuSet = containerMetrics.getCpuSetCpus();
                     }
-                    if (cpuSet != null && cpuSet.length > 0) {
+                    if (cpuSet == null) {
+                        // cgroups is mounted, but CPU resource is not limited.
+                        // We can assume the VM is run on the host CPUs.
+                        return getCpuLoad0();
+                    } else if (cpuSet.length > 0) {
                         double systemLoad = 0.0;
                         for (int cpu : cpuSet) {
                             double cpuLoad = getSingleCpuLoad0(cpu);
@@ -187,8 +191,7 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         if (containerMetrics != null && containerMetrics.getCpuSetCpus() != null) {
             return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
         }
-        // cpuset.cpus is not available, so we can assume the VM is run on the host CPUs.
-        return true;
+        return false;
     }
 
     /* native methods */


### PR DESCRIPTION
I got -1.0 from both CpuLoad and SystemCpuLoad in OperatingSystem MXBean when I run the application on Fedora 33 x64 which is installed cgroups V2.

![jconsole-cpuload](https://user-images.githubusercontent.com/7421132/114485721-6372a180-9c47-11eb-81d9-568324cba336.png)

I do not run the application in the container, nor do not run with resource limitation on cgroups, so JMX should report CPU load on host value in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265104](https://bugs.openjdk.java.net/browse/JDK-8265104): CpuLoad and SystemCpuLoad in OperatingSystem MXBean returns -1.0


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3447/head:pull/3447` \
`$ git checkout pull/3447`

Update a local copy of the PR: \
`$ git checkout pull/3447` \
`$ git pull https://git.openjdk.java.net/jdk pull/3447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3447`

View PR using the GUI difftool: \
`$ git pr show -t 3447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3447.diff">https://git.openjdk.java.net/jdk/pull/3447.diff</a>

</details>
