### PR TITLE
JDK-8265298: Hard VM crash when deadlock between "access" and higher ranked lock is detected

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -413,7 +413,7 @@ void Mutex::check_rank(Thread* thread) {
     // of m2 be less than the rank of m1. This prevents circular waits.
     if (least != NULL && least->rank() <= this->rank()) {
       if (least->rank() > Mutex::tty) {
-        // Printing owned locks acquires tty lock. If lowest rank is below or equal
+        // Printing owned locks acquires tty lock. If the least rank was below or equal
         // tty, then deadlock detection code would circle back here, until we run
         // out of stack and crash hard. Print locks only when it is safe.
         thread->print_owned_locks();

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -412,7 +412,12 @@ void Mutex::check_rank(Thread* thread) {
     // to acquire, then deadlock prevention rules require that the rank
     // of m2 be less than the rank of m1. This prevents circular waits.
     if (least != NULL && least->rank() <= this->rank()) {
-      thread->print_owned_locks();
+      if (least->rank() > Mutex::tty) {
+        // Printing owned locks acquires tty lock. If lowest rank is below or equal
+        // tty, then deadlock detection code would circle back here, until we run
+        // out of stack and crash hard. Print locks only when it is safe.
+        thread->print_owned_locks();
+      }
       assert(false, "Attempting to acquire lock %s/%d out of order with lock %s/%d -- "
              "possible deadlock", this->name(), this->rank(), least->name(), least->rank());
     }

--- a/test/hotspot/gtest/runtime/test_mutex_rank.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex_rank.cpp
@@ -104,6 +104,36 @@ TEST_VM_ASSERT_MSG(MutexRank, mutex_trylock_rank_out_of_orderB,
   mutex_rankA->unlock();
 }
 
+TEST_VM_ASSERT_MSG(MutexRank, mutex_wait_access_leaf,
+                   ".* Attempting to acquire lock mutex_rank_leaf/11 out of order with lock mutex_rank_access/1 "
+                   "-- possible deadlock") {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+
+  Mutex* mutex_rank_access = new Mutex(Mutex::access, "mutex_rank_access", false, Mutex::_safepoint_check_never);
+  Mutex* mutex_rank_leaf = new Mutex(Mutex::leaf, "mutex_rank_leaf", false, Mutex::_safepoint_check_never);
+
+  mutex_rank_access->lock_without_safepoint_check();
+  mutex_rank_leaf->lock_without_safepoint_check();
+  mutex_rank_leaf->unlock();
+  mutex_rank_access->unlock();
+}
+
+TEST_VM_ASSERT_MSG(MutexRank, mutex_wait_tty_special,
+                   ".* Attempting to acquire lock mutex_rank_special/6 out of order with lock mutex_rank_tty/3 "
+                   "-- possible deadlock") {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+
+  Mutex* mutex_rank_tty = new Mutex(Mutex::tty, "mutex_rank_tty", false, Mutex::_safepoint_check_never);
+  Mutex* mutex_rank_special = new Mutex(Mutex::special, "mutex_rank_special", false, Mutex::_safepoint_check_never);
+
+  mutex_rank_tty->lock_without_safepoint_check();
+  mutex_rank_special->lock_without_safepoint_check();
+  mutex_rank_special->unlock();
+  mutex_rank_tty->unlock();
+}
+
 TEST_OTHER_VM(MutexRank, monitor_wait_rank_in_order) {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
@@ -164,5 +194,37 @@ TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_special,
   monitor_rank_special_minus_one->wait_without_safepoint_check(1);
   monitor_rank_special_minus_one->unlock();
   monitor_rank_special->unlock();
+}
+
+TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_access_leaf,
+                   ".* Attempting to acquire lock monitor_rank_leaf/11 out of order with lock monitor_rank_access/1 "
+                   "-- possible deadlock") {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+
+  Monitor* monitor_rank_access = new Monitor(Mutex::access, "monitor_rank_access", false, Mutex::_safepoint_check_never);
+  Monitor* monitor_rank_leaf = new Monitor(Mutex::leaf, "monitor_rank_leaf", false, Mutex::_safepoint_check_never);
+
+  monitor_rank_access->lock_without_safepoint_check();
+  monitor_rank_leaf->lock_without_safepoint_check();
+  monitor_rank_leaf->wait_without_safepoint_check(1);
+  monitor_rank_leaf->unlock();
+  monitor_rank_access->unlock();
+}
+
+TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_tty_special,
+                   ".* Attempting to acquire lock monitor_rank_special/6 out of order with lock monitor_rank_tty/3 "
+                   "-- possible deadlock") {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+
+  Monitor* monitor_rank_tty = new Monitor(Mutex::tty, "monitor_rank_tty", false, Mutex::_safepoint_check_never);
+  Monitor* monitor_rank_special = new Monitor(Mutex::special, "monitor_rank_special", false, Mutex::_safepoint_check_never);
+
+  monitor_rank_tty->lock_without_safepoint_check();
+  monitor_rank_special->lock_without_safepoint_check();
+  monitor_rank_special->wait_without_safepoint_check(1);
+  monitor_rank_special->unlock();
+  monitor_rank_tty->unlock();
 }
 #endif // ASSERT


### PR DESCRIPTION
I stumbled upon this when doing some Shenandoah work. The development code tried to lock the `leaf` lock, while already holding the `access` lock. Normally it would have been detected by VM, but instead, we tried to recursively acquire `tty_lock` for `Thread::print_owned_locks`. But that `tty` lock is still ranked higher than `access`, so deadlock detection triggers over and over again until we run out of stack and crash hard. `tty` and `access` are ranked this way because of [JDK-8214315](https://bugs.openjdk.java.net/browse/JDK-8214315). Read the rest in the bug.  

I believe the way out is to only enter `Thread::print_owned_locks` when we know deadlock detection code would not run in circles. New test for `access` and `leaf` shows the original failure. Another new test checks `tty` and `special` to verify that the check should be `> tty`, not `>= tty`.

Additional testing:
 - [x] Linux x86_64 fastdebug tier1
 - [x] New regression tests (fail without the patch, pass wit it)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265298](https://bugs.openjdk.java.net/browse/JDK-8265298): Hard VM crash when deadlock between "access" and higher ranked lock is detected


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to ecf6e5bb8bec49ea573715dc4143f425169e576c
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3524/head:pull/3524` \
`$ git checkout pull/3524`

Update a local copy of the PR: \
`$ git checkout pull/3524` \
`$ git pull https://git.openjdk.java.net/jdk pull/3524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3524`

View PR using the GUI difftool: \
`$ git pr show -t 3524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3524.diff">https://git.openjdk.java.net/jdk/pull/3524.diff</a>

</details>
