### PR TITLE
8265304: Temporarily make Metal the default 2D rendering pipeline for macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
@@ -90,13 +90,16 @@ public class MacOSFlags {
                     PropertyState metalState = getBooleanProp("sun.java2d.metal", PropertyState.UNSPECIFIED);
 
                     // Handle invalid combinations to use the default rendering pipeline
-                    // Current default rendering pipeline is OpenGL
-                    // (The default can be changed to Metal in future just by toggling two states in this if condition block)
+                    // Current default rendering pipeline is Metal
+                    // (The default can be changed to OpenGL in future just by toggling two states in this if condition block)
+                    // ---------------------------------------------------------------------
+                    // TODO : Revert default rendering pipeline to OpenGL
+                    // ---------------------------------------------------------------------
                     if ((oglState == PropertyState.UNSPECIFIED && metalState == PropertyState.UNSPECIFIED) ||
                         (oglState == PropertyState.DISABLED && metalState == PropertyState.DISABLED) ||
                         (oglState == PropertyState.ENABLED && metalState == PropertyState.ENABLED)) {
-                        oglState = PropertyState.ENABLED; // Enable default pipeline
-                        metalState = PropertyState.DISABLED; // Disable non-default pipeline
+                        metalState = PropertyState.ENABLED; // Enable default pipeline
+                        oglState = PropertyState.DISABLED; // Disable non-default pipeline
                     }
 
                     if (metalState == PropertyState.UNSPECIFIED) {


### PR DESCRIPTION
This PR makes Metal as the default Java2D rendering pipeline for macOS.

Note : from JBS description :
The plan of record has always been that for JDK 17 the new Metal pipeline will be OFF by default and must be explicitly enabled by setting a system property.
We are not changing that plan but to get more testing exposure we intend to make it the default (instead of OpenGL) for approximately one month (from the next build up to the 20th May build of JDK 17).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265304](https://bugs.openjdk.java.net/browse/JDK-8265304): Temporarily make Metal the default 2D rendering pipeline for macOS


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3534/head:pull/3534` \
`$ git checkout pull/3534`

Update a local copy of the PR: \
`$ git checkout pull/3534` \
`$ git pull https://git.openjdk.java.net/jdk pull/3534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3534`

View PR using the GUI difftool: \
`$ git pr show -t 3534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3534.diff">https://git.openjdk.java.net/jdk/pull/3534.diff</a>

</details>
