### PR TITLE
8265227: Move Proc.java from security/testlibrary to test/lib

### DIFF
--- a/test/jdk/sun/security/krb5/auto/BasicProc.java
+++ b/test/jdk/sun/security/krb5/auto/BasicProc.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 import org.ietf.jgss.Oid;
 import sun.security.krb5.Config;
 

--- a/test/jdk/sun/security/krb5/auto/BasicProc.java
+++ b/test/jdk/sun/security/krb5/auto/BasicProc.java
@@ -26,7 +26,7 @@
  * @bug 8009977 8186884 8194486 8201627
  * @summary A test to launch multiple Java processes using either Java GSS
  *          or native GSS
- * @library ../../../../java/security/testlibrary/ /test/lib
+ * @library /test/lib
  * @compile -XDignore.symbol.file BasicProc.java
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm -Djdk.net.hosts.file=TestHosts BasicProc launcher
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
+import jdk.test.lib.security.Proc;
 import org.ietf.jgss.Oid;
 import sun.security.krb5.Config;
 

--- a/test/jdk/sun/security/krb5/auto/Renewal.java
+++ b/test/jdk/sun/security/krb5/auto/Renewal.java
@@ -32,7 +32,7 @@
  * @run main/othervm -Djdk.net.hosts.file=TestHosts Renewal
  */
 
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 import sun.security.krb5.Config;
 import sun.security.krb5.internal.ccache.Credentials;
 import sun.security.krb5.internal.ccache.FileCredentialsCache;

--- a/test/jdk/sun/security/krb5/auto/Renewal.java
+++ b/test/jdk/sun/security/krb5/auto/Renewal.java
@@ -26,19 +26,19 @@
  * @bug 8044500 8194486
  * @summary Add kinit options and krb5.conf flags that allow users to
  *          obtain renewable tickets and specify ticket lifetimes
- * @library ../../../../java/security/testlibrary/ /test/lib
+ * @library /test/lib
  * @compile -XDignore.symbol.file Renewal.java
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm -Djdk.net.hosts.file=TestHosts Renewal
  */
 
+import jdk.test.lib.security.Proc;
 import sun.security.krb5.Config;
 import sun.security.krb5.internal.ccache.Credentials;
 import sun.security.krb5.internal.ccache.FileCredentialsCache;
 
 import javax.security.auth.kerberos.KerberosTicket;
 import java.util.Date;
-import java.util.Random;
 import java.util.Set;
 
 // The basic krb5 test skeleton you can copy from

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 import sun.security.jgss.GSSUtil;
 import sun.security.krb5.internal.rcache.AuthTime;
 

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 7152176 8168518 8172017 8014628 8194486
  * @summary More krb5 tests
- * @library ../../../../java/security/testlibrary/ /test/lib
+ * @library /test/lib
  * @build jdk.test.lib.Platform
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.net.hosts.file=TestHosts
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
+import jdk.test.lib.security.Proc;
 import sun.security.jgss.GSSUtil;
 import sun.security.krb5.internal.rcache.AuthTime;
 

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
@@ -27,7 +27,7 @@
  * @summary  testing jdk.krb5.rcache.useMD5. This action is put in a separate
  *           test so that ReplayCacheTestProc.java can be launched with special
  *           test.* system properties easily.
- * @library ../../../../java/security/testlibrary/ /test/lib
+ * @library /test/lib
  * @build jdk.test.lib.Platform
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.krb5.rcache.useMD5=true

--- a/test/jdk/sun/security/krb5/ccache/EmptyCC.java
+++ b/test/jdk/sun/security/krb5/ccache/EmptyCC.java
@@ -36,7 +36,7 @@
  */
 import java.io.File;
 
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 import sun.security.krb5.Credentials;
 import sun.security.krb5.PrincipalName;
 import sun.security.krb5.internal.ccache.CredentialsCache;

--- a/test/jdk/sun/security/krb5/ccache/EmptyCC.java
+++ b/test/jdk/sun/security/krb5/ccache/EmptyCC.java
@@ -27,8 +27,7 @@
  * @bug 8001208
  * @summary NPE in sun.security.krb5.Credentials.acquireDefaultCreds()
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.security.jgss/sun.security.krb5
+ * @modules java.security.jgss/sun.security.krb5
  *          java.security.jgss/sun.security.krb5.internal.ccache
  * @compile -XDignore.symbol.file EmptyCC.java
  * @run main EmptyCC tmpcc

--- a/test/jdk/sun/security/krb5/ccache/EmptyCC.java
+++ b/test/jdk/sun/security/krb5/ccache/EmptyCC.java
@@ -26,7 +26,7 @@
  * @bug 7158329
  * @bug 8001208
  * @summary NPE in sun.security.krb5.Credentials.acquireDefaultCreds()
- * @library ../../../../java/security/testlibrary/
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.security.jgss/sun.security.krb5
  *          java.security.jgss/sun.security.krb5.internal.ccache
@@ -35,6 +35,8 @@
  * @run main EmptyCC FILE:tmpcc
  */
 import java.io.File;
