### PR TITLE
8264569: Remove obsolete error messages from CDSTestUtils.java

### DIFF
--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -40,7 +40,8 @@ public class CDSTestUtils {
         "UseSharedSpaces: Unable to allocate region, range is not within java heap.";
     public static final String MSG_RANGE_ALREADT_IN_USE =
         "Unable to allocate region, java heap range is already in use.";
-
+    public static final String MSG_DYNAMIC_NOT_SUPPORTED =
+        "DynamicDumpSharedSpaces is unsupported when base CDS archive is not loaded";
     public static final boolean DYNAMIC_DUMP = Boolean.getBoolean("test.dynamic.cds.archive");
 
     public interface Checker {
@@ -352,17 +353,8 @@ public class CDSTestUtils {
     // could also improve usability in the field.
     public static boolean isUnableToMap(OutputAnalyzer output) {
         String outStr = output.getOutput();
-        if ((output.getExitValue() == 1) && (
-            outStr.contains("Unable to reserve shared space at required address") ||
-            outStr.contains("Unable to map ReadOnly shared space at required address") ||
-            outStr.contains("Unable to map ReadWrite shared space at required address") ||
-            outStr.contains("Unable to map MiscData shared space at required address") ||
-            outStr.contains("Unable to map MiscCode shared space at required address") ||
-            outStr.contains("Unable to map OptionalData shared space at required address") ||
-            outStr.contains("Could not allocate metaspace at a compatible address") ||
-            outStr.contains("UseSharedSpaces: Unable to allocate region, range is not within java heap") ||
-            outStr.contains("DynamicDumpSharedSpaces is unsupported when base CDS archive is not loaded") ))
-        {
+        if ((output.getExitValue() == 1) &&
+            (outStr.contains(MSG_RANGE_NOT_WITHIN_HEAP) || outStr.contains(MSG_DYNAMIC_NOT_SUPPORTED))) {
             return true;
         }
 


### PR DESCRIPTION
Hi, Please review this simple change to remove check messages which no longer exist in vm output.

Tests: teri1,teir2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264569](https://bugs.openjdk.java.net/browse/JDK-8264569): Remove obsolete error messages from CDSTestUtils.java


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3573/head:pull/3573` \
`$ git checkout pull/3573`

Update a local copy of the PR: \
`$ git checkout pull/3573` \
`$ git pull https://git.openjdk.java.net/jdk pull/3573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3573`

View PR using the GUI difftool: \
`$ git pr show -t 3573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3573.diff">https://git.openjdk.java.net/jdk/pull/3573.diff</a>

</details>
