### PR TITLE
8265268: Unify ReservedSpace reservation code in initialize and try_reserve_heap

### DIFF
--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -115,28 +115,82 @@ static void unmap_or_release_memory(char* base, size_t size, bool is_file_mapped
   }
 }
 
-// Helper method.
-static bool failed_to_reserve_as_requested(char* base, char* requested_address,
-                                           const size_t size, bool special, bool is_file_mapped = false)
-{
-  if (base == requested_address || requested_address == NULL)
+// Helper method
+static bool failed_to_reserve_as_requested(char* base, char* requested_address) {
+  if (base == requested_address || requested_address == NULL) {
     return false; // did not fail
+  }
 
   if (base != NULL) {
     // Different reserve address may be acceptable in other cases
     // but for compressed oops heap should be at requested address.
     assert(UseCompressedOops, "currently requested address used only for compressed oops");
     log_debug(gc, heap, coops)("Reserved memory not at requested address: " PTR_FORMAT " vs " PTR_FORMAT, p2i(base), p2i(requested_address));
-    // OS ignored requested address. Try different address.
-    if (special) {
-      if (!os::release_memory_special(base, size)) {
-        fatal("os::release_memory_special failed");
-      }
-    } else {
-      unmap_or_release_memory(base, size, is_file_mapped);
-    }
   }
   return true;
+}
+
+static bool use_explicit_large_pages(bool large) {
+  return !os::can_commit_large_page_memory() && large;
+}
+
+static bool large_pages_requested() {
+  return UseLargePages &&
+         (!FLAG_IS_DEFAULT(UseLargePages) || !FLAG_IS_DEFAULT(LargePageSizeInBytes));
+}
+
+static char* reserve_memory(char* requested_address, const size_t size,
+                            const size_t alignment, int fd, bool exec) {
+  char* base;
+  // If the memory was requested at a particular address, use
+  // os::attempt_reserve_memory_at() to avoid over mapping something
+  // important.  If available space is not detected, return NULL.
+  if (requested_address != 0) {
+    assert(is_aligned(requested_address, alignment),
+           "Requested address " PTR_FORMAT "must be aligned to " SIZE_FORMAT,
+           p2i(requested_address), alignment);
+    base = attempt_map_or_reserve_memory_at(requested_address, size, fd, exec);
+  } else {
+    // Optimistically assume that the OS returns an aligned base pointer.
+    // When reserving a large address range, most OSes seem to align to at
+    // least 64K.
+    base = map_or_reserve_memory(size, fd, exec);
+    // Check alignment constraints. This is only needed when there is
+    // no requested address. If a requested address is used it must be
+    // aligned.
+    if (!is_aligned(base, alignment)) {
+      // Base not aligned, retry.
+      unmap_or_release_memory(base, size, fd != -1 /*is_file_mapped*/);
+      // Map using the requested alignment.
+      base = map_or_reserve_memory_aligned(size, alignment, fd, exec);
+    }
+  }
+
+  return base;
+}
+
+static char* reserve_memory_special(char* requested_address, const size_t size,
+                                    const size_t alignment,  bool exec) {
+
+  log_trace(pagesize)("Attempt special mapping: size: " SIZE_FORMAT "%s, "
+                      "alignment: " SIZE_FORMAT "%s",
+                      byte_size_in_exact_unit(size), exact_unit_for_byte_size(size),
+                      byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
+
+  char* base = os::reserve_memory_special(size, alignment, requested_address, exec);
+  if (base != NULL) {
+    // Check alignment constraints.
+    assert((uintptr_t)base % alignment == 0,
+           "Large pages returned a non-aligned address, base: " PTR_FORMAT
+           " alignment: " SIZE_FORMAT_HEX,
+           p2i(base), alignment);
+  } else {
+    // failed; fall back to reserve regular memory.
+    if (large_pages_requested()) {
+      log_debug(gc, heap, coops)("Reserve regular memory without large pages");
+    }
+  }
+  return base;
 }
 
 void ReservedSpace::clear_members() {
@@ -153,6 +207,49 @@ void ReservedSpace::initialize_members(char* base, size_t size, size_t alignment
   _noaccess_prefix = 0;
 }
 
+void ReservedSpace::reserve(size_t size, size_t alignment, bool large,
+                            char* requested_address,
+                            bool executable) {
+  assert(is_aligned(size, alignment), "Size must be aligned to the requested alignment");
+
+  // There are basically three different cases that we need to handle below:
+  // - Mapping backed by a file
+  // - Mapping backed by explicit large pages
+  // - Mapping backed by normal pages or transparent huge pages
+  // The first two have restrictions that requires the whole mapping to be
+  // committed up front. To record this the ReservedSpace is marked 'special'.
+
+  if (_fd_for_heap != -1) {
+    // When there is a backing file directory for this space then whether
+    // large pages are allocated is up to the filesystem of the backing file.
+    // So UseLargePages is not taken into account for this reservation.
+    char* base = reserve_memory(requested_address, size, alignment, _fd_for_heap, executable);
+    if (base != NULL) {
+      initialize_members(base, size, alignment, true, executable);
+    }
+    // Always return, not possible to fall back to reservation not using a file.
+    return;
+  } else if (use_explicit_large_pages(large)) {
+    // System can't commit large pages i.e. use transparent huge pages and
+    // the caller requested large pages. To satisfy this request we use
+    // explicit large pages and these have to be committed up front to ensure
+    // no reservations are lost.
+
+    char* base = reserve_memory_special(requested_address, size, alignment, executable);
+    if (base != NULL) {
+      // Successful reservation using large pages.
+      initialize_members(base, size, alignment, true, executable);
+      return;
+    }
+  }
+
+  // Not a 'special' reservation.
+  char* base = reserve_memory(requested_address, size, alignment, -1, executable);
+  if (base != NULL) {
+    // Successful mapping.
+    initialize_members(base, size, alignment, false, executable);
+  }
+}
 
 void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
                                char* requested_address,
@@ -171,96 +268,18 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
     return;
   }
 
+  // Adjust alignment to not be 0.
   alignment = MAX2(alignment, (size_t)os::vm_page_size());
 
-  // If OS doesn't support demand paging for large page memory, we need
-  // to use reserve_memory_special() to reserve and pin the entire region.
-  // If there is a backing file directory for this space then whether
-  // large pages are allocated is up to the filesystem of the backing file.
-  // So we ignore the UseLargePages flag in this case.
-  bool special = large && !os::can_commit_large_page_memory();
-  if (special && _fd_for_heap != -1) {
-    special = false;
-    if (UseLargePages && (!FLAG_IS_DEFAULT(UseLargePages) ||
-      !FLAG_IS_DEFAULT(LargePageSizeInBytes))) {
-      log_debug(gc, heap)("Ignoring UseLargePages since large page support is up to the file system of the backing file for Java heap");
-    }
+  // Reserve the memory.
+  reserve(size, alignment, large, requested_address, executable);
+
+  // Check that the requested address is used if given.
+  if (failed_to_reserve_as_requested(_base, requested_address)) {
+    // OS ignored the requested address, release the reservation.
+    release();
+    return;
   }
-
-  char* base = NULL;
-
-  if (special) {
-
-    base = os::reserve_memory_special(size, alignment, requested_address, executable);
-
-    if (base != NULL) {
-      if (failed_to_reserve_as_requested(base, requested_address, size, true)) {
-        // OS ignored requested address. Try different address.
-        return;
-      }
-      // Check alignment constraints.
-      assert((uintptr_t) base % alignment == 0,
-             "Large pages returned a non-aligned address, base: "
-             PTR_FORMAT " alignment: " SIZE_FORMAT_HEX,
-             p2i(base), alignment);
-    } else {
-      // failed; try to reserve regular memory below. Reservation
-      // should not be marked as special.
-      special = false;
-      if (UseLargePages && (!FLAG_IS_DEFAULT(UseLargePages) ||
-                            !FLAG_IS_DEFAULT(LargePageSizeInBytes))) {
-        log_debug(gc, heap, coops)("Reserve regular memory without large pages");
-      }
-    }
-  }
-
-  if (base == NULL) {
-    // Optimistically assume that the OS returns an aligned base pointer.
-    // When reserving a large address range, most OSes seem to align to at
-    // least 64K.
-
-    // If the memory was requested at a particular address, use
-    // os::attempt_reserve_memory_at() to avoid over mapping something
-    // important.  If available space is not detected, return NULL.
-
-    if (requested_address != 0) {
-      base = attempt_map_or_reserve_memory_at(requested_address, size, _fd_for_heap, executable);
-      if (failed_to_reserve_as_requested(base, requested_address, size, false, _fd_for_heap != -1)) {
-        // OS ignored requested address. Try different address.
-        base = NULL;
-      }
-    } else {
-      base = map_or_reserve_memory(size, _fd_for_heap, executable);
-    }
-
-    if (base == NULL) return;
-
-    // Check alignment constraints
-    if ((((size_t)base) & (alignment - 1)) != 0) {
-      // Base not aligned, retry
-      unmap_or_release_memory(base, size, _fd_for_heap != -1 /*is_file_mapped*/);
-
-      // Make sure that size is aligned
-      size = align_up(size, alignment);
-      base = map_or_reserve_memory_aligned(size, alignment, _fd_for_heap, executable);
-
-      if (requested_address != 0 &&
-          failed_to_reserve_as_requested(base, requested_address, size, false, _fd_for_heap != -1)) {
-        // As a result of the alignment constraints, the allocated base differs
-        // from the requested address. Return back to the caller who can
-        // take remedial action (like try again without a requested address).
-        assert(_base == NULL, "should be");
-        return;
-      }
-    }
-  }
-  // If heap is reserved with a backing file, the entire space has been committed. So set the special flag to true
-  if (_fd_for_heap != -1) {
-    special = true;
-  }
-
-  // Done
-  initialize_members(base, size, alignment, special, executable);
 }
 
 ReservedSpace ReservedSpace::first_part(size_t partition_size, size_t alignment) {
@@ -375,69 +394,16 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
     release();
   }
 
-  // If OS doesn't support demand paging for large page memory, we need
-  // to use reserve_memory_special() to reserve and pin the entire region.
-  // If there is a backing file directory for this space then whether
-  // large pages are allocated is up to the filesystem of the backing file.
-  // So we ignore the UseLargePages flag in this case.
-  bool special = large && !os::can_commit_large_page_memory();
-  if (special && _fd_for_heap != -1) {
-    special = false;
-    if (UseLargePages && (!FLAG_IS_DEFAULT(UseLargePages) ||
-                          !FLAG_IS_DEFAULT(LargePageSizeInBytes))) {
-      log_debug(gc, heap)("Cannot allocate large pages for Java Heap when AllocateHeapAt option is set.");
-    }
-  }
-  char* base = NULL;
-
+  // Try to reserve the memory for the heap.
   log_trace(gc, heap, coops)("Trying to allocate at address " PTR_FORMAT
                              " heap of size " SIZE_FORMAT_HEX,
                              p2i(requested_address),
                              size);
 
-  if (special) {
-    base = os::reserve_memory_special(size, alignment, requested_address, false);
+  reserve(size, alignment, large, requested_address, false);
 
-    if (base != NULL) {
-      // Check alignment constraints.
-      assert((uintptr_t) base % alignment == 0,
-             "Large pages returned a non-aligned address, base: "
-             PTR_FORMAT " alignment: " SIZE_FORMAT_HEX,
-             p2i(base), alignment);
-    }
-  }
-
-  if (base == NULL) {
-    // Failed; try to reserve regular memory below. Reservation
-    // should not be marked as special.
-    special = false;
-    if (UseLargePages && (!FLAG_IS_DEFAULT(UseLargePages) ||
-                          !FLAG_IS_DEFAULT(LargePageSizeInBytes))) {
-      log_debug(gc, heap, coops)("Reserve regular memory without large pages");
-    }
-
-    if (requested_address != 0) {
-      base = attempt_map_or_reserve_memory_at(requested_address, size, _fd_for_heap, executable());
-    } else {
-      // Optimistically assume that the OSes returns an aligned base pointer.
-      // When reserving a large address range, most OSes seem to align to at
-      // least 64K.
-      // If the returned memory is not aligned we will release and retry.
-      base = map_or_reserve_memory(size, _fd_for_heap, executable());
-    }
-  }
-  if (base == NULL) { return; }
-
-  // If heap is reserved with a backing file, the entire space has been committed. So set the special flag to true
-  if (_fd_for_heap != -1) {
-    special = true;
-  }
-
-  // Done
-  initialize_members(base, size, alignment, special, false);
-
-  // Check alignment constraints
-  if (!is_aligned(base, alignment)) {
+  // Check alignment constraints.
+  if (is_reserved() && !is_aligned(_base, _alignment)) {
     // Base not aligned, retry.
     release();
   }
@@ -640,6 +606,12 @@ ReservedHeapSpace::ReservedHeapSpace(size_t size, size_t alignment, bool large, 
     if (_fd_for_heap == -1) {
       vm_exit_during_initialization(
         err_msg("Could not create file for Heap at location %s", heap_allocation_directory));
+    }
+    // When there is a backing file directory for this space then whether
+    // large pages are allocated is up to the filesystem of the backing file.
+    // If requested, let the user know that explicit large pages can't be used.
+    if (use_explicit_large_pages(large) && large_pages_requested()) {
+      log_debug(gc, heap)("Cannot allocate explicit large pages for Java Heap when AllocateHeapAt option is set.");
     }
   }
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -184,7 +184,7 @@ static char* reserve_memory_special(char* requested_address, const size_t size,
            " alignment: " SIZE_FORMAT_HEX,
            p2i(base), alignment);
   } else {
-   if (large_pages_requested()) {
+    if (large_pages_requested()) {
       log_debug(gc, heap, coops)("Reserve regular memory without large pages");
     }
   }

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -63,6 +63,9 @@ class ReservedSpace {
                   char* requested_address,
                   bool executable);
 
+  void reserve(size_t size, size_t alignment, bool large,
+               char* requested_address,
+               bool executable);
  public:
   // Constructor
   ReservedSpace();


### PR DESCRIPTION
Please review this change to unify the reservation code in ReservedSpace. 

**Summary**
The code in `ReservedSpace::initialize(...)` and `ReservedHeapSpace::try_reserve_heap(...)` is very similar and more or less does the same things. The difference between them is logging, what is considered a failure and how that is handled.

This change introduces a new function `ReservedSpace::reserve(...)` that is used by both `initialize(...)` and `try_reserve_heap(...)`. The biggest reason for only having one function handling the reservations is to avoid code duplication and having to change two places when something needs to be updated.

There will be some small changes in what is getting logged in some cases, but the goal is to avoid changing behavior as much as possible. 

Some additional notes to help reviewing:
* There are two reservation helpers:
  `reserve_memory()` for regular pages and file backed mappings.
  `reserve_memory_special()` for explicit large pages.
* In `reserve_memory()` the `is_align()`-check at the end was previously done at the end of `initialize()`. It was moved here because this is the only case where an unaligned address can be returned. For large pages as well as when a requested address is provided, the returned address will be aligned. 
* The support to have a backing file is only used by the heap when `AllocateHeapAt` is set. If this option is used together with `UseLargePages` a debug message is printed since it is up to the backing file system if large pages are used or not. This output has been unified and is now printed when the file is created rather then deep in the reservation code. Previously this message differed depending on if `UseCompressedOops` was enabled or not. Now the same message is printed for both cases.

* The failure checking function `failed_to_reserve_as_requested(...)` now only checks if the memory was allocated at the expected address. Releasing the memory is done by the caller. 

* The size passed into `map_or_reserve_memory_aligned` was previously aligned up using the alignment, but the size should always be aligned already. An assert has been added to the start of the `reserve` function and the `align_up` has been removed.

**Testing**
A lot of local testing as well as tier1-tier5 in Mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265268](https://bugs.openjdk.java.net/browse/JDK-8265268): Unify ReservedSpace reservation code in initialize and try_reserve_heap


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 7e85384d59b93b2556b26f3effbfbfbc779666c1
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 7e85384d59b93b2556b26f3effbfbfbc779666c1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3570/head:pull/3570` \
`$ git checkout pull/3570`

Update a local copy of the PR: \
`$ git checkout pull/3570` \
`$ git pull https://git.openjdk.java.net/jdk pull/3570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3570`

View PR using the GUI difftool: \
`$ git pr show -t 3570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3570.diff">https://git.openjdk.java.net/jdk/pull/3570.diff</a>

</details>
