### PR TITLE
8264632: compiler/codecache/jmx/PoolsIndependenceTest.java fails to Notification not being received

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,6 +140,16 @@ public final class CodeCacheUtils {
         }
     }
 
+    /**
+     * For the given bean, restores it usageThreshold monitoring to the initial state - clears any reached
+     * usageThreshold and switches off the monitoring.
+     *
+     * @param bean MemoryPoolMXBean for which the clearing should be done.
+     */
+    public static void clearAndDisableUsageThreshold(MemoryPoolMXBean bean) {
+        bean.setUsageThreshold(bean.getUsage().getMax());
+        bean.setUsageThreshold(0L);
+    }
 
     public static void disableCollectionUsageThresholds() {
         BlobType.getAvailable().stream()

--- a/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
@@ -88,6 +88,8 @@ public class PoolsIndependenceTest implements NotificationListener {
     protected void runTest() {
         MemoryPoolMXBean bean = btype.getMemoryPool();
         System.out.printf("INFO: Starting scenario with %s%n", bean.getName());
+        CodeCacheUtils.clearAndDisableUsageThreshold(bean);
+
         ((NotificationEmitter) ManagementFactory.getMemoryMXBean()).
                 addNotificationListener(this, null, null);
         final long usageThresholdLimit = bean.getUsage().getUsed() + 1;


### PR DESCRIPTION
Hi all,

May I ask for reviews for this change? 

**The case**
https://bugs.openjdk.java.net/browse/JDK-8264632

**The problem**
The test calls for MemoryPoolMXBean.setUsageThreshold() and expects a Notification get fired when the threshold is breached. The Notification is never received.

The failure most probably is caused by the combination of following events:
1. Some threshold has already breached (caused by some other tests); 
2. In this case MemoryPoolMXBean never fires subsequent Notifications until the usage is less than a set threshold;
3. The usage manages to grow up between these two lines[1]:
```
final long usageThresholdLimit = bean.getUsage().getUsed() + 1;
bean.setUsageThreshold(usageThresholdLimit);
```
4. The usage has never fallen below any set threshold and therefore Notification is never sent. Setting usageThresholdLimit to 0 doesn't clear up the situation "Notification has already been sent" either.

[1] Very common, happens almost every time during my testing - the code cache usage grows up quickly at VM start.

**Proposed solution:**
1. Before the actual test, I set the usageThresholdLimit to max. possible value;
2. This causes the current usage to appear below the threshold and therefore the "Notification has already been sent" state is cleared;
3. The monitoring is then switched off (by setting usageThresholdLimit to 0), as at the VM start.

**Testing**
1. Preemptive breaching of some threshold causes the problem for non-modified test.
2. The modified test has been tested with debug versions of macosx, windows, linux x64 builds and a linux-aarch64-debug build.

Thanks,
Evgeny.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264632](https://bugs.openjdk.java.net/browse/JDK-8264632): compiler/codecache/jmx/PoolsIndependenceTest.java fails to Notification not being received


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3592/head:pull/3592` \
`$ git checkout pull/3592`

Update a local copy of the PR: \
`$ git checkout pull/3592` \
`$ git pull https://git.openjdk.java.net/jdk pull/3592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3592`

View PR using the GUI difftool: \
`$ git pr show -t 3592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3592.diff">https://git.openjdk.java.net/jdk/pull/3592.diff</a>

</details>
