### PR TITLE
8265356: need code example for getting canonical constructor of a Record

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2361,6 +2361,19 @@ public final class Class<T> implements java.io.Serializable,
      * Conversely, if {@link #isRecord()} returns {@code true}, then this method
      * returns a non-null value.
      *
+     * <p> This method can be used to find the record canonical constructor:
+     *
+     * <pre>{@code
+     * static <T extends Record>
+     * Constructor<T> getCanonicalConstructor(Class<T> cls)
+     *     throws NoSuchMethodException {
+     *   Class<?>[] paramTypes =
+     *     Arrays.stream(cls.getRecordComponents())
+     *           .map(RecordComponent::getType)
+     *           .toArray(Class<?>[]::new);
+     *   return cls.getDeclaredConstructor(paramTypes);
+     * }}</pre>
+     *
      * @return  An array of {@code RecordComponent} objects representing all the
      *          record components of this record class, or {@code null} if this
      *          class is not a record class

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1631,7 +1631,7 @@ public final class Class<T> implements java.io.Serializable,
      * in source code, can have a non-empty name including special
      * characters, such as "{@code $}".
      *
-     * <p>The simple name of an {@linkplain isArray() array class} is the simple name of the
+     * <p>The simple name of an {@linkplain #isArray() array class} is the simple name of the
      * component type with "[]" appended.  In particular the simple
      * name of an array class whose component type is anonymous is "[]".
      *
@@ -2364,8 +2364,7 @@ public final class Class<T> implements java.io.Serializable,
      * <p> This method can be used to find the record canonical constructor:
      *
      * <pre>{@code
-     * static <T extends Record>
-     * Constructor<T> getCanonicalConstructor(Class<T> cls)
+     * static <T extends Record> Constructor<T> getCanonicalConstructor(Class<T> cls)
      *     throws NoSuchMethodException {
      *   Class<?>[] paramTypes =
      *     Arrays.stream(cls.getRecordComponents())
@@ -3126,15 +3125,15 @@ public final class Class<T> implements java.io.Serializable,
             return unsafe.compareAndSetReference(clazz, reflectionDataOffset, oldData, newData);
         }
 
-        static <T> boolean casAnnotationType(Class<?> clazz,
-                                             AnnotationType oldType,
-                                             AnnotationType newType) {
+        static boolean casAnnotationType(Class<?> clazz,
+                                         AnnotationType oldType,
+                                         AnnotationType newType) {
             return unsafe.compareAndSetReference(clazz, annotationTypeOffset, oldType, newType);
         }
 
-        static <T> boolean casAnnotationData(Class<?> clazz,
-                                             AnnotationData oldData,
-                                             AnnotationData newData) {
+        static boolean casAnnotationData(Class<?> clazz,
+                                         AnnotationData oldData,
+                                         AnnotationData newData) {
             return unsafe.compareAndSetReference(clazz, annotationDataOffset, oldData, newData);
         }
     }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2361,7 +2361,8 @@ public final class Class<T> implements java.io.Serializable,
      * Conversely, if {@link #isRecord()} returns {@code true}, then this method
      * returns a non-null value.
      *
-     * <p> This method can be used to find the record canonical constructor:
+     * @apiNote
+     * <p> The following method can be used to find the record canonical constructor:
      *
      * <pre>{@code
      * static <T extends Record> Constructor<T> getCanonicalConstructor(Class<T> cls)

--- a/src/java.base/share/classes/java/lang/Record.java
+++ b/src/java.base/share/classes/java/lang/Record.java
@@ -78,7 +78,7 @@ package java.lang;
  * <a href="{@docRoot}/../specs/serialization/serial-arch.html#serialization-of-records">
  * <cite>Java Object Serialization Specification,</cite> Section 1.13,
  * "Serialization of Records"</a>.
- * 
+ *
  * @apiNote
  * A record class structure can be obtained at runtime via reflection.
  * See {@link Class#isRecord()} and {@link Class#getRecordComponents()} for more details.

--- a/src/java.base/share/classes/java/lang/Record.java
+++ b/src/java.base/share/classes/java/lang/Record.java
@@ -78,6 +78,10 @@ package java.lang;
  * <a href="{@docRoot}/../specs/serialization/serial-arch.html#serialization-of-records">
  * <cite>Java Object Serialization Specification,</cite> Section 1.13,
  * "Serialization of Records"</a>.
+ * 
+ * @apiNote
+ * A record class structure can be obtained at runtime via reflection.
+ * See {@link Class#isRecord()} and {@link Class#getRecordComponents()} for more details.
  *
  * @jls 8.10 Record Types
  * @since 16


### PR DESCRIPTION
I decided to show a complete static method in the example, so it could be copied to user utility class as is. Not sure if it's reasonable to add `assert cls.isRecord();` there. Also I don't know whether there's a limitation on max characters in the sample code. Probable a line break in `static <T extends Record>\nConstructor<T> getCanonicalConstructor(Class<T> cls)` is unnecessary.

---
Aside from this PR, I've found a couple of things to clean up in `java.lang.Class`:
1. There's erroneous JavaDoc link in `getSimpleName()` JavaDoc (introduced by @jddarcy in #3038). It should be `#isArray()` instead of `isArray()`.
2. Methods Atomic::casAnnotationType and Atomic::casAnnotationData have unused type parameters `<T>`.
3. Probably too much but AnnotationData can be nicely converted to a record! Not sure, probably nobody wants to have `java.lang.Record` initialized too early or increasing the footprint of such a basic class in the metaspace, so I don't insist on this.

```java
    private record AnnotationData(
        Map<Class<? extends Annotation>, Annotation> annotations,
        Map<Class<? extends Annotation>, Annotation> declaredAnnotations,
        // Value of classRedefinedCount when we created this AnnotationData instance
        int redefinedCount) {
    }
```

Please tell me if it's ok to fix 1 and 2 along with this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265356](https://bugs.openjdk.java.net/browse/JDK-8265356): need code example for getting canonical constructor of a Record


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 1133ab7d7a4fca89ef9abbe089539923c3b3e6ea


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3556/head:pull/3556` \
`$ git checkout pull/3556`

Update a local copy of the PR: \
`$ git checkout pull/3556` \
`$ git pull https://git.openjdk.java.net/jdk pull/3556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3556`

View PR using the GUI difftool: \
`$ git pr show -t 3556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3556.diff">https://git.openjdk.java.net/jdk/pull/3556.diff</a>

</details>
