### PR TITLE
8265335: Epsilon: Minor typo in EpsilonElasticTLABDecay description

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
@@ -64,7 +64,7 @@
           "smaller TLABs until policy catches up.")                         \
                                                                             \
   product(bool, EpsilonElasticTLABDecay, true, EXPERIMENTAL,                \
-          "Use timed decays to shrik TLAB sizes. This conserves memory "    \
+          "Use timed decays to shrink TLAB sizes. This conserves memory "   \
           "for the threads that allocate in bursts of different sizes, "    \
           "for example the small/rare allocations coming after the initial "\
           "large burst.")                                                   \


### PR DESCRIPTION
Trivial: should be "shrink", not "shrik".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265335](https://bugs.openjdk.java.net/browse/JDK-8265335): Epsilon: Minor typo in EpsilonElasticTLABDecay description


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3543/head:pull/3543` \
`$ git checkout pull/3543`

Update a local copy of the PR: \
`$ git checkout pull/3543` \
`$ git pull https://git.openjdk.java.net/jdk pull/3543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3543`

View PR using the GUI difftool: \
`$ git pr show -t 3543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3543.diff">https://git.openjdk.java.net/jdk/pull/3543.diff</a>

</details>
