### PR TITLE
8265106: IGV: Enforce en-US locale while parsing ideal graph

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
@@ -34,6 +34,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.swing.SwingUtilities;
 import javax.xml.parsers.ParserConfigurationException;
@@ -529,6 +530,8 @@ public class Parser implements GraphParser {
         }
         try {
             XMLReader reader = createReader();
+            // To enforce using English for non-English users, we must use Locale.ROOT rather than Locale.ENGLISH
+            reader.setProperty("http://apache.org/xml/properties/locale", Locale.ROOT);
             reader.setContentHandler(new XMLParser(xmlDocument, monitor));
             reader.parse(new InputSource(Channels.newInputStream(channel)));
         } catch (SAXException ex) {

--- a/src/utils/IdealGraphVisualizer/Data/src/test/java/com/sun/hotspot/igv/data/serialization/ParserTest.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/test/java/com/sun/hotspot/igv/data/serialization/ParserTest.java
@@ -222,4 +222,10 @@ public class ParserTest {
         testBoth(new GraphDocument(), "<graphDocument></graphDocument>");
     }
 
+    @Test
+    public void testParseIncompleteXML() {
+        // Exception should be swallowed, see catch clause in GraphParser.parse.
+        testBoth(new GraphDocument(), "<graphDocument>");
+    }
+
 }


### PR DESCRIPTION
IGV is designed to support parsing incomplete XML. However, it does not work for non-English users. See #3071 for detailed reasons. This patch would address it.

(P.S. Locale.ENGLISH also does not work, see  Philip Helger' [comment](https://stackoverflow.com/questions/18531633/locale-specific-messages-in-xerces-2-11-0-java) on the first answer.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265106](https://bugs.openjdk.java.net/browse/JDK-8265106): IGV: Enforce en-US locale while parsing ideal graph


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Contributors
 * Roberto Castañeda Lozano `<rcastanedalo@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3563/head:pull/3563` \
`$ git checkout pull/3563`

Update a local copy of the PR: \
`$ git checkout pull/3563` \
`$ git pull https://git.openjdk.java.net/jdk pull/3563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3563`

View PR using the GUI difftool: \
`$ git pr show -t 3563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3563.diff">https://git.openjdk.java.net/jdk/pull/3563.diff</a>

</details>
