### PR TITLE
8265325: Optimize StubRoutines::dpow() for Math.pow(x, 0.5)

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -1,5 +1,6 @@
 /*
-* Copyright (c) 2016, 2021, Intel Corporation.
+* Copyright (c) 2016, Intel Corporation.
+* Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
 * Intel Math Library (LIBM) Source Code
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, Intel Corporation.
+* Copyright (c) 2016, 2021, Intel Corporation.
 * Intel Math Library (LIBM) Source Code
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -765,6 +765,16 @@ ATTRIBUTE_ALIGNED(8) juint _DOUBLE2[] =
     0x00000000UL, 0x40000000UL
 };
 
+ATTRIBUTE_ALIGNED(8) juint _DOUBLE0[] =
+{
+    0x00000000UL, 0x00000000UL
+};
+
+ATTRIBUTE_ALIGNED(8) juint _DOUBLE0DOT5[] =
+{
+    0x00000000UL, 0x3fe00000UL
+};
+
 //registers,
 // input: xmm0, xmm1
 // scratch: xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7
@@ -789,6 +799,7 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_52_0_2, L_2TAG_PACKET_53_0_2, L_2TAG_PACKET_54_0_2, L_2TAG_PACKET_55_0_2;
   Label L_2TAG_PACKET_56_0_2;
   Label B1_2, B1_3, B1_5, start;
+  Label L_POW;
 
   assert_different_registers(tmp1, tmp2, eax, ecx, edx);
   jmp(start);
@@ -804,6 +815,8 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   address HALFMASK = (address)_HALFMASK;
   address log2 = (address)_log2_pow;
   address DOUBLE2 = (address)_DOUBLE2;
+  address DOUBLE0 = (address)_DOUBLE0;
+  address DOUBLE0DOT5 = (address)_DOUBLE0DOT5;
 
 
   bind(start);
@@ -818,7 +831,17 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   mulsd(xmm0, xmm0);
   jmp(B1_5);
 
+  // Special case: pow(x, 0.5) => sqrt(x)
   bind(B1_2);
+  cmp64(tmp1, ExternalAddress(DOUBLE0DOT5));
+  jccb(Assembler::notEqual, L_POW); // For pow(x, y), check whether y == 0.5
+  movdq(tmp2, xmm0);
+  cmp64(tmp2, ExternalAddress(DOUBLE0));
+  jccb(Assembler::less, L_POW); // pow(x, 0.5) => sqrt(x) only for x >= 0.0 or x is +inf/NaN
+  sqrtsd(xmm0, xmm0);
+  jmp(B1_5);
+
+  bind(L_POW);
   pextrw(eax, xmm0, 3);
   xorpd(xmm2, xmm2);
   mov64(tmp2, 0x3ff0000000000000);

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -35,8 +35,8 @@
 public class TestPow0Dot5Opt {
 
   static void test(double a) throws Exception {
-    // pow(x, 0.5) is replaced with sqrt(x) if and only if x > 0.0
-    if (a <= 0.0) return;
+    // pow(x, 0.5) isn't replaced with sqrt(x) for x < 0.0
+    if (a < 0.0) return;
 
     double r1 = Math.sqrt(a);
     double r2 = Math.pow(a, 0.5);
@@ -52,6 +52,8 @@ public class TestPow0Dot5Opt {
         test(1.0 / j);
       }
     }
+
+    test(0.0);
 
     // Special case: pow(+0.0, 0.5) = 0.0
     double r = Math.pow(+0.0, 0.5);

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -34,11 +34,13 @@
 
 public class TestPow0Dot5Opt {
 
+  static double r1;
+
   static void test(double a) throws Exception {
     // pow(x, 0.5) isn't replaced with sqrt(x) for x < 0.0
     if (a < 0.0) return;
 
-    double r1 = Math.sqrt(a);
+    r1 = Math.sqrt(a);
     double r2 = Math.pow(a, 0.5);
     if (r1 != r2) {
       throw new RuntimeException("pow(" + a + ", 0.5), expected: " + r1 + ", actual: " + r2);

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -34,13 +34,11 @@
 
 public class TestPow0Dot5Opt {
 
-  static double r1;
-
   static void test(double a) throws Exception {
     // pow(x, 0.5) isn't replaced with sqrt(x) for x < 0.0
     if (a < 0.0) return;
 
-    r1 = Math.sqrt(a);
+    double r1 = Math.sqrt(a);
     double r2 = Math.pow(a, 0.5);
     if (r1 != r2) {
       throw new RuntimeException("pow(" + a + ", 0.5), expected: " + r1 + ", actual: " + r2);

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265325
+ * @summary test the optimization of pow(x, 0.5)
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @run main/othervm TestPow0Dot5Opt
+ * @run main/othervm -Xint TestPow0Dot5Opt
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 TestPow0Dot5Opt
+ * @run main/othervm -Xbatch -XX:-TieredCompilation  TestPow0Dot5Opt
+ */
+
+public class TestPow0Dot5Opt {
+
+  static void test(double a) throws Exception {
+    // pow(x, 0.5) is replaced with sqrt(x) if and only if x > 0.0
+    if (a <= 0.0) return;
+
+    double r1 = Math.sqrt(a);
+    double r2 = Math.pow(a, 0.5);
+    if (r1 != r2) {
+      throw new RuntimeException("pow(" + a + ", 0.5), expected: " + r1 + ", actual: " + r2);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    for (int i = 0; i < 10; i++) {
+      for (int j = 1; j < 100000; j++) {
+        test(j * 1.0);
+        test(1.0 / j);
+      }
+    }
+
+    // Special case: pow(+0.0, 0.5) = 0.0
+    double r = Math.pow(+0.0, 0.5);
+    if (Double.doubleToRawLongBits(r) != Double.doubleToRawLongBits(0.0)) {
+      throw new RuntimeException("pow(+0.0, 0.5), expected: 0.0, actual: " + r);
+    }
+
+    // Special case: pow(-0.0, 0.5) = 0.0
+    r = Math.pow(-0.0, 0.5);
+    if (Double.doubleToRawLongBits(r) != Double.doubleToRawLongBits(0.0)) {
+      throw new RuntimeException("pow(-0.0, 0.5), expected: 0.0, actual: " + r);
+    }
+
+    // Special case: pow(Double.POSITIVE_INFINITY, 0.5) = Infinity
+    r = Math.pow(Double.POSITIVE_INFINITY, 0.5);
+    if (!(r > 0 && Double.isInfinite(r))) {
+      throw new RuntimeException("pow(+Infinity, 0.5), expected: Infinity, actual: " + r);
+    }
+
+    // Special case: pow(Double.NEGATIVE_INFINITY, 0.5) = Infinity
+    r = Math.pow(Double.NEGATIVE_INFINITY, 0.5);
+    if (!(r > 0 && Double.isInfinite(r))) {
+      throw new RuntimeException("pow(-Infinity, 0.5), expected: Infinity, actual: " + r);
+    }
+
+    // Special case: pow(Double.NaN, 0.5) = NaN
+    r = Math.pow(Double.NaN, 0.5);
+    if (!Double.isNaN(r)) {
+      throw new RuntimeException("pow(NaN, 0.5), expected: NaN, actual: " + r);
+    }
+  }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -60,7 +60,7 @@ public class MathBench {
     public int int1 = 1, int2 = 2, int42 = 42, int5 = 5;
     public long long1 = 1L, long2 = 2L, long747 = 747L, long13 = 13L;
     public float float1 = 1.0f, float2 = 2.0f, floatNegative99 = -99.0f, float7 = 7.0f, eFloat = 2.718f;
-    public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d;
+    public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d, double0Dot5 = 0.5d;
 
     @Setup
     public void setupValues() {
@@ -406,6 +406,38 @@ public class MathBench {
     @Benchmark
     public double  powDouble() {
         return  Math.pow(double4Dot1, double2);
+    }
+
+    @Benchmark
+    public double  powDoubleLoop() {
+        double sum = 0.0;
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 0; j < 1000; j++) {
+                sum += i + Math.pow(j * 1.0, i * 1.0);
+            }
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public double  powDouble0Dot5() {
+        return  Math.pow(double4Dot1, double0Dot5);
+    }
+
+    @Benchmark
+    public double  powDouble0Dot5Const() {
+        return  Math.pow(double4Dot1, 0.5);
+    }
+
+    @Benchmark
+    public double  powDouble0Dot5Loop() {
+        double sum = 0.0;
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 0; j < 1000; j++) {
+                sum += i + Math.pow(j * 1.0, 0.5);
+            }
+        }
+        return sum;
     }
 
     @Benchmark


### PR DESCRIPTION
Hi all,

I'd like to optimize the StubRoutines::dpow() for Math.pow(x, 0.5).

In the pow and sqrt discussion [1], Joe taught me that the Java library implementation of pow has been optimized for pow(x, 2.0) [2] and pow(x, 0.5) [3].
However, the hotspot StubRoutines::dpow() only implements the same opt for pow(x, 2.0), but still not for pow(x, 0.5).
This patch optimizes StubRoutines::dpow() for pow(x, 0.5).

Although not all Math.pow(x, 0.5) can be replaced with sqrt(x), we can still do it safely for the following cases:
  1) x >= 0.0    (fully implemented)
  2) x is +Inf   (fully implemented)
  3) x is NaN    (can be further divided into +NaN and -NaN and only +NaN is implemented)

