### PR TITLE
8265486: ProblemList javax/sound/midi/Sequencer/Recording.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -721,7 +721,7 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
-javax/sound/midi/Sequencer/Recording.java 8167580 linux-all
+javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
 javax/sound/midi/Sequencer/MetaCallback.java 8178698 linux-all
 
 ############################################################################


### PR DESCRIPTION
The javax/sound/midi/Sequencer/Recording.java (tier3) test fails intermittently on macosx-aarch64. Let's problem list it for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265486](https://bugs.openjdk.java.net/browse/JDK-8265486): ProblemList javax/sound/midi/Sequencer/Recording.java on macosx-aarch64


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3579/head:pull/3579` \
`$ git checkout pull/3579`

Update a local copy of the PR: \
`$ git checkout pull/3579` \
`$ git pull https://git.openjdk.java.net/jdk pull/3579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3579`

View PR using the GUI difftool: \
`$ git pr show -t 3579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3579.diff">https://git.openjdk.java.net/jdk/pull/3579.diff</a>

</details>
