### PR TITLE
8265226: (dc) API note in DatagramChannel.open should link to StandardProtocolFamily.UNIX

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -172,7 +172,8 @@ public abstract class DatagramChannel
      * java.nio.channels.spi.SelectorProvider} object.  The channel will not be
      * connected.
      *
-     * @apiNote {@link java.net.StandardProtocolFamily#UNIX} is not supported.
+     * @apiNote {@linkplain java.net.StandardProtocolFamily#UNIX Unix domain} 
+     *          sockets are not supported.
      *
      * @param   family
      *          The protocol family

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -172,8 +172,7 @@ public abstract class DatagramChannel
      * java.nio.channels.spi.SelectorProvider} object.  The channel will not be
      * connected.
      *
-     * @apiNote {@linkplain java.net.UnixDomainSocketAddress Unix domain} sockets
-     * are not supported by DatagramChannel.
+     * @apiNote {@link java.net.StandardProtocolFamily#UNIX} is not supported.
      *
      * @param   family
      *          The protocol family

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -172,7 +172,7 @@ public abstract class DatagramChannel
      * java.nio.channels.spi.SelectorProvider} object.  The channel will not be
      * connected.
      *
-     * @apiNote {@linkplain java.net.StandardProtocolFamily#UNIX Unix domain} 
+     * @apiNote {@linkplain java.net.StandardProtocolFamily#UNIX Unix domain}
      *          sockets are not supported.
      *
      * @param   family


### PR DESCRIPTION
Hi,

Could I get the following change reviewed please (which may need a CSR)?

It should have been considered as part of (8262883) which was integrated earlier today.
Any other comments on that change can be considered here too.

This is the change:

```
diff a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -170,12 +170,11 @@
      * java.nio.channels.spi.SelectorProvider#openDatagramChannel(ProtocolFamily)
      * openDatagramChannel} method of the system-wide default {@link
      * java.nio.channels.spi.SelectorProvider} object.  The channel will not be
      * connected.
      *
-     * @apiNote {@linkplain java.net.UnixDomainSocketAddress Unix domain} sockets
-     * are not supported by DatagramChannel.
+     * @apiNote {@link java.net.StandardProtocolFamily#UNIX} is not supported.
      *
      * @param   family
      *          The protocol family
      *
      * @return  A new datagram channel
```

Thanks,

Michael.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265226](https://bugs.openjdk.java.net/browse/JDK-8265226): (dc) API note in DatagramChannel.open should link to StandardProtocolFamily.UNIX


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 6f32b9a5fb6eacca3455b8de416823373c11257b
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 6f32b9a5fb6eacca3455b8de416823373c11257b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3494/head:pull/3494` \
`$ git checkout pull/3494`

Update a local copy of the PR: \
`$ git checkout pull/3494` \
`$ git pull https://git.openjdk.java.net/jdk pull/3494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3494`

View PR using the GUI difftool: \
`$ git pr show -t 3494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3494.diff">https://git.openjdk.java.net/jdk/pull/3494.diff</a>

</details>
