### PR TITLE
8265017: runtime/HiddenClasses/StressHiddenClasses.java timed out on Win* OCI

### DIFF
--- a/test/hotspot/jtreg/runtime/HiddenClasses/StressHiddenClasses.java
+++ b/test/hotspot/jtreg/runtime/HiddenClasses/StressHiddenClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @requires !vm.graal.enabled
  * @library /test/lib
  * @modules jdk.compiler
- * @run main/othervm StressHiddenClasses
+ * @run main/othervm/timeout=900 StressHiddenClasses
  */
 
 import java.lang.invoke.MethodType;
@@ -62,9 +62,13 @@ public class StressHiddenClasses {
                 }
             };
 
+            if (x % 1000 == 0) {
+                System.out.println("Executing iteration: " + x);
+            }
             parserThread.start();
             parserThread.join(PARSE_TIMEOUT);
 
+            // This code won't get executed as long as PARSE_TIMEOUT == 0.
             if (parserThread.isAlive()) {
                 System.out.println("parser thread may be hung!");
                 StackTraceElement[] stack = parserThread.getStackTrace();


### PR DESCRIPTION
Please review this small test change to try to prevent test StressHiddenClasses,java from timing out.  The change increases the test's timeout and prints some output the could be useful in future timeouts.

The test was run over 1000 times on Windows with this change without any failures.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265017](https://bugs.openjdk.java.net/browse/JDK-8265017): runtime/HiddenClasses/StressHiddenClasses.java timed out on Win* OCI


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3574/head:pull/3574` \
`$ git checkout pull/3574`

Update a local copy of the PR: \
`$ git checkout pull/3574` \
`$ git pull https://git.openjdk.java.net/jdk pull/3574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3574`

View PR using the GUI difftool: \
`$ git pr show -t 3574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3574.diff">https://git.openjdk.java.net/jdk/pull/3574.diff</a>

</details>
