### PR TITLE
8265330: G1: Fix comment in G1FullGCPrepareTask::G1CalculatePointersClosure 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -64,7 +64,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
       assert(MarkSweepDeadRatio > 0,
              "only skip compaction for other regions when MarkSweepDeadRatio > 0");
 
-      // Force the high live ratio region as compacting to skip these regions in the
+      // Force the high live ratio region as not-compacting to skip these regions in the
       // later compaction step.
       force_not_compacted = true;
       log_debug(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial(?) comment update?

Thanks,
  Thomas

Testing: local compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265330](https://bugs.openjdk.java.net/browse/JDK-8265330): G1: Fix comment in G1FullGCPrepareTask::G1CalculatePointersClosure


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to a2b5e017416315a9c34aafbfe4987045b76eb126
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to a2b5e017416315a9c34aafbfe4987045b76eb126


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3538/head:pull/3538` \
`$ git checkout pull/3538`

Update a local copy of the PR: \
`$ git checkout pull/3538` \
`$ git pull https://git.openjdk.java.net/jdk pull/3538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3538`

View PR using the GUI difftool: \
`$ git pr show -t 3538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3538.diff">https://git.openjdk.java.net/jdk/pull/3538.diff</a>

</details>
