### PR TITLE
8265244: Remove useless comparation in LibraryCallKit::inline_vector_convert()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2401,6 +2401,11 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
   } else { // NEON
     // Special cases
     switch (opcode) {
+    case Op_VectorReinterpret:
+      if (bit_size != 64 && bit_size != 128) {
+        return false;
+      }
+      break;
     case Op_MulAddVS2VI:
       if (bit_size < 128) {
         return false;

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1450,7 +1450,7 @@ bool LibraryCallKit::inline_vector_convert() {
       // Since input and output number of elements are not consistent, we need to make sure we
       // properly size. Thus, first make a cast that retains the number of elements from source.
       // In case the size exceeds the arch size, we do the minimum.
-      int num_elem_for_cast = MIN2(num_elem_from, Matcher::max_vector_size(elem_bt_to));
+      int num_elem_for_cast = num_elem_from;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.
@@ -1469,7 +1469,7 @@ bool LibraryCallKit::inline_vector_convert() {
     } else if (num_elem_from > num_elem_to) {
       // Since number elements from input is larger than output, simply reduce size of input (we are supposed to
       // drop top elements anyway).
-      int num_elem_for_resize = MAX2(num_elem_to, Matcher::min_vector_size(elem_bt_from));
+      int num_elem_for_resize = num_elem_to;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.

--- a/test/hotspot/jtreg/compiler/vectorapi/TestCast4STo2I.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestCast4STo2I.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorSpecies;
+
+
+/*
+ * @test
+ * @bug 8265244
+ * @modules jdk.incubator.vector
+ * @run main/othervm compiler.vectorapi.TestCast4STo2I
+ */
+
+public class TestCast4STo2I {
+    static final VectorSpecies<Short> SPECIESs = ShortVector.SPECIES_64;
+    static final VectorSpecies<Integer> SPECIESi = IntVector.SPECIES_64;
+
+    static final int INVOC_COUNT = 50000;
+    static final int SIZE = 64;
+
+    static short[] as = {46, 110, 117, 115, 32, 121, 109, 32, 101, 114,
+                         97, 32, 111, 104, 119, 32, 117, 111, 121, 32,
+                         115, 105, 32, 116, 105, 32, 100, 110, 65, 32,
+                         46, 110, 117, 115, 32, 101, 104, 116, 32, 121,
+                         98, 32, 121, 108, 110, 111, 32, 115, 101, 110,
+                         105, 104, 115, 32, 114, 101, 116, 97, 119, 32,
+                         101, 104, 84};
+    static int[] ai =  {46, 103, 110, 97, 117, 72, 32, 71, 78, 65, 87,
+                        32, 45, 45, 33, 117, 111, 121, 32, 103, 110,
+                        105, 115, 115, 105, 77, 46, 117, 111, 121, 32,
+                        111, 116, 32, 114, 101, 116, 116, 101, 108, 32,
+                        100, 110, 111, 99, 101, 115, 32, 121, 109, 32,
+                        115, 105, 32, 115, 105, 104, 116, 44, 121, 116,
+                        101, 101, 119, 83};
+
+    static void testVectorCastS2I(short[] input, int[] output) {
+        ShortVector sv = ShortVector.fromArray(SPECIESs, input, 0);
+        IntVector iv = (IntVector) sv.castShape(SPECIESi, 0);
+        iv.intoArray(output, 0);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < INVOC_COUNT; i++) {
+            testVectorCastS2I(as, ai);
+        }
+        for (int i = 0; i < SIZE; i++) {
+            System.out.print(ai[i] + ", ");
+        }
+        System.out.println();
+    }
+}


### PR DESCRIPTION
* aarch64 can only accept `VectorReinterpret` with 64/128 bits.
* I will fix this bug by adding a rule for `VectorReinterpret` in `match_rule_supported_vector`
* after changing note with @nsjian and @XiaohongGong , I think that two checks in `inline_vector_conver` is useless now. However, these checks impact other cpus, so I need more reviewers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265244](https://bugs.openjdk.java.net/browse/JDK-8265244): Remove useless comparation in LibraryCallKit::inline_vector_convert()


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Ai Jiaming `<aijiaming1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3507/head:pull/3507` \
`$ git checkout pull/3507`

Update a local copy of the PR: \
`$ git checkout pull/3507` \
`$ git pull https://git.openjdk.java.net/jdk pull/3507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3507`

View PR using the GUI difftool: \
`$ git pr show -t 3507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3507.diff">https://git.openjdk.java.net/jdk/pull/3507.diff</a>

</details>
