### PR TITLE
JDK-8265371: Change to Visual Studio 2019 16.9.3 for building on Windows at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1046,7 +1046,7 @@ var getJibProfilesDependencies = function (input, common) {
     var devkit_platform_revisions = {
         linux_x64: "gcc10.2.0-OL6.4+1.0",
         macosx: "Xcode12.4+1.0",
-        windows_x64: "VS2019-16.7.2+1.1",
+        windows_x64: "VS2019-16.9.3+1.0",
         linux_aarch64: "gcc10.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",


### PR DESCRIPTION
Oracle is updating the minor version of Visual Studio for building the JDK to 16.9.3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265371](https://bugs.openjdk.java.net/browse/JDK-8265371): Change to Visual Studio 2019 16.9.3 for building on Windows at Oracle


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3550/head:pull/3550` \
`$ git checkout pull/3550`

Update a local copy of the PR: \
`$ git checkout pull/3550` \
`$ git pull https://git.openjdk.java.net/jdk pull/3550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3550`

View PR using the GUI difftool: \
`$ git pr show -t 3550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3550.diff">https://git.openjdk.java.net/jdk/pull/3550.diff</a>

</details>
