### PR TITLE
8263421: Module image file is opened twice during VM startup

### DIFF
--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -117,14 +117,13 @@ class ClassPathZipEntry: public ClassPathEntry {
 // For java image files
 class ClassPathImageEntry: public ClassPathEntry {
 private:
-  JImageFile* _jimage;
   const char* _name;
   DEBUG_ONLY(static ClassPathImageEntry* _singleton;)
 public:
   bool is_modules_image() const;
-  bool is_open() const { return _jimage != NULL; }
   const char* name() const { return _name == NULL ? "" : _name; }
-  JImageFile* jimage() const { return _jimage; }
+  JImageFile* jimage() const;
+  void set_jimage(JImageFile* jimage);
   void close_jimage();
   ClassPathImageEntry(JImageFile* jimage, const char* name);
   virtual ~ClassPathImageEntry();

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -123,10 +123,11 @@ public:
   bool is_modules_image() const;
   const char* name() const { return _name == NULL ? "" : _name; }
   JImageFile* jimage() const;
+  JImageFile* jimage_non_null() const;
   void set_jimage(JImageFile* jimage);
   void close_jimage();
   ClassPathImageEntry(JImageFile* jimage, const char* name);
-  virtual ~ClassPathImageEntry();
+  virtual ~ClassPathImageEntry() { ShouldNotReachHere(); }
   ClassFileStream* open_stream(Thread* current, const char* name);
   ClassFileStream* open_stream_for_loader(Thread* current, const char* name, ClassLoaderData* loader_data);
 };

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -124,7 +124,6 @@ public:
   const char* name() const { return _name == NULL ? "" : _name; }
   JImageFile* jimage() const;
   JImageFile* jimage_non_null() const;
-  void set_jimage(JImageFile* jimage);
   void close_jimage();
   ClassPathImageEntry(JImageFile* jimage, const char* name);
   virtual ~ClassPathImageEntry() { ShouldNotReachHere(); }


### PR DESCRIPTION
Please review this fix for JDK-8263421.  The fix stores the JImageFile* in a static that gets initialized when lookup_vm_options() opens the module image file.  The static JimageFIle* is then used by setup_bootstrap_search_path_impl() when creating the ClassPathImageEntry for the module image file, avoiding having to re-open the module image file.

This fix moved the creation of the ClassPathImageEntry for the module image file from create_class_path_entry() to setup_bootstrap_search_path_impl() because create_class_path_entry() may try to do this multiple times, but the ClassPathImageEntry for the module image file is only actually created once.

The fix also removes some unused code related to module image file processing.

The changes were tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-
5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263421](https://bugs.openjdk.java.net/browse/JDK-8263421): Module image file is opened twice during VM startup


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 5341b1ededfd5f509605dbe73d106f5e3034a819
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3591/head:pull/3591` \
`$ git checkout pull/3591`

Update a local copy of the PR: \
`$ git checkout pull/3591` \
`$ git pull https://git.openjdk.java.net/jdk pull/3591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3591`

View PR using the GUI difftool: \
`$ git pr show -t 3591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3591.diff">https://git.openjdk.java.net/jdk/pull/3591.diff</a>

</details>
