### PR TITLE
8265435: Remove dummy lists in G1CalculatePointersClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -40,7 +40,7 @@
 #include "utilities/ticks.hpp"
 
 template<bool is_humongous>
-void G1FullGCPrepareTask::G1CalculatePointersClosure::free_region(HeapRegion* hr) {
+void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapRegion* hr) {
   _regions_freed = true;
   if (is_humongous) {
     _g1h->free_humongous_region(hr, nullptr);
@@ -63,12 +63,12 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
     if (hr->is_humongous()) {
       oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
       if (!_bitmap->is_marked(obj)) {
-        free_region<true>(hr);
+        free_pinned_region<true>(hr);
       }
     } else if (hr->is_open_archive()) {
       bool is_empty = _collector->live_words(hr->hrm_index()) == 0;
       if (is_empty) {
-        free_region<false>(hr);
+        free_pinned_region<false>(hr);
       }
     } else if (hr->is_closed_archive()) {
       // nothing to do with closed archive region

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -39,6 +39,17 @@
 #include "oops/oop.inline.hpp"
 #include "utilities/ticks.hpp"
 
+template<bool is_humongous>
+void G1FullGCPrepareTask::G1CalculatePointersClosure::free_region(HeapRegion* hr) {
+  _regions_freed = true;
+  if (is_humongous) {
+    _g1h->free_humongous_region(hr, nullptr);
+  } else {
+    _g1h->free_region(hr, nullptr);
+  }
+  prepare_for_compaction(hr);
+}
+
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
   bool force_not_compacted = false;
   if (should_compact(hr)) {
@@ -48,15 +59,16 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
     // There is no need to iterate and forward objects in pinned regions ie.
     // prepare them for compaction. The adjust pointers phase will skip
     // work for them.
+    assert(hr->containing_set() == nullptr, "already cleared by PrepareRegionsClosure");
     if (hr->is_humongous()) {
       oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
       if (!_bitmap->is_marked(obj)) {
-        free_humongous_region(hr);
+        free_region<true>(hr);
       }
     } else if (hr->is_open_archive()) {
       bool is_empty = _collector->live_words(hr->hrm_index()) == 0;
       if (is_empty) {
-        free_open_archive_region(hr);
+        free_region<false>(hr);
       }
     } else if (hr->is_closed_archive()) {
       // nothing to do with closed archive region
@@ -124,35 +136,6 @@ G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1Fu
     _bitmap(collector->mark_bitmap()),
     _cp(cp),
     _regions_freed(false) { }
-
-void G1FullGCPrepareTask::G1CalculatePointersClosure::free_humongous_region(HeapRegion* hr) {
-  assert(hr->is_humongous(), "must be but region %u is %s", hr->hrm_index(), hr->get_short_type_str());
-
-  FreeRegionList dummy_free_list("Humongous Dummy Free List for G1MarkSweep");
-
-  hr->set_containing_set(NULL);
-  _regions_freed = true;
-
-  _g1h->free_humongous_region(hr, &dummy_free_list);
-  prepare_for_compaction(hr);
-  dummy_free_list.remove_all();
-}
-
-void G1FullGCPrepareTask::G1CalculatePointersClosure::free_open_archive_region(HeapRegion* hr) {
-  assert(hr->is_pinned(), "must be");
-  assert(!hr->is_humongous(), "handled elsewhere");
-  assert(hr->is_open_archive(),
-         "Only Open archive regions may be freed here.");
-
-  FreeRegionList dummy_free_list("Pinned Dummy Free List for G1MarkSweep");
-
-  hr->set_containing_set(NULL);
-  _regions_freed = true;
-
-  _g1h->free_region(hr, &dummy_free_list);
-  prepare_for_compaction(hr);
-  dummy_free_list.remove_all();
-}
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::should_compact(HeapRegion* hr) {
   if (hr->is_pinned()) {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -51,6 +51,9 @@ public:
 
 protected:
   class G1CalculatePointersClosure : public HeapRegionClosure {
+  private:
+    template<bool is_humongous>
+    void free_region(HeapRegion* hr);
   protected:
     G1CollectedHeap* _g1h;
     G1FullCollector* _collector;
@@ -59,10 +62,8 @@ protected:
     bool _regions_freed;
 
     bool should_compact(HeapRegion* hr);
-    virtual void prepare_for_compaction(HeapRegion* hr);
+    void prepare_for_compaction(HeapRegion* hr);
     void prepare_for_compaction_work(G1FullGCCompactionPoint* cp, HeapRegion* hr);
-    void free_humongous_region(HeapRegion* hr);
-    void free_open_archive_region(HeapRegion* hr);
     void update_bot(HeapRegion* hr);
 
     void reset_region_metadata(HeapRegion* hr);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -53,7 +53,7 @@ protected:
   class G1CalculatePointersClosure : public HeapRegionClosure {
   private:
     template<bool is_humongous>
-    void free_region(HeapRegion* hr);
+    void free_pinned_region(HeapRegion* hr);
   protected:
     G1CollectedHeap* _g1h;
     G1FullCollector* _collector;


### PR DESCRIPTION
Remove the dummy list and some general cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265435](https://bugs.openjdk.java.net/browse/JDK-8265435): Remove dummy lists in G1CalculatePointersClosure


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 6f3b9f83626d86dbf7ad7e4fda2763f111871f9e
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3568/head:pull/3568` \
`$ git checkout pull/3568`

Update a local copy of the PR: \
`$ git checkout pull/3568` \
`$ git pull https://git.openjdk.java.net/jdk pull/3568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3568`

View PR using the GUI difftool: \
`$ git pr show -t 3568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3568.diff">https://git.openjdk.java.net/jdk/pull/3568.diff</a>

</details>
