### PR TITLE
8265768 [aarch64] Use glibc libm impl for dlog,dlog10,dexp iff 2.29 or greater on AArch64.

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -7009,17 +7009,30 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_updateBytesCRC32C = generate_updateBytesCRC32C();
     }
 
-    // Disabled until JDK-8210858 is fixed
-    // if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dlog)) {
-    //   StubRoutines::_dlog = generate_dlog();
-    // }
-
     if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dsin)) {
       StubRoutines::_dsin = generate_dsin_dcos(/* isCos = */ false);
     }
 
     if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dcos)) {
       StubRoutines::_dcos = generate_dsin_dcos(/* isCos = */ true);
+    }
+
+    if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dlog)) {
+      StubRoutines::_dlog = os::stub_use_cmath_impl(vmIntrinsics::as_int(vmIntrinsics::_dlog)) ?
+        CAST_FROM_FN_PTR(address,
+          static_cast < double( * )(double) > (log)) : NULL;
+    }
+
+    if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dlog10)) {
+      StubRoutines::_dlog10 = os::stub_use_cmath_impl(vmIntrinsics::as_int(vmIntrinsics::_dlog10)) ?
+        CAST_FROM_FN_PTR(address,
+          static_cast < double( * )(double) > (log10)) : NULL;
+    }
+
+    if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dexp)) {
+      StubRoutines::_dexp = os::stub_use_cmath_impl(vmIntrinsics::as_int(vmIntrinsics::_dexp)) ?
+        CAST_FROM_FN_PTR(address,
+          static_cast < double( * )(double) > (exp)) : NULL;
     }
 
     // Safefetch stubs.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -163,6 +163,8 @@ int (*os::Linux::_pthread_setname_np)(pthread_t, const char*) = NULL;
 pthread_t os::Linux::_main_thread;
 int os::Linux::_page_size = -1;
 bool os::Linux::_supports_fast_thread_cpu_time = false;
+int os::Linux::_libc_major_version = 0;
+int os::Linux::_libc_minor_version = 0;
 const char * os::Linux::_libc_version = NULL;
 const char * os::Linux::_libpthread_version = NULL;
 size_t os::Linux::_default_large_page_size = 0;
@@ -533,6 +535,7 @@ void os::Linux::libpthread_init() {
   char *str = (char *)malloc(n, mtInternal);
   confstr(_CS_GNU_LIBC_VERSION, str, n);
   os::Linux::set_libc_version(str);
+  os::Linux::set_libc_major_minor(str);
 
   n = confstr(_CS_GNU_LIBPTHREAD_VERSION, NULL, 0);
   assert(n > 0, "cannot retrieve pthread version");
@@ -540,6 +543,21 @@ void os::Linux::libpthread_init() {
   confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
   os::Linux::set_libpthread_version(str);
 #endif
+}
+
+void os::Linux::set_libc_major_minor(const char *libc_vers){
+  // If using alternative to glibc, not implemented yet.
+  if (!strstr(libc_vers, "glibc"))
+    return;
+
+  if (libc_vers != NULL){
+    const char *major = strchr(libc_vers, ' ');
+    const char *minor = strchr(libc_vers, '.');
+    if (major != NULL && minor != NULL) {
+      os::Linux::set_libc_major_version(strtol(major + 1, nullptr, 10));
+      os::Linux::set_libc_minor_version(strtol(minor + 1, nullptr, 10));
+    }
+  }
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -42,6 +42,8 @@ class Linux {
   static address   _initial_thread_stack_bottom;
   static uintptr_t _initial_thread_stack_size;
 
+  static int _libc_major_version;
+  static int _libc_minor_version;
   static const char *_libc_version;
   static const char *_libpthread_version;
 
@@ -69,6 +71,9 @@ class Linux {
   static int commit_memory_impl(char* addr, size_t bytes,
                                 size_t alignment_hint, bool exec);
 
+  static void set_libc_major_minor(const char *s);
+  static void set_libc_major_version(int n)   { _libc_major_version = n; }
+  static void set_libc_minor_version(int n)   { _libc_minor_version = n; }
   static void set_libc_version(const char *s)       { _libc_version = s; }
   static void set_libpthread_version(const char *s) { _libpthread_version = s; }
 
@@ -139,6 +144,9 @@ class Linux {
   static intptr_t* ucontext_get_sp(const ucontext_t* uc);
   static intptr_t* ucontext_get_fp(const ucontext_t* uc);
 
+  // Runtime GNU libc minor major verion integers
+  static const int libc_major_version()       { return _libc_major_version; }
+  static const int libc_minor_version()       { return _libc_minor_version; }
   // GNU libc and libpthread version strings
   static const char *libc_version()           { return _libc_version; }
   static const char *libpthread_version()     { return _libpthread_version; }

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,6 +31,8 @@
 #endif
 
   static void setup_fpu();
+
+  static bool stub_use_cmath_impl(int intrinsicID);
 
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -269,6 +269,10 @@ void os::print_register_info(outputStream *st, const void *context) {
 void os::setup_fpu() {
 }
 
+bool os::stub_use_cmath_impl(int intrinsicID){
+  return false;
+}
+
 bool os::supports_sse() {
   return true;
 }

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.hpp
@@ -26,6 +26,7 @@
 #define OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_HPP
 
   static void setup_fpu();
+  static bool stub_use_cmath_impl(int intrinsicID);
   static bool supports_sse();
 
   static bool      register_code_area(char *low, char *high) {


### PR DESCRIPTION
Glibc 2.29 onwards provides optimised versions of log,log10,exp.
These functions have an accuracy of 0.9ulp or better in glibc
2.29.

Therefore this patch adds code to parse, store and check
the runtime glibcs version in os_linux.cpp/hpp.
This is then used to select the glibcs implementation of
log, log10, exp at runtime for c1 and c2, iff we have
glibc 2.29 or greater.

This will ensure OpenJDK can benefit from future improvements
to glibc.

Glibc adheres to the ieee754 standard, unless stated otherwise
in its spec.

As there are no stated exceptions in the current glibc spec
for dlog, dlog10 and dexp, we can assume they currently follow
ieee754 (which testing confirms). As such, future version of
glibc are unlikely to lose this compliance with ieee754 in
future.

W.r.t performance this patch sees ~15-30% performance improvements for
log and log10, with ~50-80% performance improvements for exp for the
common input ranged (which output real numbers). However for the NaN
and inf output ranges we see a slow down of up to a factor of 2 for
some functions and architectures.

Due to this being the uncommon case we assert that this is a
worthwhile tradeoff.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8265768](https://bugs.openjdk.java.net/browse/JDK-8265768)

### Issue
 * [JDK-8265768](https://bugs.openjdk.java.net/browse/JDK-8265768): [aarch64] Use libm for common math routines ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3510/head:pull/3510` \
`$ git checkout pull/3510`

Update a local copy of the PR: \
`$ git checkout pull/3510` \
`$ git pull https://git.openjdk.java.net/jdk pull/3510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3510`

View PR using the GUI difftool: \
`$ git pr show -t 3510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3510.diff">https://git.openjdk.java.net/jdk/pull/3510.diff</a>

</details>
