### PR TITLE
8265323: Leftover local variables in PcDesc

### DIFF
--- a/src/hotspot/share/code/pcDesc.cpp
+++ b/src/hotspot/share/code/pcDesc.cpp
@@ -43,16 +43,11 @@ address PcDesc::real_pc(const CompiledMethod* code) const {
 void PcDesc::print_on(outputStream* st, CompiledMethod* code) {
 #ifndef PRODUCT
   ResourceMark rm;
-  st->print("PcDesc(pc=" PTR_FORMAT " offset=%x bits=%x):", p2i(real_pc(code)), pc_offset(), _flags);
+  st->print_cr("PcDesc(pc=" PTR_FORMAT " offset=%x bits=%x):", p2i(real_pc(code)), pc_offset(), _flags);
 
   if (scope_decode_offset() == DebugInformationRecorder::serialized_null) {
-    st->cr();
     return;
   }
-
-  int tab = 8;
-  int pos = st->position() + 2; // current column plus two spaces
-  pos = ((pos+tab-1)/tab)*tab;
 
   for (ScopeDesc* sd = code->scope_desc_at(real_pc(code));
        sd != NULL;


### PR DESCRIPTION
Leftover local variables in PcDesc. Remove it to save electric power.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265323](https://bugs.openjdk.java.net/browse/JDK-8265323): Leftover local variables in PcDesc


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3532/head:pull/3532` \
`$ git checkout pull/3532`

Update a local copy of the PR: \
`$ git checkout pull/3532` \
`$ git pull https://git.openjdk.java.net/jdk pull/3532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3532`

View PR using the GUI difftool: \
`$ git pr show -t 3532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3532.diff">https://git.openjdk.java.net/jdk/pull/3532.diff</a>

</details>
