### PR TITLE
8265236: ProblemList java/foreign/TestUpcall.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -551,6 +551,7 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 java/foreign/TestMismatch.java 8249684 macosx-all
 
 java/foreign/StdLibTest.java 8263512 macosx-aarch64
+java/foreign/TestIntrinsics.java 8265183 macosx-aarch64
 java/foreign/TestVarArgs.java 8263512 macosx-aarch64
 java/foreign/valist/VaListTest.java 8263512 macosx-aarch64
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -552,6 +552,7 @@ java/foreign/TestMismatch.java 8249684 macosx-all
 
 java/foreign/StdLibTest.java 8263512 macosx-aarch64
 java/foreign/TestIntrinsics.java 8265183 macosx-aarch64
+java/foreign/TestUpcall.java 8265182 macosx-aarch64
 java/foreign/TestVarArgs.java 8263512 macosx-aarch64
 java/foreign/valist/VaListTest.java 8263512 macosx-aarch64
 


### PR DESCRIPTION
Let's problem list java/foreign/TestUpcall.java (a tier1 test) until JDK-8265182 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265236](https://bugs.openjdk.java.net/browse/JDK-8265236): ProblemList java/foreign/TestUpcall.java on macosx-aarch64


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 681582c21351f7b8576216fc734c4600c912e790


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3500/head:pull/3500` \
`$ git checkout pull/3500`

Update a local copy of the PR: \
`$ git checkout pull/3500` \
`$ git pull https://git.openjdk.java.net/jdk pull/3500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3500`

View PR using the GUI difftool: \
`$ git pr show -t 3500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3500.diff">https://git.openjdk.java.net/jdk/pull/3500.diff</a>

</details>
