### PR TITLE
8265240: runtime/Thread/SuspendAtExit.java needs updating

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/SuspendAtExit.java
+++ b/test/hotspot/jtreg/runtime/Thread/SuspendAtExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,20 +23,28 @@
 
 /**
  * @test
- * @bug 8167108
- * @summary Stress test java.lang.Thread.suspend() at thread exit.
- * @run main/othervm -Xlog:thread+smr=debug SuspendAtExit
- * @run main/othervm -Xlog:thread+smr=debug -XX:+UnlockDiagnosticVMOptions -XX:GuaranteedSafepointInterval=1 -XX:+HandshakeALot SuspendAtExit
+ * @bug 8167108 8265240
+ * @summary Stress test SuspendThread at thread exit.
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:SuspendAtExit SuspendAtExit
+ * @run main/othervm/native -agentlib:SuspendAtExit -XX:+UnlockDiagnosticVMOptions -XX:GuaranteedSafepointInterval=1 -XX:+HandshakeALot SuspendAtExit
  */
 
 import java.util.concurrent.CountDownLatch;
 
 public class SuspendAtExit extends Thread {
-    final static int N_THREADS = 32;
-    final static int N_LATE_CALLS = 10000;
+    private final static String AGENT_LIB = "SuspendAtExit";
+    private final static int DEF_TIME_MAX = 30;  // default max # secs to test
+    private final static int N_THREADS = 32;
+    private final static int JVMTI_ERROR_THREAD_NOT_ALIVE = 15;
 
     public CountDownLatch exitSyncObj = new CountDownLatch(1);
     public CountDownLatch startSyncObj = new CountDownLatch(1);
+
+    private static void log(String msg) { System.out.println(msg); }
+
+    native static int resumeThread(SuspendAtExit thr);
+    native static int suspendThread(SuspendAtExit thr);
 
     @Override
     public void run() {
@@ -52,59 +60,122 @@ public class SuspendAtExit extends Thread {
     }
 
     public static void main(String[] args) {
-        SuspendAtExit threads[] = new SuspendAtExit[N_THREADS];
+        try {
+            System.loadLibrary(AGENT_LIB);
+            log("Loaded library: " + AGENT_LIB);
+        } catch (UnsatisfiedLinkError ule) {
+            log("Failed to load library: " + AGENT_LIB);
+            log("java.library.path: " + System.getProperty("java.library.path"));
+            throw ule;
+        }
 
-        for (int i = 0; i < N_THREADS; i++ ) {
-            threads[i] = new SuspendAtExit();
-            int late_count = 1;
-            threads[i].start();
+        int timeMax = 0;
+        if (args.length == 0) {
+            timeMax = DEF_TIME_MAX;
+        } else {
             try {
-                // Wait for the worker thread to get going.
-                threads[i].startSyncObj.await();
-
-                // This interrupt() call will break the worker out
-                // of the exitSyncObj.await() call and the suspend()
-                // calls will come in during thread exit.
-                threads[i].interrupt();
-                for (; late_count <= N_LATE_CALLS; late_count++) {
-                    threads[i].suspend();
-
-                    if (!threads[i].isAlive()) {
-                        // Done with Thread.suspend() calls since
-                        // thread is not alive.
-                        break;
-                    }
-                    threads[i].resume();
-                }
-            } catch (InterruptedException e) {
-                throw new Error("Unexpected: " + e);
-            }
-
-            System.out.println("INFO: thread #" + i + ": made " + late_count +
-                               " late calls to java.lang.Thread.suspend()");
-            System.out.println("INFO: thread #" + i + ": N_LATE_CALLS==" +
-                               N_LATE_CALLS + " value is " +
-                               ((late_count >= N_LATE_CALLS) ? "NOT " : "") +
-                               "large enough to cause a Thread.suspend() " +
-                               "call after thread exit.");
-
-            try {
-                threads[i].join();
-            } catch (InterruptedException e) {
-                throw new Error("Unexpected: " + e);
-            }
-            threads[i].suspend();
-            threads[i].resume();
-            if (threads[i].isAlive()) {
-                throw new Error("Expected !Thread.isAlive() after thread #" +
-                                i + " has been join()'ed");
+                timeMax = Integer.parseUnsignedInt(args[0]);
+            } catch (NumberFormatException nfe) {
+                System.err.println("'" + args[0] + "': invalid timeMax value.");
+                    usage();
             }
         }
+
+        System.out.println("About to execute for " + timeMax + " seconds.");
+
+        long count = 0;
+        long start_time = System.currentTimeMillis();
+        while (System.currentTimeMillis() < start_time + (timeMax * 1000)) {
+            count++;
+            SuspendAtExit threads[] = new SuspendAtExit[N_THREADS];
+
+            int retCode;
+            for (int i = 0; i < N_THREADS; i++ ) {
+                threads[i] = new SuspendAtExit();
+                threads[i].start();
+                try {
+                    // Wait for the worker thread to get going.
+                    threads[i].startSyncObj.await();
+
+                    // This interrupt() call will break the worker out of
+                    // the exitSyncObj.await() call and the SuspendThread()
+                    // calls will come in during thread exit.
+                    threads[i].interrupt();
+                    while (true) {
+                        retCode = suspendThread(threads[i]);
+
+                        if (retCode == JVMTI_ERROR_THREAD_NOT_ALIVE) {
+                            // Done with SuspendThread() calls since
+                            // thread is not alive.
+                            break;
+                        } else if (retCode != 0) {
+                            throw new RuntimeException("thread #" + i +
+                                                       ": suspendThread() " +
+                                                       "retCode=" + retCode +
+                                                       ": unexpected value.");
+                        }
+
+                        if (!threads[i].isAlive()) {
+                            throw new RuntimeException("thread #" + i +
+                                                       ": is not alive " +
+                                                       "after successful " +
+                                                       "suspendThread().");
+                        }
+                        retCode = resumeThread(threads[i]);
+                        if (retCode != 0) {
+                            throw new RuntimeException("thread #" + i +
+                                                       ": resumeThread() " +
+                                                       "retCode=" + retCode +
+                                                       ": unexpected value.");
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("Unexpected: " + e);
+                }
+
+                try {
+                    threads[i].join();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("Unexpected: " + e);
+                }
+                retCode = suspendThread(threads[i]);
+                if (retCode != JVMTI_ERROR_THREAD_NOT_ALIVE) {
+                    throw new RuntimeException("thread #" + i +
+                                               ": suspendThread() " +
+                                               "retCode=" + retCode +
+                                               ": unexpected value.");
+                }
+                retCode = resumeThread(threads[i]);
+                if (retCode != JVMTI_ERROR_THREAD_NOT_ALIVE) {
+                    throw new RuntimeException("thread #" + i +
+                                               ": suspendThread() " +
+                                               "retCode=" + retCode +
+                                               ": unexpected value.");
+                }
+                if (threads[i].isAlive()) {
+                    throw new RuntimeException("Expected !Thread.isAlive() " +
+                                               "after thread #" + i +
+                                               " has been join()'ed");
+                }
+            }
+        }
+
+        System.out.println("Executed " + count + " loops in " + timeMax +
+                           " seconds.");
 
         String cmd = System.getProperty("sun.java.command");
         if (cmd != null && !cmd.startsWith("com.sun.javatest.regtest.agent.MainWrapper")) {
             // Exit with success in a non-JavaTest environment:
             System.exit(0);
         }
+    }
+
+    public static void usage() {
+        System.err.println("Usage: " + AGENT_LIB + " [time_max]");
+        System.err.println("where:");
+        System.err.println("    time_max ::= max looping time in seconds");
+        System.err.println("                 (default is " + DEF_TIME_MAX +
+                           " seconds)");
+        System.exit(1);
     }
 }

--- a/test/hotspot/jtreg/runtime/Thread/SuspendAtExit.java
+++ b/test/hotspot/jtreg/runtime/Thread/SuspendAtExit.java
@@ -35,7 +35,6 @@ import java.util.concurrent.CountDownLatch;
 public class SuspendAtExit extends Thread {
     private final static String AGENT_LIB = "SuspendAtExit";
     private final static int DEF_TIME_MAX = 30;  // default max # secs to test
-    private final static int N_THREADS = 32;
     private final static int JVMTI_ERROR_THREAD_NOT_ALIVE = 15;
 
     public CountDownLatch exitSyncObj = new CountDownLatch(1);

--- a/test/hotspot/jtreg/runtime/Thread/libSuspendAtExit.cpp
+++ b/test/hotspot/jtreg/runtime/Thread/libSuspendAtExit.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jvmti.h"
+
+extern "C" {
+
+static jvmtiEnv* jvmti = NULL;
+
+#define LOG(...) \
+  do { \
+    printf(__VA_ARGS__); \
+    printf("\n"); \
+    fflush(stdout); \
+  } while (0)
+
+JNIEXPORT jint JNICALL
+Java_SuspendAtExit_suspendThread(JNIEnv *jni, jclass cls, jthread thr) {
+  return jvmti->SuspendThread(thr);
+}
+
+JNIEXPORT jint JNICALL
+Java_SuspendAtExit_resumeThread(JNIEnv *jni, jclass cls, jthread thr) {
+  return jvmti->ResumeThread(thr);
+}
+
+
+/** Agent library initialization. */
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  LOG("\nAgent_OnLoad started");
+
+  // create JVMTI environment
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+
+  // add specific capabilities for suspending thread
+  jvmtiCapabilities suspendCaps;
+  memset(&suspendCaps, 0, sizeof(suspendCaps));
+  suspendCaps.can_suspend = 1;
+
+  jvmtiError err = jvmti->AddCapabilities(&suspendCaps);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+  LOG("Agent_OnLoad finished\n");
+  return JNI_OK;
+}
+
+}


### PR DESCRIPTION
I'm updating the runtime/Thread/SuspendAtExit.java test:

- switch from java.lang.Thread.suspend() to JVM/TI SuspendThread()
- switch from java.lang.Thread.resume() to JVM/TI ResumeThread()
- switch from counter-based to time-based testing
- improve error checking since we're now using an API with error codes!

I've used this test to stress @robehn's fix for JDK-8257831 using both
invocation styles for 9 hours each in {fastdebug, release, slowdebug}
configs without any issues.

I've run the updated test thru Mach5 Tier[134567] testing; one timeout
was observed in a single Tier6 run on Win-X64. I believe this is a case of
a lost Thread.interrupt() call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265240](https://bugs.openjdk.java.net/browse/JDK-8265240): runtime/Thread/SuspendAtExit.java needs updating


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to 8235e5f241aca96ef43e9cf9c8b499df65f9c0b3
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3576/head:pull/3576` \
`$ git checkout pull/3576`

Update a local copy of the PR: \
`$ git checkout pull/3576` \
`$ git pull https://git.openjdk.java.net/jdk pull/3576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3576`

View PR using the GUI difftool: \
`$ git pr show -t 3576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3576.diff">https://git.openjdk.java.net/jdk/pull/3576.diff</a>

</details>
