### PR TITLE
8264821: DirectIOTest fails on a system with large block size

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,30 +46,37 @@ import com.sun.nio.file.ExtendedOpenOption;
 
 public class DirectIOTest {
 
-    private static final int SIZE = 4096;
+    private static final int BASE_SIZE = 4096;
+    private static long blockSize;
 
-    private static void testWrite(Path p) throws Exception {
+    private static int testWrite(Path p) throws Exception {
         try (FileChannel fc = FileChannel.open(p, StandardOpenOption.WRITE,
              ExtendedOpenOption.DIRECT)) {
-            FileStore fs = Files.getFileStore(p);
-            int alignment = (int)fs.getBlockSize();
-            ByteBuffer src = ByteBuffer.allocateDirect(SIZE + alignment - 1)
+            int bs = (int)blockSize;
+            int size = Math.max(BASE_SIZE, bs);
+            int alignment = bs;
+            ByteBuffer src = ByteBuffer.allocateDirect(size + alignment - 1)
                                        .alignedSlice(alignment);
-            for (int j = 0; j < SIZE; j++) {
+            assert src.capacity() != 0;
+            for (int j = 0; j < size; j++) {
                 src.put((byte)0);
             }
             src.flip();
             fc.write(src);
+            return size;
         }
     }
 
-    private static void testRead(Path p) throws Exception {
+    private static int testRead(Path p) throws Exception {
         try (FileChannel fc = FileChannel.open(p, ExtendedOpenOption.DIRECT)) {
-            FileStore fs = Files.getFileStore(p);
-            int alignment = (int)fs.getBlockSize();
-            ByteBuffer dest = ByteBuffer.allocateDirect(SIZE + alignment - 1)
+            int bs = (int)blockSize;
+            int size = Math.max(BASE_SIZE, bs);
+            int alignment = bs;
+            ByteBuffer dest = ByteBuffer.allocateDirect(size + alignment - 1)
                                         .alignedSlice(alignment);
+            assert dest.capacity() != 0;
             fc.read(dest);
+            return size;
         }
     }
 
@@ -78,35 +85,27 @@ public class DirectIOTest {
             Paths.get(System.getProperty("test.dir", ".")), "test", null);
     }
 
-    public static boolean isDirectIOSupportedByFS(Path p) throws Exception {
-        return true;
-    }
-
-    private static boolean isFileInCache(Path p) {
+    private static boolean isFileInCache(int size, Path p) {
         String path = p.toString();
-        return isFileInCache0(SIZE, path);
+        return isFileInCache0(size, path);
     }
 
     private static native boolean isFileInCache0(int size, String path);
 
     public static void main(String[] args) throws Exception {
         Path p = createTempFile();
-
-        if (!isDirectIOSupportedByFS(p)) {
-            Files.delete(p);
-            return;
-        }
+        blockSize = Files.getFileStore(p).getBlockSize();
 
         System.loadLibrary("DirectIO");
 
         try {
-            testWrite(p);
-            if (isFileInCache(p)) {
+            int size = testWrite(p);
+            if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "write. File still exists in cache!");
             }
-            testRead(p);
-            if (isFileInCache(p)) {
+            size = testRead(p);
+            if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "read. File still exists in cache!");
             }


### PR DESCRIPTION
Please review this request to clean up a test. The main change is to ensure that the capacity passed to `ByteBuffer.allocateDirect()` is large enough that when `alignedSlice()` is called on the new buffer, it creates an aligned buffer which does not have size zero due due to position rounding resulting in out-of-bound values. Other changes in the test are cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264821](https://bugs.openjdk.java.net/browse/JDK-8264821): DirectIOTest fails on a system with large block size


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3482/head:pull/3482` \
`$ git checkout pull/3482`

Update a local copy of the PR: \
`$ git checkout pull/3482` \
`$ git pull https://git.openjdk.java.net/jdk pull/3482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3482`

View PR using the GUI difftool: \
`$ git pr show -t 3482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3482.diff">https://git.openjdk.java.net/jdk/pull/3482.diff</a>

</details>
