### PR TITLE
8265192: [macos_aarch64] configure script fails if GNU uname in PATH

### DIFF
--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -104,6 +104,10 @@ fi
 
 # Test and fix cpu on macos-aarch64, uname -p reports arm, buildsys expects aarch64
 echo $OUT | grep arm-apple-darwin > /dev/null 2> /dev/null
+if test $? != 0; then
+  # The GNU version of uname may be on the PATH which reports arm64 instead
+  echo $OUT | grep arm64-apple-darwin > /dev/null 2> /dev/null
+fi
 if test $? = 0; then
   if [ `uname -m` = arm64 ]; then
     OUT=aarch64`echo $OUT | sed -e 's/[^-]*//'`


### PR DESCRIPTION
With GNU coreutils from Homebrew in the PATH, configure fails on Apple
silicon Macs with:

```
checking build system type... Invalid configuration `arm64-apple-darwin20.2.0': machine `arm64-apple' not recognized
configure: error: /opt/homebrew/bin/bash /Users/nicgas01/jdk/make/autoconf/build-aux/config.sub arm64-apple-darwin20.2.0 failed
configure exiting with result code 1
```

The system `uname -p` prints "arm" but GNU's version prints "arm64".
This patch just extends config.guess to handle this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265192](https://bugs.openjdk.java.net/browse/JDK-8265192): [macos_aarch64] configure script fails if GNU uname in PATH


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3487/head:pull/3487` \
`$ git checkout pull/3487`

Update a local copy of the PR: \
`$ git checkout pull/3487` \
`$ git pull https://git.openjdk.java.net/jdk pull/3487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3487`

View PR using the GUI difftool: \
`$ git pr show -t 3487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3487.diff">https://git.openjdk.java.net/jdk/pull/3487.diff</a>

</details>
