### PR TITLE
8197811 : Test java/awt/Choice/PopupPosTest/PopupPosTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -271,7 +271,6 @@ java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8197796 ge
 java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java 8196300 windows-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
-java/awt/Choice/PopupPosTest/PopupPosTest.java  8197811 windows-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all,linux-all
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all

--- a/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
+++ b/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
@@ -26,23 +26,16 @@
   @key headful
   @bug 5044150
   @summary Tests that pupup doesn't popdown if no space to display under
-  @library /test/lib
-  @build jdk.test.lib.Platform
+  @requires (os.family == "linux")
   @run main PopupPosTest
 */
 
 import java.awt.*;
 import java.awt.event.*;
 
-import jdk.test.lib.Platform;
-
 public class PopupPosTest {
 
     public static void main(final String[] args) {
-        if (Platform.isOSX()) {
-            // On OS X, popup isn't under the mouse
-            return;
-        }
         Frame frame = new TestFrame();
     }
 }


### PR DESCRIPTION
The test PopupPosTest.java fails for windows every time, and was problem listed.
This test was added under the JDK-5044150,  And the change was specific to  XToolkit as mentioned in JDK-5044150.
"this change is for XToolkit thus testing it on Linux will be sufficient"/

This test runs fine in linux(i have tested on ubuntu).
So making this test linux specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8197811](https://bugs.openjdk.java.net/browse/JDK-8197811): Test java/awt/Choice/PopupPosTest/PopupPosTest.java fails on Windows


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3567/head:pull/3567` \
`$ git checkout pull/3567`

Update a local copy of the PR: \
`$ git checkout pull/3567` \
`$ git pull https://git.openjdk.java.net/jdk pull/3567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3567`

View PR using the GUI difftool: \
`$ git pr show -t 3567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3567.diff">https://git.openjdk.java.net/jdk/pull/3567.diff</a>

</details>
