### PR TITLE
8200559: Java agents doing instrumentation need a means to define auxiliary classes

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -147,6 +147,7 @@ module java.base {
         jdk.jshell;
     exports jdk.internal.access to
         java.desktop,
+        java.instrument,
         java.logging,
         java.management,
         java.naming,
@@ -174,6 +175,7 @@ module java.base {
     exports jdk.internal.logger to
         java.logging;
     exports jdk.internal.org.objectweb.asm to
+        java.instrument,
         jdk.jartool,
         jdk.jfr,
         jdk.jlink;
@@ -190,6 +192,7 @@ module java.base {
         jdk.jfr;
     exports jdk.internal.misc to
         java.desktop,
+        java.instrument,
         java.logging,
         java.management,
         java.naming,

--- a/src/java.instrument/share/classes/java/lang/instrument/Instrumentation.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/Instrumentation.java
@@ -536,6 +536,50 @@ public interface Instrumentation {
     appendToSystemClassLoaderSearch(JarFile jarfile);
 
     /**
+     * Defines a new class or interface for the given class loader using the specified
+     * class file. This has the same effect as if calling
+     * {@link ClassLoader#defineClass(String, byte[], int, int, ProtectionDomain)}.
+     *
+     * <p> The {@code bytes} parameter is the class bytes of a valid class file (as defined
+     * by the <em>The Java Virtual Machine Specification</em>) with a class name in the
+     * same package as the lookup class. </p>
+     *
+     * <p> This method does not run the class initializer. The class initializer may
+     * run at a later time, as detailed in section 12.4 of the <em>The Java Language
+     * Specification</em>. </p>
+     *
+     * <p>
+     * <cite>The Java Virtual Machine Specification</cite>
+     * specifies that a subsequent attempt to resolve a symbolic
+     * reference that the Java virtual machine has previously unsuccessfully attempted
+     * to resolve always fails with the same error that was thrown as a result of the
+     * initial resolution attempt. Consequently, if the JAR file contains an entry
+     * that corresponds to a class for which the Java virtual machine has
+     * unsuccessfully attempted to resolve a reference, then subsequent attempts to
+     * resolve that reference will fail with the same error as the initial attempt.
+     *
+     * @param loader The class loader in which the class is to be defined. This might
+     *               be {@code null} to represent the bootstrap class loader.
+     * @param pd    The class's protection domain or {@code null} for defining a
+     *              default protection domain with all permissions.
+     * @param bytes The class file of the class that is being defined.
+     * @throws java.lang.NullPointerException if passed <code>null</code> for the
+     * class file
+     * @throws java.lang.ClassFormatError if passed an invalid class file.\
+     * @throws java.lang.IllegalArgumentException if passed a non-injectable class
+     * file, for example a module-info
+     * @throws java.lang.UnsupportedClassVersionError if passed a class file in a
+     * version that the current VM does not support.
+     * @throws VerifyError if the newly created class cannot be verified
+     * @throws LinkageError if a class with the same name already was defined by
+     * the targeted class loader or if the class cannot be linked for any other reason
+     * @return The class that has been defined.
+     *
+     * @since 17
+     */
+    Class<?> defineClass(ClassLoader loader, ProtectionDomain pd, byte[] bytes);
+
+    /**
      * Returns whether the current JVM configuration supports
      * {@linkplain #setNativeMethodPrefix(ClassFileTransformer,String)
      * setting a native method prefix}.

--- a/test/jdk/java/lang/instrument/DefineClass/DefineClassInstrumentation.java
+++ b/test/jdk/java/lang/instrument/DefineClass/DefineClassInstrumentation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8200559
+ * @summary Test class definition by use of instrumentation API.
+ * @library /test/lib
+ * @modules java.instrument
+ * @run main RedefineClassHelper
+ * @run main/othervm -javaagent:redefineagent.jar DefineClassInstrumentation
+ */
+
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.AllPermission;
+import java.security.ProtectionDomain;
+
+public class DefineClassInstrumentation {
+
+    public static void main(String[] unused) throws Throwable {
+        doDefine(null);
+        doDefine(new ProtectionDomain(null, null));
+    }
+
+    private static void doDefine(ProtectionDomain pd) {
+        try {
+            URLClassLoader loader = new URLClassLoader(new URL[0], null);
+
+            byte[] classFile;
+            try (InputStream inputStream = DefineClassInstrumentation.class.getResourceAsStream("DefineClassInstrumentation.class")) {
+                classFile = inputStream.readAllBytes();
+            }
+            Class<?> c = RedefineClassHelper.instrumentation.defineClass(loader, pd, classFile);
+            if (c == DefineClassInstrumentation.class) {
+                throw new RuntimeException("Class defined by system loader");
+            }
+            if (pd == null) {
+                if (!c.getProtectionDomain().getPermissions().implies(new AllPermission())) {
+                    throw new RuntimeException("Protection domain not set to default protection domain");
+                }
+            } else if (pd != c.getProtectionDomain()) {
+                throw new RuntimeException("Protection domain not set correctly");
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw new RuntimeException("Failed class definition");
+        }
+    }
+}


### PR DESCRIPTION
To allow agents the definition of auxiliary classes, an API is needed to allow this. Currently, this is often achieved by using `sun.misc.Unsafe` or `jdk.internal.misc.Unsafe` ever since the `defineClass` method was removed from `sun.misc.Unsafe`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8200559](https://bugs.openjdk.java.net/browse/JDK-8200559): Java agents doing instrumentation need a means to define auxiliary classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3546/head:pull/3546` \
`$ git checkout pull/3546`

Update a local copy of the PR: \
`$ git checkout pull/3546` \
`$ git pull https://git.openjdk.java.net/jdk pull/3546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3546`

View PR using the GUI difftool: \
`$ git pr show -t 3546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3546.diff">https://git.openjdk.java.net/jdk/pull/3546.diff</a>

</details>
