### PR TITLE
8265531: doc/building.md should mention homebrew install freetype

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -320,6 +320,7 @@
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libfreetype6-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install freetype-devel</code>.</li>
 <li>To install on Alpine Linux, try running <code>sudo apk add freetype-dev</code>.</li>
+<li>To install on macOS, try running <code>brew install freetype</code>.</li>
 </ul>
 <p>Use <code>--with-freetype-include=&lt;path&gt;</code> and <code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code> does not automatically locate the platform FreeType files.</p>
 <h3 id="cups">CUPS</h3>

--- a/doc/building.md
+++ b/doc/building.md
@@ -454,6 +454,7 @@ rather than bundling the JDK's own copy.
   * To install on an rpm-based Linux, try running `sudo yum install
     freetype-devel`.
   * To install on Alpine Linux, try running `sudo apk add freetype-dev`.
+  * To install on macOS, try running `brew install freetype`.
 
 Use `--with-freetype-include=<path>` and `--with-freetype-lib=<path>`
 if `configure` does not automatically locate the platform FreeType files.


### PR DESCRIPTION
Updates the docs/building.html guide to include steps to install FreeType on macOS using homebrew.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265531](https://bugs.openjdk.java.net/browse/JDK-8265531): doc/building.md should mention homebrew install freetype


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3590/head:pull/3590` \
`$ git checkout pull/3590`

Update a local copy of the PR: \
`$ git checkout pull/3590` \
`$ git pull https://git.openjdk.java.net/jdk pull/3590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3590`

View PR using the GUI difftool: \
`$ git pr show -t 3590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3590.diff">https://git.openjdk.java.net/jdk/pull/3590.diff</a>

</details>
