### PR TITLE
8265450: Merge PreservedMarksSet::restore code paths

### DIFF
--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ void RemoveForwardedPointerClosure::do_object(oop obj) {
 }
 
 void PreservedMarksSet::init(uint num) {
-  assert(_stacks == NULL && _num == 0, "do not re-initialize");
+  assert(_stacks == nullptr && _num == 0, "do not re-initialize");
   assert(num > 0, "pre-condition");
   if (_in_c_heap) {
     _stacks = NEW_C_HEAP_ARRAY(Padded<PreservedMarks>, num, mtGC);
@@ -92,57 +92,53 @@ void PreservedMarksSet::init(uint num) {
   assert_empty();
 }
 
-class ParRestoreTask : public AbstractGangTask {
-private:
+class RestorePreservedMarksTask : public AbstractGangTask {
   PreservedMarksSet* const _preserved_marks_set;
   SequentialSubTasksDone _sub_tasks;
-  volatile size_t* const _total_size_addr;
+  volatile size_t _total_size;
+#ifdef ASSERT
+  size_t _total_size_before;
+#endif // ASSERT
 
 public:
-  virtual void work(uint worker_id) {
+  void work(uint worker_id) override {
     uint task_id = 0;
-    while (_sub_tasks.try_claim_task(/* reference */ task_id)) {
-      _preserved_marks_set->get(task_id)->restore_and_increment(_total_size_addr);
+    while (_sub_tasks.try_claim_task(task_id)) {
+      _preserved_marks_set->get(task_id)->restore_and_increment(&_total_size);
     }
   }
 
-  ParRestoreTask(PreservedMarksSet* preserved_marks_set,
-                 volatile size_t* total_size_addr)
-      : AbstractGangTask("Parallel Preserved Mark Restoration"),
-        _preserved_marks_set(preserved_marks_set),
-        _sub_tasks(preserved_marks_set->num()),
-        _total_size_addr(total_size_addr) {
+  RestorePreservedMarksTask(PreservedMarksSet* preserved_marks_set)
+    : AbstractGangTask("Restore Preserved Marks"),
+      _preserved_marks_set(preserved_marks_set),
+      _sub_tasks(preserved_marks_set->num()),
+      _total_size(0)
+      DEBUG_ONLY(COMMA _total_size_before(0)) {
+#ifdef ASSERT
+    // This is to make sure the total_size we'll calculate below is correct.
+    for (uint i = 0; i < _preserved_marks_set->num(); ++i) {
+      _total_size_before += _preserved_marks_set->get(i)->size();
     }
+#endif // ASSERT
+  }
+
+  virtual ~RestorePreservedMarksTask() {
+    assert(_total_size == _total_size_before, "total_size = %zu before = %zu", _total_size, _total_size_before);
+
+    log_trace(gc)("Restored %zu marks", _total_size);
+  }
 };
 
 void PreservedMarksSet::restore(WorkGang* workers) {
-  volatile size_t total_size = 0;
+  RestorePreservedMarksTask cl(this);
 
-#ifdef ASSERT
-  // This is to make sure the total_size we'll calculate below is correct.
-  size_t total_size_before = 0;
-  for (uint i = 0; i < _num; i += 1) {
-    total_size_before += get(i)->size();
-  }
-#endif // ASSERT
-
-  if (workers == NULL) {
-    for (uint i = 0; i < num(); i += 1) {
-      total_size += get(i)->size();
-      get(i)->restore();
-    }
+  if (workers == nullptr) {
+    cl.work(0);
   } else {
-    ParRestoreTask task(this, &total_size);
-    workers->run_task(&task);
+    workers->run_task(&cl);
   }
 
   assert_empty();
-
-  assert(total_size == total_size_before,
-         "total_size = " SIZE_FORMAT " before = " SIZE_FORMAT,
-         total_size, total_size_before);
-
-  log_trace(gc)("Restored " SIZE_FORMAT " marks", total_size);
 }
 
 void PreservedMarksSet::reclaim() {
@@ -157,13 +153,13 @@ void PreservedMarksSet::reclaim() {
   } else {
     // the array was resource-allocated, so nothing to do
   }
-  _stacks = NULL;
+  _stacks = nullptr;
   _num = 0;
 }
 
 #ifndef PRODUCT
 void PreservedMarksSet::assert_empty() {
-  assert(_stacks != NULL && _num > 0, "should have been initialized");
+  assert(_stacks != nullptr && _num > 0, "should have been initialized");
   for (uint i = 0; i < _num; i += 1) {
     get(i)->assert_empty();
   }

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -122,7 +122,7 @@ public:
 #endif // ASSERT
   }
 
-  virtual ~RestorePreservedMarksTask() {
+  ~RestorePreservedMarksTask() {
     assert(_total_size == _total_size_before, "total_size = %zu before = %zu", _total_size, _total_size_before);
 
     log_trace(gc)("Restored %zu marks", _total_size);
@@ -130,12 +130,13 @@ public:
 };
 
 void PreservedMarksSet::restore(WorkGang* workers) {
-  RestorePreservedMarksTask cl(this);
-
-  if (workers == nullptr) {
-    cl.work(0);
-  } else {
-    workers->run_task(&cl);
+  {
+    RestorePreservedMarksTask cl(this);
+    if (workers == nullptr) {
+      cl.work(0);
+    } else {
+      workers->run_task(&cl);
+    }
   }
 
   assert_empty();

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -122,7 +122,7 @@ public:
 #endif // ASSERT
   }
 
-  ~RestorePreservedMarksTask() {
+  virtual ~RestorePreservedMarksTask() {
     assert(_total_size == _total_size_before, "total_size = %zu before = %zu", _total_size, _total_size_before);
 
     log_trace(gc)("Restored %zu marks", _total_size);

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -122,7 +122,7 @@ public:
 #endif // ASSERT
   }
 
-  virtual ~RestorePreservedMarksTask() {
+  ~RestorePreservedMarksTask() {
     assert(_total_size == _total_size_before, "total_size = %zu before = %zu", _total_size, _total_size_before);
 
     log_trace(gc)("Restored %zu marks", _total_size);

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -59,7 +59,7 @@ class GangTaskDispatcher;
 
 // An abstract task to be worked on by a gang.
 // You subclass this to supply your own work() method
-class AbstractGangTask {
+class AbstractGangTask : public CHeapObj<mtInternal> {
   const char* _name;
   const uint _gc_id;
 

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -59,7 +59,7 @@ class GangTaskDispatcher;
 
 // An abstract task to be worked on by a gang.
 // You subclass this to supply your own work() method
-class AbstractGangTask : public CHeapObj<mtInternal> {
+class AbstractGangTask {
   const char* _name;
   const uint _gc_id;
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this refactoring  that merges parallel and serial preserved marks restoration during evacuation failure into a single code path, simply by having the serial path call the parallel path in the VM thread.

This just reduces code and avoids the potential bugs when updating one path but not the other (which already happened).

The execution difference should not really matter for Serial GC where the serial path is executed:
- we are talking about the evacuation failure path
- there are likely a lot of preserved marks (random writes to the heap) that offset these two additional calls and some tiny superfluous member initialization.

Testing: tier1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265450](https://bugs.openjdk.java.net/browse/JDK-8265450): Merge PreservedMarksSet::restore code paths


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3584/head:pull/3584` \
`$ git checkout pull/3584`

Update a local copy of the PR: \
`$ git checkout pull/3584` \
`$ git pull https://git.openjdk.java.net/jdk pull/3584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3584`

View PR using the GUI difftool: \
`$ git pr show -t 3584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3584.diff">https://git.openjdk.java.net/jdk/pull/3584.diff</a>

</details>
