### PR TITLE
8265246: Fix macos-Aarch64 build after JDK-8263709

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1265,7 +1265,7 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
 
   // Enable WXWrite: the function is called by c1 stub as a runtime function
   // (see another implementation above).
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   if (TracePatching) {
     tty->print_cr("Deoptimizing because patch is needed");

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2472,7 +2472,7 @@ Deoptimization::update_method_data_from_interpreter(MethodData* trap_mdo, int tr
 
 Deoptimization::UnrollBlock* Deoptimization::uncommon_trap(JavaThread* current, jint trap_request, jint exec_mode) {
   // Enable WXWrite: current function is called from methods compiled by C2 directly
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   if (TraceDeoptimization) {
     tty->print("Uncommon trap ");


### PR DESCRIPTION
Two recent macOS-Aarch64 fixes were merged into my changes without conflict, but needed editing to match my changes:

s/thread/current/

in two places.

Testing: all platform builds in mach5, including macOS-Aarch64 of course (in progress)

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265246](https://bugs.openjdk.java.net/browse/JDK-8265246): Fix macos-Aarch64 build after JDK-8263709


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3506/head:pull/3506` \
`$ git checkout pull/3506`

Update a local copy of the PR: \
`$ git checkout pull/3506` \
`$ git pull https://git.openjdk.java.net/jdk pull/3506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3506`

View PR using the GUI difftool: \
`$ git pr show -t 3506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3506.diff">https://git.openjdk.java.net/jdk/pull/3506.diff</a>

</details>
