### PR TITLE
8265491: Math Signum optimization for x86

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1061,8 +1061,8 @@ void C2_MacroAssembler::signum_fp(int opcode, XMMRegister dst,
     ucomisd(dst, zero);
   }
 
-  jcc(Assembler::equal, DONE_LABEL);
-  jcc(Assembler::parity, DONE_LABEL);
+  jcc(Assembler::equal, DONE_LABEL);    // handle special case +0.0/-0.0, if argument is +0.0/-0.0, return argument
+  jcc(Assembler::parity, DONE_LABEL);   // handle special case NaN, if argument NaN, return NaN
 
   if (opcode == Op_SignumF){
     movflt(dst, one);
@@ -1073,9 +1073,9 @@ void C2_MacroAssembler::signum_fp(int opcode, XMMRegister dst,
   jcc(Assembler::above, DONE_LABEL);
 
   if (opcode == Op_SignumF){
-    xorps(dst, ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), scratch);
+    xorps(dst, ExternalAddress(StubRoutines::x86::float_sign_flip()), scratch);
   } else if (opcode == Op_SignumD){
-    xorpd(dst, ExternalAddress(StubRoutines::x86::vector_double_sign_flip()), scratch);
+    xorpd(dst, ExternalAddress(StubRoutines::x86::double_sign_flip()), scratch);
   }
 
   bind(DONE_LABEL);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1053,28 +1053,21 @@ void C2_MacroAssembler::signum_fp(int opcode, XMMRegister dst,
 
   Label DONE_LABEL;
 
-  if (opcode == Op_SignumF){
+  if (opcode == Op_SignumF) {
     assert(UseSSE > 0, "required");
     ucomiss(dst, zero);
-  } else if (opcode == Op_SignumD){
+    jcc(Assembler::equal, DONE_LABEL);    // handle special case +0.0/-0.0, if argument is +0.0/-0.0, return argument
+    jcc(Assembler::parity, DONE_LABEL);   // handle special case NaN, if argument NaN, return NaN
+    movflt(dst, one);
+    jcc(Assembler::above, DONE_LABEL);
+    xorps(dst, ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), scratch);
+  } else if (opcode == Op_SignumD) {
     assert(UseSSE > 1, "required");
     ucomisd(dst, zero);
-  }
-
-  jcc(Assembler::equal, DONE_LABEL);    // handle special case +0.0/-0.0, if argument is +0.0/-0.0, return argument
-  jcc(Assembler::parity, DONE_LABEL);   // handle special case NaN, if argument NaN, return NaN
-
-  if (opcode == Op_SignumF){
-    movflt(dst, one);
-  } else if (opcode == Op_SignumD){
+    jcc(Assembler::equal, DONE_LABEL);    // handle special case +0.0/-0.0, if argument is +0.0/-0.0, return argument
+    jcc(Assembler::parity, DONE_LABEL);   // handle special case NaN, if argument NaN, return NaN
     movdbl(dst, one);
-  }
-
-  jcc(Assembler::above, DONE_LABEL);
-
-  if (opcode == Op_SignumF){
-    xorps(dst, ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), scratch);
-  } else if (opcode == Op_SignumD){
+    jcc(Assembler::above, DONE_LABEL);
     xorpd(dst, ExternalAddress(StubRoutines::x86::vector_double_sign_flip()), scratch);
   }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -34,33 +34,6 @@
 #include "runtime/objectMonitor.hpp"
 #include "runtime/stubRoutines.hpp"
 
-// Note: 'double' and 'long long' have 32-bits alignment on x86.
-static jlong* double_quadword(jlong *adr, jlong lo, jlong hi) {
-  // Use the expression (adr)&(~0xF) to provide 128-bits aligned address
-  // of 128-bits operands for SSE instructions.
-  jlong *operand = (jlong*)(((uintptr_t)adr)&((uintptr_t)(~0xF)));
-  // Store the value to a 128-bits operand.
-  operand[0] = lo;
-  operand[1] = hi;
-  return operand;
-}
-
-// Buffer for 128-bits masks used by SSE instructions.
-static jlong fp_signmask_pool[(4+1)*2]; // 4*128bits(data) + 128bits(alignment)
-
-// Static initialization during VM startup.
-static jlong *float_signflip_pool  = double_quadword(&fp_signmask_pool[3*2], CONST64(0x8000000080000000), CONST64(0x8000000080000000));
-static jlong *double_signflip_pool = double_quadword(&fp_signmask_pool[4*2], CONST64(0x8000000000000000), CONST64(0x8000000000000000));
-
-  // Float masks come from different places depending on platform.
-#ifdef _LP64
-  static address float_signflip()  { return StubRoutines::x86::float_sign_flip(); }
-  static address double_signflip() { return StubRoutines::x86::double_sign_flip(); }
-#else
-  static address float_signflip()  { return (address)float_signflip_pool; }
-  static address double_signflip() { return (address)double_signflip_pool; }
-#endif
-
 inline Assembler::AvxVectorLen C2_MacroAssembler::vector_length_encoding(int vlen_in_bytes) {
   switch (vlen_in_bytes) {
     case  4: // fall-through
@@ -1100,9 +1073,9 @@ void C2_MacroAssembler::signum_fp(int opcode, XMMRegister dst,
   jcc(Assembler::above, DONE_LABEL);
 
   if (opcode == Op_SignumF){
-    xorps(dst, ExternalAddress(float_signflip()), scratch);
+    xorps(dst, ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), scratch);
   } else if (opcode == Op_SignumD){
-    xorpd(dst, ExternalAddress(double_signflip()), scratch);
+    xorpd(dst, ExternalAddress(StubRoutines::x86::vector_double_sign_flip()), scratch);
   }
 
   bind(DONE_LABEL);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -89,6 +89,10 @@ public:
                    KRegister ktmp, XMMRegister atmp, XMMRegister btmp,
                    int vlen_enc);
 
+  void signum_fp(int opcode, XMMRegister dst,
+                 XMMRegister zero, XMMRegister one,
+                 Register scratch);
+
   void vextendbw(bool sign, XMMRegister dst, XMMRegister src, int vector_len);
   void vextendbw(bool sign, XMMRegister dst, XMMRegister src);
   void vextendbd(bool sign, XMMRegister dst, XMMRegister src, int vector_len);

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1700,6 +1700,9 @@ void VM_Version::get_processor_features() {
     }
   }
 #endif // !PRODUCT
+  if (FLAG_IS_DEFAULT(UseSignumIntrinsic) && (UseSSE >= 2)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+  }
 }
 
 void VM_Version::print_platform_virtualization_info(outputStream* st) {

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1700,7 +1700,7 @@ void VM_Version::get_processor_features() {
     }
   }
 #endif // !PRODUCT
