### PR TITLE
8265239: Shenandoah: Shenandoah heap region count could be off by 1

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -153,6 +153,7 @@ jint ShenandoahHeap::initialize() {
   Universe::check_alignment(init_byte_size, reg_size_bytes, "Shenandoah heap");
 
   _num_regions = ShenandoahHeapRegion::region_count();
+  assert(_num_regions == (max_byte_size / reg_size_bytes), "Must match");
 
   // Now we know the number of regions, initialize the heuristics.
   initialize_heuristics();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -575,7 +575,7 @@ void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   RegionSizeBytesMask = RegionSizeBytes - 1;
 
   guarantee(RegionCount == 0, "we should only set it once");
-  RegionCount = max_heap_size / RegionSizeBytes;
+  RegionCount = align_up(max_heap_size, RegionSizeBytes) / RegionSizeBytes;
   guarantee(RegionCount >= MIN_NUM_REGIONS, "Should have at least minimum regions");
 
   guarantee(HumongousThresholdWords == 0, "we should only set it once");


### PR DESCRIPTION
henandoah uses MaxHeapSize to calculate region size, then aligns up heap size to region size alignment, but when it calculates region count, it does not take alignment into account, that may result 1 region short than actual count.

MaxHeapSize eventually aligns to HeapAlignment (which is region size in Shenandoah case) in GCArguments::initialize_heap_flags_and_sizes(), but it is too late.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265239](https://bugs.openjdk.java.net/browse/JDK-8265239): Shenandoah: Shenandoah heap region count could be off by 1


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3504/head:pull/3504` \
`$ git checkout pull/3504`

Update a local copy of the PR: \
`$ git checkout pull/3504` \
`$ git pull https://git.openjdk.java.net/jdk pull/3504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3504`

View PR using the GUI difftool: \
`$ git pr show -t 3504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3504.diff">https://git.openjdk.java.net/jdk/pull/3504.diff</a>

</details>
