### PR TITLE
8264734: Some SA classes could use better hashCode() implementation

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdAddress.java
@@ -52,8 +52,7 @@ class BsdAddress implements Address {
     }
 
     public int hashCode() {
-        // FIXME: suggestions on a better hash code?
-        return (int) addr;
+        return Long.hashCode(addr);
     }
 
     public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyAddress.java
@@ -56,8 +56,7 @@ class DummyAddress implements Address {
   }
 
   public int hashCode() {
-    // FIXME: suggestions on a better hash code?
-    return (int) addr;
+    return Long.hashCode(addr);
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxAddress.java
@@ -52,8 +52,7 @@ public class LinuxAddress implements Address {
     }
 
     public int hashCode() {
-        // FIXME: suggestions on a better hash code?
-        return (int) addr;
+        return Long.hashCode(addr);
     }
 
     public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcAddress.java
@@ -52,8 +52,7 @@ class ProcAddress implements Address {
   }
 
   public int hashCode() {
-    // FIXME: suggestions on a better hash code?
-    return (int) addr;
+    return Long.hashCode(addr);
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteAddress.java
@@ -52,8 +52,7 @@ class RemoteAddress implements Address {
   }
 
   public int hashCode() {
-    // FIXME: suggestions on a better hash code?
-    return (int) addr;
+    return Long.hashCode(addr);
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
@@ -387,7 +387,7 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
        return remoteDebugger.getThreadHashCode(id, false);
     } catch (RemoteException e) {
     }
-    return (int) id;
+    return Long.hashCode(id);
   }
 
   public ThreadProxy getThreadForIdentifierAddress(Address addr) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgAddress.java
@@ -52,8 +52,7 @@ class WindbgAddress implements Address {
   }
 
   public int hashCode() {
-    // FIXME: suggestions on a better hash code?
-    return (int) addr;
+    return Long.hashCode(addr);
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgAddress.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
@@ -75,7 +75,7 @@ class WindbgAARCH64Thread implements ThreadProxy {
   }
 
   public int hashCode() {
-    return (int) getThreadID();
+    return Long.hashCode(getThreadID());
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/amd64/WindbgAMD64Thread.java
@@ -78,7 +78,7 @@ class WindbgAMD64Thread implements ThreadProxy {
   }
 
   public int hashCode() {
-    return (int) getThreadID();
+    return Long.hashCode(getThreadID());
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/x86/WindbgX86Thread.java
@@ -74,7 +74,7 @@ class WindbgX86Thread implements ThreadProxy {
   }
 
   public int hashCode() {
-    return (int) getThreadID();
+    return Long.hashCode(getThreadID());
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shenandoah/ShenandoahHeapRegion.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shenandoah/ShenandoahHeapRegion.java
@@ -127,7 +127,7 @@ public class ShenandoahHeapRegion extends VMObject implements LiveRegionsProvide
 
     @Override
     public int hashCode() {
-        return (int)index();
+        return Long.hashCode(index());
     }
 
     @Override


### PR DESCRIPTION
The current `hashCode` implementation of SA's Address subclasses ignores the upper 32 bits of the long value.
This PR changes to use `Long.hashCode` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264734](https://bugs.openjdk.java.net/browse/JDK-8264734): Some SA classes could use better hashCode() implementation


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to ac5c266025ca76c862b36de0ed428d9a33f0ceec


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3522/head:pull/3522` \
`$ git checkout pull/3522`

Update a local copy of the PR: \
`$ git checkout pull/3522` \
`$ git pull https://git.openjdk.java.net/jdk pull/3522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3522`

View PR using the GUI difftool: \
`$ git pr show -t 3522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3522.diff">https://git.openjdk.java.net/jdk/pull/3522.diff</a>

</details>
