### PR TITLE
8265421: java/lang/String/StringRepeat.java test is missing a memory requirement

### DIFF
--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary This exercises String#repeat patterns and limits.
- * @run main/othervm -Xmx2g StringRepeat
+ * @run main/othervm StringRepeat
  */
 
 /*

--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,21 +27,33 @@
  * @run main/othervm -Xmx2g StringRepeat
  */
 
+/*
+ * @test
+ * @summary This exercises String#repeat patterns with 16 * 1024 * 1024 repeats.
+ * @requires os.maxMemory >= 2G
+ * @run main/othervm -Xmx2g StringRepeat 16777216
+ */
+
 import java.nio.CharBuffer;
 
 public class StringRepeat {
-    public static void main(String... arg) {
+    public static void main(String... args) {
+        if (args.length > 0) {
+            REPEATS = new int[args.length];
+            for (int i = 0; i < args.length; ++i) {
+                REPEATS[i] = Integer.parseInt(args[i]);
+            }
+        }
         test1();
         test2();
     }
 
     /*
-     * Varitions of repeat count.
+     * Default varitions of repeat count.
      */
     static int[] REPEATS = {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        32, 64, 128, 256, 512, 1024, 64 * 1024, 1024 * 1024,
-        16 * 1024 * 1024
+        32, 64, 128, 256, 512, 1024, 64 * 1024, 1024 * 1024
     };
 
     /*


### PR DESCRIPTION
Please review the following patch, which fixes the mentioned test case for memory constrained devices. This can be tested on a linux based development machine, using systemd as follows:

```
$ systemd-run --user --scope -p MemoryMax=800M -p MemorySwapMax=0 /usr/bin/make TEST="test/jdk/java/lang/String/StringRepeat.java" run-test
```

I split up the test case in a part which only executes the small repeat counts, and in one part which executes the huge repeat count. The second part is guarded by a requirement, so it is only executed if enough memory is available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265421](https://bugs.openjdk.java.net/browse/JDK-8265421): java/lang/String/StringRepeat.java test is missing a memory requirement


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Rahul Yadav](https://openjdk.java.net/census#ryadav) (@rhyadav - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3566/head:pull/3566` \
`$ git checkout pull/3566`

Update a local copy of the PR: \
`$ git checkout pull/3566` \
`$ git pull https://git.openjdk.java.net/jdk pull/3566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3566`

View PR using the GUI difftool: \
`$ git pr show -t 3566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3566.diff">https://git.openjdk.java.net/jdk/pull/3566.diff</a>

</details>
