### PR TITLE
8265302: ProblemList runtime/logging/RedefineClasses.java on linux-x64 -Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,3 +28,5 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
+
+runtime/logging/RedefineClasses.java 8265218 linux-x64


### PR DESCRIPTION
A trivial fix to ProblemList runtime/logging/RedefineClasses.java on linux-x64 -Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265302](https://bugs.openjdk.java.net/browse/JDK-8265302): ProblemList runtime/logging/RedefineClasses.java on linux-x64 -Xcomp


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3525/head:pull/3525` \
`$ git checkout pull/3525`

Update a local copy of the PR: \
`$ git checkout pull/3525` \
`$ git pull https://git.openjdk.java.net/jdk pull/3525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3525`

View PR using the GUI difftool: \
`$ git pr show -t 3525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3525.diff">https://git.openjdk.java.net/jdk/pull/3525.diff</a>

</details>
