### PR TITLE
8265111: ProblemList java/util/concurrent/locks/Lock/TimedAcquireLeak.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -796,6 +796,8 @@ com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-al
 
 # jdk_util
 
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java           8262897 macosx-aarch64
+
 ############################################################################
 
 # jdk_instrument


### PR DESCRIPTION
Let's problem list java/util/concurrent/locks/Lock/TimedAcquireLeak.java (a tier1 test) until JDK-8262897 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265111](https://bugs.openjdk.java.net/browse/JDK-8265111): ProblemList java/util/concurrent/locks/Lock/TimedAcquireLeak.java on macosx-aarch64


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3452/head:pull/3452` \
`$ git checkout pull/3452`

Update a local copy of the PR: \
`$ git checkout pull/3452` \
`$ git pull https://git.openjdk.java.net/jdk pull/3452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3452`

View PR using the GUI difftool: \
`$ git pr show -t 3452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3452.diff">https://git.openjdk.java.net/jdk/pull/3452.diff</a>

</details>
