### PR TITLE
8262883: doccheck: Broken links in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1891,7 +1891,7 @@ public class MethodHandles {
              *
              * <p> By default, a hidden class or interface may be unloaded
              * even if the class loader that is marked as its defining loader is
-             * <a href="../ref/package.html#reachability">reachable</a>.
+             * <a href="../ref/package-summary.html#reachability">reachable</a>.
 
              *
              * @jls 12.7 Unloading of Classes and Interfaces
@@ -2031,7 +2031,7 @@ public class MethodHandles {
          *
          * By default, however, a hidden class or interface may be unloaded even if
          * the class loader that is marked as its defining loader is
-         * <a href="../ref/package.html#reachability">reachable</a>.
+         * <a href="../ref/package-summary.html#reachability">reachable</a>.
          * This behavior is useful when a hidden class or interface serves multiple
          * classes defined by arbitrary class loaders.  In other cases, a hidden
          * class or interface may be linked to a single class (or a small number of classes)

--- a/src/java.base/share/classes/java/net/UnixDomainSocketAddress.java
+++ b/src/java.base/share/classes/java/net/UnixDomainSocketAddress.java
@@ -35,7 +35,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 /**
- * A <a href="package-summary.html#unixdomain">Unix domain</a> socket address.
+ * A Unix domain socket address.
  * A Unix domain socket address encapsulates a file-system path that Unix domain sockets
  * bind or connect to.
  *

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -172,7 +172,7 @@ public abstract class DatagramChannel
      * java.nio.channels.spi.SelectorProvider} object.  The channel will not be
      * connected.
      *
-     * @apiNote <a href="package-summary.html#unixdomain">Unix domain</a> sockets
+     * @apiNote {@linkplain java.net.UnixDomainSocketAddress Unix domain} sockets
      * are not supported by DatagramChannel.
      *
      * @param   family

--- a/src/java.base/share/classes/java/nio/channels/SocketChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SocketChannel.java
@@ -332,7 +332,7 @@ public abstract class SocketChannel
      * another socket can bind to the same name. If a socket channel to a Unix
      * Domain socket is <i>implicitly</i> bound by connecting it without calling
      * bind first, then its socket is
-     * <a href="../../java/net/UnixDomainSocketAddress.html#unnamed">unnamed</a>
+     * <a href="../../../java/net/UnixDomainSocketAddress.html#unnamed">unnamed</a>
      * with no corresponding socket file in the file-system. If a socket channel
      * to a Unix Domain socket is <i>automatically</i> bound by calling {@code
      * bind(null)} this results in an unnamed socket also.


### PR DESCRIPTION
Hi,

Could I get the following trivial doc changes reviewed please, caused by:

- broken <A> tags in MethodHandles referring to package.html instead of package-summary.html

- references to a package level #unixdomain anchor that no longer exists.

- a <a> tag missing a "../" in SocketChannel

Thanks,

Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262883](https://bugs.openjdk.java.net/browse/JDK-8262883): doccheck: Broken links in java.base


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3491/head:pull/3491` \
`$ git checkout pull/3491`

Update a local copy of the PR: \
`$ git checkout pull/3491` \
`$ git pull https://git.openjdk.java.net/jdk pull/3491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3491`

View PR using the GUI difftool: \
`$ git pr show -t 3491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3491.diff">https://git.openjdk.java.net/jdk/pull/3491.diff</a>

</details>