-  if (FLAG_IS_DEFAULT(UseSignumIntrinsic) && (UseSSE >= 2)) {
+  if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
       FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
   }
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5775,6 +5775,46 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
   ins_pipe( pipe_slow );
 %}
 
+// --------------------------------- Signum ---------------------------
+
+instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
+  match(Set dst (SignumF dst (Binary zero one)));
+  effect(KILL cr);
+  format %{ "signumF $dst, $dst" %}
+  ins_encode %{
+    Label exit;
+
+    __ ucomiss($dst$$XMMRegister, $zero$$XMMRegister);
+    __ jcc(Assembler::parity, exit);
+    __ jcc(Assembler::equal, exit);
+    __ movflt($dst$$XMMRegister, $one$$XMMRegister);
+    __ jcc(Assembler::above, exit);
+    __ movflt($dst$$XMMRegister, $zero$$XMMRegister);
+    __ subss($dst$$XMMRegister, $one$$XMMRegister);
+    __ bind(exit);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
+  match(Set dst (SignumD dst (Binary zero one)));
+  effect(KILL cr);
+  format %{ "signumD $dst, $dst" %}
+  ins_encode %{
+    Label exit;
+
+    __ ucomisd($dst$$XMMRegister, $zero$$XMMRegister);
+    __ jcc(Assembler::parity, exit);
+    __ jcc(Assembler::equal, exit);
+    __ movdbl($dst$$XMMRegister, $one$$XMMRegister);
+    __ jcc(Assembler::above, exit);
+    __ movdbl($dst$$XMMRegister, $zero$$XMMRegister);
+    __ subsd($dst$$XMMRegister, $one$$XMMRegister);
+    __ bind(exit);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // --------------------------------- Sqrt --------------------------------------
 
 instruct vsqrtF_reg(vec dst, vec src) %{

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5778,7 +5778,7 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
 // --------------------------------- Signum ---------------------------
 
 instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
-  predicate(UseSSE>=1)
+  predicate(UseSSE>=1);
   match(Set dst (SignumF dst (Binary zero one)));
   effect(KILL cr);
   format %{ "signumF $dst, $dst" %}
@@ -5798,7 +5798,7 @@ instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
 %}
 
 instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
-  predicate(UseSSE>=2)
+  predicate(UseSSE>=2);
   match(Set dst (SignumD dst (Binary zero one)));
   effect(KILL cr);
   format %{ "signumD $dst, $dst" %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5793,15 +5793,8 @@ instruct signumF_reg(regF dst, regF zero, regF one, rRegP scratch, rFlagsReg cr)
   effect(TEMP scratch, KILL cr);
   format %{ "signumF $dst, $dst\t! using $scratch as TEMP" %}
   ins_encode %{
-    Label exit;
-
-    __ ucomiss($dst$$XMMRegister, $zero$$XMMRegister);
-    __ jcc(Assembler::equal, exit);
-    __ jcc(Assembler::parity, exit);
-    __ movflt($dst$$XMMRegister, $one$$XMMRegister);
-    __ jcc(Assembler::above, exit);
-    __ xorps($dst$$XMMRegister, ExternalAddress(float_signflip()), $scratch$$Register);
-    __ bind(exit);
+    int opcode = this->ideal_Opcode();
+    __ signum_fp(opcode, $dst$$XMMRegister, $zero$$XMMRegister, $one$$XMMRegister, $scratch$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -5812,15 +5805,8 @@ instruct signumD_reg(regD dst, regD zero, regD one, rRegP scratch, rFlagsReg cr)
   effect(TEMP scratch, KILL cr);
   format %{ "signumD $dst, $dst\t! using $scratch as TEMP" %}
   ins_encode %{
-    Label exit;
-
-    __ ucomisd($dst$$XMMRegister, $zero$$XMMRegister);
-    __ jcc(Assembler::equal, exit);
-    __ jcc(Assembler::parity, exit);
-    __ movdbl($dst$$XMMRegister, $one$$XMMRegister);
-    __ jcc(Assembler::above, exit);
-    __ xorpd($dst$$XMMRegister, ExternalAddress(double_signflip()), $scratch$$Register);
-    __ bind(exit);
+    int opcode = this->ideal_Opcode();
+    __ signum_fp(opcode, $dst$$XMMRegister, $zero$$XMMRegister, $one$$XMMRegister, $scratch$$Register);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1599,6 +1599,16 @@ const bool Matcher::match_rule_supported(int opcode) {
       }
       break;
 #endif // !LP64
+    case Op_SignumF:
+      if (UseSSE < 1) {
+        return false;
+      }
+      break;
+    case Op_SignumD:
+      if (UseSSE < 2) {
+        return false;
+      }
+      break;
   }
   return true;  // Match rules are supported by default.
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5778,6 +5778,7 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
 // --------------------------------- Signum ---------------------------
 
 instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
+  predicate(UseSSE>=1)
   match(Set dst (SignumF dst (Binary zero one)));
   effect(KILL cr);
   format %{ "signumF $dst, $dst" %}
@@ -5797,6 +5798,7 @@ instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
 %}
 
 instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
+  predicate(UseSSE>=2)
   match(Set dst (SignumD dst (Binary zero one)));
   effect(KILL cr);
   format %{ "signumD $dst, $dst" %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5777,11 +5777,11 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
 
 // --------------------------------- Signum ---------------------------
 
-instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
+instruct signumF_reg(regF dst, regF zero, regF one, rRegP scratch, rFlagsReg cr) %{
   predicate(UseSSE>=1);
   match(Set dst (SignumF dst (Binary zero one)));
-  effect(KILL cr);
-  format %{ "signumF $dst, $dst" %}
+  effect(TEMP scratch, KILL cr);
+  format %{ "signumF $dst, $dst\t! using $scratch as TEMP" %}
   ins_encode %{
     Label exit;
 
@@ -5790,17 +5790,17 @@ instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
     __ jcc(Assembler::parity, exit);
     __ movflt($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
-    __ xorps($dst$$XMMRegister, ExternalAddress(float_signflip()));
+    __ xorps($dst$$XMMRegister, ExternalAddress(float_signflip()), $scratch$$Register);
     __ bind(exit);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
+instruct signumD_reg(regD dst, regD zero, regD one, rRegP scratch, rFlagsReg cr) %{
   predicate(UseSSE>=2);
   match(Set dst (SignumD dst (Binary zero one)));
-  effect(KILL cr);
-  format %{ "signumD $dst, $dst" %}
+  effect(TEMP scratch, KILL cr);
+  format %{ "signumD $dst, $dst\t! using $scratch as TEMP" %}
   ins_encode %{
     Label exit;
 
@@ -5809,7 +5809,7 @@ instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
     __ jcc(Assembler::parity, exit);
     __ movdbl($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
-    __ xorpd($dst$$XMMRegister, ExternalAddress(double_signflip()));
+    __ xorpd($dst$$XMMRegister, ExternalAddress(double_signflip()), $scratch$$Register);
     __ bind(exit);
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5790,8 +5790,7 @@ instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
     __ jcc(Assembler::equal, exit);
     __ movflt($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
-    __ movflt($dst$$XMMRegister, $zero$$XMMRegister);
-    __ subss($dst$$XMMRegister, $one$$XMMRegister);
+    __ xorps($dst$$XMMRegister, ExternalAddress(float_signflip()));
     __ bind(exit);
   %}
   ins_pipe( pipe_slow );
@@ -5810,8 +5809,7 @@ instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
     __ jcc(Assembler::equal, exit);
     __ movdbl($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
-    __ movdbl($dst$$XMMRegister, $zero$$XMMRegister);
-    __ subsd($dst$$XMMRegister, $one$$XMMRegister);
+    __ xorpd($dst$$XMMRegister, ExternalAddress(double_signflip()));
     __ bind(exit);
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5786,8 +5786,8 @@ instruct signumF_reg(regF dst, regF zero, regF one, rFlagsReg cr) %{
     Label exit;
 
     __ ucomiss($dst$$XMMRegister, $zero$$XMMRegister);
-    __ jcc(Assembler::parity, exit);
     __ jcc(Assembler::equal, exit);
+    __ jcc(Assembler::parity, exit);
     __ movflt($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
     __ xorps($dst$$XMMRegister, ExternalAddress(float_signflip()));
@@ -5805,8 +5805,8 @@ instruct signumD_reg(regD dst, regD zero, regD one, rFlagsReg cr) %{
     Label exit;
 
     __ ucomisd($dst$$XMMRegister, $zero$$XMMRegister);
-    __ jcc(Assembler::parity, exit);
     __ jcc(Assembler::equal, exit);
+    __ jcc(Assembler::parity, exit);
     __ movdbl($dst$$XMMRegister, $one$$XMMRegister);
     __ jcc(Assembler::above, exit);
     __ xorpd($dst$$XMMRegister, ExternalAddress(double_signflip()));

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5788,7 +5788,6 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
 // --------------------------------- Signum ---------------------------
 
 instruct signumF_reg(regF dst, regF zero, regF one, rRegP scratch, rFlagsReg cr) %{
-  predicate(UseSSE>=1);
   match(Set dst (SignumF dst (Binary zero one)));
   effect(TEMP scratch, KILL cr);
   format %{ "signumF $dst, $dst\t! using $scratch as TEMP" %}
@@ -5800,7 +5799,6 @@ instruct signumF_reg(regF dst, regF zero, regF one, rRegP scratch, rFlagsReg cr)
 %}
 
 instruct signumD_reg(regD dst, regD zero, regD one, rRegP scratch, rFlagsReg cr) %{
-  predicate(UseSSE>=2);
   match(Set dst (SignumD dst (Binary zero one)));
   effect(TEMP scratch, KILL cr);
   format %{ "signumD $dst, $dst\t! using $scratch as TEMP" %}

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1690,8 +1690,8 @@ bool LibraryCallKit::inline_math_native(vmIntrinsics::ID id) {
 
   case vmIntrinsics::_dcopySign: return inline_double_math(id);
   case vmIntrinsics::_fcopySign: return inline_math(id);
-  case vmIntrinsics::_dsignum: return inline_double_math(id);
-  case vmIntrinsics::_fsignum: return inline_math(id);
+  case vmIntrinsics::_dsignum: return Matcher::match_rule_supported(Op_SignumD) ? inline_double_math(id) : false;
+  case vmIntrinsics::_fsignum: return Matcher::match_rule_supported(Op_SignumF) ? inline_math(id) : false;
 
    // These intrinsics are not yet correctly implemented
   case vmIntrinsics::_datan2:

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test compiler intrinsics for signum
- * @requires os.arch=="aarch64" | os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="aarch64" | os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib
  *
  * @run main/othervm

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test compiler intrinsics for signum
- * @requires os.arch=="aarch64"
+ * @requires os.arch=="aarch64" | os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib
  *
  * @run main/othervm
@@ -100,7 +100,7 @@ public class TestSignumIntrinsic {
             float arg = fcase[0];
             float expected = fcase[1];
             float calculated = Math.signum(arg);
-            Asserts.assertEQ(expected, calculated, "Unexpected float result");
+            Asserts.assertEQ(expected, calculated, "Unexpected float result from " + arg);
             accum += calculated;
         }
         return accum;
@@ -112,7 +112,7 @@ public class TestSignumIntrinsic {
             double arg = dcase[0];
             double expected = dcase[1];
             double calculated = Math.signum(arg);
-            Asserts.assertEQ(expected, calculated, "Unexpected double result");
+            Asserts.assertEQ(expected, calculated, "Unexpected double result from " + arg);
             accum += calculated;
         }
         return accum;

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
@@ -25,7 +25,6 @@
 /*
  * @test
  * @summary Test compiler intrinsics for signum
- * @requires os.arch=="aarch64" | os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib
  *
  * @run main/othervm

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestSignumIntrinsic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/micro/org/openjdk/bench/vm/compiler/Signum.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/Signum.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Intel, 2021 All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class Signum {
+
+    private final int ITERATIONS = 15000;
+
+    private double doubleValue = 1D;
+    private float floatValue = 1F;
+
+    private static final float[] float_values = {
+        123.4f,
+        -56.7f,
+        7e30f,
+        -0.3e30f,
+        Float.MAX_VALUE,
+        -Float.MAX_VALUE,
+        Float.MIN_VALUE,
+        -Float.MIN_VALUE,
+        0.0f,
+        -0.0f,
+        Float.POSITIVE_INFINITY,
+        Float.NEGATIVE_INFINITY,
+        Float.NaN,
+        Float.MIN_NORMAL,
+        -Float.MIN_NORMAL,
+        0x0.0002P-126f,
+        -0x0.0002P-126f
+    };
+
+    private static final double[] double_values = {
+        123.4d,
+        -56.7d,
+        7e30d,
+        -0.3e30d,
+        Double.MAX_VALUE,
+        -Double.MAX_VALUE,
+        Double.MIN_VALUE,
+        -Double.MIN_VALUE,
+        0.0d,
+        -0.0d,
+        Double.POSITIVE_INFINITY,
+        Double.NEGATIVE_INFINITY,
+        Double.NaN,
+        Double.MIN_NORMAL,
+        -Double.MIN_NORMAL,
+        0x0.00000001P-1022,
+        -0x0.00000001P-1022,
+    };
+
+    private static double Signum_Kernel(double data)
+    {
+        return Math.signum(data);
+    }
+
+    private static float Signum_Kernel(float data)
+    {
+        return Math.signum(data);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS * 17)
+    public void _1_signumFloatTest(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            for (float f : float_values) {
+                bh.consume(Signum_Kernel(f));
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS * 17)
+    public void _2_overheadFloat(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            for (float f : float_values) {
+                bh.consume(f);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS * 17)
+    public void _3_signumDoubleTest(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            for (double d : double_values) {
+                bh.consume(Signum_Kernel(d));
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS * 17)
+    public void _4_overheadDouble(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            for (double d : double_values) {
+                bh.consume(d);
+            }
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/Signum.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/Signum.java
@@ -31,7 +31,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;


### PR DESCRIPTION
x86 Math.Signum() uses two floating point compares and a copy sign operation involving data movement to gpr and XMM.

We can optimize to one floating point compare and sign computation in XMM. We observe ~25% performance improvement with this optimization.

Base:
```
Benchmark                       Mode Cnt Score Error Units
Signum._1_signumFloatTest avgt 5 4.660 ? 0.040 ns/op
Signum._2_overheadFloat avgt 5 3.314 ? 0.023 ns/op
Signum._3_signumDoubleTest avgt 5 4.809 ? 0.043 ns/op
Signum._4_overheadDouble avgt 5 3.313 ? 0.015 ns/op
```
 
Optimized:
signum intrinsic patch
```
Benchmark                       Mode  Cnt  Score   Error  Units
Signum._1_signumFloatTest       avgt    5  3.769 ? 0.015  ns/op
Signum._2_overheadFloat         avgt    5  3.312 ? 0.025  ns/op
Signum._3_signumDoubleTest      avgt    5  3.765 ? 0.005  ns/op
Signum._4_overheadDouble        avgt    5  3.309 ? 0.010  ns/op
```

Signed-off-by: Marcus G K Williams <marcus.williams@intel.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265491](https://bugs.openjdk.java.net/browse/JDK-8265491): Math Signum optimization for x86


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Jatin Bhateja](https://openjdk.java.net/census#jbhateja) (@jatin-bhateja - Committer)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3581/head:pull/3581` \
`$ git checkout pull/3581`

Update a local copy of the PR: \
`$ git checkout pull/3581` \
`$ git pull https://git.openjdk.java.net/jdk pull/3581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3581`

View PR using the GUI difftool: \
`$ git pr show -t 3581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3581.diff">https://git.openjdk.java.net/jdk/pull/3581.diff</a>

</details>
