### PR TITLE
8260255: C1: LoopInvariantCodeMotion constructor can leave some fields uninitialized

### DIFF
--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -328,7 +328,7 @@ class LoopInvariantCodeMotion : public StackObj  {
 };
 
 LoopInvariantCodeMotion::LoopInvariantCodeMotion(ShortLoopOptimizer *slo, GlobalValueNumbering* gvn, BlockBegin* loop_header, BlockList* loop_blocks)
-  : _gvn(gvn), _short_loop_optimizer(slo) {
+  : _gvn(gvn), _short_loop_optimizer(slo), _insertion_point(NULL), _state(NULL), _insert_is_pred(false) {
 
   TRACE_VALUE_NUMBERING(tty->print_cr("using loop invariant code motion loop_header = %d", loop_header->block_id()));
   TRACE_VALUE_NUMBERING(tty->print_cr("** loop invariant code motion for short loop B%d", loop_header->block_id()));


### PR DESCRIPTION
Initialize instance variables to default values to avoid uninitialized values for early return.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260255](https://bugs.openjdk.java.net/browse/JDK-8260255): C1: LoopInvariantCodeMotion constructor can leave some fields uninitialized


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3484/head:pull/3484` \
`$ git checkout pull/3484`

Update a local copy of the PR: \
`$ git checkout pull/3484` \
`$ git pull https://git.openjdk.java.net/jdk pull/3484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3484`

View PR using the GUI difftool: \
`$ git pr show -t 3484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3484.diff">https://git.openjdk.java.net/jdk/pull/3484.diff</a>

</details>
