### PR TITLE
8163086: java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -859,7 +859,6 @@ java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
 java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html 8080185 macosx-all,linux-all
 javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
-java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java 8163086 macosx-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/print/Dialog/RestoreActiveWindowTest/RestoreActiveWindowTest.java 8185429 macosx-all

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -22,11 +22,10 @@
  */
 
 /*
- * @test %I% %E%
+ * @test
  * @key headful
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
- * @author Kenneth.Russell@sun.com: area=Graphics
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
  * @run main TranslucentJAppletTest
  */

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -23,11 +23,12 @@
 
 /*
  * @test %I% %E%
+ * @key headful
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
  * @author Kenneth.Russell@sun.com: area=Graphics
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
- * @run main/manual/othervm TranslucentJAppletTest
+ * @run main TranslucentJAppletTest
  */
 
 import java.awt.*;

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This bug is filed because of pixel color mismatch and i suspect it to be related to wrong display color profile in macOS.
This test doesn't fail in local machine and in CI test machines in multiple runs.

Also this test was made to run in manual mode even though it doesnt need any User input. Modified the test to run as automated headful test and it runs fine.

I will file separate Verification task/bug to go through remaining manual tests and check whether they can be made automated headful tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8163086](https://bugs.openjdk.java.net/browse/JDK-8163086): java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3509/head:pull/3509` \
`$ git checkout pull/3509`

Update a local copy of the PR: \
`$ git checkout pull/3509` \
`$ git pull https://git.openjdk.java.net/jdk pull/3509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3509`

View PR using the GUI difftool: \
`$ git pr show -t 3509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3509.diff">https://git.openjdk.java.net/jdk/pull/3509.diff</a>

</details>
