### PR TITLE
8265120: hs_err improvement: align the output of Virtual space metadata

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -78,7 +78,7 @@ static void print_vs(outputStream* out, size_t scale) {
     out->print(" committed, ");
     out->print(" %d nodes.", num_nodes_c);
     out->cr();
-    out->print("              Both:  ");
+    out->print("             Both:  ");
     print_scaled_words(out, reserved_c + reserved_nc, scale, 7);
     out->print(" reserved, ");
     print_scaled_words_and_percentage(out, committed_c + committed_nc, reserved_c + reserved_nc, scale, 7);


### PR DESCRIPTION
In the "virtual space" section of the VM error log, the "Both" line doesn't align well will the above two lines - there is a redundant leading space in this line.

```
Metaspace:

Usage:
  Non-class:    216.95 KB used.
      Class:     10.45 KB used.
       Both:    227.40 KB used.

Virtual space:
  Non-class space:        8.00 MB reserved,     320.00 KB (  4%) committed,  1 nodes.
      Class space:        1.00 GB reserved,     128.00 KB ( <1%) committed,  1 nodes.
              Both:        1.01 GB reserved,     448.00 KB ( <1%) committed.     <---- Not aligned here
```

It can be simply fixed by removing the redundant space in function `print_vs` in `src/hotspot/share/memory/metaspace/metaspaceReporter.cpp`.

Here is the fixed result:
```
Metaspace:

Usage:
  Non-class:    216.95 KB used.
      Class:     10.45 KB used.
       Both:    227.40 KB used.

Virtual space:
  Non-class space:        8.00 MB reserved,     320.00 KB (  4%) committed,  1 nodes.
      Class space:        1.00 GB reserved,     128.00 KB ( <1%) committed,  1 nodes.
             Both:        1.01 GB reserved,     448.00 KB ( <1%) committed.    <----- Fixed
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265120](https://bugs.openjdk.java.net/browse/JDK-8265120): hs_err improvement: align the output of Virtual space metadata


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3458/head:pull/3458` \
`$ git checkout pull/3458`

Update a local copy of the PR: \
`$ git checkout pull/3458` \
`$ git pull https://git.openjdk.java.net/jdk pull/3458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3458`

View PR using the GUI difftool: \
`$ git pr show -t 3458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3458.diff">https://git.openjdk.java.net/jdk/pull/3458.diff</a>

</details>
