### PR TITLE
8265135: Reduce work initializing VarForms

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -109,9 +109,9 @@ final class VarForm {
 
     @ForceInline
     final MemberName getMemberName(int mode) {
-        MemberName mn = memberName_table[mode];
+        MemberName mn = getMemberNameOrNull(mode);
         if (mn == null) {
-            mn = resolveMemberName(mode, false);
+            throw new UnsupportedOperationException();
         }
         return mn;
     }
@@ -120,13 +120,13 @@ final class VarForm {
     final MemberName getMemberNameOrNull(int mode) {
         MemberName mn = memberName_table[mode];
         if (mn == null) {
-            mn = resolveMemberName(mode, true);
+            mn = resolveMemberName(mode);
         }
         return mn;
     }
 
     @DontInline
-    MemberName resolveMemberName(int mode, boolean graceful) {
+    MemberName resolveMemberName(int mode) {
         AccessMode value = AccessMode.values()[mode];
         String methodName = value.methodName();
         try {
@@ -135,11 +135,7 @@ final class VarForm {
                 = MethodHandles.Lookup.IMPL_LOOKUP
                     .resolveOrFail(REF_invokeStatic, implClass, methodName, type);
         } catch (ReflectiveOperationException e) {
-            if (graceful) {
-                return null;
-            } else {
-                throw new UnsupportedOperationException();
-            }
+            return null;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -129,14 +129,9 @@ final class VarForm {
     MemberName resolveMemberName(int mode) {
         AccessMode value = AccessMode.values()[mode];
         String methodName = value.methodName();
-        try {
-            MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
-            return memberName_table[mode]
-                = MethodHandles.Lookup.IMPL_LOOKUP
-                    .resolveOrFail(REF_invokeStatic, implClass, methodName, type);
-        } catch (ReflectiveOperationException e) {
-            return null;
-        }
+        MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
+        return memberName_table[mode] = MethodHandles.Lookup.IMPL_LOOKUP
+            .resolveOrNull(REF_invokeStatic, implClass, methodName, type);
     }
 
     @Stable

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -24,6 +24,7 @@
  */
 package java.lang.invoke;
 
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Stable;
 
@@ -33,18 +34,24 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.lang.invoke.MethodHandleNatives.Constants.REF_invokeStatic;
+
 /**
  * A var handle form containing a set of member name, one for each operation.
  * Each member characterizes a static method.
  */
 final class VarForm {
 
+    final Class<?> implClass;
+
     final @Stable MethodType[] methodType_table;
 
-    final @Stable MemberName[] memberName_table;
+    private final @Stable MemberName[] memberName_table;
 
     VarForm(Class<?> implClass, Class<?> receiver, Class<?> value, Class<?>... intermediate) {
         this.methodType_table = new MethodType[VarHandle.AccessType.values().length];
+        this.memberName_table = new MemberName[VarHandle.AccessMode.values().length];
+        this.implClass = implClass;
         if (receiver == null) {
             initMethodTypes(value, intermediate);
         } else {
@@ -53,37 +60,46 @@ final class VarForm {
             System.arraycopy(intermediate, 0, coordinates, 1, intermediate.length);
             initMethodTypes(value, coordinates);
         }
-
-        // TODO lazily calculate
-        this.memberName_table = linkFromStatic(implClass);
     }
 
+    // Used by IndirectVarHandle
     VarForm(Class<?> value, Class<?>[] coordinates) {
         this.methodType_table = new MethodType[VarHandle.AccessType.values().length];
         this.memberName_table = null;
+        this.implClass = null;
         initMethodTypes(value, coordinates);
     }
 
     void initMethodTypes(Class<?> value, Class<?>... coordinates) {
-        // (Receiver, <Intermediates>)Value
-        methodType_table[VarHandle.AccessType.GET.ordinal()] =
-                MethodType.methodType(value, coordinates).erase();
+        Class<?> erasedValue = MethodTypeForm.canonicalize(value, MethodTypeForm.ERASE);
+        Class<?>[] erasedCoordinates = MethodTypeForm.canonicalizeAll(coordinates, MethodTypeForm.ERASE);
 
-        // (Receiver, <Intermediates>, Value)void
-        methodType_table[VarHandle.AccessType.SET.ordinal()] =
-                MethodType.methodType(void.class, coordinates).appendParameterTypes(value).erase();
+        if (erasedValue != null) {
+            value = erasedValue;
+        }
+        if (erasedCoordinates != null) {
+            coordinates = erasedCoordinates;
+        }
+
+        MethodType type = MethodType.methodType(value, coordinates);
+
+        // (Receiver, <Intermediates>)Value
+        methodType_table[VarHandle.AccessType.GET.ordinal()] = type;
 
         // (Receiver, <Intermediates>, Value)Value
-        methodType_table[VarHandle.AccessType.GET_AND_UPDATE.ordinal()] =
-                MethodType.methodType(value, coordinates).appendParameterTypes(value).erase();
+        type = methodType_table[VarHandle.AccessType.GET_AND_UPDATE.ordinal()] =
+                type.appendParameterTypes(value);
+
+        // (Receiver, <Intermediates>, Value)void
+        methodType_table[VarHandle.AccessType.SET.ordinal()] = type.changeReturnType(void.class);
+
+        // (Receiver, <Intermediates>, Value, Value)Value
+        type = methodType_table[VarHandle.AccessType.COMPARE_AND_EXCHANGE.ordinal()] =
+                type.appendParameterTypes(value);
 
         // (Receiver, <Intermediates>, Value, Value)boolean
         methodType_table[VarHandle.AccessType.COMPARE_AND_SET.ordinal()] =
-                MethodType.methodType(boolean.class, coordinates).appendParameterTypes(value, value).erase();
-
-        // (Receiver, <Intermediates>, Value, Value)Value
-        methodType_table[VarHandle.AccessType.COMPARE_AND_EXCHANGE.ordinal()] =
-                MethodType.methodType(value, coordinates).appendParameterTypes(value, value).erase();
+                type.changeReturnType(boolean.class);
     }
 
     @ForceInline
@@ -93,14 +109,26 @@ final class VarForm {
 
     @ForceInline
     final MemberName getMemberName(int mode) {
-        // TODO calculate lazily
         MemberName mn = memberName_table[mode];
         if (mn == null) {
-            throw new UnsupportedOperationException();
+            mn = resolveMemberName(mode);
         }
         return mn;
     }
 
+    @DontInline
+    private final MemberName resolveMemberName(int mode) {
+        AccessMode value = AccessMode.values()[mode];
+        String methodName = value.methodName();
+        try {
+            MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
+            return memberName_table[mode]
+                = MethodHandles.Lookup.IMPL_LOOKUP
+                    .resolveOrFail(REF_invokeStatic, implClass, methodName, type);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new UnsupportedOperationException();
+        }
+    }
 
     @Stable
     MethodType[] methodType_V_table;
@@ -124,26 +152,5 @@ final class VarForm {
             table = getMethodType_V_init();
         }
         return table[type];
-    }
-
-
-    /**
-     * Link all signature polymorphic methods.
-     */
-    private static MemberName[] linkFromStatic(Class<?> implClass) {
-        MemberName[] table = new MemberName[AccessMode.values().length];
-
-        for (Class<?> c = implClass; c != VarHandle.class; c = c.getSuperclass()) {
-            for (Method m : c.getDeclaredMethods()) {
-                if (Modifier.isStatic(m.getModifiers())) {
-                    AccessMode am = AccessMode.methodNameToAccessMode.get(m.getName());
-                    if (am != null) {
-                        assert table[am.ordinal()] == null;
-                        table[am.ordinal()] = new MemberName(m);
-                    }
-                }
-            }
-        }
-        return table;
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -125,8 +125,8 @@ final class VarForm {
             return memberName_table[mode]
                 = MethodHandles.Lookup.IMPL_LOOKUP
                     .resolveOrFail(REF_invokeStatic, implClass, methodName, type);
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            throw new UnsupportedOperationException();
+        } catch (ReflectiveOperationException e) {
+            throw new InternalError("Failed resolving VarHandle member name", e);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1938,11 +1938,6 @@ public abstract class VarHandle implements Constable {
             if (am != null) return am;
             throw new IllegalArgumentException("No AccessMode value for method name " + methodName);
         }
-
-        @ForceInline
-        static MemberName getMemberName(int ordinal, VarForm vform) {
-            return vform.getMemberName(ordinal);
-        }
     }
 
     static final class AccessDescriptor {
@@ -2045,7 +2040,7 @@ public abstract class VarHandle implements Constable {
      * {@code false}.
      */
     public final boolean isAccessModeSupported(AccessMode accessMode) {
-        return AccessMode.getMemberName(accessMode.ordinal(), vform) != null;
+        return vform.getMemberNameOrNull(accessMode.ordinal()) != null;
     }
 
     /**
@@ -2068,8 +2063,7 @@ public abstract class VarHandle implements Constable {
      * @return a method handle bound to this VarHandle and the given access mode
      */
     public MethodHandle toMethodHandle(AccessMode accessMode) {
-        MemberName mn = AccessMode.getMemberName(accessMode.ordinal(), vform);
-        if (mn != null) {
+        if (isAccessModeSupported(accessMode)) {
             MethodHandle mh = getMethodHandle(accessMode.ordinal());
             return mh.bindTo(this);
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1941,7 +1941,7 @@ public abstract class VarHandle implements Constable {
 
         @ForceInline
         static MemberName getMemberName(int ordinal, VarForm vform) {
-            return vform.memberName_table[ordinal];
+            return vform.getMemberName(ordinal);
         }
     }
 


### PR DESCRIPTION
This patch reduces work done initializing VarForms - mostly observed when loading each VarHandle implementation class.

- Lazily resolve MemberNames.
- Streamline MethodType creation. This reduces the number of MethodTypes created. 

Net effect is a reduction in bytecode executed per VH class by 50-60%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265135](https://bugs.openjdk.java.net/browse/JDK-8265135): Reduce work initializing VarForms


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to f206768600d8df444ddbfeea813033fad207e4a7
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3472/head:pull/3472` \
`$ git checkout pull/3472`

Update a local copy of the PR: \
`$ git checkout pull/3472` \
`$ git pull https://git.openjdk.java.net/jdk pull/3472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3472`

View PR using the GUI difftool: \
`$ git pr show -t 3472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3472.diff">https://git.openjdk.java.net/jdk/pull/3472.diff</a>

</details>
