### PR TITLE
8264958: C2 compilation fails with assert "n is later than its clone"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1479,7 +1479,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
               IdealLoopTree* x_loop = get_loop(x_ctrl);
               Node* x_head = x_loop->_head;
               if (x_head->is_Loop() && (x_head->is_OuterStripMinedLoop() || x_head->as_Loop()->is_strip_mined())) {
-                if (is_dominator(n_ctrl, x_head)) {
+                if (is_dominator(n_ctrl, x_head) && n_ctrl != x_head) {
                   // Anti dependence analysis is sometimes too
                   // conservative: a store in the outer strip mined loop
                   // can prevent a load from floating out of the outer

--- a/test/hotspot/jtreg/compiler/loopstripmining/OuterStripMinedLoopLoadWronglyHoisted.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/OuterStripMinedLoopLoadWronglyHoisted.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8264958
+ * @summary C2 compilation fails with assert "n is later than its clone"
+ *
+ * @run main/othervm -Xbatch OuterStripMinedLoopLoadWronglyHoisted
+ *
+ */
+
+
+public class OuterStripMinedLoopLoadWronglyHoisted {
+    int a;
+    int b;
+    short c;
+
+    void test() {
+        for (int i = 0; i < 10; ++i) {
+            a = c;
+            if (i > 1) {
+                b = 0;
+            }
+            c = (short)(b - 7);
+        }
+        a--;
+    }
+
+    public static void main(String[] args) {
+        OuterStripMinedLoopLoadWronglyHoisted t = new OuterStripMinedLoopLoadWronglyHoisted();
+        for (int i = 0; i < 100_000; ++i) {
+            t.test();
+        }
+    }
+}
+


### PR DESCRIPTION
JDK-8229483 added logic to hoist a load that would wrongly end up in
an outer strip mined loop. That logic checks that it's legal to do so
with:

is_dominator(n_ctrl, x_head)

but that test passes for n_ctrl == x_head when it's not legal to hoist
the load i.e. the test we want is for strict domination. The fix I
propose is to add an explicit check for that case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264958](https://bugs.openjdk.java.net/browse/JDK-8264958): C2 compilation fails with assert "n is later than its clone"


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3539/head:pull/3539` \
`$ git checkout pull/3539`

Update a local copy of the PR: \
`$ git checkout pull/3539` \
`$ git pull https://git.openjdk.java.net/jdk pull/3539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3539`

View PR using the GUI difftool: \
`$ git pr show -t 3539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3539.diff">https://git.openjdk.java.net/jdk/pull/3539.diff</a>

</details>
