### PR TITLE
8265436: G1: Improve gc+phases log output during full gc 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -74,7 +74,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
         // performance during scanning their card tables in the collection pauses later.
         update_bot(hr);
       }
-      log_debug(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
+      log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
     }
   }

--- a/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
@@ -48,7 +48,7 @@ public class TestG1SkipCompaction {
             "-XX:MarkSweepDeadRatio=3",
             "-Xmx8m",
             "-Xms8M",
-            "-Xlog:gc+phases=debug",
+            "-Xlog:gc+phases=trace",
             "-XX:G1HeapRegionSize=1m",
             GCTest.class.getName()
             };

--- a/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1SkipCompaction.java
@@ -61,9 +61,8 @@ public class TestG1SkipCompaction {
         Matcher m = r.matcher(output.getStdout());
 
         if (!m.find()) {
-            throw new RuntimeException("Could not find any no moving region output");
+            throw new RuntimeException("Could not find any not compacted regions in the logs");
         }
-
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

  can I have reviews for this fix to remove recently introduced log messages from `debug` to `trace` level?

If you select `gc+phases=debug` logging with [JDK-8262068](https://bugs.openjdk.java.net/browse/JDK-8262068), you get:

    [0.695s][debug][gc,phases] GC(51) Phase 1: Weak Processing 0.309ms
    [0.695s][debug][gc,phases] GC(51) ClassLoaderData 0.003ms
    [0.695s][debug][gc,phases] GC(51) Trigger cleanups 0.002ms
    [0.699s][debug][gc,phases] GC(51) Phase 1: Class Unloading and Cleanup 4.056ms
    [0.699s][info ][gc,phases] GC(51) Phase 1: Mark live objects 7.722ms
    [0.699s][debug][gc,phases] GC(51) Phase 2: skip compaction region index: 0, live words: 125610
    [repeated for every region skipped] 

the last per-region message is quite annyoing and just fills up logs as the code prints one line per affected region (which may be a lot), so I suggest to move it to `trace` level. I did suggest to add some nice phase 2 region summary in [JDK-8265437](https://bugs.openjdk.java.net/browse/JDK-8265437), but that is out of scope for this change.

Testing: local testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265436](https://bugs.openjdk.java.net/browse/JDK-8265436): G1: Improve gc+phases log output during full gc


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to 340167e389ac0eecc30a178c1280c35f6aeb7fe3
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 340167e389ac0eecc30a178c1280c35f6aeb7fe3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3569/head:pull/3569` \
`$ git checkout pull/3569`

Update a local copy of the PR: \
`$ git checkout pull/3569` \
`$ git pull https://git.openjdk.java.net/jdk pull/3569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3569`

View PR using the GUI difftool: \
`$ git pr show -t 3569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3569.diff">https://git.openjdk.java.net/jdk/pull/3569.diff</a>

</details>
