### PR TITLE
8262108: SimpleDateFormat formatting broken for sq_MK Locale

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
@@ -189,7 +189,20 @@ public class CalendarNameProviderImpl extends CalendarNameProvider implements Av
                             if (name.isEmpty()) {
                                 continue;
                             }
-                            map.put(name, base + i);
+                            if (field == AM_PM) {
+                                // Convert the dayPeriod "type" to either AM or PM field value.
+                                // Following is a mapping of dayPeriod "type" to their array index
+                                // in Calendar resource bundle
+                                // am = 0, pm = 1, midnight = 2, noon = 3, morning1 = 4,
+                                // morning2 = 5, afternoon1 = 6, afternoon2 = 7, evening1 = 8,
+                                // evening2 = 9, night1 = 10, night2 = 11
+                                switch (i) {
+                                    case 0, 2, 3, 4, 5 -> map.put(name, AM);
+                                    case 1, 6, 7, 8, 9, 10, 11 -> map.put(name, PM);
+                                }
+                            } else {
+                                map.put(name, base + i);
+                            }
                         }
                     }
                 }

--- a/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
@@ -189,17 +189,11 @@ public class CalendarNameProviderImpl extends CalendarNameProvider implements Av
                             if (name.isEmpty()) {
                                 continue;
                             }
