### PR TITLE
8263970: Manual test javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java failed

### DIFF
--- a/test/jdk/javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java
+++ b/test/jdk/javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ public class JapaneseReadingAttributes {
     private static void setupUI() {
         String description = " 1. Go to \"Language Preferences -> Add a Language"
                             + "\" and add \"Japanese\"\n"
-                            + " 2. Set current IM to \"Japanese\" \n"
+                            + " 2. Set current IM to \"Japanese\" and IME option to \"Full width Katakana\" \n"
                             + " 3. Try typing in the text field to ensure"
                             + " that Japanese IME has been successfully"
                             + " selected \n"


### PR DESCRIPTION
Modified test instruction to point that IME option is supposed to be "Full width Katakana" for the test to pass which by default was picking up "Half width Alphanumeric" english style input IME option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263970](https://bugs.openjdk.java.net/browse/JDK-8263970): Manual test javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java failed


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3489/head:pull/3489` \
`$ git checkout pull/3489`

Update a local copy of the PR: \
`$ git checkout pull/3489` \
`$ git pull https://git.openjdk.java.net/jdk pull/3489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3489`

View PR using the GUI difftool: \
`$ git pr show -t 3489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3489.diff">https://git.openjdk.java.net/jdk/pull/3489.diff</a>

</details>
