### PR TITLE
8233565: [TESTBUG] NullModalityDialogTest.java fails on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -518,7 +518,6 @@ java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,windows
 java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
 java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java 8233558 macosx-all
 java/awt/Mouse/MouseComboBoxTest/MouseComboBoxTest.java 8233564 macosx-all
-java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java 8233565 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all

--- a/test/jdk/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
+++ b/test/jdk/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,8 @@ public class NullModalityDialogTest {
     NullModalityDialogTest() throws Exception {
 
         robot = new ExtendedRobot();
-        EventQueue.invokeLater(this::createGUI);
+        robot.setAutoDelay(100);
+        EventQueue.invokeAndWait(this::createGUI);
     }
 
     private void createGUI() {
@@ -134,7 +135,9 @@ public class NullModalityDialogTest {
 
         dialog.openGained.reset();
 
-        robot.type(KeyEvent.VK_TAB);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+        robot.waitForIdle();
 
         dialog.openGained.waitForFlagTriggered();
         assertTrue(dialog.openGained.flag(),


### PR DESCRIPTION
This test NullModalityDialogTest.java was failing repeatedly on macos in automated testing citing "Tab navigation did not happen properly". 
Modified to use invokeAndWait() instead of invokeLater and also use setAutoDelay() with appropriate delay time, in consistent with other automated tests running on mach5.
Several iterations of the test works fine in all platforms after this modification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233565](https://bugs.openjdk.java.net/browse/JDK-8233565): [TESTBUG] NullModalityDialogTest.java fails on MacOS


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3488/head:pull/3488` \
`$ git checkout pull/3488`

Update a local copy of the PR: \
`$ git checkout pull/3488` \
`$ git pull https://git.openjdk.java.net/jdk pull/3488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3488`

View PR using the GUI difftool: \
`$ git pr show -t 3488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3488.diff">https://git.openjdk.java.net/jdk/pull/3488.diff</a>

</details>
