### PR TITLE
8265112: ProblemList some java/foreign tests on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -550,6 +550,10 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 
 java/foreign/TestMismatch.java 8249684 macosx-all
 
+java/foreign/StdLibTest.java 8263512 macosx-aarch64
+java/foreign/TestVarArgs.java 8263512 macosx-aarch64
+java/foreign/valist/VaListTest.java 8263512 macosx-aarch64
+
 ############################################################################
 
 # jdk_lang


### PR DESCRIPTION
Let's problem list java/foreign/{StdLibTest,TestVarArgs,valist/VaListTest}.java (all tier1 tests) until JDK-8263512 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265112](https://bugs.openjdk.java.net/browse/JDK-8265112): ProblemList some java/foreign tests on macosx-aarch64


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3451/head:pull/3451` \
`$ git checkout pull/3451`

Update a local copy of the PR: \
`$ git checkout pull/3451` \
`$ git pull https://git.openjdk.java.net/jdk pull/3451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3451`

View PR using the GUI difftool: \
`$ git pr show -t 3451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3451.diff">https://git.openjdk.java.net/jdk/pull/3451.diff</a>

</details>
