### PR TITLE
 8262501: jdk17 libjvm link failure with --as-needed and clock_gettime in librt

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -108,13 +108,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       OS_LDFLAGS_JVM_ONLY="-Wl,-rpath,@loader_path/. -Wl,-rpath,@loader_path/.."
       OS_LDFLAGS="-mmacosx-version-min=$MACOSX_VERSION_MIN"
     fi
-    if test "x$OPENJDK_TARGET_OS" = xlinux; then
-      # Hotspot needs to link librt to get the clock_* functions.
-      # But once our supported minimum build and runtime platform
-      # has glibc 2.17, this can be removed as the functions are
-      # in libc.
-      OS_LDFLAGS_JVM_ONLY="-lrt"
-    fi
   fi
 
   # Setup debug level-dependent LDFLAGS

--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -132,7 +132,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     # in libc.
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lrt"
   fi
-                              
+
   # Atomic library
   # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
   if HOTSPOT_CHECK_JVM_VARIANT(zero); then

--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -124,6 +124,15 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lpthread"
   fi
 
+  # librt for legacy clock_gettime
+  if test "x$OPENJDK_TARGET_OS" = xlinux; then
+    # Hotspot needs to link librt to get the clock_* functions.
+    # But once our supported minimum build and runtime platform
+    # has glibc 2.17, this can be removed as the functions are
+    # in libc.
+    BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lrt"
+  fi
+                              
   # Atomic library
   # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
   if HOTSPOT_CHECK_JVM_VARIANT(zero); then


### PR DESCRIPTION
The fix for JDK-8246112 put the -lrt link flag in the wrong place, causing it to appear too early in the linker command-line. This changes puts it in the right place.

Contributed by: Matthias Klose  (~doko)

Testing: 
   - local testing by Matthias
   - tiers 1-3
   - GHA builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262501](https://bugs.openjdk.java.net/browse/JDK-8262501): jdk17 libjvm link failure with --as-needed and clock_gettime in librt


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Contributors
 * Matthias Klose `<doko@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3503/head:pull/3503` \
`$ git checkout pull/3503`

Update a local copy of the PR: \
`$ git checkout pull/3503` \
`$ git pull https://git.openjdk.java.net/jdk pull/3503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3503`

View PR using the GUI difftool: \
`$ git pr show -t 3503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3503.diff">https://git.openjdk.java.net/jdk/pull/3503.diff</a>

</details>