The effect of this opt has been tested on serveral platforms showing 3.0x ~ 6.3x performance improvement.
And no performance drop was observed.

Testing:
  - tier1 ~ tier3 on Linux/x64

Thanks.
Best regards,
Jie

[1] https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-April/076220.html
[2] https://github.com/openjdk/jdk/blob/d84a7e55be40eae57b6c322694d55661a5053a55/src/java.base/share/classes/java/lang/FdLibm.java#L362
[3] https://github.com/openjdk/jdk/blob/d84a7e55be40eae57b6c322694d55661a5053a55/src/java.base/share/classes/java/lang/FdLibm.java#L364

Detailed performance numbers:
* Linux/Intel
```
--------- Before -----------
Benchmark                      (seed)   Mode  Cnt       Score       Error   Units
MathBench.powDouble                 0  thrpt    8  218783.605 ?   838.379  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8   45498.351 ?     7.558  ops/ms
MathBench.powDouble0Dot5Const       0  thrpt    8   45243.530 ?  1097.100  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.031 ?     0.001  ops/ms
MathBench.powDoubleLoop             0  thrpt    8       0.031 ?     0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8  176106.602 ? 13127.650  ops/ms
----------------------------

--------- After -----------
Benchmark                      (seed)   Mode  Cnt       Score       Error   Units
MathBench.powDouble                 0  thrpt    8  219930.462 ?   181.922  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8  204966.834 ?   329.032  ops/ms   <-- 4.5x up
MathBench.powDouble0Dot5Const       0  thrpt    8  203004.302 ?   684.072  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.121 ?     0.001  ops/ms   <-- 3.9x up
MathBench.powDoubleLoop             0  thrpt    8       0.031 ?     0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8  178818.861 ? 16235.465  ops/ms
----------------------------
```

