### PR TITLE
8199594: Add doc describing how (?x) ignores spaces in character classes

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -820,6 +820,10 @@ public final class Pattern
      *
      * <p> Comments mode can also be enabled via the embedded flag
      * expression&nbsp;{@code (?x)}.
+     *
+     * <p> Note that comments mode ignores whitespace within a character class
+     * contained in a pattern string. Such whitespace needs to be escaped
+     * in order to be treated as if comments mode were not enabled. </p>
      */
     public static final int COMMENTS = 0x04;
 

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -755,6 +755,12 @@ import jdk.internal.util.ArraysSupport;
  *    within a group; in the latter case, flags are restored at the end of the
  *    group just as in Perl.  </p></li>
  *
+ *    <li><p> In Perl, <i>free-spacing mode</i> (<i>comments mode</i> in this
+ *    class) denoted by {@code (?x)} will not ignore whitespace inside of
+ *    character classes. In this class, whitespace inside of character classes
+ *    must be escaped to be considered as part of the regular expression when in
+ *    comments mode.  </p></li>
+ *
  * </ul>
  *
  *

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -755,11 +755,11 @@ import jdk.internal.util.ArraysSupport;
  *    within a group; in the latter case, flags are restored at the end of the
  *    group just as in Perl.  </p></li>
  *
- *    <li><p> In Perl, <i>free-spacing mode</i> (<i>comments mode</i> in this
- *    class) denoted by {@code (?x)} will not ignore whitespace inside of
- *    character classes. In this class, whitespace inside of character classes
- *    must be escaped to be considered as part of the regular expression when in
- *    comments mode.  </p></li>
+ *    <li><p> In Perl, <i>free-spacing mode</i> (which is called <i>comments
+ *    mode</i> in this class) denoted by {@code (?x)} will not ignore whitespace
+ *    inside of character classes. In this class, whitespace inside of character
+ *    classes must be escaped to be considered as part of the regular expression
+ *    when in comments mode.  </p></li>
  *
  * </ul>
  *
@@ -822,14 +822,13 @@ public final class Pattern
      * Permits whitespace and comments in pattern.
      *
      * <p> In this mode, whitespace is ignored, and embedded comments starting
-     * with {@code #} are ignored until the end of a line.
+     * with {@code #} are ignored until the end of a line. Comments mode ignores
+     * whitespace within a character class contained in a pattern string. Such
+     * whitespace must be escaped in order to be considered significant.  </p>
      *
      * <p> Comments mode can also be enabled via the embedded flag
      * expression&nbsp;{@code (?x)}.
      *
-     * <p> Note that comments mode ignores whitespace within a character class
-     * contained in a pattern string. Such whitespace needs to be escaped
-     * in order to be treated as if comments mode were not enabled. </p>
      */
     public static final int COMMENTS = 0x04;
 


### PR DESCRIPTION
Clarifying note on comments mode to explicitly note that whitespace within character classes is ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8199594](https://bugs.openjdk.java.net/browse/JDK-8199594): Add doc describing how (?x) ignores spaces in character classes


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 8ab051aa9ecd67fffbb0ebdc842a7d124b3e3193


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3577/head:pull/3577` \
`$ git checkout pull/3577`

Update a local copy of the PR: \
`$ git checkout pull/3577` \
`$ git pull https://git.openjdk.java.net/jdk pull/3577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3577`

View PR using the GUI difftool: \
`$ git pr show -t 3577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3577.diff">https://git.openjdk.java.net/jdk/pull/3577.diff</a>

</details>