+
+import jdk.test.lib.security.Proc;
 import sun.security.krb5.Credentials;
 import sun.security.krb5.PrincipalName;
 import sun.security.krb5.internal.ccache.CredentialsCache;

--- a/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
+++ b/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8164705 8168410
  * @summary check compatibility after FilePermission change
- * @library /java/security/testlibrary/
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main CompatImpact prepare
  * @run main CompatImpact builtin
@@ -33,6 +33,8 @@
  * @run main/fail CompatImpact mine
  * @run main CompatImpact dopriv
  */
+
+import jdk.test.lib.security.Proc;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
+++ b/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
@@ -34,7 +34,7 @@
  * @run main CompatImpact dopriv
  */
 
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
+++ b/test/jdk/sun/security/util/FilePermCompat/CompatImpact.java
@@ -26,7 +26,6 @@
  * @bug 8164705 8168410
  * @summary check compatibility after FilePermission change
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
  * @run main CompatImpact prepare
  * @run main CompatImpact builtin
  * @run main/othervm -Djdk.security.filePermCompat=true CompatImpact mine

--- a/test/jdk/sun/security/util/FilePermCompat/Flag.java
+++ b/test/jdk/sun/security/util/FilePermCompat/Flag.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8164705 8209901
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
  * @summary check jdk.filepermission.canonicalize
  */
 

--- a/test/jdk/sun/security/util/FilePermCompat/Flag.java
+++ b/test/jdk/sun/security/util/FilePermCompat/Flag.java
@@ -24,11 +24,12 @@
 /*
  * @test
  * @bug 8164705 8209901
- * @library /test/jdk/java/security/testlibrary
+ * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @summary check jdk.filepermission.canonicalize
  */
 
+import jdk.test.lib.security.Proc;
 import java.io.File;
 import java.io.FilePermission;
 import java.lang.*;

--- a/test/jdk/sun/security/util/FilePermCompat/Flag.java
+++ b/test/jdk/sun/security/util/FilePermCompat/Flag.java
@@ -29,7 +29,7 @@
  * @summary check jdk.filepermission.canonicalize
  */
 
-import jdk.test.lib.security.Proc;
+import jdk.test.lib.process.Proc;
 import java.io.File;
 import java.io.FilePermission;
 import java.lang.*;

--- a/test/lib-test/jdk/test/lib/process/ProcTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265227
+ * @summary Test Proc
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ */
+
+import jdk.test.lib.process.Proc;
+
+import java.util.Random;
+import java.util.List;
+
+public class ProcTest {
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            Proc p1 = Proc.create("ProcTest")
+                    .args("p1")
+                    .debug("p1")
+                    .start();
+            Proc p2 = Proc.create("ProcTest")
+                    .args("p2")
+                    .debug("p2")
+                    .start();
+            while (true) {
+                String s1 = p1.readData(); // p1 shows to p2
+                if (s1 != null) p2.println(s1);
+                String s2 = p2.readData(); // p2 shows to p1
+                if (s2 != null) p1.println(s2);
+                if (s1 == null && s2 == null) break;
+            }
+            p1.waitFor();
+            p2.waitFor();
+        } else {
+            List<String> gestures = List.of("Rock", "Paper", "Scissors");
+            int wins = 0;
+            Random r = new Random();
+            while (true) {
+                String my = gestures.get(r.nextInt(3));
+                Proc.textOut(my); // show first, next line might block
+                String peer = Proc.textIn();
+                if (!my.equals(peer)) {
+                    if (my.equals("Paper") && peer.equals("Rock")
+                            || my.equals("Rock") && peer.equals("Scissors")
+                            || my.equals("Scissors") && peer.equals("Paper")) {
+                        wins++;
+                    } else {
+                        wins--;
+                    }
+                }
+                // Message not from textOut() will be ignored by readData().
+                System.out.println(my + " vs " + peer + ", I win " + wins + " times");
+                if (wins > 2 || wins < -2) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/test/lib-test/jdk/test/lib/process/ProcTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8265227
  * @summary Test Proc
- * @modules java.base/jdk.internal.misc
  * @library /test/lib
  */
 

--- a/test/lib/jdk/test/lib/process/Proc.java
+++ b/test/lib/jdk/test/lib/process/Proc.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package jdk.test.lib.security;
+package jdk.test.lib.process;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/test/lib/jdk/test/lib/security/Proc.java
+++ b/test/lib/jdk/test/lib/security/Proc.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package jdk.test.lib.security;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
I'd like to move this tool to test/lib inside a proper named package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265227](https://bugs.openjdk.java.net/browse/JDK-8265227): Move Proc.java from security/testlibrary to test/lib


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 4823a1c6c36f00bfd890172d61fe93d9ec4f4a8d
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)
 * [Sibabrata Sahoo](https://openjdk.java.net/census#ssahoo) (@sisahoo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3496/head:pull/3496` \
`$ git checkout pull/3496`

Update a local copy of the PR: \
`$ git checkout pull/3496` \
`$ git pull https://git.openjdk.java.net/jdk pull/3496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3496`

View PR using the GUI difftool: \
`$ git pr show -t 3496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3496.diff">https://git.openjdk.java.net/jdk/pull/3496.diff</a>

</details>
