### PR TITLE
8265019 : Update tests for additional TestNG test permissions

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/PermissionTest.java
+++ b/test/jdk/java/lang/ProcessHandle/PermissionTest.java
@@ -206,19 +206,19 @@ class TestPolicy extends Policy {
         permissions.add(new RuntimePermission("getClassLoader"));
         permissions.add(new RuntimePermission("setSecurityManager"));
         permissions.add(new RuntimePermission("createSecurityManager"));
-        permissions.add(new PropertyPermission("testng.show.stack.frames",
-                "read"));
-        permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
-        permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
-        permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
-        permissions.add(new ReflectPermission("suppressAccessChecks"));
-        permissions.add(new PropertyPermission("testng.timezone", "read"));
         permissions.add(new PropertyPermission("user.dir", "read"));
         permissions.add(new PropertyPermission("test.src", "read"));
         permissions.add(new PropertyPermission("file.separator", "read"));
         permissions.add(new PropertyPermission("line.separator", "read"));
         permissions.add(new PropertyPermission("fileStringBuffer", "read"));
         permissions.add(new PropertyPermission("dataproviderthreadcount", "read"));
+        permissions.add(new PropertyPermission("testng.show.stack.frames",
+                "read"));
+        permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
+        permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
+        permissions.add(new PropertyPermission("testng.timezone", "read"));
+        permissions.add(new ReflectPermission("suppressAccessChecks"));
         permissions.add(new FilePermission("<<ALL FILES>>", "execute"));
     }
 

--- a/test/jdk/java/lang/ProcessHandle/PermissionTest.java
+++ b/test/jdk/java/lang/ProcessHandle/PermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import java.io.FilePermission;
 import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -207,6 +208,11 @@ class TestPolicy extends Policy {
         permissions.add(new RuntimePermission("createSecurityManager"));
         permissions.add(new PropertyPermission("testng.show.stack.frames",
                 "read"));
+        permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
+        permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
+        permissions.add(new ReflectPermission("suppressAccessChecks"));
+        permissions.add(new PropertyPermission("testng.timezone", "read"));
         permissions.add(new PropertyPermission("user.dir", "read"));
         permissions.add(new PropertyPermission("test.src", "read"));
         permissions.add(new PropertyPermission("file.separator", "read"));

--- a/test/jdk/java/sql/testng/util/TestPolicy.java
+++ b/test/jdk/java/sql/testng/util/TestPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,8 @@
 package util;
 
 import java.io.FilePermission;
-import java.security.AllPermission;
-import java.security.CodeSource;
-import java.security.Permission;
-import java.security.PermissionCollection;
-import java.security.Permissions;
-import java.security.Policy;
-import java.security.ProtectionDomain;
-import java.security.SecurityPermission;
+import java.lang.reflect.ReflectPermission;
+import java.security.*;
 import java.sql.SQLPermission;
 import java.util.Enumeration;
 import java.util.PropertyPermission;
@@ -108,6 +102,11 @@ public class TestPolicy extends Policy {
         permissions.add(new PropertyPermission("fileStringBuffer", "read"));
         permissions.add(new PropertyPermission("dataproviderthreadcount", "read"));
         permissions.add(new PropertyPermission("java.io.tmpdir", "read"));
+        permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
+        permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
+        permissions.add(new ReflectPermission("suppressAccessChecks"));
+        permissions.add(new PropertyPermission("testng.timezone", "read"));
         permissions.add(new FilePermission("<<ALL FILES>>",
                 "read, write, delete"));
     }

--- a/test/jdk/java/sql/testng/util/TestPolicy.java
+++ b/test/jdk/java/sql/testng/util/TestPolicy.java
@@ -96,17 +96,17 @@ public class TestPolicy extends Policy {
         permissions.add(new RuntimePermission("getClassLoader"));
         permissions.add(new RuntimePermission("setSecurityManager"));
         permissions.add(new RuntimePermission("createSecurityManager"));
-        permissions.add(new PropertyPermission("testng.show.stack.frames",
-                "read"));
         permissions.add(new PropertyPermission("line.separator", "read"));
         permissions.add(new PropertyPermission("fileStringBuffer", "read"));
         permissions.add(new PropertyPermission("dataproviderthreadcount", "read"));
         permissions.add(new PropertyPermission("java.io.tmpdir", "read"));
+        permissions.add(new PropertyPermission("testng.show.stack.frames",
+                "read"));
         permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
         permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
         permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
-        permissions.add(new ReflectPermission("suppressAccessChecks"));
         permissions.add(new PropertyPermission("testng.timezone", "read"));
+        permissions.add(new ReflectPermission("suppressAccessChecks"));
         permissions.add(new FilePermission("<<ALL FILES>>",
                 "read, write, delete"));
     }

--- a/test/jdk/java/sql/testng/util/TestPolicy.java
+++ b/test/jdk/java/sql/testng/util/TestPolicy.java
@@ -24,7 +24,14 @@ package util;
 
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
-import java.security.*;
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.security.SecurityPermission;
 import java.sql.SQLPermission;
 import java.util.Enumeration;
 import java.util.PropertyPermission;


### PR DESCRIPTION
Hi all,

Please review the following patch which adds additional permissions needed for when JTREG upgrades to a newer version of TestNG.

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265019](https://bugs.openjdk.java.net/browse/JDK-8265019): Update tests for additional TestNG test permissions


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 20ef2bd07d3980537d28c0a307beffa067a75db0
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 20ef2bd07d3980537d28c0a307beffa067a75db0
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 20ef2bd07d3980537d28c0a307beffa067a75db0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3471/head:pull/3471` \
`$ git checkout pull/3471`

Update a local copy of the PR: \
`$ git checkout pull/3471` \
`$ git pull https://git.openjdk.java.net/jdk pull/3471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3471`

View PR using the GUI difftool: \
`$ git pr show -t 3471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3471.diff">https://git.openjdk.java.net/jdk/pull/3471.diff</a>

</details>
