### PR TITLE
8264818: G1: Improve liveness check for empty pinned regions after full gc marking 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -54,7 +54,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
         free_humongous_region(hr);
       }
     } else if (hr->is_open_archive()) {
-      bool is_empty = _bitmap->get_next_marked_addr(hr->bottom(), hr->top()) >= hr->top();
+      bool is_empty = _collector->live_words(hr->hrm_index()) == 0;
       if (is_empty) {
         free_open_archive_region(hr);
       }
@@ -62,10 +62,10 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
       // nothing to do with closed archive region
     } else {
       assert(MarkSweepDeadRatio > 0,
-                "it should not trigger skipping compaction, when MarkSweepDeadRatio == 0");
+             "only skip compaction for other regions when MarkSweepDeadRatio > 0");
 
-      // Force the high live ration region pinned,
-      // as we need skip these regions in the later compact step.
+      // Force the high live ratio region as pinned to skip these regions in the
+      // later compaction step.
       force_pinned = true;
       log_debug(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));


### PR DESCRIPTION
Hi all,

  can I have reviews for this small change improving the check for empty Open Archive regions using information that has recently been added to the full gc in [JDK-8263495](https://bugs.openjdk.java.net/browse/JDK-8263495) instead of scanning the region?

Testing: tier1-3, manual check that the freeing still works using some hack to create a dummy Open Archive region which contents are completely unreferenced and then running a "Hello World" app doing a system.gc. The patch for the VM to create that archive is [here](https://github.com/tschatzl/jdk/tree/a8264818-create-dummy-open-archive).