### PR TITLE
8265138: Simplify DerUtils::checkAlg

### DIFF
--- a/test/jdk/sun/security/pkcs12/ParamsPreferences.java
+++ b/test/jdk/sun/security/pkcs12/ParamsPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,8 +236,8 @@ public class ParamsPreferences {
             checkAlg(data, "110c110110", certAlg);
             if (certAlg == PBES2) {
                 checkAlg(data, "110c11011100", PBKDF2WithHmacSHA1);
-                checkAlg(data, "110c1101110130", args[i++]);
-                checkAlg(data, "110c11011110", args[i++]);
+                checkAlg(data, "110c1101110130", (KnownOIDs)args[i++]);
+                checkAlg(data, "110c11011110", (KnownOIDs)args[i++]);
                 checkInt(data, "110c110111011", (int) args[i++]);
             } else {
                 checkInt(data, "110c1101111", (int) args[i++]);
@@ -249,8 +249,8 @@ public class ParamsPreferences {
         checkAlg(data, "110c010c01000", keyAlg);
         if (keyAlg == PBES2) {
             checkAlg(data, "110c010c0100100", PBKDF2WithHmacSHA1);
-            checkAlg(data, "110c010c010010130", args[i++]);
-            checkAlg(data, "110c010c0100110", args[i++]);
+            checkAlg(data, "110c010c010010130", (KnownOIDs)args[i++]);
+            checkAlg(data, "110c010c0100110", (KnownOIDs)args[i++]);
             checkInt(data, "110c010c01001011", (int) args[i++]);
         } else {
             checkInt(data, "110c010c010011", (int) args[i++]);

--- a/test/lib/jdk/test/lib/security/DerUtils.java
+++ b/test/lib/jdk/test/lib/security/DerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,18 +96,17 @@ public class DerUtils {
      * Ensures that the inner DerValue is the expected ObjectIdentifier.
      */
     public static void checkAlg(byte[] der, String location,
-            Object expected) throws Exception {
-        ObjectIdentifier oid;
-        if (expected instanceof ObjectIdentifier) {
-            oid = (ObjectIdentifier)expected;
-        } else if (expected instanceof KnownOIDs) {
-            oid = ObjectIdentifier.of((KnownOIDs) expected);
-        } else if (expected instanceof String) {
-            oid = ObjectIdentifier.of(KnownOIDs.findMatch((String)expected));
-        } else {
-            throw new IllegalArgumentException(expected.toString());
-        }
-        Asserts.assertEQ(innerDerValue(der, location).getOID(), oid);
+            ObjectIdentifier expected) throws Exception {
+        Asserts.assertEQ(innerDerValue(der, location).getOID(), expected);
+    }
+
+    /**
+     * Ensures that the inner DerValue is the expected ObjectIdentifier.
+     */
+    public static void checkAlg(byte[] der, String location,
+            KnownOIDs expected) throws Exception {
+        Asserts.assertEQ(innerDerValue(der, location).getOID(),
+                ObjectIdentifier.of(expected));
     }
 
     /**


### PR DESCRIPTION
This fix makes `DerUtils::checkAlg` simple and clear, no more raw `Object` and ambiguous string arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265138](https://bugs.openjdk.java.net/browse/JDK-8265138): Simplify DerUtils::checkAlg


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3467/head:pull/3467` \
`$ git checkout pull/3467`

Update a local copy of the PR: \
`$ git checkout pull/3467` \
`$ git pull https://git.openjdk.java.net/jdk pull/3467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3467`

View PR using the GUI difftool: \
`$ git pr show -t 3467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3467.diff">https://git.openjdk.java.net/jdk/pull/3467.diff</a>

</details>
