### PR TITLE
JDK-8265259: G1: Fix HeapRegion::block_is_obj for unloading class in full gc

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -141,7 +141,12 @@ inline bool HeapRegion::block_is_obj(const HeapWord* p) const {
     assert(is_continues_humongous(), "This case can only happen for humongous regions");
     return (p == humongous_start_region()->bottom());
   }
-  if (ClassUnloadingWithConcurrentMark) {
+  // In full gc, we might have skipped compacting some heap regions with high live ratio,
+  // for objs in these regions, the corresponding class info might have been unloaded if
+  // they're not marked in the full gc.
+  // So, only when ClassUnloading is false, it's safe to tell an obj is indeed an obj when
+  // it's under the top of the region, otherwise we have to go to the slow path below.
+  if (ClassUnloading) {
     return !g1h->is_obj_dead(cast_to_oop(p), this);
   }
   return p < top();

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -124,7 +124,7 @@ inline bool HeapRegion::is_obj_dead_with_size(const oop obj, const G1CMBitMap* c
   assert(!is_humongous(), "Humongous objects not handled here");
   bool obj_is_dead = is_obj_dead(obj, prev_bitmap);
 
-  if (ClassUnloadingWithConcurrentMark && obj_is_dead) {
+  if (ClassUnloading && obj_is_dead) {
     assert(!block_is_obj(addr), "must be");
     *size = block_size_using_bitmap(addr, prev_bitmap);
   } else {
@@ -141,11 +141,13 @@ inline bool HeapRegion::block_is_obj(const HeapWord* p) const {
     assert(is_continues_humongous(), "This case can only happen for humongous regions");
     return (p == humongous_start_region()->bottom());
   }
-  // In full gc, we might have skipped compacting some heap regions with high live ratio,
-  // for objs in these regions, the corresponding class info might have been unloaded if
-  // they're not marked in the full gc.
-  // So, only when ClassUnloading is false, it's safe to tell an obj is indeed an obj when
-  // it's under the top of the region, otherwise we have to go to the slow path below.
+  // When class unloading is enabled it is not safe to only consider top() to conclude if the
+  // given pointer is a valid object. The situation can occur both for class unloading in a
+  // Full GC and during a concurrent cycle.
+  // During a Full GC regions can be excluded from compaction due to high live ratio, and
+  // because of this there can be stale objects for unloaded classes left in these regions.
+  // During a concurrent cycle class unloading is done after marking is complete and objects
+  // for the unloaded classes will be stale until the regions are collected.
   if (ClassUnloading) {
     return !g1h->is_obj_dead(cast_to_oop(p), this);
   }
@@ -153,7 +155,7 @@ inline bool HeapRegion::block_is_obj(const HeapWord* p) const {
 }
 
 inline size_t HeapRegion::block_size_using_bitmap(const HeapWord* addr, const G1CMBitMap* const prev_bitmap) const {
-  assert(ClassUnloadingWithConcurrentMark,
+  assert(ClassUnloading,
          "All blocks should be objects if class unloading isn't used, so this method should not be called. "
          "HR: [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ") "
          "addr: " PTR_FORMAT,


### PR DESCRIPTION
In JDK-8262068, we have introduced an enhancement to skip compacting some heap regions.
But the objs in these regions might have been dead, and their classes might have been unloaded, at this situation, we need following change to make sure we don't get into trouble when calls HeapRegion::block_is_obj(const HeapWord* p) and subsequent calls e.g. to get obj size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265259](https://bugs.openjdk.java.net/browse/JDK-8265259): G1: Fix HeapRegion::block_is_obj for unloading class in full gc


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3514/head:pull/3514` \
`$ git checkout pull/3514`

Update a local copy of the PR: \
`$ git checkout pull/3514` \
`$ git pull https://git.openjdk.java.net/jdk pull/3514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3514`

View PR using the GUI difftool: \
`$ git pr show -t 3514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3514.diff">https://git.openjdk.java.net/jdk/pull/3514.diff</a>

</details>
