### PR TITLE
8264480: Unreachable code in nmethod.cpp inside #ifdef DEBUG

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1170,7 +1170,7 @@ void nmethod::inc_decompile_count() {
 
 bool nmethod::try_transition(int new_state_int) {
   signed char new_state = new_state_int;
-#ifdef DEBUG
+#ifdef ASSERT
   if (new_state != unloaded) {
     assert_lock_strong(CompiledMethod_lock);
   }


### PR DESCRIPTION
Fixed ifdef to use correct define.

Stress tested locally, running t1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264480](https://bugs.openjdk.java.net/browse/JDK-8264480): Unreachable code in nmethod.cpp inside #ifdef DEBUG


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3517/head:pull/3517` \
`$ git checkout pull/3517`

Update a local copy of the PR: \
`$ git checkout pull/3517` \
`$ git pull https://git.openjdk.java.net/jdk pull/3517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3517`

View PR using the GUI difftool: \
`$ git pr show -t 3517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3517.diff">https://git.openjdk.java.net/jdk/pull/3517.diff</a>

</details>
