### PR TITLE
8265116: ZGC: Steal local stacks instead of flushing them

### DIFF
--- a/src/hotspot/share/gc/z/zMark.hpp
+++ b/src/hotspot/share/gc/z/zMark.hpp
@@ -71,10 +71,8 @@ private:
                                    ZMarkThreadLocalStacks* stacks,
                                    ZMarkCache* cache,
                                    T* timeout);
-  template <typename T> bool drain_and_flush(ZMarkStripe* stripe,
-                                             ZMarkThreadLocalStacks* stacks,
-                                             ZMarkCache* cache,
-                                             T* timeout);
+  bool try_steal_local(ZMarkStripe* stripe, ZMarkThreadLocalStacks* stacks);
+  bool try_steal_global(ZMarkStripe* stripe, ZMarkThreadLocalStacks* stacks);
   bool try_steal(ZMarkStripe* stripe, ZMarkThreadLocalStacks* stacks);
   void idle() const;
   bool flush(bool at_safepoint);

--- a/src/hotspot/share/gc/z/zMarkStack.hpp
+++ b/src/hotspot/share/gc/z/zMarkStack.hpp
@@ -139,6 +139,9 @@ public:
                ZMarkStripe* stripe,
                ZMarkStack* stack);
 
+  ZMarkStack* steal(ZMarkStripeSet* stripes,
+                    ZMarkStripe* stripe);
+
   bool push(ZMarkStackAllocator* allocator,
             ZMarkStripeSet* stripes,
             ZMarkStripe* stripe,

--- a/src/hotspot/share/gc/z/zMarkStack.inline.hpp
+++ b/src/hotspot/share/gc/z/zMarkStack.inline.hpp
@@ -219,6 +219,17 @@ inline void ZMarkThreadLocalStacks::install(ZMarkStripeSet* stripes,
   *stackp = stack;
 }
 
+inline ZMarkStack* ZMarkThreadLocalStacks::steal(ZMarkStripeSet* stripes,
+                                                 ZMarkStripe* stripe) {
+  ZMarkStack** const stackp = &_stacks[stripes->stripe_id(stripe)];
+  ZMarkStack* const stack = *stackp;
+  if (stack != NULL) {
+    *stackp = NULL;
+  }
+
+  return stack;
+}
+
 inline bool ZMarkThreadLocalStacks::push(ZMarkStackAllocator* allocator,
                                          ZMarkStripeSet* stripes,
                                          ZMarkStripe* stripe,


### PR DESCRIPTION
As part of addressing the issue of excessive mark stack usage, it was observed that sometimes mark stack utilization can be very low. For example, casparcwang@tencent.com reported that when running Apache Zookeeper, mark stack utilization was ~10%.

The problem is that GC workers are a bit too eager to flush mark stacks. Currently, whenever a GC worker has drained its home stripe it will always flush all remaining mark stacks. This causes non-full mark stacks to be flushed. This in turn means that the GC worker who receives that non-full stack (small amount of work) tends to also produce non-full stacks (small amount of work) for other GC workers. This can lead to a vicious cycle, which results in excessive mark stack memory usage.

The solution proposed here is to not let GC workers flush non-full stacks. After draining the home stripe, a GC worker will instead try to steal any non-full local stack belonging to a different stripe, and if no such stacks exist it will (as it does today) try to steal a global stack belonging to a different stripe.

(Note: This PR only addresses one part of the mark stack usage problem. Other improvements, such as the discussed "mark before push"-patch will be a separate PR).

Testing:
 * Tier1-7.
 * SPECjbb2015, score and mark times unaffected.
 * casparcwang@tencent.com reports that this patch (in combination with the "mark before push"-patch) solves the problem for Apache Zookeeper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265116](https://bugs.openjdk.java.net/browse/JDK-8265116): ZGC: Steal local stacks instead of flushing them


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Contributors
 * Wang Chao `<wchao@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3455/head:pull/3455` \
`$ git checkout pull/3455`

Update a local copy of the PR: \
`$ git checkout pull/3455` \
`$ git pull https://git.openjdk.java.net/jdk pull/3455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3455`

View PR using the GUI difftool: \
`$ git pr show -t 3455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3455.diff">https://git.openjdk.java.net/jdk/pull/3455.diff</a>

</details>
