### PR TITLE
8265407: JFR: Fix Typos

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -373,7 +373,7 @@ public final class PlatformRecording implements AutoCloseable {
     public void setMaxSize(long maxSize) {
         synchronized (recorder) {
             if (getState() == RecordingState.CLOSED) {
-                throw new IllegalStateException("Can't set max age when recording is closed");
+                throw new IllegalStateException("Can't set max size when recording is closed");
             }
             this.maxSize = maxSize;
             trimToSize();

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,6 @@ import jdk.jfr.internal.management.EventByteStream;
  * usage on a remote host and print the events to standard out.
  *
  * <pre>
- * {
  *     {@literal
  *     String host = "com.example";
  *     int port = 4711;
@@ -83,7 +82,7 @@ import jdk.jfr.internal.management.EventByteStream;
  *         rs.onEvent("jdk.GCPhasePause", System.out::println);
  *         rs.start();
  *     }
- * }
+ *     }
  * </pre>
  *
  * @since 16


### PR DESCRIPTION
Hi,

Could I have a review of a fix that takes care of couple of typos.

Testing: test/jdk/jdk/jfr/

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265407](https://bugs.openjdk.java.net/browse/JDK-8265407): JFR: Fix Typos


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3562/head:pull/3562` \
`$ git checkout pull/3562`

Update a local copy of the PR: \
`$ git checkout pull/3562` \
`$ git pull https://git.openjdk.java.net/jdk pull/3562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3562`

View PR using the GUI difftool: \
`$ git pr show -t 3562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3562.diff">https://git.openjdk.java.net/jdk/pull/3562.diff</a>

</details>
