### PR TITLE
8265152: jpackage cleanup fails on Windows with IOException deleting msi

### DIFF
--- a/src/jdk.jpackage/windows/native/common/MsiDb.h
+++ b/src/jdk.jpackage/windows/native/common/MsiDb.h
@@ -172,6 +172,12 @@ public:
     DatabaseView(const Database& db, const tstring& sqlQuery,
                         const DatabaseRecord& queryParam=DatabaseRecord());
 
+    ~DatabaseView() {
+      if (handle != 0) {
+        closeMSIHANDLE(handle);
+      }
+    }
+
     DatabaseRecord fetch();
 
     DatabaseRecord tryFetch();


### PR DESCRIPTION
When creating an "exe" installer on Windows, `AbstractBundler.cleanup()` calls `IOUtils.deleteRecursive()` to delete the tmp directory. It can intermittently fail trying to delete the msi file.

[JDK-8263135](https://bugs.openjdk.java.net/browse/JDK-8263135) removed `unique_ptr` from jpackage sources due to compiler warnings in VS 2019 (16.9.0), so we need to release the resource manually. However `DatabaseView` didn't do that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265152](https://bugs.openjdk.java.net/browse/JDK-8265152): jpackage cleanup fails on Windows with IOException deleting msi


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3560/head:pull/3560` \
`$ git checkout pull/3560`

Update a local copy of the PR: \
`$ git checkout pull/3560` \
`$ git pull https://git.openjdk.java.net/jdk pull/3560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3560`

View PR using the GUI difftool: \
`$ git pr show -t 3560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3560.diff">https://git.openjdk.java.net/jdk/pull/3560.diff</a>

</details>
