### PR TITLE
8265505: findsym does not work on remote debug server

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -599,32 +599,8 @@ public class CommandProcessor {
                 if (t.countTokens() != 1) {
                     usage();
                 } else {
-                    String symbol = t.nextToken();
-                    Address addr = VM.getVM().getDebugger().lookup(null, symbol);
-                    if (addr == null && VM.getVM().getDebugger().getOS().equals("win32")) {
-                        // On win32 symbols are prefixed with the dll name. Do the user
-                        // a favor and see if this is a symbol in jvm.dll or java.dll.
-                        addr = VM.getVM().getDebugger().lookup(null, "jvm!" + symbol);
-                        if (addr == null) {
-                            addr = VM.getVM().getDebugger().lookup(null, "java!" + symbol);
-                        }
-                    }
-                    if (addr == null) {
-                        out.println("Symbol not found");
-                        return;
-                    }
-                    out.print(addr);  // Print the address of the symbol.
-                    CDebugger cdbg = VM.getVM().getDebugger().getCDebugger();
-                    LoadObject loadObject = cdbg.loadObjectContainingPC(addr);
-                    // Print the shared library path and the offset of the symbol.
-                    if (loadObject != null) {
-                        out.print(": " + loadObject.getName());
-                        long diff = addr.minus(loadObject.getBase());
-                        if (diff != 0L) {
-                            out.print(" + 0x" + Long.toHexString(diff));
-                        }
-                    }
-                    out.println();
+                    String result = VM.getVM().getDebugger().findSymbol(t.nextToken());
+                    out.println(result == null ? "Symbol not found" : result);
                 }
             }
         },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -47,8 +47,6 @@ import sun.jvm.hotspot.ci.ciEnv;
 import sun.jvm.hotspot.code.CodeBlob;
 import sun.jvm.hotspot.code.CodeCacheVisitor;
 import sun.jvm.hotspot.code.NMethod;
