### PR TITLE
8265105: gc/arguments/TestSelectDefaultGC.java fails when compiler1 is disabled

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -159,7 +159,8 @@ intx CompilerConfig::scaled_freq_log(intx freq_log, double scale) {
   }
 }
 
-void set_client_emulation_mode_flags() {
+void CompilerConfig::set_client_emulation_mode_flags() {
+  assert(has_c1(), "Must have C1 compiler present");
   CompilationModeFlag::set_quick_only();
 
   FLAG_SET_ERGO(ProfileInterpreter, false);
@@ -560,17 +561,19 @@ void CompilerConfig::ergo_initialize() {
   return;
 #endif
 
-  if (!is_compilation_mode_selected()) {
+  if (has_c1()) {
+    if (!is_compilation_mode_selected()) {
 #if defined(_WINDOWS) && !defined(_LP64)
-    if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
-      FLAG_SET_ERGO(NeverActAsServerClassMachine, true);
-    }
+      if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
+        FLAG_SET_ERGO(NeverActAsServerClassMachine, true);
+      }
 #endif
-    if (NeverActAsServerClassMachine) {
+      if (NeverActAsServerClassMachine) {
+        set_client_emulation_mode_flags();
+      }
+    } else if (!has_c2() && !is_jvmci_compiler()) {
       set_client_emulation_mode_flags();
     }
-  } else if (!has_c2() && !is_jvmci_compiler()) {
-    set_client_emulation_mode_flags();
   }
 
   set_legacy_emulation_flags();

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -246,6 +246,7 @@ private:
   static void set_compilation_policy_flags();
   static void set_jvmci_specific_flags();
   static void set_legacy_emulation_flags();
+  static void set_client_emulation_mode_flags();
 };
 
 #endif // SHARE_COMPILER_COMPILERDEFINITIONS_HPP


### PR DESCRIPTION
On MIPS64 platform has not impliment C1,only has C2.
 so when tiered compilation is off, it is unnecessary to set client emulation mode flags.
 perhaps this bug be included by https://bugs.openjdk.java.net/browse/JDK-8251462

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265105](https://bugs.openjdk.java.net/browse/JDK-8265105): gc/arguments/TestSelectDefaultGC.java fails when compiler1 is disabled


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3449/head:pull/3449` \
`$ git checkout pull/3449`

Update a local copy of the PR: \
`$ git checkout pull/3449` \
`$ git pull https://git.openjdk.java.net/jdk pull/3449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3449`

View PR using the GUI difftool: \
`$ git pr show -t 3449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3449.diff">https://git.openjdk.java.net/jdk/pull/3449.diff</a>

</details>
