### PR TITLE
JDK-8265078: jpackage tests on Windows leave large temp files

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import  java.util.concurrent.atomic.AtomicReference;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -56,7 +57,7 @@ import javax.xml.stream.XMLStreamWriter;
 public class IOUtils {
 
     public static void deleteRecursive(Path directory) throws IOException {
-        final IOException [] exception = { (IOException) null };
+        final AtomicReference<IOException> exception = new AtomicReference<>();
 
         if (!Files.exists(directory)) {
             return;
@@ -71,10 +72,8 @@ public class IOUtils {
                 }
                 try {
                     Files.delete(file);
-                } catch (IOException e) {
-                    if (exception[0] == null) {
-                        exception[0] = e;
-                    }
+                } catch (IOException ex) {
+                    exception.compareAndSet(ex, null);
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -94,15 +93,13 @@ public class IOUtils {
                 try {
                     Files.delete(dir);
                 } catch (IOException ex) {
-                    if (exception[0] == null) {
-                        exception[0] = ex;
-                    }
+                    exception.compareAndSet(ex, null);
                 }
                 return FileVisitResult.CONTINUE;
             }
         });
-        if (exception[0] != null) {
-            throw exception[0];
+        if (exception.get() != null) {
+            throw exception.get();
         }
     }
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -73,7 +73,7 @@ public class IOUtils {
                 try {
                     Files.delete(file);
                 } catch (IOException ex) {
-                    exception.compareAndSet(ex, null);
+                    exception.compareAndSet(null, ex);
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -93,7 +93,7 @@ public class IOUtils {
                 try {
                     Files.delete(dir);
                 } catch (IOException ex) {
-                    exception.compareAndSet(ex, null);
+                    exception.compareAndSet(null, ex);
                 }
                 return FileVisitResult.CONTINUE;
             }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -89,6 +89,11 @@ public final class Executor extends CommandArguments<Executor> {
         return this;
     }
 
+    public Executor setTmpDir(String tmp) {
+        tmpDir = tmp;
+        return this;
+    }
+
     /**
      * Configures this instance to save full output that command will produce.
      * This function is mutual exclusive with
@@ -279,6 +284,9 @@ public final class Executor extends CommandArguments<Executor> {
         command.add(executablePath().toString());
         command.addAll(args);
         ProcessBuilder builder = new ProcessBuilder(command);
+        if (tmpDir != null) {
+            builder.environment().put("TMP", tmpDir);
+        }
         StringBuilder sb = new StringBuilder(getPrintableCommandLine());
         if (withSavedOutput()) {
             builder.redirectErrorStream(true);
@@ -426,6 +434,7 @@ public final class Executor extends CommandArguments<Executor> {
     private Set<SaveOutputType> saveOutputType;
     private Path directory;
     private boolean removePath;
+    private String tmpDir = null;
 
     private static enum SaveOutputType {
         NONE, FULL, FIRST_LINE, DUMP

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -90,6 +90,8 @@ public final class Executor extends CommandArguments<Executor> {
     }
 
     public Executor setWindowsTmpDir(String tmp) {
+        TKit.assertTrue(TKit.isWindows(),
+                "setWindowsTmpDir is only valid on Windows platform");
         winTmpDir = tmp;
         return this;
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -89,8 +89,8 @@ public final class Executor extends CommandArguments<Executor> {
         return this;
     }
 
-    public Executor setTmpDir(String tmp) {
-        tmpDir = tmp;
+    public Executor setWindowsTmpDir(String tmp) {
+        winTmpDir = tmp;
         return this;
     }
 
@@ -284,8 +284,8 @@ public final class Executor extends CommandArguments<Executor> {
         command.add(executablePath().toString());
         command.addAll(args);
         ProcessBuilder builder = new ProcessBuilder(command);
-        if (tmpDir != null) {
-            builder.environment().put("TMP", tmpDir);
+        if (winTmpDir != null) {
+            builder.environment().put("TMP", winTmpDir);
         }
         StringBuilder sb = new StringBuilder(getPrintableCommandLine());
         if (withSavedOutput()) {
@@ -434,7 +434,7 @@ public final class Executor extends CommandArguments<Executor> {
     private Set<SaveOutputType> saveOutputType;
     private Path directory;
     private boolean removePath;
-    private String tmpDir = null;
+    private String winTmpDir = null;
 
     private static enum SaveOutputType {
         NONE, FULL, FIRST_LINE, DUMP

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -643,7 +643,9 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
             exec.setToolProvider(JavaTool.JPACKAGE);
         } else {
             exec.setExecutable(JavaTool.JPACKAGE);
-            exec.setTmpDir(System.getProperty("java.io.tmpdir"));
+            if (TKit.isWindows()) {
+                exec.setWindowsTmpDir(System.getProperty("java.io.tmpdir"));
+            }
         }
 
         return exec;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -643,6 +643,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
             exec.setToolProvider(JavaTool.JPACKAGE);
         } else {
             exec.setExecutable(JavaTool.JPACKAGE);
+            exec.setTmpDir(System.getProperty("java.io.tmpdir"));
         }
 
         return exec;


### PR DESCRIPTION
two changes:
One to jpackage, when recursively removing directory, when IOException occurs, record it and continue (deleting as much as possible) before throwing the exception.
The other to tests, when running jpackage via ProcessBuilder.execute(), set the "TMP" environment variable to the current value of System Property "java.io.tmpdir".  This causes the sub-process (jpackage) to output tmp files to the tmp file location used by the test. (So the test harness can clean up after test exits).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265078](https://bugs.openjdk.java.net/browse/JDK-8265078): jpackage tests on Windows leave large temp files


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3473/head:pull/3473` \
`$ git checkout pull/3473`

Update a local copy of the PR: \
`$ git checkout pull/3473` \
`$ git pull https://git.openjdk.java.net/jdk pull/3473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3473`

View PR using the GUI difftool: \
`$ git pr show -t 3473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3473.diff">https://git.openjdk.java.net/jdk/pull/3473.diff</a>

</details>
