### PR TITLE
8265062: Remove duplication constant MaxTextureSize

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.h
@@ -47,10 +47,4 @@ typedef struct _MTLGraphicsConfigInfo {
     MTLContext          *context;
 } MTLGraphicsConfigInfo;
 
-// From "Metal Feature Set Tables"
-// There are 2 GPU families for mac - MTLGPUFamilyMac1 and MTLGPUFamilyMac2
-// Both of them support "Maximum 2D texture width and height" of 16384 pixels
-// Note : there is no API to get this value, hence hardcoding by reading from the table
-#define MaxTextureSize 16384
-
 #endif /* MTLGraphicsConfig_h_Included */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -225,5 +225,5 @@ Java_sun_java2d_metal_MTLGraphicsConfig_nativeGetMaxTextureSize
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLGraphicsConfig_nativeGetMaxTextureSize");
 
-    return (jint)MaxTextureSize;
+    return (jint)MTL_GPU_FAMILY_MAC_TXT_SIZE;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
@@ -68,11 +68,11 @@ static jboolean MTLSurfaceData_initTexture(BMTLSDOps *bmtlsdo, jboolean isOpaque
 
         MTLContext* ctx = mtlsdo->configInfo->context;
 
-        width = (width <= MaxTextureSize) ? width : 0;
-        height = (height <= MaxTextureSize) ? height : 0;
+        width = (width <= MTL_GPU_FAMILY_MAC_TXT_SIZE) ? width : 0;
+        height = (height <= MTL_GPU_FAMILY_MAC_TXT_SIZE) ? height : 0;
 
         J2dTraceLn3(J2D_TRACE_VERBOSE, "  desired texture dimensions: w=%d h=%d max=%d",
-                width, height, MaxTextureSize);
+                width, height, MTL_GPU_FAMILY_MAC_TXT_SIZE);
 
         // if either dimension is 0, we cannot allocate a texture with the
         // requested dimensions


### PR DESCRIPTION
I've removed MaxTextureSize and replaced its usages with MTL_GPU_FAMILY_MAC_TXT_SIZE

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265062](https://bugs.openjdk.java.net/browse/JDK-8265062): Remove duplication constant MaxTextureSize


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3519/head:pull/3519` \
`$ git checkout pull/3519`

Update a local copy of the PR: \
`$ git checkout pull/3519` \
`$ git pull https://git.openjdk.java.net/jdk pull/3519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3519`

View PR using the GUI difftool: \
`$ git pr show -t 3519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3519.diff">https://git.openjdk.java.net/jdk/pull/3519.diff</a>

</details>