* Linux/AMD
```
--------- Before -----------
Benchmark                      (seed)   Mode  Cnt       Score     Error   Units
MathBench.powDouble                 0  thrpt    8  100741.348 ? 207.766  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8   33896.623 ? 103.352  ops/ms
MathBench.powDouble0Dot5Const       0  thrpt    8   34195.944 ? 230.703  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.039 ?   0.001  ops/ms
MathBench.powDoubleLoop             0  thrpt    8       0.038 ?   0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8   72000.166 ? 135.002  ops/ms
----------------------------

--------- After -----------
Benchmark                      (seed)   Mode  Cnt       Score     Error   Units
MathBench.powDouble                 0  thrpt    8  100738.866 ? 222.820  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8  100799.098 ?  95.537  ops/ms   <-- 3.0x up
MathBench.powDouble0Dot5Const       0  thrpt    8  100765.571 ? 178.436  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.244 ?   0.002  ops/ms   <-- 6.3x up
MathBench.powDoubleLoop             0  thrpt    8       0.038 ?   0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8   71758.725 ? 339.660  ops/ms
----------------------------
```

* MacOS/Intel
```
--------- Before -----------
Benchmark                      (seed)   Mode  Cnt       Score      Error   Units
MathBench.powDouble                 0  thrpt    8  238064.722 ? 5181.318  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8   59235.979 ? 2046.519  ops/ms
MathBench.powDouble0Dot5Const       0  thrpt    8   59695.014 ? 1079.692  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.040 ?    0.001  ops/ms
MathBench.powDoubleLoop             0  thrpt    8       0.041 ?    0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8  238391.026 ? 2743.385  ops/ms
----------------------------

--------- After -----------
Benchmark                      (seed)   Mode  Cnt       Score       Error   Units
MathBench.powDouble                 0  thrpt    8  238582.414 ?  3661.261  ops/ms
MathBench.powDouble0Dot5            0  thrpt    8  224102.701 ?  2846.892  ops/ms   <-- 3.8x up
MathBench.powDouble0Dot5Const       0  thrpt    8  224542.331 ? 19027.596  ops/ms
MathBench.powDouble0Dot5Loop        0  thrpt    8       0.158 ?     0.002  ops/ms   <-- 4.0x up
MathBench.powDoubleLoop             0  thrpt    8       0.041 ?     0.001  ops/ms
StrictMathBench.powDouble         N/A  thrpt    8  233689.504 ? 10141.034  ops/ms
----------------------------
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265325](https://bugs.openjdk.java.net/browse/JDK-8265325): Optimize StubRoutines::dpow() for Math.pow(x, 0.5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3536/head:pull/3536` \
`$ git checkout pull/3536`

Update a local copy of the PR: \
`$ git checkout pull/3536` \
`$ git pull https://git.openjdk.java.net/jdk pull/3536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3536`

View PR using the GUI difftool: \
`$ git pr show -t 3536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3536.diff">https://git.openjdk.java.net/jdk/pull/3536.diff</a>

</details>