-                            if (field == AM_PM) {
-                                // Convert the dayPeriod "type" to either AM or PM field value.
-                                // Following is a mapping of dayPeriod "type" to their array index
-                                // in Calendar resource bundle
-                                // am = 0, pm = 1, midnight = 2, noon = 3, morning1 = 4,
-                                // morning2 = 5, afternoon1 = 6, afternoon2 = 7, evening1 = 8,
-                                // evening2 = 9, night1 = 10, night2 = 11
-                                switch (i) {
-                                    case 0, 2, 3, 4, 5 -> map.put(name, AM);
-                                    case 1, 6, 7, 8, 9, 10, 11 -> map.put(name, PM);
-                                }
+                            if (field == AM_PM && !javatime && i > PM) {
+                                // when dealing with calendar fields, don't set AM_PM field value
+                                // to anything that isn't either AM or PM (this can happen when
+                                // day periods are involved)
+                                continue;
                             } else {
                                 map.put(name, base + i);
                             }

--- a/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
@@ -190,7 +190,8 @@ public class CalendarNameProviderImpl extends CalendarNameProvider implements Av
                                 continue;
                             }
                             if (field == AM_PM && !javatime && i > PM) {
-                                // when dealing with calendar fields, don't set AM_PM field value
+                                // Unlike in the case of java.time.format.DateTimeFormatter(Builder),
+                                // when dealing with java.util.Calendar, don't set AM_PM field value
                                 // to anything that isn't either AM or PM (this can happen when
                                 // day periods are involved)
                                 continue;

--- a/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/CalendarNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
+++ b/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
@@ -50,7 +50,6 @@ public class CalendarDisplayNamesTest {
         for (final Locale locale : Locale.getAvailableLocales()) {
             for (final int style : styles) {
                 final Calendar cal = Calendar.getInstance();
-                cal.setLenient(false);
                 final Map<String, Integer> names = cal.getDisplayNames(Calendar.AM_PM, style, locale);
                 if (names == null) {
                     continue;

--- a/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
+++ b/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @test
+ * @bug 8262108
+ * @summary Verify the results returned by Calendar.getDisplayNames() API
+ * @comment Locale providers: COMPAT,SPI
+ * @run testng/othervm -Djava.locale.providers=COMPAT,SPI CalendarDisplayNamesTest
+ * @comment Locale providers: CLDR
+ * @run testng/othervm -Djava.locale.providers=CLDR CalendarDisplayNamesTest
+ */
+public class CalendarDisplayNamesTest {
+
+    /**
+     * Test that the {@link Calendar#getDisplayNames(int, int, Locale)} returns valid field values
+     * for the {@link Calendar#AM_PM} field in various locales and styles
+     */
+    @Test
+    public void testAM_PMDisplayNameValues() {
+        final int[] styles = new int[]{Calendar.ALL_STYLES, Calendar.SHORT_FORMAT, Calendar.LONG_FORMAT,
+                Calendar.SHORT_STANDALONE, Calendar.LONG_STANDALONE, Calendar.SHORT, Calendar.LONG};
+        for (final Locale locale : Locale.getAvailableLocales()) {
+            for (final int style : styles) {
+                final Calendar cal = Calendar.getInstance();
+                cal.setLenient(false);
+                final Map<String, Integer> names = cal.getDisplayNames(Calendar.AM_PM, style, locale);
+                if (names == null) {
+                    continue;
+                }
+                for (final Integer fieldValue : names.values()) {
+                    Assert.assertTrue(fieldValue == Calendar.AM || fieldValue == Calendar.PM,
+                            "Invalid field value " + fieldValue + " for calendar field AM_PM, in locale "
+                                    + locale + " with style " + style);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8000983 8008577 8247781
+ * @bug 8000983 8008577 8247781 8262108
  * @summary Unit test for narrow names support. This test is locale data-dependent
  *          and assumes that both COMPAT and CLDR have the same narrow names if not
  *          explicitly specified.

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -111,12 +111,10 @@ public class NarrowNamesTest {
             expectedFieldValues.put("n", null);
             testAM_PM(US, ALL_STYLES, expectedFieldValues);
         } else {
-            Map<String, Integer> expectedFieldValues = new HashMap<>();
-            expectedFieldValues.put("AM", Calendar.AM);
-            expectedFieldValues.put("PM", Calendar.PM);
-            expectedFieldValues.put("a", Calendar.AM);
-            expectedFieldValues.put("p", Calendar.PM);
-            testAM_PM(US, ALL_STYLES, expectedFieldValues);
+            testMap(US, AM_PM, ALL_STYLES,
+                    "AM", "PM",
+                    RESET_INDEX,
+                    "a", "p");
         }
         testMap(JAJPJP, DAY_OF_WEEK, NARROW_STANDALONE,
                 "", // 1-based indexing for DAY_OF_WEEK

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -37,7 +37,6 @@
 import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -95,27 +94,10 @@ public class NarrowNamesTest {
                 "Sat"        // abb Saturday
                 );
         testMap(US, DAY_OF_WEEK, NARROW_FORMAT); // expect null
-        if (providers.startsWith("CLDR")) {
-            Map<String, Integer> expectedFieldValues = new HashMap<>();
-            expectedFieldValues.put("AM", Calendar.AM);
-            expectedFieldValues.put("PM", Calendar.PM);
-            expectedFieldValues.put("midnight", null);
-            expectedFieldValues.put("noon", null);
-            expectedFieldValues.put("in the morning", null);
-            expectedFieldValues.put("in the afternoon", null);
-            expectedFieldValues.put("in the evening", null);
-            expectedFieldValues.put("at night", null);
-            expectedFieldValues.put("a", Calendar.AM);
-            expectedFieldValues.put("p", Calendar.PM);
-            expectedFieldValues.put("mi", null);
-            expectedFieldValues.put("n", null);
-            testAM_PM(US, ALL_STYLES, expectedFieldValues);
-        } else {
-            testMap(US, AM_PM, ALL_STYLES,
-                    "AM", "PM",
-                    RESET_INDEX,
-                    "a", "p");
-        }
+        testMap(US, AM_PM, ALL_STYLES,
+                "AM", "PM",
+                RESET_INDEX,
+                "a", "p");
         testMap(JAJPJP, DAY_OF_WEEK, NARROW_STANDALONE,
                 "", // 1-based indexing for DAY_OF_WEEK
                 "\u65e5",
@@ -211,33 +193,6 @@ public class NarrowNamesTest {
             && !(expectedMap != null && expectedMap.equals(got))) {
             System.err.printf("testMap: locale=%s, field=%d, style=%d, expected=%s, got=%s%n",
                               locale, field, style, expectedMap, got);
-            errors++;
-        }
-    }
-
-    /**
-     * Verify that the values returned by Calendar.getDisplayNames() for the passed
-     * locale and style matches the expected field values
-     */
-    private static void testAM_PM(Locale locale, int style, Map<String, Integer> expectedNameValuePair) {
-        Calendar cal = Calendar.getInstance(locale);
-        Map<String, Integer> got = cal.getDisplayNames(Calendar.AM_PM, style, locale);
-        boolean unexpectedValues = false;
-        for (Map.Entry<String, Integer> expected : expectedNameValuePair.entrySet()) {
-            final Integer expectedFieldValue = expected.getValue();
-            final Integer gotFieldValue = got.remove(expected.getKey());
-            if ((expectedFieldValue == null && gotFieldValue != null) ||
-                    (expectedFieldValue != null && !expectedFieldValue.equals(gotFieldValue))) {
-                unexpectedValues = true;
-                break;
-            }
-        }
-        if (!got.isEmpty()) {
-            unexpectedValues = true;
-        }
-        if (unexpectedValues) {
-            System.err.printf("testAM_PM: locale=%s, field=%d, style=%d, expected=%s, got=%s%n",
-                    locale, Calendar.AM_PM, style, expectedNameValuePair, got);
             errors++;
         }
     }

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -99,16 +99,16 @@ public class NarrowNamesTest {
             Map<String, Integer> expectedFieldValues = new HashMap<>();
             expectedFieldValues.put("AM", Calendar.AM);
             expectedFieldValues.put("PM", Calendar.PM);
-            expectedFieldValues.put("midnight", Calendar.AM);
-            expectedFieldValues.put("noon", Calendar.AM);
-            expectedFieldValues.put("in the morning", Calendar.AM);
-            expectedFieldValues.put("in the afternoon", Calendar.PM);
-            expectedFieldValues.put("in the evening", Calendar.PM);
-            expectedFieldValues.put("at night", Calendar.PM);
+            expectedFieldValues.put("midnight", null);
+            expectedFieldValues.put("noon", null);
+            expectedFieldValues.put("in the morning", null);
+            expectedFieldValues.put("in the afternoon", null);
+            expectedFieldValues.put("in the evening", null);
+            expectedFieldValues.put("at night", null);
             expectedFieldValues.put("a", Calendar.AM);
             expectedFieldValues.put("p", Calendar.PM);
-            expectedFieldValues.put("mi", Calendar.AM);
-            expectedFieldValues.put("n", Calendar.AM);
+            expectedFieldValues.put("mi", null);
+            expectedFieldValues.put("n", null);
             testAM_PM(US, ALL_STYLES, expectedFieldValues);
         } else {
             Map<String, Integer> expectedFieldValues = new HashMap<>();
@@ -224,8 +224,20 @@ public class NarrowNamesTest {
     private static void testAM_PM(Locale locale, int style, Map<String, Integer> expectedNameValuePair) {
         Calendar cal = Calendar.getInstance(locale);
         Map<String, Integer> got = cal.getDisplayNames(Calendar.AM_PM, style, locale);
-        if (!(expectedNameValuePair == null && got == null)
-                && !(expectedNameValuePair != null && expectedNameValuePair.equals(got))) {
+        boolean unexpectedValues = false;
+        for (Map.Entry<String, Integer> expected : expectedNameValuePair.entrySet()) {
+            final Integer expectedFieldValue = expected.getValue();
+            final Integer gotFieldValue = got.remove(expected.getKey());
+            if ((expectedFieldValue == null && gotFieldValue != null) ||
+                    (expectedFieldValue != null && !expectedFieldValue.equals(gotFieldValue))) {
+                unexpectedValues = true;
+                break;
+            }
+        }
+        if (!got.isEmpty()) {
+            unexpectedValues = true;
+        }
+        if (unexpectedValues) {
             System.err.printf("testAM_PM: locale=%s, field=%d, style=%d, expected=%s, got=%s%n",
                     locale, Calendar.AM_PM, style, expectedNameValuePair, got);
             errors++;

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -37,6 +37,7 @@
 import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -95,26 +96,27 @@ public class NarrowNamesTest {
                 );
         testMap(US, DAY_OF_WEEK, NARROW_FORMAT); // expect null
         if (providers.startsWith("CLDR")) {
-            testMap(US, AM_PM, ALL_STYLES,
-                    "AM",
-                    "PM",
-                    "midnight",
-                    "noon",
-                    "in the morning",
-                    "",
-                    "in the afternoon",
-                    "",
-                    "in the evening",
-                    "",
-                    "at night",
-                    "",
-                    RESET_INDEX,
-                    "a", "p", "mi", "n", "", "", "", "", "", "", "", "");
+            Map<String, Integer> expectedFieldValues = new HashMap<>();
+            expectedFieldValues.put("AM", Calendar.AM);
+            expectedFieldValues.put("PM", Calendar.PM);
+            expectedFieldValues.put("midnight", Calendar.AM);
+            expectedFieldValues.put("noon", Calendar.AM);
+            expectedFieldValues.put("in the morning", Calendar.AM);
+            expectedFieldValues.put("in the afternoon", Calendar.PM);
+            expectedFieldValues.put("in the evening", Calendar.PM);
+            expectedFieldValues.put("at night", Calendar.PM);
+            expectedFieldValues.put("a", Calendar.AM);
+            expectedFieldValues.put("p", Calendar.PM);
+            expectedFieldValues.put("mi", Calendar.AM);
+            expectedFieldValues.put("n", Calendar.AM);
+            testAM_PM(US, ALL_STYLES, expectedFieldValues);
         } else {
-            testMap(US, AM_PM, ALL_STYLES,
-                    "AM", "PM",
-                    RESET_INDEX,
-                    "a", "p");
+            Map<String, Integer> expectedFieldValues = new HashMap<>();
+            expectedFieldValues.put("AM", Calendar.AM);
+            expectedFieldValues.put("PM", Calendar.PM);
+            expectedFieldValues.put("a", Calendar.AM);
+            expectedFieldValues.put("p", Calendar.PM);
+            testAM_PM(US, ALL_STYLES, expectedFieldValues);
         }
         testMap(JAJPJP, DAY_OF_WEEK, NARROW_STANDALONE,
                 "", // 1-based indexing for DAY_OF_WEEK
@@ -211,6 +213,21 @@ public class NarrowNamesTest {
             && !(expectedMap != null && expectedMap.equals(got))) {
             System.err.printf("testMap: locale=%s, field=%d, style=%d, expected=%s, got=%s%n",
                               locale, field, style, expectedMap, got);
+            errors++;
+        }
+    }
+
+    /**
+     * Verify that the values returned by Calendar.getDisplayNames() for the passed
+     * locale and style matches the expected field values
+     */
+    private static void testAM_PM(Locale locale, int style, Map<String, Integer> expectedNameValuePair) {
+        Calendar cal = Calendar.getInstance(locale);
+        Map<String, Integer> got = cal.getDisplayNames(Calendar.AM_PM, style, locale);
+        if (!(expectedNameValuePair == null && got == null)
+                && !(expectedNameValuePair != null && expectedNameValuePair.equals(got))) {
+            System.err.printf("testAM_PM: locale=%s, field=%d, style=%d, expected=%s, got=%s%n",
+                    locale, Calendar.AM_PM, style, expectedNameValuePair, got);
             errors++;
         }
     }


### PR DESCRIPTION
Can I please get a review for this proposed fix for https://bugs.openjdk.java.net/browse/JDK-8262108?

As noted in a comment in that issue, the bug relates to the return value of `Calendar.getDisplayNames` for the `Calendar.AM_PM` field. The implementation has started returning invalid values for the `AM_PM` field after the "day period" support was added recently in the JDK as part of https://bugs.openjdk.java.net/browse/JDK-8262108.

The commit here adds a check in the internal implementation of the display name handling logic, to special case the `AM_PM` field and properly convert the display name array indexes (which is an internal detail) to valid values that represent the `AM_PM` calendar field.

The commit also has a new jtreg test case `CalendarDisplayNamesTest` reproduces this issue and verifies the fix.

After this fix was introduced, I ran the test in `test/jdk/java/util/Calendar/` and that showed up a failure in an existing test case `NarrowNamesTest`. Looking at that test case, IMO, the current testing in that `NarrowNamesTest` is incorrect and is probably what hid this issue in the first place? To fix this, I have added an additional commit which updates this test case to properly test the `AM_PM` field values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262108](https://bugs.openjdk.java.net/browse/JDK-8262108): SimpleDateFormat formatting broken for sq_MK Locale


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3463/head:pull/3463` \
`$ git checkout pull/3463`

Update a local copy of the PR: \
`$ git checkout pull/3463` \
`$ git pull https://git.openjdk.java.net/jdk pull/3463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3463`

View PR using the GUI difftool: \
`$ git pr show -t 3463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3463.diff">https://git.openjdk.java.net/jdk/pull/3463.diff</a>

</details>
