### PR TITLE
JDK-8155004: CrashOnOutOfMemoryError doesn't work for OOM caused by inability to create threads

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -92,6 +92,7 @@
 #include "services/management.hpp"
 #include "services/threadService.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
@@ -2912,6 +2913,10 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_THREADS,
         os::native_thread_creation_failed_msg());
     }
+
+    // Handle xxxOnOutOfMemoryError switches.
+    report_java_out_of_memory(os::native_thread_creation_failed_msg());
+
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               os::native_thread_creation_failed_msg());
   }


### PR DESCRIPTION
Greetings,

this is an old issue and I'd like to fix it. If we fail to create a java thread due to platform limitations we throw an OOM. But we fail to honor the various xxxOnOutOfMemoryError switches.

The fix is very straightforward. 

If fixes 
- CrashOnOutOfMemoryError
- ExitOnOutOfMemoryError
- HeapDumpOnOutOfMemoryError
- and, in theory "OnOutOfMemoryError=<user comand>".

the latter only in theory because most of the times whatever prevented the thread to start up will also prevent the fork needed to get the user command running.

One remaining question, maybe for a future RFE, is how we want to handle native threads creation error. AFAICS currently, failing to create a native thread may or may not result in a fatal shutdown, a log output, or just be ignored, depending on the thread. 

If `...OnOutOfMemoryError` is specified, should native thread creation failure be handled the same way as a java thread?

- No if I take the option name literally, since there is no OOM involved
- Yes if I take into account what these switches are actually used for - analysis or quick shutdown of a JVM inside a container in case of an OOM. Since it is completely random which thread is hit by the limit.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8155004](https://bugs.openjdk.java.net/browse/JDK-8155004): CrashOnOutOfMemoryError doesn't work for OOM caused by inability to create threads


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3586/head:pull/3586` \
`$ git checkout pull/3586`

Update a local copy of the PR: \
`$ git checkout pull/3586` \
`$ git pull https://git.openjdk.java.net/jdk pull/3586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3586`

View PR using the GUI difftool: \
`$ git pr show -t 3586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3586.diff">https://git.openjdk.java.net/jdk/pull/3586.diff</a>

</details>
