### PR TITLE
8265036: JFR: Remove use of -XX:StartFlightRecording= and -XX:FlightRecorderOptions=

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1361,7 +1361,7 @@ bool SystemDictionaryShared::should_be_excluded(InstanceKlass* k) {
   }
   if (is_jfr_event_class(k)) {
     // We cannot include JFR event classes because they need runtime-specific
-    // instrumentation in order to work with -XX:FlightRecorderOptions=retransform=false.
+    // instrumentation in order to work with -XX:FlightRecorderOptions:retransform=false.
     // There are only a small number of these classes, so it's not worthwhile to
     // support them and make CDS more complicated.
     warn_excluded(k, "JFR event class");

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -46,13 +46,13 @@ struct ObsoleteOption {
 
 static const ObsoleteOption OBSOLETE_OPTIONS[] = {
   {"checkpointbuffersize", ""},
-  {"maxsize",              "Use -XX:StartFlightRecording=maxsize=... instead."},
-  {"maxage",               "Use -XX:StartFlightRecording=maxage=... instead."},
-  {"settings",             "Use -XX:StartFlightRecording=settings=... instead."},
-  {"defaultrecording",     "Use -XX:StartFlightRecording=disk=false to create an in-memory recording."},
-  {"disk",                 "Use -XX:StartFlightRecording=disk=... instead."},
-  {"dumponexit",           "Use -XX:StartFlightRecording=dumponexit=... instead."},
-  {"dumponexitpath",       "Use -XX:StartFlightRecording=filename=... instead."},
+  {"maxsize",              "Use -XX:StartFlightRecording:maxsize=... instead."},
+  {"maxage",               "Use -XX:StartFlightRecording:maxage=... instead."},
+  {"settings",             "Use -XX:StartFlightRecording:settings=... instead."},
+  {"defaultrecording",     "Use -XX:StartFlightRecording:disk=false to create an in-memory recording."},
+  {"disk",                 "Use -XX:StartFlightRecording:disk=... instead."},
+  {"dumponexit",           "Use -XX:StartFlightRecording:dumponexit=... instead."},
+  {"dumponexitpath",       "Use -XX:StartFlightRecording:filename=... instead."},
   {"loglevel",             "Use -Xlog:jfr=... instead."}
 };
 

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -1310,7 +1310,7 @@ By default this option is disabled.
 .RS
 .RE
 .TP
-.B \f[CB]\-XX:FlightRecorderOptions=\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R] (or)\f[CB]\-XX:FlightRecorderOptions:\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R]
+.B \f[CB]\-XX:FlightRecorderOptions:\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R] (or)\f[CB]\-XX:FlightRecorderOptions:\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R]
 Sets the parameters that control the behavior of JFR.
 .RS
 .PP
@@ -1635,7 +1635,7 @@ By default, this option is disabled.
 .RS
 .RE
 .TP
-.B \f[CB]\-XX:StartFlightRecording=\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R]
+.B \f[CB]\-XX:StartFlightRecording:\f[R]\f[I]parameter\f[R]\f[CB]=\f[R]\f[I]value\f[R]
 Starts a JFR recording for the Java application.
 This option is equivalent to the \f[CB]JFR.start\f[R] diagnostic command
 that starts a recording during runtime.

