### PR TITLE
8265231: (fc) ReadDirect and WriteDirect tests fail after fix for JDK-8264821

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
@@ -47,9 +47,8 @@ import com.sun.nio.file.ExtendedOpenOption;
 public class DirectIOTest {
 
     private static final int BASE_SIZE = 4096;
-    private static long blockSize;
 
-    private static int testWrite(Path p) throws Exception {
+    private static int testWrite(Path p, long blockSize) throws Exception {
         try (FileChannel fc = FileChannel.open(p, StandardOpenOption.WRITE,
              ExtendedOpenOption.DIRECT)) {
             int bs = (int)blockSize;
@@ -67,7 +66,7 @@ public class DirectIOTest {
         }
     }
 
-    private static int testRead(Path p) throws Exception {
+    private static int testRead(Path p, long blockSize) throws Exception {
         try (FileChannel fc = FileChannel.open(p, ExtendedOpenOption.DIRECT)) {
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
@@ -94,17 +93,17 @@ public class DirectIOTest {
 
     public static void main(String[] args) throws Exception {
         Path p = createTempFile();
-        blockSize = Files.getFileStore(p).getBlockSize();
+        long blockSize = Files.getFileStore(p).getBlockSize();
 
         System.loadLibrary("DirectIO");
 
         try {
-            int size = testWrite(p);
+            int size = testWrite(p, blockSize);
             if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "write. File still exists in cache!");
             }
-            size = testRead(p);
+            size = testRead(p, blockSize);
             if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "read. File still exists in cache!");

--- a/test/jdk/java/nio/channels/FileChannel/directio/PreadDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/PreadDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,10 +70,6 @@ public class PreadDirect {
 
     private static boolean initTests() throws Exception {
         Path p = DirectIOTest.createTempFile();
-        if (!DirectIOTest.isDirectIOSupportedByFS(p)) {
-            Files.delete(p);
-            return false;
-        }
         try {
             FileStore fs = Files.getFileStore(p);
             alignment = (int)fs.getBlockSize();

--- a/test/jdk/java/nio/channels/FileChannel/directio/PwriteDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/PwriteDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,10 +59,6 @@ public class PwriteDirect {
 
     private static boolean initTests() throws Exception {
         Path p = DirectIOTest.createTempFile();
-        if (!DirectIOTest.isDirectIOSupportedByFS(p)) {
-            Files.delete(p);
-            return false;
-        }
         try {
             FileStore fs = Files.getFileStore(p);
             alignment = (int)fs.getBlockSize();

--- a/test/jdk/java/nio/channels/FileChannel/directio/ReadDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/ReadDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,10 +58,6 @@ public class ReadDirect {
 
     private static boolean initTests() throws Exception {
         Path p = DirectIOTest.createTempFile();
-        if (!DirectIOTest.isDirectIOSupportedByFS(p)) {
-            Files.delete(p);
-            return false;
-        }
         try {
             FileStore fs = Files.getFileStore(p);
             alignment = (int)fs.getBlockSize();

--- a/test/jdk/java/nio/channels/FileChannel/directio/WriteDirect.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/WriteDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,10 +48,6 @@ public class WriteDirect {
 
     private static boolean initTests() throws Exception {
         Path p = DirectIOTest.createTempFile();
-        if (!DirectIOTest.isDirectIOSupportedByFS(p)) {
-            Files.delete(p);
-            return false;
-        }
         try {
             FileStore fs = Files.getFileStore(p);
             alignment = (int)fs.getBlockSize();


### PR DESCRIPTION
Please review this request to fix a test build failure caused by removing the `isDirectIOSupportedByFS()` method from the test `DirectIOTest` but not removing its use in other tests.

This also addresses the comment [1] in PR [2] of [3].

[1] https://github.com/openjdk/jdk/pull/3482#discussion_r613362581
[2] https://github.com/openjdk/jdk/pull/3482
[3] https://bugs.openjdk.java.net/browse/JDK-8264821

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265231](https://bugs.openjdk.java.net/browse/JDK-8265231): (fc) ReadDirect and WriteDirect tests fail after fix for JDK-8264821


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3498/head:pull/3498` \
`$ git checkout pull/3498`

Update a local copy of the PR: \
`$ git checkout pull/3498` \
`$ git pull https://git.openjdk.java.net/jdk pull/3498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3498`

View PR using the GUI difftool: \
`$ git pr show -t 3498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3498.diff">https://git.openjdk.java.net/jdk/pull/3498.diff</a>

</details>
