### PR TITLE
8265208: [JEP-356] : SplittableRandom and SplittableGenerators - splits() methods does not throw NullPointerException when source is null

### DIFF
--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -617,27 +617,18 @@ public class Random extends AbstractSpliteratorGenerator
 
     // Methods required by class AbstractSpliteratorGenerator
 
-    /**
-     * @hidden
-     */
     @Override
-    public Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
+    protected Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
         return new RandomIntsSpliterator(this, index, fence, origin, bound);
     }
 
-    /**
-     * @hidden
-     */
     @Override
-    public Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
+    protected Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
         return new RandomLongsSpliterator(this, index, fence, origin, bound);
     }
 
-    /**
-     * @hidden
-     */
     @Override
-    public Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
+    protected Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
         return new RandomDoublesSpliterator(this, index, fence, origin, bound);
     }
 

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -280,30 +280,6 @@ public final class SplittableRandom extends AbstractSplittableGenerator {
         return new SplittableRandom(source.nextLong(), mixGamma(source.nextLong()));
     }
 
-    /**
-     * @hidden
-     */
-    @Override
-    public Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
-        return super.makeIntsSpliterator(index, fence, origin, bound);
-    }
-
-    /**
-     * @hidden
-     */
-    @Override
-    public Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
-        return super.makeLongsSpliterator(index, fence, origin, bound);
-    }
-
-    /**
-     * @hidden
-     */
-    @Override
-    public Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
-        return super.makeDoublesSpliterator(index, fence, origin, bound);
-    }
-
     @Override
     public int nextInt() {
         return mix32(nextSeed());

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -51,11 +51,7 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import jdk.internal.util.random.RandomSupport;
-import jdk.internal.util.random.RandomSupport.AbstractSpliteratorGenerator;
-import jdk.internal.util.random.RandomSupport.RandomIntsSpliterator;
-import jdk.internal.util.random.RandomSupport.RandomLongsSpliterator;
-import jdk.internal.util.random.RandomSupport.RandomDoublesSpliterator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
+import jdk.internal.util.random.RandomSupport.*;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
 
@@ -395,40 +391,6 @@ public class ThreadLocalRandom extends Random {
 
     /** The common ThreadLocalRandom */
     private static final ThreadLocalRandom instance = new ThreadLocalRandom();
-
-    private static final class ThreadLocalRandomProxy extends Random {
-        @java.io.Serial
-        static final long serialVersionUID = 0L;
-
-
-        static final AbstractSpliteratorGenerator proxy = new ThreadLocalRandomProxy();
-
-
-        public int nextInt() {
-            return ThreadLocalRandom.current().nextInt();
-        }
-
-        public long nextLong() {
-            return ThreadLocalRandom.current().nextLong();
-        }
-    }
-
-    // Methods required by class AbstractSpliteratorGenerator
-
-    @Override
-    protected Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
-        return new RandomIntsSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
-    }
-
-    @Override
-    protected Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
-        return new RandomLongsSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
-    }
-
-    @Override
-    protected Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
-        return new RandomDoublesSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
-    }
 
     /**
      * The next seed for default constructors.

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -414,27 +414,19 @@ public class ThreadLocalRandom extends Random {
     }
 
     // Methods required by class AbstractSpliteratorGenerator
-    /**
-     * @hidden
-     */
+
     @Override
-    public Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
+    protected Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
         return new RandomIntsSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
     }
 
-    /**
-     * @hidden
-     */
     @Override
-    public Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
+    protected Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
         return new RandomLongsSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
     }
 
-    /**
-     * @hidden
-     */
     @Override
