### PR TITLE
8265047: Inconsistent warning message in jcmd VM.log

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -427,6 +427,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
 
   ConfigurationLock cl;
   size_t idx;
+  bool is_added = false;
   if (outputstr[0] == '#') { // Output specified using index
     int ret = sscanf(outputstr + 1, SIZE_FORMAT, &idx);
     if (ret != 1 || idx >= _n_outputs) {
@@ -447,15 +448,17 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       LogOutput* output = new_output(normalized, output_options, errstream);
       if (output != NULL) {
         idx = add_output(output);
+        is_added = true;
       }
-    } else if (output_options != NULL && strlen(output_options) > 0) {
-      errstream->print_cr("Output options for existing outputs are ignored.");
     }
 
     FREE_C_HEAP_ARRAY(char, normalized);
     if (idx == SIZE_MAX) {
       return false;
     }
+  }
+  if (!is_added && output_options != NULL && strlen(output_options) > 0) {
+    errstream->print_cr("Output options for existing outputs are ignored.");
   }
   configure_output(idx, selections, decorators);
   notify_update_listeners();

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -427,7 +427,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
 
   ConfigurationLock cl;
   size_t idx;
-  bool is_added = false;
+  bool added = false;
   if (outputstr[0] == '#') { // Output specified using index
     int ret = sscanf(outputstr + 1, SIZE_FORMAT, &idx);
     if (ret != 1 || idx >= _n_outputs) {
@@ -448,7 +448,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       LogOutput* output = new_output(normalized, output_options, errstream);
       if (output != NULL) {
         idx = add_output(output);
-        is_added = true;
+        added = true;
       }
     }
 
@@ -457,7 +457,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       return false;
     }
   }
-  if (!is_added && output_options != NULL && strlen(output_options) > 0) {
+  if (!added && output_options != NULL && strlen(output_options) > 0) {
     errstream->print_cr("Output options for existing outputs are ignored.");
   }
   configure_output(idx, selections, decorators);


### PR DESCRIPTION
When reconfiguring log output options of an existing log setting with jcmd VM.log and the file name, a warning message is shown. However, when reconfiguring them with jcmd VM.log and the output index, the message is not shown.

```
$ java -Xlog::sample.log:: Sample
$ jcmd 4976 VM.log list
Log output configuration:
 #0: stdout all=warning uptime,level,tags
 #1: stderr all=off uptime,level,tags
 #2: file=sample.log all=info uptime,level,tags filecount=5,filesize=20480K

$ jcmd 4976 VM.log output="sample.log" output_options="filecount=100"
4976:
Output options for existing outputs are ignored.

$ jcmd 4976 VM.log output="#2" output_options="filecount=100"
4976:
Command executed successfully
```

It's better to show the same message also in the latter case, I think. Because the output options is not updated in both cases.

```
$ jcmd 4976 VM.log list
 #0: stdout all=warning uptime,level,tags
 #1: stderr all=off uptime,level,tags
 #2: file=sample.log all=info uptime,level,tags filecount=5,filesize=20480K (reconfigured)
```
This pull request enable to show the warning message when specifying the output index.

```
$ java -Xlog::sample.log:: Sample
$ jcmd 5054 VM.log output="sample.log" output_options="filecount=100"
5054:
Output options for existing outputs are ignored.

$ jcmd 5054 VM.log output="#2" output_options="filecount=100"
5054:
Output options for existing outputs are ignored.
```

### gtest result

```
$ ./build/linux-x86_64-server-fastdebug/hotspot/variant-server/libjvm/gtest/gtestLauncher -jdk:./build/linux-x86_64-server-fastdebug/jdk --gtest_filter=LogConfigurationTest.\*
Note: Google Test filter = LogConfigurationTest.*
[==========] Running 15 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 15 tests from LogConfigurationTest
[ RUN      ] LogConfigurationTest.describe_vm
[       OK ] LogConfigurationTest.describe_vm (1 ms)
[ RUN      ] LogConfigurationTest.update_output_vm
[       OK ] LogConfigurationTest.update_output_vm (0 ms)
[ RUN      ] LogConfigurationTest.add_new_output_vm
[       OK ] LogConfigurationTest.add_new_output_vm (0 ms)
[ RUN      ] LogConfigurationTest.disable_logging_vm
[       OK ] LogConfigurationTest.disable_logging_vm (1 ms)
[ RUN      ] LogConfigurationTest.disable_output_vm
[       OK ] LogConfigurationTest.disable_output_vm (0 ms)
[ RUN      ] LogConfigurationTest.reconfigure_decorators_vm
[       OK ] LogConfigurationTest.reconfigure_decorators_vm (0 ms)
[ RUN      ] LogConfigurationTest.invalid_configure_options_vm
[       OK ] LogConfigurationTest.invalid_configure_options_vm (0 ms)
[ RUN      ] LogConfigurationTest.parse_empty_command_line_arguments_vm
[0.462s][warning][logging] Ignoring excess -Xlog options: ""
[       OK ] LogConfigurationTest.parse_empty_command_line_arguments_vm (0 ms)
[ RUN      ] LogConfigurationTest.parse_command_line_arguments_vm
[       OK ] LogConfigurationTest.parse_command_line_arguments_vm (1 ms)
[ RUN      ] LogConfigurationTest.parse_log_arguments_vm
[       OK ] LogConfigurationTest.parse_log_arguments_vm (188 ms)
[ RUN      ] LogConfigurationTest.configure_stdout_vm
[       OK ] LogConfigurationTest.configure_stdout_vm (2 ms)
[ RUN      ] LogConfigurationTest.subscribe_vm
[       OK ] LogConfigurationTest.subscribe_vm (2 ms)
[ RUN      ] LogConfigurationTest.parse_invalid_tagset_vm
[       OK ] LogConfigurationTest.parse_invalid_tagset_vm (0 ms)
[ RUN      ] LogConfigurationTest.output_name_normalization_vm
[       OK ] LogConfigurationTest.output_name_normalization_vm (1 ms)
[ RUN      ] LogConfigurationTest.suggest_similar_selection_vm
[       OK ] LogConfigurationTest.suggest_similar_selection_vm (1 ms)
[----------] 15 tests from LogConfigurationTest (658 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 1 test case ran. (659 ms total)
[  PASSED  ] 15 tests.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265047](https://bugs.openjdk.java.net/browse/JDK-8265047): Inconsistent warning message in jcmd VM.log


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to e37e8c50504b6274c135b1b80be173cbba4c321f
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to e37e8c50504b6274c135b1b80be173cbba4c321f
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to e37e8c50504b6274c135b1b80be173cbba4c321f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3448/head:pull/3448` \
`$ git checkout pull/3448`

Update a local copy of the PR: \
`$ git checkout pull/3448` \
`$ git pull https://git.openjdk.java.net/jdk pull/3448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3448`

View PR using the GUI difftool: \
`$ git pr show -t 3448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3448.diff">https://git.openjdk.java.net/jdk/pull/3448.diff</a>

</details>
