### PR TITLE
8265075: Improve and simplify Class.resolveName()

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3066,18 +3066,12 @@ public final class Class<T> implements java.io.Serializable,
     private String resolveName(String name) {
         if (!name.startsWith("/")) {
             String baseName = getPackageName();
-            if (baseName != null && !baseName.isEmpty()) {
-                int len = baseName.length() + 1 + name.length();
-                StringBuilder sb = new StringBuilder(len);
-                name = sb.append(baseName.replace('.', '/'))
-                    .append('/')
-                    .append(name)
-                    .toString();
+            if (!baseName.isEmpty()) {
+                return baseName.replace('.', '/') + '/' + name;
             }
-        } else {
-            name = name.substring(1);
+            return name;
         }
-        return name;
+        return name.substring(1);
     }
 
     /**
@@ -4493,7 +4487,6 @@ public final class Class<T> implements java.io.Serializable,
      * @since 15
      */
     @jdk.internal.javac.PreviewFeature(feature=jdk.internal.javac.PreviewFeature.Feature.SEALED_CLASSES, reflective=true)
-    @SuppressWarnings("preview")
     public boolean isSealed() {
         if (isArray() || isPrimitive()) {
             return false;


### PR DESCRIPTION
In mentioned method this code snippet
```java
int len = baseName.length() + 1 + name.length();
StringBuilder sb = new StringBuilder(len);
name = sb.append(baseName.replace('.', '/'))
        .append('/')
        .append(name)
        .toString();
```

can be simplified with performance improvement as
```
name = baseName.replace('.', '/') + '/' + name;
```
Also null check of `baseName` can be removed as Class.getPackageName() never returns null.

This benchmark
```java
@State(Scope.Thread)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class ResolveNameBenchmark {

  private final Class<? extends ResolveNameBenchmark> klazz = getClass();

  @Benchmark
  public Object original() {
    return original("com/tsypanov/ovn/ResolveNameBenchmark.class");
  }

  @Benchmark
  public Object patched() {
    return patched("com/tsypanov/ovn/ResolveNameBenchmark.class");
  }

  private String original(String name) {
    if (!name.startsWith("/")) {
      String baseName = getPackageName();
      if (baseName != null && !baseName.isEmpty()) {
        int len = baseName.length() + 1 + name.length();
        StringBuilder sb = new StringBuilder(len);
        name = sb.append(baseName.replace('.', '/'))
                .append('/')
                .append(name)
                .toString();
      }
    } else {
      name = name.substring(1);
    }
    return name;
  }

  private String patched(String name) {
      if (!name.startsWith("/")) {
          String baseName = getPackageName();
          if (!baseName.isEmpty()) {
              return baseName.replace('.', '/') + '/' + name;
          }
          return name;
      }
      return name.substring(1);
  }

  private String getPackageName() {
    return klazz.getPackageName();
  }
}
```
demonstrates good improvement, especially as of memory consumption:
```
                                            Mode  Cnt     Score     Error   Units

original                                    avgt   50    57.974 ±   0.365   ns/op
original:·gc.alloc.rate                     avgt   50  3419.447 ±  21.154  MB/sec
original:·gc.alloc.rate.norm                avgt   50   312.006 ±   0.001    B/op
original:·gc.churn.G1_Eden_Space            avgt   50  3399.396 ± 149.836  MB/sec
original:·gc.churn.G1_Eden_Space.norm       avgt   50   310.198 ±  13.628    B/op
original:·gc.churn.G1_Survivor_Space        avgt   50     0.004 ±   0.001  MB/sec
original:·gc.churn.G1_Survivor_Space.norm   avgt   50    ≈ 10⁻³              B/op
original:·gc.count                          avgt   50   208.000            counts
original:·gc.time                           avgt   50   224.000                ms

patched                                     avgt   50    44.367 ±   0.162   ns/op
patched:·gc.alloc.rate                      avgt   50  2749.265 ±  10.014  MB/sec
patched:·gc.alloc.rate.norm                 avgt   50   192.004 ±   0.001    B/op
patched:·gc.churn.G1_Eden_Space             avgt   50  2729.221 ± 193.552  MB/sec
patched:·gc.churn.G1_Eden_Space.norm        avgt   50   190.615 ±  13.539    B/op
patched:·gc.churn.G1_Survivor_Space         avgt   50     0.003 ±   0.001  MB/sec
patched:·gc.churn.G1_Survivor_Space.norm    avgt   50    ≈ 10⁻⁴              B/op
patched:·gc.count                           avgt   50   167.000            counts
patched:·gc.time                            avgt   50   181.000                ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265075](https://bugs.openjdk.java.net/browse/JDK-8265075): Improve and simplify Class.resolveName()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3464/head:pull/3464` \
`$ git checkout pull/3464`

Update a local copy of the PR: \
`$ git checkout pull/3464` \
`$ git pull https://git.openjdk.java.net/jdk pull/3464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3464`

View PR using the GUI difftool: \
`$ git pr show -t 3464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3464.diff">https://git.openjdk.java.net/jdk/pull/3464.diff</a>

</details>
