### PR TITLE
8185127: Add tests to cover hashCode() method for java supported crypto key types

### DIFF
--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.crypto.SecretKey;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Arrays;
+import javax.crypto.KeyGenerator;
+
+/*
+ * @test
+ * @bug 8185127
+ * @summary Test key comparison between the Keys generated through KeyGenerator
+ * @run main CompareKeys
+ */
+public class CompareKeys {
+
+    public static void main(String[] args) throws Exception {
+
+        for (KeyAlgo ka : KeyAlgo.values()) {
+            SecretKey k = ka.genSecretKey();
+            checkKeyEquality(k, copy(k));
+        }
+
+        for (KeyPairAlgo kpa : KeyPairAlgo.values()) {
+            KeyPair kp = kpa.genKeyPair();
+            checkKeyPairEquality(kp, copy(kp));
+        }
+        System.out.println("Done!");
+    }
+
+    private static void checkKeyPairEquality(KeyPair origkp, KeyPair copykp)
+            throws Exception {
+
+        checkKeyEquality(origkp.getPrivate(), copykp.getPrivate());
+        checkKeyEquality(origkp.getPublic(), copykp.getPublic());
+    }
+
+    /**
+     * Compare original KeyPair with another copy.
+     */
+    private static void checkKeyEquality(Key origKey, Key copyKey) {
+
+        if (!origKey.equals(copyKey)
+                && !Arrays.equals(origKey.getEncoded(), copyKey.getEncoded())
+                && origKey.hashCode() != copyKey.hashCode()) {
+            throw new RuntimeException("Key inequality found");
+        }
+        System.out.printf("Equality check Passed for key Type:%s & Algo: %s%n",
+                origKey.getClass(), origKey.getAlgorithm());
+    }
+
+    /**
+     * Get a copy of the original object type.
+     */
+    private static <T extends Object> T copy(T orig)
+            throws IOException, ClassNotFoundException {
+
+        byte[] serialize;
+        try ( ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(orig);
+            serialize = bos.toByteArray();
+        }
+
+        T copy;
+        try ( ByteArrayInputStream bis = new ByteArrayInputStream(serialize);
+                ObjectInputStream ois = new ObjectInputStream(bis)) {
+            copy = (T) ois.readObject();
+        }
+        return copy;
+    }
+
+    private enum KeyAlgo {
+
+        AES("AES"),
+        ARCFOUR("ARCFOUR"),
+        Blowfish("Blowfish"),
+        ChaCha20("ChaCha20"),
+        DES("DES"),
+        DESede("DESede"),
+        HmacMD5("HmacMD5"),
+        HmacSHA1("HmacSHA1"),
+        HmacSHA224("HmacSHA224"),
+        HmacSHA256("HmacSHA256"),
+        HmacSHA384("HmacSHA384"),
+        HmacSHA512("HmacSHA512"),
+        RC2("RC2");
+
+        private String algoName;
+
+        private KeyAlgo(String name) {
+            this.algoName = name;
+        }
+
+        public SecretKey genSecretKey() throws Exception {
+            KeyGenerator kg = KeyGenerator.getInstance(this.algoName);
+            return kg.generateKey();
+        }
+    }
+
+    private enum KeyPairAlgo {
+
+        DiffieHellman("DiffieHellman"),
+        DSA("DSA"),
+        RSA("RSA"),
+        RSASSAPSS("RSASSA-PSS"),
+        EC("EC"),
+        EdDSA("EdDSA"),
+        Ed25519("Ed25519"),
+        Ed448("Ed448"),
+        XDH("XDH"),
+        X25519("X25519"),
+        X448("X448");
+
+        private final String algoName;
+
+        private KeyPairAlgo(String name) {
+            this.algoName = name;
+        }
+
+        public KeyPair genKeyPair() throws Exception {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(this.algoName);
+            return kpg.generateKeyPair();
+        }
+    }
+}

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -63,7 +63,7 @@ public class CompareKeys {
     }
 
     /**
-     * Compare original KeyPair with another copy.
+     * Compare original Key with another copy.
      */
     private static void checkKeyEquality(Key origKey, Key copyKey) {
 

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -63,7 +63,7 @@ public class CompareKeys {
     }
 
     @SuppressWarnings("preview")
-            private record KeygenAlgo(String algoName, Provider provider) {
+    private record KeygenAlgo(String algoName, Provider provider) {
 
     }
 
@@ -119,6 +119,9 @@ public class CompareKeys {
             for (Provider.Service s : p.getServices()) {
                 // Remove the algorithms from the list which require
                 // pre-initialisation to make the Test generic across algorithms
+                // SunMSCAPI provider removed too because of incompatibilty
+                // for serialization and with PKCS8EncodedKeySpec for certain
+                // algorithms like RSA.
                 if (s.getType().contains(type)
                         && !((s.getAlgorithm().startsWith("SunTls"))
                         || s.getProvider().getName().equals("SunMSCAPI"))) {

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -76,7 +76,7 @@ public class CompareKeys {
     }
 
     /**
-     * Compare original KeyPair with another copy.
+     * Compare original Key with another copy.
      */
     private static void checkKeyEquality(Key origKey, Key copyKey) {
 

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -117,9 +117,9 @@ public class CompareKeys {
         List<KeygenAlgo> kgs = new LinkedList<>();
         for (Provider p : Security.getProviders()) {
             for (Provider.Service s : p.getServices()) {
-                // Remove the algorithms from the list which require
+                // Ignore the algorithms from the list which require
                 // pre-initialisation to make the Test generic across algorithms
-                // SunMSCAPI provider removed too because of incompatibilty
+                // SunMSCAPI provider ignored too because of incompatibilty
                 // for serialization and with PKCS8EncodedKeySpec for certain
                 // algorithms like RSA.
                 if (s.getType().contains(type)

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -120,7 +120,7 @@ public class CompareKeys {
         for (Provider p : Security.getProviders()) {
             for (Provider.Service s : p.getServices()) {
                 // Ignore the algorithms from the list which require
-                // pre-initialisation to make the Test generic across algorithms.
+                // pre-initialization to make the Test generic across algorithms.
                 // SunMSCAPI provider is ignored too because of incompatibilty
                 // for serialization and with PKCS8EncodedKeySpec for certain
                 // algorithms like RSA.

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -79,21 +79,23 @@ public class CompareKeys {
      */
     private static void checkKeyEquality(Key origKey, Key copyKey) {
 
-        if (!(origKey.equals(copyKey)
-                || origKey.hashCode() == copyKey.hashCode())
-                && !Arrays.equals(origKey.getEncoded(), copyKey.getEncoded())
-                && !origKey.getFormat().equals(copyKey.getFormat())) {
-            System.out.println("Result- equals/hashCode: "
-                    + !(origKey.equals(copyKey)
-                    || origKey.hashCode() == copyKey.hashCode()));
+        if ((origKey.equals(copyKey)
+                && origKey.hashCode() == copyKey.hashCode()
+                && Arrays.equals(origKey.getEncoded(), copyKey.getEncoded())
+                && origKey.getFormat().equals(copyKey.getFormat()))) {
+            System.out.printf("%s equality check Passed%n",
+                    origKey.getClass().getName());
+        } else {
+            System.out.println("Result- equals: "
+                    + !origKey.equals(copyKey));
+            System.out.println("Result- hashCode: "
+                    + !(origKey.hashCode() == copyKey.hashCode()));
             System.out.println("Result- encoded check: " + !Arrays.equals(
                     origKey.getEncoded(), copyKey.getEncoded()));
             System.out.println("Result- format check: "
                     + !origKey.getFormat().equals(copyKey.getFormat()));
             throw new RuntimeException("Key inequality found");
         }
-        System.out.printf("%s equality check Passed%n",
-                origKey.getClass().getName());
     }
 
     private static Key copy(String algo, Key key) throws Exception {
@@ -118,8 +120,8 @@ public class CompareKeys {
         for (Provider p : Security.getProviders()) {
             for (Provider.Service s : p.getServices()) {
                 // Ignore the algorithms from the list which require
-                // pre-initialisation to make the Test generic across algorithms
-                // SunMSCAPI provider ignored too because of incompatibilty
+                // pre-initialisation to make the Test generic across algorithms.
+                // SunMSCAPI provider is ignored too because of incompatibilty
                 // for serialization and with PKCS8EncodedKeySpec for certain
                 // algorithms like RSA.
                 if (s.getType().contains(type)

--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -87,13 +87,13 @@ public class CompareKeys {
                     origKey.getClass().getName());
         } else {
             System.out.println("Result- equals: "
-                    + !origKey.equals(copyKey));
+                    + origKey.equals(copyKey));
             System.out.println("Result- hashCode: "
-                    + !(origKey.hashCode() == copyKey.hashCode()));
-            System.out.println("Result- encoded check: " + !Arrays.equals(
+                    + (origKey.hashCode() == copyKey.hashCode()));
+            System.out.println("Result- encoded check: " + Arrays.equals(
                     origKey.getEncoded(), copyKey.getEncoded()));
             System.out.println("Result- format check: "
-                    + !origKey.getFormat().equals(copyKey.getFormat()));
+                    + origKey.getFormat().equals(copyKey.getFormat()));
             throw new RuntimeException("Key inequality found");
         }
     }


### PR DESCRIPTION
This is a simple Test to add few additional API coverage for all java supported key types. The objective of this Test is to cover equals() and hashcode() methods for each key types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8185127](https://bugs.openjdk.java.net/browse/JDK-8185127): Add tests to cover hashCode() method for java supported crypto key types


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to b990d100077d8006ab578d81cd3a02d02b5ee911


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3490/head:pull/3490` \
`$ git checkout pull/3490`

Update a local copy of the PR: \
`$ git checkout pull/3490` \
`$ git pull https://git.openjdk.java.net/jdk pull/3490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3490`

View PR using the GUI difftool: \
`$ git pr show -t 3490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3490.diff">https://git.openjdk.java.net/jdk/pull/3490.diff</a>

</details>