-    public Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
+    protected Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
         return new RandomDoublesSpliterator(ThreadLocalRandomProxy.proxy, index, fence, origin, bound);
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -1438,59 +1438,9 @@ public class RandomSupport {
         protected AbstractSpliteratorGenerator() {
         }
 
-        /**
-         * Create an instance of {@link Spliterator.OfInt} that for each
-         * traversal position between the specified index (inclusive) and the
-         * specified fence (exclusive) generates a pseudorandomly chosen
-         * {@code int} value between the specified origin (inclusive) and the
-         * specified bound (exclusive).
-         *
-         * @param index the (inclusive) lower bound on traversal positions
-         * @param fence the (exclusive) upper bound on traversal positions
-         * @param origin the (inclusive) lower bound on the pseudorandom values to be generated
-         * @param bound the (exclusive) upper bound on the pseudorandom values to be generated
-         *
-         * @return an instance of {@link Spliterator.OfInt}
-         *
-         * @hidden
-         */
-        public abstract Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound);
-
-        /**
-         * Create an instance of {@link Spliterator.OfLong} that for each
-         * traversal position between the specified index (inclusive) and the
-         * specified fence (exclusive) generates a pseudorandomly chosen
-         * {@code long} value between the specified origin (inclusive) and the
-         * specified bound (exclusive).
-         *
-         * @param index the (inclusive) lower bound on traversal positions
-         * @param fence the (exclusive) upper bound on traversal positions
-         * @param origin the (inclusive) lower bound on the pseudorandom values to be generated
-         * @param bound the (exclusive) upper bound on the pseudorandom values to be generated
-         *
-         * @return an instance of {@link Spliterator.OfLong}
-         *
-         * @hidden
-         */
-        public abstract Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound);
-
-        /**
-         * Create an instance of {@link Spliterator.OfDouble} that for each
-         * traversal position between the specified index (inclusive) and the
-         * specified fence (exclusive) generates a pseudorandomly chosen
-         * {@code double} value between the specified origin (inclusive) and the
-         * specified bound (exclusive).
-         *
-         * @param index the (inclusive) lower bound on traversal positions
-         * @param fence the (exclusive) upper bound on traversal positions
-         * @param origin the (inclusive) lower bound on the pseudorandom values to be generated
-         * @param bound the (exclusive) upper bound on the pseudorandom values to be generated
-         *
-         * @return an instance of {@link Spliterator.OfDouble}
-         *
-         * @hidden
-         */
-        public abstract Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound);
+        protected abstract Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound);
+        protected abstract Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound);
+        protected abstract Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound);
 
         /* ---------------- public methods ---------------- */
 
@@ -1663,15 +1613,15 @@ public class RandomSupport {
 
         // Methods required by class AbstractSpliteratorGenerator
 
-        public Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
+        protected Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
             return new RandomIntsSpliterator(this, index, fence, origin, bound);
         }
 
-        public Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
+        protected Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
             return new RandomLongsSpliterator(this, index, fence, origin, bound);
         }
 
-        public Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
+        protected Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
             return new RandomDoublesSpliterator(this, index, fence, origin, bound);
         }
 
@@ -2103,15 +2053,15 @@ public class RandomSupport {
         protected AbstractSplittableGenerator() {
         }
 
-        public Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
+        protected Spliterator.OfInt makeIntsSpliterator(long index, long fence, int origin, int bound) {
             return new RandomIntsSpliterator(this, index, fence, origin, bound);
         }
 
-        public Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
+        protected Spliterator.OfLong makeLongsSpliterator(long index, long fence, long origin, long bound) {
             return new RandomLongsSpliterator(this, index, fence, origin, bound);
         }
 
-        public Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
+        protected Spliterator.OfDouble makeDoublesSpliterator(long index, long fence, double origin, double bound) {
             return new RandomDoublesSpliterator(this, index, fence, origin, bound);
         }
 

--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2101,6 +2101,8 @@ public class RandomSupport {
         @Override
         public Stream<SplittableGenerator> splits(long streamSize, SplittableGenerator source) {
             RandomSupport.checkStreamSize(streamSize);
+            Objects.requireNonNull(source, "source should be non-null");
+
             return StreamSupport.stream(makeSplitsSpliterator(0L, streamSize, source), false);
         }
 


### PR DESCRIPTION
Add check for null.