### PR TITLE
8265381: ProblemList runtime/logging/RedefineClasses.java on macos-x64 -Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -29,4 +29,4 @@
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 
-runtime/logging/RedefineClasses.java 8265218 linux-x64
+runtime/logging/RedefineClasses.java 8265218 linux-x64,macosx-x64


### PR DESCRIPTION
A trivial change to ProblemList runtime/logging/RedefineClasses.java on macos-x64 -Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265381](https://bugs.openjdk.java.net/browse/JDK-8265381): ProblemList runtime/logging/RedefineClasses.java on macos-x64 -Xcomp


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3552/head:pull/3552` \
`$ git checkout pull/3552`

Update a local copy of the PR: \
`$ git checkout pull/3552` \
`$ git pull https://git.openjdk.java.net/jdk pull/3552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3552`

View PR using the GUI difftool: \
`$ git pr show -t 3552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3552.diff">https://git.openjdk.java.net/jdk/pull/3552.diff</a>

</details>
