### PR TITLE
8265278: doc build fails after JDK-8262981

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -1591,12 +1591,12 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
          * @return true.
          * @see #getAccessibleActionCount
          */
-        public boolean doAccessibleAction(int direction) {
-            if (direction < 0 || direction > 1) {
+        public boolean doAccessibleAction(int i) {
+            if (i < 0 || i > 1) {
                 return false;
             }
             //0 is increment, 1 is decrrement
-            int delta = ((direction > 0) ? -1 : 1);
+            int delta = ((i > 0) ? -1 : 1);
             JSlider.this.setValue(oldModelValue + delta);
             return true;
         }


### PR DESCRIPTION
The doc build fails after the JDK-8262981. The JDK-8262981 adds a new function, but by mistake the param name used in function is different from the param name mentioned in @param tag. This breaks the doc build.

This change corrects the param name. I have verified that the doc build runs successfully after the changes by running following command. It fails before the current change and passes with the change.

"make jdk-image docs-jdk"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265278](https://bugs.openjdk.java.net/browse/JDK-8265278): doc build fails after JDK-8262981


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3518/head:pull/3518` \
`$ git checkout pull/3518`

Update a local copy of the PR: \
`$ git checkout pull/3518` \
`$ git pull https://git.openjdk.java.net/jdk pull/3518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3518`

View PR using the GUI difftool: \
`$ git pr show -t 3518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3518.diff">https://git.openjdk.java.net/jdk/pull/3518.diff</a>

</details>
