### PR TITLE
8265414: Variable assigned but not used in G1FreeHumongousRegionClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -4347,14 +4347,13 @@ void G1CollectedHeap::free_collection_set(G1CollectionSet* collection_set, G1Eva
 }
 
 class G1FreeHumongousRegionClosure : public HeapRegionClosure {
-  HeapRegionSet* _proxy_set;
   uint _humongous_objects_reclaimed;
   uint _humongous_regions_reclaimed;
   size_t _freed_bytes;
 public:
 
   G1FreeHumongousRegionClosure() :
-    _proxy_set(NULL), _humongous_objects_reclaimed(0), _humongous_regions_reclaimed(0), _freed_bytes(0) {
+    _humongous_objects_reclaimed(0), _humongous_regions_reclaimed(0), _freed_bytes(0) {
   }
 
   virtual bool do_heap_region(HeapRegion* r) {


### PR DESCRIPTION
Trivial change of removing an unused field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265414](https://bugs.openjdk.java.net/browse/JDK-8265414): Variable assigned but not used in G1FreeHumongousRegionClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3565/head:pull/3565` \
`$ git checkout pull/3565`

Update a local copy of the PR: \
`$ git checkout pull/3565` \
`$ git pull https://git.openjdk.java.net/jdk pull/3565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3565`

View PR using the GUI difftool: \
`$ git pr show -t 3565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3565.diff">https://git.openjdk.java.net/jdk/pull/3565.diff</a>

</details>
