### PR TITLE
8265173: [test] divert spurious log output away from stream under test in ProcessBuilder Basic test

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -27,7 +27,7 @@
  *      5026830 5023243 5070673 4052517 4811767 6192449 6397034 6413313
  *      6464154 6523983 6206031 4960438 6631352 6631966 6850957 6850958
  *      4947220 7018606 7034570 4244896 5049299 8003488 8054494 8058464
- *      8067796 8224905 8263729
+ *      8067796 8224905 8263729 8265173
  * @key intermittent
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
@@ -2150,10 +2150,12 @@ public class Basic {
                     switch (action & 0x1) {
                         case 0:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStderr");
+                            childArgs.add(2, "-Xlog:all=warning:stderr");
                             pb.redirectError(INHERIT);
                             break;
                         case 1:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStdout");
+                            childArgs.add(2, "-Xlog:all=warning:stdout");
                             pb.redirectOutput(INHERIT);
                             break;
                         default:


### PR DESCRIPTION
The most recent intermittent failure showed that the error occurred during VM initialization.
Only the tty output was diverted, but not log output.
Add diversion of log output as well tty output.

Add `-Xlog:all=warning:stderr` and `-Xlog:all=warning:stdout` to correspond to 
`-XX:+DisplayVMOutputToStderr` and `-XX:+DisplayVMOutputToStdout`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265173](https://bugs.openjdk.java.net/browse/JDK-8265173): [test] divert spurious log output away from stream under test in ProcessBuilder Basic test


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3492/head:pull/3492` \
`$ git checkout pull/3492`

Update a local copy of the PR: \
`$ git checkout pull/3492` \
`$ git pull https://git.openjdk.java.net/jdk pull/3492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3492`

View PR using the GUI difftool: \
`$ git pr show -t 3492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3492.diff">https://git.openjdk.java.net/jdk/pull/3492.diff</a>

</details>
