### PR TITLE
8262462: IGV: cannot remove specific groups imported via network

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ public final class OutlineTopComponent extends TopComponent implements ExplorerM
             public void started(Group g) {
                 synchronized(OutlineTopComponent.this) {
                     getDocument().addElement(g);
+                    g.setParent(getDocument());
                 }
             }
         };


### PR DESCRIPTION
This change connects groups to their `GraphDocument` parents when the groups are imported via network, making it possible to remove the imported groups later. Before the change, this connection was made only when groups are imported from a file:

https://github.com/openjdk/jdk/blob/1d66a155c711906fbb5e8e976fd6585ef491ea68/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/ImportAction.java#L147

Tested manually on JDK 8, 11, and 15 (latest version currently supported by IGV) by following the steps in the [bug report](https://bugs.openjdk.java.net/browse/JDK-8262462).

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262462](https://bugs.openjdk.java.net/browse/JDK-8262462): IGV: cannot remove specific groups imported via network


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3515/head:pull/3515` \
`$ git checkout pull/3515`

Update a local copy of the PR: \
`$ git checkout pull/3515` \
`$ git pull https://git.openjdk.java.net/jdk pull/3515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3515`

View PR using the GUI difftool: \
`$ git pr show -t 3515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3515.diff">https://git.openjdk.java.net/jdk/pull/3515.diff</a>

</details>
