### PR TITLE
8264372: Threads::destroy_vm only ever returns true 

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3731,17 +3731,10 @@ static jint JNICALL jni_DestroyJavaVM_inner(JavaVM *vm) {
   MACOS_AARCH64_ONLY(WXMode oldmode = thread->enable_wx(WXWrite));
 
   ThreadStateTransition::transition_from_native(thread, _thread_in_vm);
-  if (Threads::destroy_vm()) {
-    // Should not change thread state, VM is gone
-    vm_created = 0;
-    res = JNI_OK;
-    return res;
-  } else {
-    ThreadStateTransition::transition(thread, _thread_in_vm, _thread_in_native);
-    MACOS_AARCH64_ONLY(thread->enable_wx(oldmode));
-    res = JNI_ERR;
-    return res;
-  }
+  Threads::destroy_vm();
+  // Should not change thread state, VM is gone
+  vm_created = 0;
+  return JNI_OK;
 }
 
 jint JNICALL jni_DestroyJavaVM(JavaVM *vm) {

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3732,7 +3732,7 @@ static jint JNICALL jni_DestroyJavaVM_inner(JavaVM *vm) {
 
   ThreadStateTransition::transition_from_native(thread, _thread_in_vm);
   Threads::destroy_vm();
-  // Should not change thread state, VM is gone
+  // Don't bother restoring thread state, VM is gone.
   vm_created = 0;
   return JNI_OK;
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3699,7 +3699,7 @@ void JavaThread::invoke_shutdown_hooks() {
 //   + Delete this thread
 //   + Return to caller
 
-bool Threads::destroy_vm() {
+void Threads::destroy_vm() {
   JavaThread* thread = JavaThread::current();
 
 #ifdef ASSERT
@@ -3792,8 +3792,6 @@ bool Threads::destroy_vm() {
 #endif
 
   LogConfiguration::finalize();
-
-  return true;
 }
 
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1812,7 +1812,7 @@ class Threads: AllStatic {
   static void create_vm_init_libraries();
   static void create_vm_init_agents();
   static void shutdown_vm_agents();
-  static bool destroy_vm();
+  static void destroy_vm();
   // Supported VM versions via JNI
   // Includes JNI_VERSION_1_1
   static jboolean is_supported_jni_version_including_1_1(jint version);


### PR DESCRIPTION
Trivial cleanup to remove the bool return from Threads::destroy_vm as it only ever returned true.

Testing: tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264372](https://bugs.openjdk.java.net/browse/JDK-8264372): Threads::destroy_vm only ever returns true


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 778b233b5be5ffe83a77a00b8fddc216cd10811b
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 778b233b5be5ffe83a77a00b8fddc216cd10811b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3535/head:pull/3535` \
`$ git checkout pull/3535`

Update a local copy of the PR: \
`$ git checkout pull/3535` \
`$ git pull https://git.openjdk.java.net/jdk pull/3535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3535`

View PR using the GUI difftool: \
`$ git pr show -t 3535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3535.diff">https://git.openjdk.java.net/jdk/pull/3535.diff</a>

</details>
