### PR TITLE
8265066: Split ReservedSpace constructor to avoid default parameter

### DIFF
--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -227,7 +227,8 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   const size_t committed_segments_size = align_to_page_size(_number_of_committed_segments);
 
   // reserve space for _segmap
-  if (!_segmap.initialize(reserved_segments_size, committed_segments_size)) {
+  ReservedSpace seg_rs(reserved_segments_size);
+  if (!_segmap.initialize(seg_rs, committed_segments_size)) {
     return false;
   }
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -55,8 +55,6 @@ ReservedSpace::ReservedSpace(size_t size) : _fd_for_heap(-1) {
 }
 
 ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size) : _fd_for_heap(-1) {
-  assert(is_power_of_2(preferred_page_size), "invariant");
-
   // When a page size is given we don't want to mix large
   // and normal pages. If the size is not a multiple of the
   // page size it will be aligned up to achieve this.

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -44,21 +44,27 @@ ReservedSpace::ReservedSpace() : _base(NULL), _size(0), _noaccess_prefix(0),
     _alignment(0), _special(false), _fd_for_heap(-1), _executable(false) {
 }
 
-ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size) : _fd_for_heap(-1) {
-  bool has_preferred_page_size = preferred_page_size != 0;
-  // Want to use large pages where possible and pad with small pages.
-  size_t page_size = has_preferred_page_size ? preferred_page_size : os::page_size_for_region_unaligned(size, 1);
+ReservedSpace::ReservedSpace(size_t size) : _fd_for_heap(-1) {
+  // Want to use large pages where possible. If the size is
+  // not large page aligned the mapping will be a mix of
+  // large and normal pages.
+  size_t page_size = os::page_size_for_region_unaligned(size, 1);
+  size_t alignment = os::vm_allocation_granularity();
   bool large_pages = page_size != (size_t)os::vm_page_size();
-  size_t alignment;
-  if (large_pages && has_preferred_page_size) {
-    alignment = MAX2(page_size, (size_t)os::vm_allocation_granularity());
-    // ReservedSpace initialization requires size to be aligned to the given
-    // alignment. Align the size up.
+  initialize(size, alignment, large_pages, NULL, false);
+}
+
+ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size) : _fd_for_heap(-1) {
+  assert(is_power_of_2(preferred_page_size), "invariant");
+
+  // When a page size is given we don't want to mix large
+  // and normal pages. If the size is not a multiple of the
+  // page size it will be aligned up to achieve this.
+  size_t alignment = os::vm_allocation_granularity();;
+  bool large_pages = preferred_page_size != (size_t)os::vm_page_size();
+  if (large_pages) {
+    alignment = MAX2(preferred_page_size, alignment);
     size = align_up(size, alignment);
-  } else {
-    // Don't force the alignment to be large page aligned,
-    // since that will waste memory.
-    alignment = os::vm_allocation_granularity();
   }
   initialize(size, alignment, large_pages, NULL, false);
 }

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -55,11 +55,14 @@ class ReservedSpace {
  public:
   // Constructor
   ReservedSpace();
-  // Initialize the reserved space with the given size. If preferred_page_size
-  // is set, use this as minimum page size/alignment. This may waste some space
-  // if the given size is not aligned to that value, as the reservation will be
+  // Initialize the reserved space with the given size. Depending on the size
+  // a suitable page size and alignment will be used.
+  explicit ReservedSpace(size_t size);
+  // Initialize the reserved space with the given size. The preferred_page_size
+  // is used as the minimum page size/alignment. This may waste some space if
+  // the given size is not aligned to that value, as the reservation will be
   // aligned up to the final alignment in this case.
-  ReservedSpace(size_t size, size_t preferred_page_size = 0);
+  ReservedSpace(size_t size, size_t preferred_page_size);
   ReservedSpace(size_t size, size_t alignment, bool large,
                 char* requested_address = NULL);
 


### PR DESCRIPTION
Please review this change to change this constructor in ReservedSpace:
```
  // Initialize the reserved space with the given size. If preferred_page_size
  // is set, use this as minimum page size/alignment. This may waste some space
  // if the given size is not aligned to that value, as the reservation will be
  // aligned up to the final alignment in this case.
  ReservedSpace(size_t size, size_t preferred_page_size = 0);
```

I propose to split this constructor into two instead of having the default parameter. This makes the implementation more straight forward. I also make the single argument constructor explicit to avoid implicit conversion. There was one place where we relied on implicit conversion and this has been updated to explicitly create the ReservedSpace.

This cleanup is another step towards:
[JDK-8261527: Record page size used for underlying mapping in ReservedSpace](https://bugs.openjdk.java.net/browse/JDK-8261527)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265066](https://bugs.openjdk.java.net/browse/JDK-8265066): Split ReservedSpace constructor to avoid default parameter


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3457/head:pull/3457` \
`$ git checkout pull/3457`

Update a local copy of the PR: \
`$ git checkout pull/3457` \
`$ git pull https://git.openjdk.java.net/jdk pull/3457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3457`

View PR using the GUI difftool: \
`$ git pr show -t 3457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3457.diff">https://git.openjdk.java.net/jdk/pull/3457.diff</a>

</details>
