### PR TITLE
8265237: String.join and StringJoiner can be improved further

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2308,6 +2308,10 @@ public final class System {
                 return StringConcatHelper.mix(lengthCoder, constant);
             }
 
+            public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
+                return String.join(prefix, suffix, delimiter, elements, size);
+            }
+
             public Object classData(Class<?> c) {
                 return c.getClassData();
             }

--- a/src/java.base/share/classes/java/util/StringJoiner.java
+++ b/src/java.base/share/classes/java/util/StringJoiner.java
@@ -24,6 +24,9 @@
  */
 package java.util;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+
 /**
  * {@code StringJoiner} is used to construct a sequence of characters separated
  * by a delimiter and optionally starting with a supplied prefix
@@ -63,6 +66,8 @@ package java.util;
  * @since  1.8
 */
 public final class StringJoiner {
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
     private final String prefix;
     private final String delimiter;
     private final String suffix;
@@ -158,27 +163,15 @@ public final class StringJoiner {
      */
     @Override
     public String toString() {
-        final String[] elts = this.elts;
-        if (elts == null && emptyValue != null) {
-            return emptyValue;
-        }
         final int size = this.size;
-        final int addLen = prefix.length() + suffix.length();
+        var elts = this.elts;
         if (size == 0) {
-            if (addLen == 0) {
-                return "";
+            if (emptyValue != null) {
+                return emptyValue;
             }
-            return prefix + suffix;
+            elts = EMPTY_STRING_ARRAY;
         }
-        final String delimiter = this.delimiter;
-        StringBuilder sb = new StringBuilder(len + addLen).append(prefix);
-        if (size > 0) {
-            sb.append(elts[0]);
-            for (int i = 1; i < size; i++) {
-                sb.append(delimiter).append(elts[i]);
-            }
-        }
-        return sb.append(suffix).toString();
+        return JLA.join(prefix, suffix, delimiter, elts, size);
     }
 
     /**
@@ -233,7 +226,7 @@ public final class StringJoiner {
      */
     public StringJoiner merge(StringJoiner other) {
         Objects.requireNonNull(other);
-        if (other.elts == null) {
+        if (other.size == 0) {
             return this;
         }
         other.compactElts();
@@ -241,15 +234,11 @@ public final class StringJoiner {
     }
 
     private void compactElts() {
-        if (size > 1) {
-            StringBuilder sb = new StringBuilder(len).append(elts[0]);
-            int i = 1;
-            do {
-                sb.append(delimiter).append(elts[i]);
-                elts[i] = null;
-            } while (++i < size);
+        int sz = size;
+        if (sz > 1) {
+            elts[0] = JLA.join("", "", delimiter, elts, sz);
+            Arrays.fill(elts, 1, sz, null);
             size = 1;
-            elts[0] = sb.toString();
         }
     }
 
@@ -267,4 +256,6 @@ public final class StringJoiner {
         return (size == 0 && emptyValue != null) ? emptyValue.length() :
             len + prefix.length() + suffix.length();
     }
+
+    JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 }

--- a/src/java.base/share/classes/java/util/StringJoiner.java
+++ b/src/java.base/share/classes/java/util/StringJoiner.java
@@ -257,5 +257,5 @@ public final class StringJoiner {
             len + prefix.length() + suffix.length();
     }
 
-    JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -367,6 +367,11 @@ public interface JavaLangAccess {
      */
     long stringConcatMix(long lengthCoder, String constant);
 
+    /**
+     * Join strings
+     */
+    String join(String prefix, String suffix, String delimiter, String[] elements, int size);
+
     /*
      * Get the class data associated with the given class.
      * @param c the class

--- a/test/jdk/java/util/StringJoiner/StringJoinerOomUtf16Test.java
+++ b/test/jdk/java/util/StringJoiner/StringJoinerOomUtf16Test.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8265237
+ * @summary tests StringJoiner OOME when joining sub-max-length Strings
+ * @modules java.base/jdk.internal.util
+ * @requires vm.bits == "64" & os.maxMemory > 4G
+ * @run testng/othervm -Xmx4g -XX:+CompactStrings StringJoinerOomUtf16Test
+ */
+
+import org.testng.annotations.Test;
+
+import static jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
+import static org.testng.Assert.fail;
+
+import java.util.StringJoiner;
+
+
+@Test(groups = {"unit","string","util","libs"})
+public class StringJoinerOomUtf16Test {
+
+    // the sum of lengths of the following two strings is way less than
+    // SOFT_MAX_ARRAY_LENGTH, but the byte[] array holding the UTF16 representation
+    // would need to be bigger than Integer.MAX_VALUE...
+    private static final String HALF_MAX_LATIN1_STRING =
+        "*".repeat(SOFT_MAX_ARRAY_LENGTH >> 1);
+    private static final String OVERFLOW_UTF16_STRING =
+        "\u017D".repeat(((Integer.MAX_VALUE - SOFT_MAX_ARRAY_LENGTH) >> 1) + 1);
+
+    public void OOM1() {
+        try {
+            new StringJoiner("")
+                .add(HALF_MAX_LATIN1_STRING)
+                .add(OVERFLOW_UTF16_STRING)
+                .toString();
+            fail("Should have thrown OutOfMemoryError");
+        } catch (OutOfMemoryError ex) {
+            System.out.println("Expected: " + ex);
+        }
+    }
+
+    public void OOM2() {
+        try {
+            new StringJoiner(HALF_MAX_LATIN1_STRING)
+                .add("")
+                .add(OVERFLOW_UTF16_STRING)
+                .toString();
+            fail("Should have thrown OutOfMemoryError");
+        } catch (OutOfMemoryError ex) {
+            System.out.println("Expected: " + ex);
+        }
+    }
+
+    public void OOM3() {
+        try {
+            new StringJoiner(OVERFLOW_UTF16_STRING)
+                .add("")
+                .add(HALF_MAX_LATIN1_STRING)
+                .toString();
+            fail("Should have thrown OutOfMemoryError");
+        } catch (OutOfMemoryError ex) {
+            System.out.println("Expected: " + ex);
+        }
+    }
+
+    public void OOM4() {
+        try {
+            new StringJoiner("", HALF_MAX_LATIN1_STRING, OVERFLOW_UTF16_STRING)
+                .toString();
+            fail("Should have thrown OutOfMemoryError");
+        } catch (OutOfMemoryError ex) {
+            System.out.println("Expected: " + ex);
+        }
+    }
+}
+

--- a/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
@@ -41,8 +41,16 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
 public class StringJoinerBenchmark {
+
+    @Benchmark
+    public String join(Data data) {
+        String[] stringArray = data.stringArray;
+        return String.join(",", stringArray);
+    }
 
     @Benchmark
     public String stringJoiner(Data data) {
@@ -56,10 +64,10 @@ public class StringJoinerBenchmark {
         @Param({"latin", "cyrillic"})
         private String mode;
 
-        @Param({"8", "32"})
+        @Param({"8", "32", "128"})
         private int length;
 
-        @Param({"5", "10"})
+        @Param({"5", "20"})
         private int count;
 
         private String[] stringArray;

--- a/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
@@ -25,12 +25,14 @@ package org.openjdk.bench.java.util;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
@@ -64,7 +66,7 @@ public class StringJoinerBenchmark {
         @Param({"latin", "cyrillic"})
         private String mode;
 
-        @Param({"8", "32", "128"})
+        @Param({"1", "8", "32", "128"})
         private int length;
 
         @Param({"5", "20"})

--- a/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 1, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
 public class StringJoinerBenchmark {
 
     @Benchmark


### PR DESCRIPTION
While JDK-8148937 improved StringJoiner class by replacing internal use of getChars that copies out characters from String elements into a char[] array with StringBuilder which is somehow more optimal, the improvement was marginal in speed (0% ... 10%) and mainly for smaller strings, while GC was reduced by about 50% in average per operation.
Initial attempt to tackle that issue was more involved, but was later discarded because it was apparently using too much internal String details in code that lives outside String and outside java.lang package.
But there is another way to package such "intimate" code - we can put it into String itself and just call it from StringJoiner.
This PR is an attempt at doing just that. It introduces new package-private method in `java.lang.String` which is then used from both pubic static `String.join` methods as well as from `java.util.StringJoiner` (via SharedSecrets). The improvements can be seen by running the following JMH benchmark:

https://gist.github.com/plevart/86ac7fc6d4541dbc08256cde544019ce

The comparative results are here:

https://jmh.morethan.io/?gist=7eb421cf7982456a2962269137f71c15

The jmh-result.json files are here:

https://gist.github.com/plevart/7eb421cf7982456a2962269137f71c15

Improvement in speed ranges from 8% (for small strings) to 200% (for long strings), while creation of garbage has been further reduced to an almost garbage-free operation.

So WDYT?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265237](https://bugs.openjdk.java.net/browse/JDK-8265237): String.join and StringJoiner can be improved further


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to a2d5e819fd72411909a300b775928ac837641361
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to a2d5e819fd72411909a300b775928ac837641361


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3501/head:pull/3501` \
`$ git checkout pull/3501`

Update a local copy of the PR: \
`$ git checkout pull/3501` \
`$ git pull https://git.openjdk.java.net/jdk pull/3501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3501`

View PR using the GUI difftool: \
`$ git pr show -t 3501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3501.diff">https://git.openjdk.java.net/jdk/pull/3501.diff</a>

</details>
