### PR TITLE
8265326: Strange Characters in G1GC GC Log

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -139,8 +139,8 @@ void G1ConcurrentMarkThread::run_service() {
     assert(in_progress(), "must be");
 
     GCIdMark gc_id_mark;
-    FormatBuffer<128> _format("Concurrent %s Cycle", _state == FullMark ? "Mark" : "Undo");
-    GCTraceConcTime(Info, gc) tt(_format);
+    FormatBuffer<128> title("Concurrent %s Cycle", _state == FullMark ? "Mark" : "Undo");
+    GCTraceConcTime(Info, gc) tt(title);
 
     concurrent_cycle_start();
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,8 +139,8 @@ void G1ConcurrentMarkThread::run_service() {
     assert(in_progress(), "must be");
 
     GCIdMark gc_id_mark;
-    GCTraceConcTime(Info, gc) tt(FormatBuffer<128>("Concurrent %s Cycle",
-                                                   _state == FullMark ? "Mark" : "Undo"));
+    FormatBuffer<128> _format("Concurrent %s Cycle", _state == FullMark ? "Mark" : "Undo");
+    GCTraceConcTime(Info, gc) tt(_format);
 
     concurrent_cycle_start();
 


### PR DESCRIPTION
There was an character formating issue on mac-os due to usage of "
`FormatBuffer<128>`" 
Used explicit variable to hold the FormatBuffer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265326](https://bugs.openjdk.java.net/browse/JDK-8265326): Strange Characters in G1GC GC Log


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3589/head:pull/3589` \
`$ git checkout pull/3589`

Update a local copy of the PR: \
`$ git checkout pull/3589` \
`$ git pull https://git.openjdk.java.net/jdk pull/3589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3589`

View PR using the GUI difftool: \
`$ git pr show -t 3589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3589.diff">https://git.openjdk.java.net/jdk/pull/3589.diff</a>

</details>
