### PR TITLE
8257804 Test runtime/modules/ModuleStress/ModuleStressGC.java fails: 'package test defined in module jdk.test, exports list being walked' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStressGC.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStressGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,11 +68,11 @@ public class ModuleStressGC {
             throw new RuntimeException("Test failed to compile module jdk.translet");
         }
 
-        // Sanity check that the test, jdk.test/test/MainGC.java,
-        // correctly walks module jdk.test's reads list and package
-        // test's, defined to module jdk.translet, export list at
-        // GC safepoints.
+        // Check that jdk.test/test.MainGC walks module jdk.test's
+        // reads list and walks the exports list for package test,
+        // defined in module jdk.test, during a GC.
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Xmx128m",
             "-Xlog:module=trace",
             "-p", MODS_DIR.toString(),
             "-m", "jdk.test/test.MainGC");


### PR DESCRIPTION
Please review this small test change to reduce the size of the Java heap used by the test so that the test's call to System.gc() is potentially more likely to walk the JVM's module reads-list and exports-list structures.

The modified test was tested on Linux, Mac OS, and run 1000 times on Windows, where the previous failures had occurred.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257804](https://bugs.openjdk.java.net/browse/JDK-8257804): Test runtime/modules/ModuleStress/ModuleStressGC.java fails: 'package test defined in module jdk.test, exports list being walked' missing from stdout/stderr


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3497/head:pull/3497` \
`$ git checkout pull/3497`

Update a local copy of the PR: \
`$ git checkout pull/3497` \
`$ git pull https://git.openjdk.java.net/jdk pull/3497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3497`

View PR using the GUI difftool: \
`$ git pr show -t 3497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3497.diff">https://git.openjdk.java.net/jdk/pull/3497.diff</a>

</details>
