### PR TITLE
8265113: ProblemList gtest/GTestWrapper.java:os.release_multi_mappings on macosx-aarch64

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -412,7 +412,11 @@ struct NUMASwitcher {
 #endif
 
 #ifndef _AIX // JDK-8257041
+#if defined(__APPLE__) && defined(AARCH64)
+TEST_VM(os, DISABLED_release_multi_mappings) {
+#else
 TEST_VM(os, release_multi_mappings) {
+#endif
   // Test that we can release an area created with multiple reservation calls
   const size_t stripe_len = 4 * M;
   const int num_stripes = 4;


### PR DESCRIPTION
Let's do the equivalent of problem listing the gtest/GTestWrapper.java os.release_multi_mappings sub-test (included in tier1) until JDK-8262952 is fixed.

Note: I considered a few different ways of disabling the test on macosx-aarch64. The gtest docs (https://github.com/google/googletest/blob/master/docs/advanced.md#temporarily-disabling-tests) note, and I agree, that adding the DISABLED_ prefix is preferable over preprocessor excluding the whole test. There are several ways to add the DISABLED_ prefix conditionally, only on macosx-aarch64. In the end I found this the easiest to read and understand.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265113](https://bugs.openjdk.java.net/browse/JDK-8265113): ProblemList gtest/GTestWrapper.java:os.release_multi_mappings on macosx-aarch64


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3454/head:pull/3454` \
`$ git checkout pull/3454`

Update a local copy of the PR: \
`$ git checkout pull/3454` \
`$ git pull https://git.openjdk.java.net/jdk pull/3454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3454`

View PR using the GUI difftool: \
`$ git pr show -t 3454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3454.diff">https://git.openjdk.java.net/jdk/pull/3454.diff</a>

</details>