-import sun.jvm.hotspot.debugger.cdbg.CDebugger;
-import sun.jvm.hotspot.debugger.cdbg.LoadObject;
 import sun.jvm.hotspot.debugger.Address;
 import sun.jvm.hotspot.debugger.OopHandle;
 import sun.jvm.hotspot.classfile.ClassLoaderDataGraph;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,11 @@ public interface Debugger extends SymbolLookup, ThreadAccess {
       interface, returns a CDebugger object; otherwise returns
       null. */
   public CDebugger getCDebugger() throws DebuggerException;
+
+  /**
+   * Find address and executable which contains symbol.
+  */
+  public String findSymbol(String symbol);
 
   /** the following methods are intended only for RemoteDebuggerClient */
   public long getJBooleanSize();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/Debugger.java
@@ -111,7 +111,7 @@ public interface Debugger extends SymbolLookup, ThreadAccess {
 
   /**
    * Find address and executable which contains symbol.
-  */
+   */
   public String findSymbol(String symbol);
 
   /** the following methods are intended only for RemoteDebuggerClient */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerClient.java
@@ -423,4 +423,9 @@ public class RemoteDebuggerClient extends DebuggerBase implements JVMDebugger {
       throw new DebuggerException(e);
     }
   }
+
+  @Override
+  public String findSymbol(String symbol) {
+    return execCommandOnServer("findsym", Map.of("symbol", symbol));
+  }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerServer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/remote/RemoteDebuggerServer.java
@@ -181,20 +181,23 @@ public class RemoteDebuggerServer extends UnicastRemoteObject
 
   @Override
   public String execCommandOnServer(String command, Map<String, Object> options) throws RemoteException {
-    ByteArrayOutputStream bout = new ByteArrayOutputStream();
-    try (var out = new PrintStream(bout)) {
-      if (command.equals("pmap")) {
-        (new PMap(debugger)).run(out, debugger);
-      } else if (command.equals("pstack")) {
-        PStack pstack = new PStack(debugger);
-        pstack.setVerbose(false);
-        pstack.setConcurrentLocks((boolean)options.get("concurrentLocks"));
-        pstack.run(out, debugger);
-      } else {
-        throw new DebuggerException(command + " is not supported in this debugger");
+    if (command.equals("findsym")) {
+      return debugger.findSymbol((String)options.get("symbol"));
+    } else {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      try (var out = new PrintStream(bout)) {
+        if (command.equals("pmap")) {
+          (new PMap(debugger)).run(out, debugger);
+        } else if (command.equals("pstack")) {
+          PStack pstack = new PStack(debugger);
+          pstack.setVerbose(false);
+          pstack.setConcurrentLocks((boolean)options.get("concurrentLocks"));
+          pstack.run(out, debugger);
+        } else {
+          throw new DebuggerException(command + " is not supported in this debugger");
+        }
       }
+      return bout.toString();
     }
-
-    return bout.toString();
   }
 }

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.PrintStream;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
+
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8265505
+ * @summary Test clhsdb command which should be run on debugd server
+ * @requires vm.hasSA
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm RunCommandOnServerTest
+ */
+
+public class RunCommandOnServerTest {
+
+    public static void main(String[] args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+        SATestUtils.validateSADebugDPrivileges();
+
+        LingeredApp theApp = null;
+        DebugdUtils debugd = null;
+        try {
+            theApp = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+            debugd = new DebugdUtils(null);
+            debugd.attach(theApp.getPid());
+
+            JDKToolLauncher jhsdbLauncher = JDKToolLauncher.createUsingTestJDK("jhsdb");
+            jhsdbLauncher.addToolArg("clhsdb");
+            jhsdbLauncher.addToolArg("--connect");
+            jhsdbLauncher.addToolArg("localhost");
+
+            Process jhsdb = (SATestUtils.createProcessBuilder(jhsdbLauncher)).start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            try (PrintStream console = new PrintStream(jhsdb.getOutputStream(), true)) {
+                console.println("echo true");
+                console.println("verbose true");
+                console.println("findsym gHotSpotVMTypes");
+                console.println("quit");
+            }
+
+            jhsdb.waitFor();
+            System.out.println(out.getStdout());
+            System.err.println(out.getStderr());
+
+            out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+            out.shouldMatch("^0x[0-9a-f]+: .+/libjvm\\.(so|dylib) \\+ 0x[0-9a-f]+$");
+            out.shouldHaveExitValue(0);
+
+            // This will detect most SA failures, including during the attach.
+            out.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
+            // This will detect unexpected exceptions, like NPEs and asserts, that are caught
+            // by sun.jvm.hotspot.CommandProcessor.
+            out.shouldNotMatch("^Error: .*$");
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            if (debugd != null) {
+                debugd.detach();
+            }
+            LingeredApp.stopApp(theApp);
+        }
+        System.out.println("Test PASSED");
+    }
+}


### PR DESCRIPTION
We can see following error when we run `findsym` on CLHSDB which connects to remote debug server.

```
hsdb> verbose true
hsdb> findsym gHotSpotVMTypes
0x00007f913d4a45b0Error: java.lang.NullPointerException: Cannot invoke "sun.jvm.hotspot.debugger.cdbg.CDebugger.loadObjectContainingPC(sun.jvm.hotspot.debugger.Address)" because "cdbg" is null
java.lang.NullPointerException: Cannot invoke "sun.jvm.hotspot.debugger.cdbg.CDebugger.loadObjectContainingPC(sun.jvm.hotspot.debugger.Address)" because "cdbg" is null
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$7.doit(CommandProcessor.java:618)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2116)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2086)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.run(CommandProcessor.java:1957)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:112)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:44)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:282)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:493)
```

The cause of this NPE is that CDebugger is null.  It happens when the debugger is running on debugd server.
Command line debugger like CLHSDB can delegate the command to debugd, like `pmap` and `pstack`. `findsym` can also use this scheme.

This PR has passed serviceability/sa tests on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265505](https://bugs.openjdk.java.net/browse/JDK-8265505): findsym does not work on remote debug server


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 6ef93d7d310cb982907f75c7658d5b433865623b
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to b6bbadacac0c7263bf47552e70b59184360887cd


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3582/head:pull/3582` \
`$ git checkout pull/3582`

Update a local copy of the PR: \
`$ git checkout pull/3582` \
`$ git pull https://git.openjdk.java.net/jdk pull/3582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3582`

View PR using the GUI difftool: \
`$ git pr show -t 3582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3582.diff">https://git.openjdk.java.net/jdk/pull/3582.diff</a>

</details>
