### PR TITLE
8264423: G1: Rename full gc attribute table states 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -228,12 +228,12 @@ void G1FullCollector::complete_collection() {
   _heap->print_heap_after_full_collection(scope()->heap_transition());
 }
 
-void G1FullCollector::update_attribute_table(HeapRegion* hr, bool force_pinned) {
+void G1FullCollector::update_attribute_table(HeapRegion* hr, bool force_not_compacted) {
   if (hr->is_free()) {
     _region_attr_table.set_invalid(hr->hrm_index());
   } else if (hr->is_closed_archive()) {
     _region_attr_table.set_not_marked_through(hr->hrm_index());
-  } else if (hr->is_pinned() || force_pinned) {
+  } else if (hr->is_pinned() || force_not_compacted) {
     _region_attr_table.set_not_compacted(hr->hrm_index());
   } else {
     // Everything else is processed normally.

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -232,7 +232,7 @@ void G1FullCollector::update_attribute_table(HeapRegion* hr, bool force_not_comp
   if (hr->is_free()) {
     _region_attr_table.set_invalid(hr->hrm_index());
   } else if (hr->is_closed_archive()) {
-    _region_attr_table.set_not_marked_through(hr->hrm_index());
+    _region_attr_table.set_always_live(hr->hrm_index());
   } else if (hr->is_pinned() || force_not_compacted) {
     _region_attr_table.set_not_compacted(hr->hrm_index());
   } else {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -232,12 +232,12 @@ void G1FullCollector::update_attribute_table(HeapRegion* hr, bool force_pinned) 
   if (hr->is_free()) {
     _region_attr_table.set_invalid(hr->hrm_index());
   } else if (hr->is_closed_archive()) {
-    _region_attr_table.set_closed_archive(hr->hrm_index());
+    _region_attr_table.set_not_marked_through(hr->hrm_index());
   } else if (hr->is_pinned() || force_pinned) {
-    _region_attr_table.set_pinned(hr->hrm_index());
+    _region_attr_table.set_not_compacted(hr->hrm_index());
   } else {
     // Everything else is processed normally.
-    _region_attr_table.set_normal(hr->hrm_index());
+    _region_attr_table.set_compacted(hr->hrm_index());
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -232,7 +232,7 @@ void G1FullCollector::update_attribute_table(HeapRegion* hr, bool force_not_comp
   if (hr->is_free()) {
     _region_attr_table.set_invalid(hr->hrm_index());
   } else if (hr->is_closed_archive()) {
-    _region_attr_table.set_always_live(hr->hrm_index());
+    _region_attr_table.set_skip_marking(hr->hrm_index());
   } else if (hr->is_pinned() || force_not_compacted) {
     _region_attr_table.set_not_compacted(hr->hrm_index());
   } else {

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -103,7 +103,7 @@ public:
     return _live_stats[region_index]._live_words;
   }
 
-  void update_attribute_table(HeapRegion* hr, bool force_pinned = false);
+  void update_attribute_table(HeapRegion* hr, bool force_not_compacted = false);
 
   inline bool is_compacted(oop obj) const;
   inline bool is_not_compacted_but_marked_through(uint region_index) const;

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -106,8 +106,8 @@ public:
   void update_attribute_table(HeapRegion* hr, bool force_not_compacted = false);
 
   inline bool is_compacted(oop obj) const;
-  inline bool is_compacted_or_marked_through(uint region_index) const;
-  inline bool is_not_marked_through(oop obj) const;
+  inline bool is_compacted_or_always_live(uint region_index) const;
+  inline bool is_always_live(oop obj) const;
 
 private:
   void phase1_mark_live_objects();

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -106,8 +106,8 @@ public:
   void update_attribute_table(HeapRegion* hr, bool force_not_compacted = false);
 
   inline bool is_compacted(oop obj) const;
-  inline bool is_compacted_or_always_live(uint region_index) const;
-  inline bool is_always_live(oop obj) const;
+  inline bool is_compacted_or_skip_marking(uint region_index) const;
+  inline bool is_skip_marking(oop obj) const;
 
 private:
   void phase1_mark_live_objects();

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -105,10 +105,9 @@ public:
 
   void update_attribute_table(HeapRegion* hr, bool force_pinned = false);
 
-  inline bool is_in_pinned_or_closed(oop obj) const;
-  inline bool is_in_pinned(oop obj) const;
-  inline bool is_in_pinned(uint region_index) const;
-  inline bool is_in_closed(oop obj) const;
+  inline bool is_compacted(oop obj) const;
+  inline bool is_not_compacted_but_marked_through(uint region_index) const;
+  inline bool is_not_marked_through(oop obj) const;
 
 private:
   void phase1_mark_live_objects();

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -106,7 +106,7 @@ public:
   void update_attribute_table(HeapRegion* hr, bool force_not_compacted = false);
 
   inline bool is_compacted(oop obj) const;
-  inline bool is_not_compacted_but_marked_through(uint region_index) const;
+  inline bool is_compacted_or_marked_through(uint region_index) const;
   inline bool is_not_marked_through(oop obj) const;
 
 private:

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -29,20 +29,17 @@
 #include "gc/g1/g1FullGCHeapRegionAttr.hpp"
 #include "oops/oopsHierarchy.hpp"
 
-bool G1FullCollector::is_in_pinned_or_closed(oop obj) const {
-  return _region_attr_table.is_pinned_or_closed(cast_from_oop<HeapWord*>(obj));
+
+bool G1FullCollector::is_compacted(oop obj) const {
+  return _region_attr_table.is_compacted(cast_from_oop<HeapWord*>(obj));
 }
 
-bool G1FullCollector::is_in_pinned(oop obj) const {
-  return _region_attr_table.is_pinned(cast_from_oop<HeapWord*>(obj));
+bool G1FullCollector::is_not_compacted_but_marked_through(uint region_index) const {
+  return _region_attr_table.is_not_compacted_but_marked_through(region_index);
 }
 
-bool G1FullCollector::is_in_pinned(uint region_index) const {
-  return _region_attr_table.is_pinned(region_index);
-}
-
-bool G1FullCollector::is_in_closed(oop obj) const {
-  return _region_attr_table.is_closed_archive(cast_from_oop<HeapWord*>(obj));
+bool G1FullCollector::is_not_marked_through(oop obj) const {
+  return _region_attr_table.is_not_marked_through(cast_from_oop<HeapWord*>(obj));
 }
 
 #endif // SHARE_GC_G1_G1FULLCOLLECTOR_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -34,12 +34,12 @@ bool G1FullCollector::is_compacted(oop obj) const {
   return _region_attr_table.is_compacted(cast_from_oop<HeapWord*>(obj));
 }
 
-bool G1FullCollector::is_compacted_or_marked_through(uint region_index) const {
-  return _region_attr_table.is_compacted_or_marked_through(region_index);
+bool G1FullCollector::is_compacted_or_always_live(uint region_index) const {
+  return _region_attr_table.is_compacted_or_always_live(region_index);
 }
 
-bool G1FullCollector::is_not_marked_through(oop obj) const {
-  return _region_attr_table.is_not_marked_through(cast_from_oop<HeapWord*>(obj));
+bool G1FullCollector::is_always_live(oop obj) const {
+  return _region_attr_table.is_always_live(cast_from_oop<HeapWord*>(obj));
 }
 
 #endif // SHARE_GC_G1_G1FULLCOLLECTOR_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -34,8 +34,8 @@ bool G1FullCollector::is_compacted(oop obj) const {
   return _region_attr_table.is_compacted(cast_from_oop<HeapWord*>(obj));
 }
 
-bool G1FullCollector::is_not_compacted_but_marked_through(uint region_index) const {
-  return _region_attr_table.is_not_compacted_but_marked_through(region_index);
+bool G1FullCollector::is_compacted_or_marked_through(uint region_index) const {
+  return _region_attr_table.is_compacted_or_marked_through(region_index);
 }
 
 bool G1FullCollector::is_not_marked_through(oop obj) const {

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -34,12 +34,12 @@ bool G1FullCollector::is_compacted(oop obj) const {
   return _region_attr_table.is_compacted(cast_from_oop<HeapWord*>(obj));
 }
 
-bool G1FullCollector::is_compacted_or_always_live(uint region_index) const {
-  return _region_attr_table.is_compacted_or_always_live(region_index);
+bool G1FullCollector::is_compacted_or_skip_marking(uint region_index) const {
+  return _region_attr_table.is_compacted_or_skip_marking(region_index);
 }
 
-bool G1FullCollector::is_always_live(oop obj) const {
-  return _region_attr_table.is_always_live(cast_from_oop<HeapWord*>(obj));
+bool G1FullCollector::is_skip_marking(oop obj) const {
+  return _region_attr_table.is_skip_marking(cast_from_oop<HeapWord*>(obj));
 }
 
 #endif // SHARE_GC_G1_G1FULLCOLLECTOR_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -45,7 +45,7 @@ public:
   bool do_heap_region(HeapRegion* r) {
     uint region_index = r->hrm_index();
     // There is nothing to do for compacted or not marked through regions.
-    if (!_collector->is_not_compacted_but_marked_through(region_index)) {
+    if (_collector->is_compacted_or_marked_through(region_index)) {
       return false;
     }
     assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold() ||

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -44,8 +44,8 @@ public:
 
   bool do_heap_region(HeapRegion* r) {
     uint region_index = r->hrm_index();
-    // There is nothing to do for compacted or always live regions.
-    if (_collector->is_compacted_or_always_live(region_index)) {
+    // There is nothing to do for compacted or skip marking regions.
+    if (_collector->is_compacted_or_skip_marking(region_index)) {
       return false;
     }
     assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold() ||

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -44,8 +44,8 @@ public:
 
   bool do_heap_region(HeapRegion* r) {
     uint region_index = r->hrm_index();
-    // There is nothing to do for compacted or not marked through regions.
-    if (_collector->is_compacted_or_marked_through(region_index)) {
+    // There is nothing to do for compacted or always live regions.
+    if (_collector->is_compacted_or_always_live(region_index)) {
       return false;
     }
     assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold() ||

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -35,15 +35,17 @@
 #include "oops/oop.inline.hpp"
 #include "utilities/ticks.hpp"
 
-class G1ResetPinnedClosure : public HeapRegionClosure {
+// Do work for all not-compacted regions.
+class G1ResetNotCompactedClosure : public HeapRegionClosure {
   G1FullCollector* _collector;
 
 public:
-  G1ResetPinnedClosure(G1FullCollector* collector) : _collector(collector) { }
+  G1ResetNotCompactedClosure(G1FullCollector* collector) : _collector(collector) { }
 
   bool do_heap_region(HeapRegion* r) {
     uint region_index = r->hrm_index();
-    if (!_collector->is_in_pinned(region_index)) {
+    // There is nothing to do for compacted or not marked through regions.
+    if (!_collector->is_not_compacted_but_marked_through(region_index)) {
       return false;
     }
     assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold() ||
@@ -95,7 +97,7 @@ void G1FullGCCompactTask::work(uint worker_id) {
     compact_region(*it);
   }
 
-  G1ResetPinnedClosure hc(collector());
+  G1ResetNotCompactedClosure hc(collector());
   G1CollectedHeap::heap()->heap_region_par_iterate_from_worker_offset(&hc, &_claimer, worker_id);
   log_task("Compaction task", worker_id, start);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -54,25 +54,22 @@ protected:
 
 public:
   void set_invalid(uint idx) { set_by_index(idx, Invalid); }
-
+  void set_compacted(uint idx) { set_by_index(idx, Compacted); }
   void set_not_marked_through(uint idx) { set_by_index(idx, NotMarkedThrough); }
+  void set_not_compacted(uint idx) { set_by_index(idx, NotCompacted); }
 
   bool is_not_marked_through(HeapWord* obj) const {
     assert(!is_invalid(obj), "not initialized yet");
     return get_by_address(obj) == NotMarkedThrough;
   }
 
-  void set_not_compacted(uint idx) { set_by_index(idx, NotCompacted); }
-
-  bool is_not_compacted_but_marked_through(uint idx) const {
-    return get_by_index(idx) == NotCompacted;
-  }
-
-  void set_compacted(uint idx) { set_by_index(idx, Compacted); }
-
   bool is_compacted(HeapWord* obj) const {
     assert(!is_invalid(obj), "not initialized yet");
     return get_by_address(obj) == Compacted;
+  }
+
+  bool is_compacted_or_marked_through(uint idx) const {
+    return get_by_index(idx) != NotCompacted;
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -32,16 +32,16 @@
 // type information is encoded in these per-region bytes.
 // Value encoding has been specifically chosen to make required accesses fast.
 // In particular, the table collects whether a region should be compacted, not
-// compacted, or not even marked through.
+// compacted, or always live (not even marked through, and do not contain references
+// outside of other always live regions).
 // Reasons for not compacting a region:
 // (1) the HeapRegion itself has been pinned at the start of Full GC.
 // (2) the occupancy of the region is too high to be considered eligible for compaction.
-// Not marked through regions are neither compacted nor even marked through for
-// performance reasons. Currently only Closed Archive regions are of this kind.
+// The only examples for always live regions are Closed Archive regions.
 class G1FullGCHeapRegionAttr : public G1BiasedMappedArray<uint8_t> {
   static const uint8_t Compacted = 0;        // Region will be compacted.
   static const uint8_t NotCompacted = 1;     // Region should not be compacted, but otherwise handled as usual.
-  static const uint8_t NotMarkedThrough = 2; // Region should not even be marked through.
+  static const uint8_t AlwaysLive = 2;       // Region contents are always live. Do not even mark through.
 
   static const uint8_t Invalid = 255;
 
@@ -55,12 +55,12 @@ protected:
 public:
   void set_invalid(uint idx) { set_by_index(idx, Invalid); }
   void set_compacted(uint idx) { set_by_index(idx, Compacted); }
-  void set_not_marked_through(uint idx) { set_by_index(idx, NotMarkedThrough); }
+  void set_always_live(uint idx) { set_by_index(idx, AlwaysLive); }
   void set_not_compacted(uint idx) { set_by_index(idx, NotCompacted); }
 
-  bool is_not_marked_through(HeapWord* obj) const {
+  bool is_always_live(HeapWord* obj) const {
     assert(!is_invalid(obj), "not initialized yet");
-    return get_by_address(obj) == NotMarkedThrough;
+    return get_by_address(obj) == AlwaysLive;
   }
 
   bool is_compacted(HeapWord* obj) const {
@@ -68,7 +68,7 @@ public:
     return get_by_address(obj) == Compacted;
   }
 
-  bool is_compacted_or_marked_through(uint idx) const {
+  bool is_compacted_or_always_live(uint idx) const {
     return get_by_index(idx) != NotCompacted;
   }
 };

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -42,7 +42,7 @@
 #include "utilities/debug.hpp"
 
 inline bool G1FullGCMarker::mark_object(oop obj) {
-  if (_collector->is_in_closed(obj)) {
+  if (_collector->is_not_marked_through(obj)) {
     return false;
   }
 
@@ -55,9 +55,9 @@ inline bool G1FullGCMarker::mark_object(oop obj) {
   // Marked by us, preserve if needed.
   markWord mark = obj->mark();
   if (obj->mark_must_be_preserved(mark) &&
-      // It is not necessary to preserve marks for objects in pinned regions because
-      // we do not change their headers (i.e. forward them).
-      !_collector->is_in_pinned(obj)) {
+      // It is not necessary to preserve marks for objects in regions we do not
+      // compact because we do not change their headers (i.e. forward them).
+      _collector->is_compacted(obj)) {
     preserved_stack()->push(obj, mark);
   }
 
@@ -81,8 +81,8 @@ template <class T> inline void G1FullGCMarker::mark_and_push(T* p) {
       _oop_stack.push(obj);
       assert(_bitmap->is_marked(obj), "Must be marked now - map self");
     } else {
-      assert(_bitmap->is_marked(obj) || _collector->is_in_closed(obj),
-             "Must be marked by other or closed archive object");
+      assert(_bitmap->is_marked(obj) || _collector->is_not_marked_through(obj),
+             "Must be marked by other or object in not marked through region");
     }
   }
 }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -42,7 +42,7 @@
 #include "utilities/debug.hpp"
 
 inline bool G1FullGCMarker::mark_object(oop obj) {
-  if (_collector->is_always_live(obj)) {
+  if (_collector->is_skip_marking(obj)) {
     return false;
   }
 
@@ -81,8 +81,8 @@ template <class T> inline void G1FullGCMarker::mark_and_push(T* p) {
       _oop_stack.push(obj);
       assert(_bitmap->is_marked(obj), "Must be marked now - map self");
     } else {
-      assert(_bitmap->is_marked(obj) || _collector->is_always_live(obj),
-             "Must be marked by other or object in always live region");
+      assert(_bitmap->is_marked(obj) || _collector->is_skip_marking(obj),
+             "Must be marked by other or object in skip marking region");
     }
   }
 }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -42,7 +42,7 @@
 #include "utilities/debug.hpp"
 
 inline bool G1FullGCMarker::mark_object(oop obj) {
-  if (_collector->is_not_marked_through(obj)) {
+  if (_collector->is_always_live(obj)) {
     return false;
   }
 
@@ -81,8 +81,8 @@ template <class T> inline void G1FullGCMarker::mark_and_push(T* p) {
       _oop_stack.push(obj);
       assert(_bitmap->is_marked(obj), "Must be marked now - map self");
     } else {
-      assert(_bitmap->is_marked(obj) || _collector->is_not_marked_through(obj),
-             "Must be marked by other or object in not marked through region");
+      assert(_bitmap->is_marked(obj) || _collector->is_always_live(obj),
+             "Must be marked by other or object in always live region");
     }
   }
 }

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -96,7 +96,7 @@ inline void G1AdjustClosure::do_oop(oop* p)       { do_oop_work(p); }
 inline void G1AdjustClosure::do_oop(narrowOop* p) { do_oop_work(p); }
 
 inline bool G1IsAliveClosure::do_object_b(oop p) {
-  return _bitmap->is_marked(p) || _collector->is_always_live(p);
+  return _bitmap->is_marked(p) || _collector->is_skip_marking(p);
 }
 
 template<typename T>

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -70,8 +70,8 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
 
   oop obj = CompressedOops::decode_not_null(heap_oop);
   assert(Universe::heap()->is_in(obj), "should be in heap");
-  if (_collector->is_in_pinned_or_closed(obj)) {
-    // We never forward objects in pinned regions so there is no need to
+  if (!_collector->is_compacted(obj)) {
+    // We never forward objects in non-compacted regions so there is no need to
     // process them further.
     return;
   }
@@ -96,7 +96,7 @@ inline void G1AdjustClosure::do_oop(oop* p)       { do_oop_work(p); }
 inline void G1AdjustClosure::do_oop(narrowOop* p) { do_oop_work(p); }
 
 inline bool G1IsAliveClosure::do_object_b(oop p) {
-  return _bitmap->is_marked(p) || _collector->is_in_closed(p);
+  return _bitmap->is_marked(p) || _collector->is_not_marked_through(p);
 }
 
 template<typename T>

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -96,7 +96,7 @@ inline void G1AdjustClosure::do_oop(oop* p)       { do_oop_work(p); }
 inline void G1AdjustClosure::do_oop(narrowOop* p) { do_oop_work(p); }
 
 inline bool G1IsAliveClosure::do_object_b(oop p) {
-  return _bitmap->is_marked(p) || _collector->is_not_marked_through(p);
+  return _bitmap->is_marked(p) || _collector->is_always_live(p);
 }
 
 template<typename T>

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -40,7 +40,7 @@
 #include "utilities/ticks.hpp"
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
-  bool force_pinned = false;
+  bool force_not_compacted = false;
   if (should_compact(hr)) {
     assert(!hr->is_humongous(), "moving humongous objects not supported.");
     prepare_for_compaction(hr);
@@ -66,7 +66,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
 
       // Force the high live ration region pinned,
       // as we need skip these regions in the later compact step.
-      force_pinned = true;
+      force_not_compacted = true;
       log_debug(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
     }
@@ -74,7 +74,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
 
   // Reset data structures not valid after Full GC.
   reset_region_metadata(hr);
-  _collector->update_attribute_table(hr, force_pinned);
+  _collector->update_attribute_table(hr, force_not_compacted);
 
   return false;
 }


### PR DESCRIPTION
Hi all,

  please review this cleanup change suggested in PR#2760 that renames some code in the g1 full gc attribute table.

This is the description from the CR:

>  Since JDK-8253600 g1 full gc has its own (temporary) attribute table storing information that it needs for evacuation.
> 
> Currently the naming corresponds to the attributes in HeapRegion. This is somewhat confusing, as they do not completely match.
> 
> While discussing this in the review for JDK-8262068 we thought of changing this to more reflect the purpose:
> 
> I.e.
> closed -> not_marked_through (or "always live" or "always_marked" something similar to indicate that we do not need to mark through them)
> pinned -> not_compacted
> normal -> compacted (or just keep "normal" as it is some internal state) 

Some additional renaming has been performed.

Testing: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264423](https://bugs.openjdk.java.net/browse/JDK-8264423): G1: Rename full gc attribute table states


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 2047bc11cf09f74b719cb0dde0bcdd6e811faf3f
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3486/head:pull/3486` \
`$ git checkout pull/3486`

Update a local copy of the PR: \
`$ git checkout pull/3486` \
`$ git pull https://git.openjdk.java.net/jdk pull/3486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3486`

View PR using the GUI difftool: \
`$ git pr show -t 3486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3486.diff">https://git.openjdk.java.net/jdk/pull/3486.diff</a>

</details>
