### PR TITLE
8257836: Add additional test cases to TestSyncOnValueBasedClassEvent.java

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ import jdk.test.lib.jfr.Events;
 public class TestSyncOnValueBasedClassEvent {
     static final String EVENT_NAME = EventNames.SyncOnValueBasedClass;
     static String[] classesWanted = {"java/lang/Character", "java/lang/Boolean", "java/lang/Byte", "java/lang/Short",
-                                     "java/lang/Integer", "java/lang/Long", "java/lang/Float", "java/lang/Double"};
+                                     "java/lang/Integer", "java/lang/Long", "java/lang/Float", "java/lang/Double",
+                                     "java/time/Duration", "java/util/OptionalInt", "java/lang/Runtime$Version"};
     static List<Object> testObjects = new ArrayList<Object>();
     static Integer counter = 0;
 
@@ -56,6 +57,9 @@ public class TestSyncOnValueBasedClassEvent {
         testObjects.add(Long.valueOf(0x4000000000000000L));
         testObjects.add(Float.valueOf(1.20f));
         testObjects.add(Double.valueOf(1.2345));
+        testObjects.add(Duration.ofMillis(5));
+        testObjects.add(OptionalInt.of(10));
+        testObjects.add(Runtime.version());
     }
 
     public static void main(String[] args) throws Throwable {


### PR DESCRIPTION
Please review this small change to add additional test cases to TestSyncOnValueBasedClassEvent.java.  The modified test was tested using Mach5 on Linux x64, Linux aarch64, Mac OS and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257836](https://bugs.openjdk.java.net/browse/JDK-8257836): Add additional test cases to TestSyncOnValueBasedClassEvent.java


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3465/head:pull/3465` \
`$ git checkout pull/3465`

Update a local copy of the PR: \
`$ git checkout pull/3465` \
`$ git pull https://git.openjdk.java.net/jdk pull/3465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3465`

View PR using the GUI difftool: \
`$ git pr show -t 3465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3465.diff">https://git.openjdk.java.net/jdk/pull/3465.diff</a>

</details>