--- a/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
+++ b/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
@@ -83,7 +83,7 @@ public class TestLogCompilation {
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+LogCompilation",
         "-XX:LogFile=target/jfr.log",
-        "-XX:StartFlightRecording=dumponexit=true,filename=rwrecording.jfr"
+        "-XX:StartFlightRecording:dumponexit=true,filename=rwrecording.jfr"
     };
 
     static final String allSetupArgs[][] = {

--- a/test/hotspot/jtreg/runtime/cds/appcds/CDSandJFR.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CDSandJFR.java
@@ -64,20 +64,20 @@ public class CDSandJFR {
         TestCommon.checkDump(output, "Skipping jdk/jfr/Event: JFR event class");
 
         output = TestCommon.exec(appJar,
-                                 "-XX:StartFlightRecording=dumponexit=true",
+                                 "-XX:StartFlightRecording:dumponexit=true",
                                  "Hello");
         TestCommon.checkExec(output, "Hello World");
 
         TestCommon.checkExec(TestCommon.exec(appJar,
-                                             "-XX:FlightRecorderOptions=retransform=true",
+                                             "-XX:FlightRecorderOptions:retransform=true",
                                              "GetFlightRecorder"));
         TestCommon.checkExec(TestCommon.exec(appJar,
-                                             "-XX:FlightRecorderOptions=retransform=false",
+                                             "-XX:FlightRecorderOptions:retransform=false",
                                              "GetFlightRecorder"));
 
         // Test dumping with flight recorder enabled.
         output = TestCommon.testDump(appJar, TestCommon.list(classes),
-                                     "-XX:StartFlightRecording=dumponexit=true");
+                                     "-XX:StartFlightRecording:dumponexit=true");
         TestCommon.checkDump(output, "warning: JFR will be disabled during CDS dumping");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -417,7 +417,7 @@ public class TestCommon extends CDSTestUtils {
         if (RUN_WITH_JFR) {
             boolean usesJFR = false;
             for (String s : cmd) {
-                if (s.startsWith("-XX:StartFlightRecording=") || s.startsWith("-XX:FlightRecorderOptions")) {
+                if (s.startsWith("-XX:StartFlightRecording") || s.startsWith("-XX:FlightRecorderOptions")) {
                     System.out.println("JFR option might have been specified. Don't interfere: " + s);
                     usesJFR = true;
                     break;
@@ -425,7 +425,7 @@ public class TestCommon extends CDSTestUtils {
             }
             if (!usesJFR) {
                 System.out.println("JFR option not specified. Enabling JFR ...");
-                cmd.add(0, "-XX:StartFlightRecording=dumponexit=true");
+                cmd.add(0, "-XX:StartFlightRecording:dumponexit=true");
                 System.out.println(cmd);
             }
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestWithProfiler.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestWithProfiler.java
@@ -49,7 +49,7 @@ public class TestWithProfiler {
         output = TestCommon.exec(appJar,
             "-XX:+UnlockDiagnosticVMOptions",
             "-Xint",
-            "-XX:StartFlightRecording=duration=15s,filename=myrecording.jfr,settings=profile,dumponexit=true",
+            "-XX:StartFlightRecording:duration=15s,filename=myrecording.jfr,settings=profile,dumponexit=true",
             "TestWithProfilerHelper");
         TestCommon.checkExec(output);
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom_JFR.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom_JFR.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @summary Same as HelloCustom, but add -XX:StartFlightRecording=dumponexit=true to the runtime
+ * @summary Same as HelloCustom, but add -XX:StartFlightRecording:dumponexit=true to the runtime
  *          options. This makes sure that the shared classes are compatible with both
  *          JFR and JVMTI ClassFileLoadHook.
  * @requires vm.hasJFR
@@ -47,6 +47,6 @@ import sun.hotspot.WhiteBox;
 
 public class HelloCustom_JFR {
     public static void main(String[] args) throws Exception {
-        HelloCustom.run("-XX:StartFlightRecording=dumponexit=true", "-Xlog:cds+jvmti=debug");
+        HelloCustom.run("-XX:StartFlightRecording:dumponexit=true", "-Xlog:cds+jvmti=debug");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,14 @@
  * @requires vm.hasJFR & vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver/timeout=480 ModulePathAndCP_JFR
- * @summary Same as ModulePathAndCP, but add -XX:StartFlightRecording=dumponexit=true to the runtime
+ * @summary Same as ModulePathAndCP, but add -XX:StartFlightRecording:dumponexit=true to the runtime
  *          options. This makes sure that the shared classes are compatible with both
  *          JFR and JVMTI ClassFileLoadHook.
  */
 
 public class ModulePathAndCP_JFR {
     public static void main(String... args) throws Exception {
-        ModulePathAndCP.run("-XX:StartFlightRecording=dumponexit=true", "-Xlog:cds+jvmti=debug,jfr+startup=off");
+        ModulePathAndCP.run("-XX:StartFlightRecording:dumponexit=true", "-Xlog:cds+jvmti=debug,jfr+startup=off");
     }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class FlagCombo {
 
         if (args.length == 0) {
             SharedStringsUtils.runWithArchiveAuto("HelloString",
-                "-XX:StartFlightRecording=dumponexit=true");
+                "-XX:StartFlightRecording:dumponexit=true");
         }
 
         SharedStringsUtils.runWithArchive("HelloString", "-XX:+UnlockDiagnosticVMOptions",

--- a/test/jdk/com/sun/jdi/JdbOptions.java
+++ b/test/jdk/com/sun/jdi/JdbOptions.java
@@ -120,19 +120,19 @@ public class JdbOptions {
         test("-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options=\"-client\" \"-XX:+PrintVMOptions\""
                 + " -XX:+IgnoreUnrecognizedVMOptions"
-                + " \"-XX:StartFlightRecording=dumponexit=true,maxsize=500M\" \"-XX:FlightRecorderOptions=repository=jfrrep\""
+                + " \"-XX:StartFlightRecording:dumponexit=true,maxsize=500M\" \"-XX:FlightRecorderOptions:repository=jfrrep\""
                 + ",main=" + targ + " " + outFilename)
-            .expectedArg("-XX:StartFlightRecording=dumponexit=true,maxsize=500M")
-            .expectedArg("-XX:FlightRecorderOptions=repository=jfrrep");
+            .expectedArg("-XX:StartFlightRecording:dumponexit=true,maxsize=500M")
+            .expectedArg("-XX:FlightRecorderOptions:repository=jfrrep");
 
         // 'options' contains commas - values are quoted (single quotes)
         test("-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options='-client' '-XX:+PrintVMOptions'"
                         + " -XX:+IgnoreUnrecognizedVMOptions"
-                        + " '-XX:StartFlightRecording=dumponexit=true,maxsize=500M' '-XX:FlightRecorderOptions=repository=jfrrep'"
+                        + " '-XX:StartFlightRecording:dumponexit=true,maxsize=500M' '-XX:FlightRecorderOptions:repository=jfrrep'"
                         + ",main=" + targ + " " + outFilename)
-            .expectedArg("-XX:StartFlightRecording=dumponexit=true,maxsize=500M")
-            .expectedArg("-XX:FlightRecorderOptions=repository=jfrrep");
+            .expectedArg("-XX:StartFlightRecording:dumponexit=true,maxsize=500M")
+            .expectedArg("-XX:FlightRecorderOptions:repository=jfrrep");
 
         // java options are specified in 2 ways, with and without spaces
         // options are quoted by using single and double quotes.
@@ -141,15 +141,15 @@ public class JdbOptions {
                 "-connect",
                 "com.sun.jdi.CommandLineLaunch:vmexec=java,options=-Dprop3=val3 '-Dprop4=val 4'"
                         + " -XX:+IgnoreUnrecognizedVMOptions"
-                        + " \"-XX:StartFlightRecording=dumponexit=true,maxsize=500M\""
-                        + " '-XX:FlightRecorderOptions=repository=jfrrep'"
+                        + " \"-XX:StartFlightRecording:dumponexit=true,maxsize=500M\""
+                        + " '-XX:FlightRecorderOptions:repository=jfrrep'"
                         + ",main=" + targ + " " + outFilename + " prop1 prop2 prop3 prop4")
                 .expectedProp("prop1", "val1")
                 .expectedProp("prop2", "val 2")
                 .expectedProp("prop3", "val3")
                 .expectedProp("prop4", "val 4")
-                .expectedArg("-XX:StartFlightRecording=dumponexit=true,maxsize=500M")
-                .expectedArg("-XX:FlightRecorderOptions=repository=jfrrep");
+                .expectedArg("-XX:StartFlightRecording:dumponexit=true,maxsize=500M")
+                .expectedArg("-XX:FlightRecorderOptions:repository=jfrrep");
 
     }
 

--- a/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
@@ -60,7 +60,7 @@ import org.testng.annotations.DataProvider;
  * @build GlobalFilterTest SerialFilterTest
  * @requires vm.hasJFR
  * @run testng/othervm/policy=security.policy
- *        -XX:StartFlightRecording=name=DeserializationEvent,dumponexit=true
+ *        -XX:StartFlightRecording:name=DeserializationEvent,dumponexit=true
  *        -Djava.security.properties=${test.src}/java.security-extra1
  *        -Djava.security.debug=properties GlobalFilterTest
  */

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestRegisteredFalseAndRunning.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestRegisteredFalseAndRunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import jdk.jfr.Registered;
  * @requires vm.hasJFR
  * @library /test/lib
  * @run main/othervm jdk.jfr.api.metadata.annotations.TestRegisteredFalseAndRunning
- * @run main/othervm -XX:FlightRecorderOptions=retransform=false jdk.jfr.api.metadata.annotations.TestRegisteredFalseAndRunning
+ * @run main/othervm -XX:FlightRecorderOptions:retransform=false jdk.jfr.api.metadata.annotations.TestRegisteredFalseAndRunning
  */
 public class TestRegisteredFalseAndRunning {
     @Registered(false)

--- a/test/jdk/jdk/jfr/event/gc/stacktrace/TestMetaspaceSerialGCAllocationPendingStackTrace.java
+++ b/test/jdk/jdk/jfr/event/gc/stacktrace/TestMetaspaceSerialGCAllocationPendingStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package jdk.jfr.event.gc.stacktrace;
  *
  * @requires vm.gc == "null" | vm.gc == "Serial"
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:+UseSerialGC -Xlog:gc* -XX:MaxMetaspaceSize=64M -XX:+FlightRecorder jdk.jfr.event.gc.stacktrace.TestMetaspaceSerialGCAllocationPendingStackTrace
+ * @run main/othervm -XX:+UseSerialGC -Xlog:gc* -XX:MaxMetaspaceSize=64M jdk.jfr.event.gc.stacktrace.TestMetaspaceSerialGCAllocationPendingStackTrace
  */
 public class TestMetaspaceSerialGCAllocationPendingStackTrace {
 

--- a/test/jdk/jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java
+++ b/test/jdk/jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package jdk.jfr.event.gc.stacktrace;
  *
  * @requires vm.gc == "null" | vm.gc == "Parallel"
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:MaxNewSize=10M -Xmx64M -XX:+UseParallelGC -Xlog:gc* -XX:+FlightRecorder jdk.jfr.event.gc.stacktrace.TestParallelMarkSweepAllocationPendingStackTrace
+ * @run main/othervm -XX:MaxNewSize=10M -Xmx64M -XX:+UseParallelGC -Xlog:gc* jdk.jfr.event.gc.stacktrace.TestParallelMarkSweepAllocationPendingStackTrace
  */
 public class TestParallelMarkSweepAllocationPendingStackTrace {
 

--- a/test/jdk/jdk/jfr/event/gc/stacktrace/TestParallelScavengeAllocationPendingStackTrace.java
+++ b/test/jdk/jdk/jfr/event/gc/stacktrace/TestParallelScavengeAllocationPendingStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ package jdk.jfr.event.gc.stacktrace;
  *
  * @requires vm.gc == "null" | vm.gc == "Parallel"
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:+UseParallelGC -Xlog:gc* -XX:+FlightRecorder jdk.jfr.event.gc.stacktrace.TestParallelScavengeAllocationPendingStackTrace
+ * @run main/othervm -XX:+UseParallelGC -Xlog:gc* jdk.jfr.event.gc.stacktrace.TestParallelScavengeAllocationPendingStackTrace
  */
 public class TestParallelScavengeAllocationPendingStackTrace {
 

--- a/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
@@ -44,7 +44,7 @@ import sun.hotspot.WhiteBox;
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
- *                   -XX:+FlightRecorder -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   jdk.jfr.event.runtime.TestSafepointEvents
  */
 public class TestSafepointEvents {

--- a/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class TestShutdownEvent {
                                 "-Xlog:jfr=debug",
                                 "-XX:-CreateCoredumpOnCrash",
                                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
-                                "-XX:StartFlightRecording=filename=./dumped.jfr,dumponexit=true,settings=default",
+                                "-XX:StartFlightRecording:filename=./dumped.jfr,dumponexit=true,settings=default",
                                 "jdk.jfr.event.runtime.TestShutdownEvent$TestMain",
                                 String.valueOf(subTestIndex));
         OutputAnalyzer output = ProcessTools.executeProcess(pb);

--- a/test/jdk/jdk/jfr/event/runtime/TestThrowableInstrumentation.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestThrowableInstrumentation.java
@@ -39,7 +39,7 @@ import jdk.test.lib.Platform;
  * @build  sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -Xbatch -XX:StartFlightRecording=dumponexit=true jdk.jfr.event.runtime.TestThrowableInstrumentation
+ *                   -Xbatch -XX:StartFlightRecording:dumponexit=true jdk.jfr.event.runtime.TestThrowableInstrumentation
  */
 public class TestThrowableInstrumentation {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStartPathToGCRoots.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStartPathToGCRoots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,15 +44,15 @@ public class TestJcmdStartPathToGCRoots {
     public static void main(String[] args) throws Exception {
 
         JcmdHelper.jcmd("JFR.start", "path-to-gc-roots=true");
-        assertCutoff("infinity", "Expected cutoff to be '0 ns' wuth -XX:StartFlightRecording=path-to-gc-roots=true");
+        assertCutoff("infinity", "Expected cutoff to be '0 ns' wuth -XX:StartFlightRecording:path-to-gc-roots=true");
         closeRecording();
 
         JcmdHelper.jcmd("JFR.start", "path-to-gc-roots=false");
-        assertCutoff("0 ns", "Expected cutoff to be '0 ns' with -XX:StartFlightRecording=path-to-gc-roots=false");
+        assertCutoff("0 ns", "Expected cutoff to be '0 ns' with -XX:StartFlightRecording:path-to-gc-roots=false");
         closeRecording();
 
         JcmdHelper.jcmd("JFR.start");
-        assertCutoff("0 ns", "Expected cutoff to be '0 ns' with -XX:StartFlightRecording=");
+        assertCutoff("0 ns", "Expected cutoff to be '0 ns' with -XX:StartFlightRecording:");
         closeRecording();
     }
 

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStartWithOptions.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStartWithOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:+FlightRecorder -XX:FlightRecorderOptions=maxchunksize=2097152 jdk.jfr.jcmd.TestJcmdStartWithOptions
+ * @run main/othervm -XX:FlightRecorderOptions:maxchunksize=2097152 jdk.jfr.jcmd.TestJcmdStartWithOptions
  */
 public class TestJcmdStartWithOptions {
 

--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public class TestDumpOnCrash {
                 "-Xmx64m",
                 "-XX:-CreateCoredumpOnCrash",
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
-                "-XX:StartFlightRecording=" + flightRecordingOptions,
+                "-XX:StartFlightRecording:" + flightRecordingOptions,
                 crasher.getName(),
                 signal)
             .start();

--- a/test/jdk/jdk/jfr/jvm/TestJfrJavaBase.java
+++ b/test/jdk/jdk/jfr/jvm/TestJfrJavaBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class TestJfrJavaBase {
                 TestJfrJavaBase.class.getName(), "runtest"));
             output.shouldHaveExitValue(0);
         } else {
-            output = ProcessTools.executeTestJava("-XX:StartFlightRecording=dumponexit=true",
+            output = ProcessTools.executeTestJava("-XX:StartFlightRecording:dumponexit=true",
                 "--limit-modules", "java.base", "-version");
             checkOutput(output);
             output.shouldHaveExitValue(1);

--- a/test/jdk/jdk/jfr/jvm/TestLogOutput.java
+++ b/test/jdk/jdk/jfr/jvm/TestLogOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.List;
  * @summary Sanity test jfr logging output
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -Xlog:disable -Xlog:jfr*=trace:file=jfr_trace.txt -XX:StartFlightRecording=duration=1s,filename=recording.jfr jdk.jfr.jvm.TestLogOutput
+ * @run main/othervm -Xlog:disable -Xlog:jfr*=trace:file=jfr_trace.txt -XX:StartFlightRecording:duration=1s,filename=recording.jfr jdk.jfr.jvm.TestLogOutput
  */
 public class TestLogOutput {
     public static void main(String[] args) throws Exception {

--- a/test/jdk/jdk/jfr/startupargs/TestBadOptionValues.java
+++ b/test/jdk/jdk/jfr/startupargs/TestBadOptionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import jdk.test.lib.process.ProcessTools;
  */
 public class TestBadOptionValues {
 
-    private static final String START_FLIGHT_RECORDING = "-XX:StartFlightRecording=";
-    private static final String FLIGHT_RECORDER_OPTIONS = "-XX:FlightRecorderOptions=";
+    private static final String START_FLIGHT_RECORDING = "-XX:StartFlightRecording:";
+    private static final String FLIGHT_RECORDER_OPTIONS = "-XX:FlightRecorderOptions:";
 
     private static void test(String prepend, String expectedOutput, String... options) throws Exception {
         ProcessBuilder pb;

--- a/test/jdk/jdk/jfr/startupargs/TestDumpOnExit.java
+++ b/test/jdk/jdk/jfr/startupargs/TestDumpOnExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,27 +52,27 @@ public class TestDumpOnExit {
         // Test without security manager and a file name relative to current directory
         testDumponExit(() -> dumpPath,
                 "-Xlog:jfr=trace",
-                "-XX:StartFlightRecording=filename=./dumped.jfr,dumponexit=true,settings=profile",
+                "-XX:StartFlightRecording:filename=./dumped.jfr,dumponexit=true,settings=profile",
                 "jdk.jfr.startupargs.TestDumpOnExit$TestMain"
         );
         // Test a memory recording without a security manager
         testDumponExit(() -> findJFRFileInCurrentDirectory(),
                 "-Xlog:jfr=trace",
-                "-XX:StartFlightRecording=dumponexit=true,disk=false",
+                "-XX:StartFlightRecording:dumponexit=true,disk=false",
                 "jdk.jfr.startupargs.TestDumpOnExit$TestMain"
         );
 
         // Test with security manager and a file name relative to current directory
         testDumponExit(() -> dumpPath,
                 "-Xlog:jfr=trace",
-                "-XX:StartFlightRecording=filename=./dumped.jfr,dumponexit=true,settings=profile",
+                "-XX:StartFlightRecording:filename=./dumped.jfr,dumponexit=true,settings=profile",
                 "-Djava.security.manager",
                 "jdk.jfr.startupargs.TestDumpOnExit$TestMain"
         );
         // Test with security manager but without a name
         testDumponExit(() -> findJFRFileInCurrentDirectory(),
                 "-Xlog:jfr=trace",
-                "-XX:StartFlightRecording=dumponexit=true,settings=profile",
+                "-XX:StartFlightRecording:dumponexit=true,settings=profile",
                 "-Djava.security.manager",
                 "jdk.jfr.startupargs.TestDumpOnExit$TestMain"
         );

--- a/test/jdk/jdk/jfr/startupargs/TestFlushInterval.java
+++ b/test/jdk/jdk/jfr/startupargs/TestFlushInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import jdk.jfr.internal.PrivateAccess;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal
- * @run main/othervm -XX:StartFlightRecording=flush-interval=2s jdk.jfr.startupargs.TestFlushInterval
+ * @run main/othervm -XX:StartFlightRecording:flush-interval=2s jdk.jfr.startupargs.TestFlushInterval
  */
 public class TestFlushInterval {
 

--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,7 +325,7 @@ public class TestMemoryOptions {
         }
 
         public String getTestString() {
-            String optionString = "-XX:FlightRecorderOptions=";
+            String optionString = "-XX:FlightRecorderOptions:";
             for (Option o : optionList) {
                 String optionParamString = o.getOptionParamString();
                 if (optionParamString == null) {
@@ -334,7 +334,7 @@ public class TestMemoryOptions {
                 optionString = optionString.concat(optionParamString);
                 optionString = optionString.concat(",");
             }
-            if (optionString.equals("-XX:FlightRecorderOptions=")) {
+            if (optionString.equals("-XX:FlightRecorderOptions:")) {
                 return null;
             }
             // strip last ","

--- a/test/jdk/jdk/jfr/startupargs/TestOldObjectQueueSize.java
+++ b/test/jdk/jdk/jfr/startupargs/TestOldObjectQueueSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,15 +34,15 @@ import jdk.test.lib.jfr.Events;
 
 /**
  * @test
- * @summary Test -XX:FlightRecorderOptions=old-object-queue-size
+ * @summary Test -XX:FlightRecorderOptions:old-object-queue-size
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @library /test/lib
  * @key jfr
  *
- * @run main/othervm -XX:TLABSize=2k -XX:FlightRecorderOptions=old-object-queue-size=0 jdk.jfr.startupargs.TestOldObjectQueueSize off
- * @run main/othervm -XX:TLABSize=2k -Xlog:gc+tlab=trace -XX:FlightRecorderOptions=old-object-queue-size=10000 jdk.jfr.startupargs.TestOldObjectQueueSize many
- * @run main/othervm -XX:TLABSize=2k -Xlog:gc+tlab=trace -XX:FlightRecorderOptions=old-object-queue-size=1000000 jdk.jfr.startupargs.TestOldObjectQueueSize many
+ * @run main/othervm -XX:TLABSize=2k -XX:FlightRecorderOptions:old-object-queue-size=0 jdk.jfr.startupargs.TestOldObjectQueueSize off
+ * @run main/othervm -XX:TLABSize=2k -Xlog:gc+tlab=trace -XX:FlightRecorderOptions:old-object-queue-size=10000 jdk.jfr.startupargs.TestOldObjectQueueSize many
+ * @run main/othervm -XX:TLABSize=2k -Xlog:gc+tlab=trace -XX:FlightRecorderOptions:old-object-queue-size=1000000 jdk.jfr.startupargs.TestOldObjectQueueSize many
  */
 public class TestOldObjectQueueSize {
 

--- a/test/jdk/jdk/jfr/startupargs/TestRepositoryPath.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRepositoryPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.test.lib.Asserts;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=TestStartRecording,settings=profile -XX:FlightRecorderOptions=repository=./repo jdk.jfr.startupargs.TestRepositoryPath
+ * @run main/othervm -XX:StartFlightRecording:name=TestStartRecording,settings=profile -XX:FlightRecorderOptions:repository=./repo jdk.jfr.startupargs.TestRepositoryPath
  */
 public class TestRepositoryPath {
 

--- a/test/jdk/jdk/jfr/startupargs/TestRepositoryPathLong.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRepositoryPathLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.test.lib.Asserts;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=myrec,settings=profile -XX:FlightRecorderOptions=repository=./subdirectory/subdirectory1/subdirectory2/subdirectory3/subdirectory4/subdirectory5/subdirectory6/subdirectory7/subdirectory8/subdirectory9/subdirectory10/subdirectory11/subdirectory12/subdirectory13/subdirectory14/subdirectory15 jdk.jfr.startupargs.TestRepositoryPathLong
+ * @run main/othervm -XX:StartFlightRecording:name=myrec,settings=profile -XX:FlightRecorderOptions:repository=./subdirectory/subdirectory1/subdirectory2/subdirectory3/subdirectory4/subdirectory5/subdirectory6/subdirectory7/subdirectory8/subdirectory9/subdirectory10/subdirectory11/subdirectory12/subdirectory13/subdirectory14/subdirectory15 jdk.jfr.startupargs.TestRepositoryPathLong
  */
 public class TestRepositoryPathLong {
 

--- a/test/jdk/jdk/jfr/startupargs/TestRetransform.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRetransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ import jdk.test.lib.jfr.SimpleEvent;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -XX:FlightRecorderOptions=retransform=false jdk.jfr.startupargs.TestRetransform
- * @run main/othervm -XX:FlightRecorderOptions=retransform=true jdk.jfr.startupargs.TestRetransform
+ * @run main/othervm -XX:FlightRecorderOptions:retransform=false jdk.jfr.startupargs.TestRetransform
+ * @run main/othervm -XX:FlightRecorderOptions:retransform=true jdk.jfr.startupargs.TestRetransform
  */
 public class TestRetransform {
     private static class TestEvent extends Event {

--- a/test/jdk/jdk/jfr/startupargs/TestRetransformUsingLog.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRetransformUsingLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ public class TestRetransformUsingLog {
     private static void startApp(boolean recording, boolean retransform, Consumer<OutputAnalyzer> verifier) throws Exception {
         List<String> args = new ArrayList<>();
         args.add("-Xlog:jfr+system");
-        args.add("-XX:FlightRecorderOptions=retransform=" + retransform);
+        args.add("-XX:FlightRecorderOptions:retransform=" + retransform);
         if (recording) {
             args.add("-XX:StartFlightRecording");
         }

--- a/test/jdk/jdk/jfr/startupargs/TestStartDelay.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import jdk.test.lib.jfr.CommonHelper;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=TestStartDelay,delay=5000s jdk.jfr.startupargs.TestStartDelay
+ * @run main/othervm -XX:StartFlightRecording:name=TestStartDelay,delay=5000s jdk.jfr.startupargs.TestStartDelay
  */
 public class TestStartDelay {
 

--- a/test/jdk/jdk/jfr/startupargs/TestStartDelayRunning.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDelayRunning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.jfr.CommonHelper;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=TestStartDelay,delay=1s jdk.jfr.startupargs.TestStartDelayRunning
+ * @run main/othervm -XX:StartFlightRecording:name=TestStartDelay,delay=1s jdk.jfr.startupargs.TestStartDelayRunning
  */
 public class TestStartDelayRunning {
 

--- a/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestStartDuration {
 
     private static void testDurationInRange(String duration, Duration durationString, boolean wait) throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-            "-XX:StartFlightRecording=name=TestStartDuration,duration=" + duration, TestValues.class.getName(),
+            "-XX:StartFlightRecording:name=TestStartDuration,duration=" + duration, TestValues.class.getName(),
             durationString.toString(), wait ? "wait" : "");
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 
@@ -64,7 +64,7 @@ public class TestStartDuration {
 
     private static void testDurationJavaVersion(String duration, boolean inRange) throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-            "-XX:StartFlightRecording=name=TestStartDuration,duration=" + duration, "-version");
+            "-XX:StartFlightRecording:name=TestStartDuration,duration=" + duration, "-version");
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 
         if (inRange) {

--- a/test/jdk/jdk/jfr/startupargs/TestStartMaxAgeSize.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartMaxAgeSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.jfr.CommonHelper;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=TestStartMaxAgeSize,maxage=10s,maxsize=1000000 jdk.jfr.startupargs.TestStartMaxAgeSize
+ * @run main/othervm -XX:StartFlightRecording:name=TestStartMaxAgeSize,maxage=10s,maxsize=1000000 jdk.jfr.startupargs.TestStartMaxAgeSize
  */
 public class TestStartMaxAgeSize {
 

--- a/test/jdk/jdk/jfr/startupargs/TestStartName.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class TestStartName {
 
     private static void testName(String recordingName, boolean validName) throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-            "-XX:StartFlightRecording=name=" + recordingName, TestName.class.getName(), recordingName);
+            "-XX:StartFlightRecording:name=" + recordingName, TestName.class.getName(), recordingName);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 
         if (validName) {

--- a/test/jdk/jdk/jfr/startupargs/TestStartNoSettings.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartNoSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.jfr.Recording;
  * @requires vm.hasJFR
  * @library /test/lib
  * @run main/othervm jdk.jfr.startupargs.TestStartNoSettings
- *      -XX:StartFlightRecording=settings=none
+ *      -XX:StartFlightRecording:settings=none
  */
 public class TestStartNoSettings {
 
@@ -61,7 +61,7 @@ public class TestStartNoSettings {
         }
 
         if (!userEnabled)  {
-            throw new Exception("Expected 'UserEvent' to be enabled with -XX:StartFlightRecording=settings=none");
+            throw new Exception("Expected 'UserEvent' to be enabled with -XX:StartFlightRecording:settings=none");
         }
     }
 }

--- a/test/jdk/jdk/jfr/startupargs/TestStartRecording.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm -XX:StartFlightRecording=name=TestStartRecording,settings=profile jdk.jfr.startupargs.TestStartRecording
+ * @run main/othervm -XX:StartFlightRecording:name=TestStartRecording,settings=profile jdk.jfr.startupargs.TestStartRecording
  */
 public class TestStartRecording {
 


### PR DESCRIPTION
Hi,

Could I have a review of fix that removes the use of "=" together with -XX:StartFlightRecording and -XX:FlightRecorderOptions. It's been possible to use "-XX:StartFlightRecording:" and "-XX:FlightRecorderOption:" since JFR was introduced into OpenJDK (JDK 11), so this is not a change of the specification, just an update to make the use consistent in tests, comments, documentation etc.

I also removed the use of -XX:+FlightRecorder, which is not needed, and has been deprecated since JDK 13. 

Testing: jdk/jdk/jfr, tier 1-4.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265036](https://bugs.openjdk.java.net/browse/JDK-8265036): JFR: Remove use of -XX:StartFlightRecording= and -XX:FlightRecorderOptions=


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 4ce0893911cee60ec4509030ec1cd5bfa165ff4d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3561/head:pull/3561` \
`$ git checkout pull/3561`

Update a local copy of the PR: \
`$ git checkout pull/3561` \
`$ git pull https://git.openjdk.java.net/jdk pull/3561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3561`

View PR using the GUI difftool: \
`$ git pr show -t 3561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3561.diff">https://git.openjdk.java.net/jdk/pull/3561.diff</a>

</details>
