### PR TITLE
8264842: IGV: different nodes sharing idx are treated as equal

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -553,6 +553,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
                   _do_cleanup(false),
                   _has_reserved_stack_access(target->has_reserved_stack_access()),
 #ifndef PRODUCT
+                  _igv_idx(0),
                   _trace_opto_output(directive->TraceOptoOutputOption),
                   _print_ideal(directive->PrintIdealOption),
 #endif
@@ -859,6 +860,7 @@ Compile::Compile( ciEnv* ci_env,
     _inlining_incrementally(false),
     _has_reserved_stack_access(false),
 #ifndef PRODUCT
+    _igv_idx(0),
     _trace_opto_output(directive->TraceOptoOutputOption),
     _print_ideal(directive->PrintIdealOption),
 #endif

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -293,6 +293,7 @@ class Compile : public Phase {
   bool                  _print_inlining;        // True if we should print inlining for this compilation
   bool                  _print_intrinsics;      // True if we should print intrinsics for this compilation
 #ifndef PRODUCT
+  uint                  _igv_idx;               // Counter for IGV node identifiers
   bool                  _trace_opto_output;
   bool                  _print_ideal;
   bool                  _parsed_irreducible_loop; // True if ciTypeFlow detected irreducible loops during parsing
@@ -601,6 +602,7 @@ class Compile : public Phase {
   }
 
 #ifndef PRODUCT
+  uint          next_igv_idx()                  { return _igv_idx++; }
   bool          trace_opto_output() const       { return _trace_opto_output; }
   bool          print_ideal() const             { return _print_ideal; }
   bool              parsed_irreducible_loop() const { return _parsed_irreducible_loop; }

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -340,14 +340,12 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
   if (edges) {
 
-    // Output edge
-    node_idx_t dest_id = n->_idx;
-    for ( uint i = 0; i < n->len(); i++ ) {
-      if ( n->in(i) ) {
+    for (uint i = 0; i < n->len(); i++) {
+      if (n->in(i)) {
         Node *source = n->in(i);
         begin_elem(EDGE_ELEMENT);
-        print_attr(FROM_PROPERTY, source->_idx);
-        print_attr(TO_PROPERTY, dest_id);
+        print_attr(FROM_PROPERTY, source->_igv_idx);
+        print_attr(TO_PROPERTY, n->_igv_idx);
         print_attr(INDEX_PROPERTY, i);
         end_elem();
       }
@@ -357,7 +355,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
     // Output node
     begin_head(NODE_ELEMENT);
-    print_attr(NODE_ID_PROPERTY, n->_idx);
+    print_attr(NODE_ID_PROPERTY, n->_igv_idx);
     end_head();
 
     head(PROPERTIES_ELEMENT);
@@ -715,7 +713,7 @@ void IdealGraphPrinter::print(const char *name, Node *node) {
       head(NODES_ELEMENT);
       for (uint s = 0; s < block->number_of_nodes(); s++) {
         begin_elem(NODE_ELEMENT);
-        print_attr(NODE_ID_PROPERTY, block->get_node(s)->_idx);
+        print_attr(NODE_ID_PROPERTY, block->get_node(s)->_igv_idx);
         end_elem();
       }
       tail(NODES_ELEMENT);

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -303,6 +303,7 @@ static void init_node_notes(Compile* C, int idx, Node_Notes* nn) {
 inline int Node::Init(int req) {
   Compile* C = Compile::current();
   int idx = C->next_unique();
+  NOT_PRODUCT(_igv_idx = C->next_igv_idx());
 
   // Allocate memory for the necessary number of edges.
   if (req > 0) {
@@ -531,6 +532,7 @@ Node *Node::clone() const {
   bs->register_potential_barrier_node(n);
 
   n->set_idx(C->next_unique()); // Get new unique index as well
+  NOT_PRODUCT(n->_igv_idx = C->next_igv_idx());
   debug_only( n->verify_construction() );
   NOT_PRODUCT(nodes_created++);
   // Do not patch over the debug_idx of a clone, because it makes it

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -323,6 +323,10 @@ protected:
   // preserved in _parse_idx.
   const node_idx_t _idx;
   DEBUG_ONLY(const node_idx_t _parse_idx;)
+  // IGV node identifier. It is similar to Node::_debug_idx in that it is unique
+  // across all compilation phases, but different in that it is initialized in
+  // each compilation, for stability.
+  NOT_PRODUCT(node_idx_t _igv_idx;)
 
   // Get the (read-only) number of input edges
   uint req() const { return _cnt; }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputNode.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,6 @@ public class InputNode extends Properties.Entity {
 
     public void setId(int id) {
         this.id = id;
-        getProperties().setProperty("id", "" + id);
     }
 
     public int getId() {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Properties.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -450,5 +450,37 @@ public class Properties implements Serializable, Iterable<Property> {
     @Override
     public Iterator<Property> iterator() {
         return new PropertiesIterator();
+    }
+
+    public final String resolveString(String string) {
+
+        StringBuilder sb = new StringBuilder();
+        boolean inBrackets = false;
+        StringBuilder curIdent = new StringBuilder();
+
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (inBrackets) {
+                if (c == ']') {
+                    String value = get(curIdent.toString());
+                    if (value == null) {
+                        value = "";
+                    }
+                    sb.append(value);
+                    inBrackets = false;
+                } else {
+                    curIdent.append(c);
+                }
+            } else {
+                if (c == '[') {
+                    inBrackets = true;
+                    curIdent = new StringBuilder();
+                } else {
+                    sb.append(c);
+                }
+            }
+        }
+
+        return sb.toString();
     }
 }

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/SplitFilter.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/SplitFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class SplitFilter extends AbstractFilter {
                     }
 
 
-                    String s = Figure.resolveString(propertyName, f.getProperties());
+                    String s = f.getProperties().resolveString(propertyName);
                     if (s != null) {
                         os.setShortName(s);
                     }
@@ -79,7 +79,7 @@ public class SplitFilter extends AbstractFilter {
                         is.setColor(f.getColor());
                     }
 
-                    String s = Figure.resolveString(propertyName, f.getProperties());
+                    String s = f.getProperties().resolveString(propertyName);
                     if (s != null) {
                         is.setShortName(s);
                     }

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Connection.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Connection.java
@@ -128,10 +128,12 @@ public class Connection implements Source.Provider, Link {
         if (type != null) {
             builder.append(type).append(" ");
         }
-        builder.append("from ");
-        builder.append(getOutputSlot().getFigure().getSource().getSourceNodes().get(0).getId());
-        builder.append(" to ");
-        builder.append(getInputSlot().getFigure().getSource().getSourceNodes().get(0).getId());
+        // Resolve strings lazily every time the tooltip is shown, instead of
+        // eagerly as for node labels, for efficiency.
+        String shortNodeText = getInputSlot().getFigure().getDiagram().getShortNodeText();
+        builder.append(getOutputSlot().getFigure().getProperties().resolveString(shortNodeText));
+        builder.append(" → ");
+        builder.append(getInputSlot().getFigure().getProperties().resolveString(shortNodeText));
         return builder.toString();
     }
 

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ public class Diagram {
     private InputGraph graph;
     private int curId;
     private String nodeText;
+    private String shortNodeText;
     private final Font font;
     private final Font slotFont;
     private final Font boldFont;
@@ -63,6 +64,7 @@ public class Diagram {
         figures = new ArrayList<>();
         blocks = new LinkedHashMap<>(8);
         this.nodeText = "";
+        this.shortNodeText = "";
         this.font = new Font("Arial", Font.PLAIN, 12);
         this.slotFont = new Font("Arial", Font.PLAIN, 10);
         this.boldFont = this.font.deriveFont(Font.BOLD);
@@ -77,6 +79,10 @@ public class Diagram {
         return nodeText;
     }
 
+    public String getShortNodeText() {
+        return shortNodeText;
+    }
+
     public void updateBlocks() {
         blocks.clear();
         for (InputBlock b : graph.getBlocks()) {
@@ -86,7 +92,7 @@ public class Diagram {
     }
 
     public Diagram getNext() {
-        return Diagram.createDiagram(graph.getNext(), nodeText);
+        return Diagram.createDiagram(graph.getNext(), nodeText, shortNodeText);
     }
 
     public Collection<Block> getBlocks() {
@@ -94,7 +100,7 @@ public class Diagram {
     }
 
     public Diagram getPrev() {
-        return Diagram.createDiagram(graph.getPrev(), nodeText);
+        return Diagram.createDiagram(graph.getPrev(), nodeText, shortNodeText);
     }
 
     public List<Figure> getFigures() {
@@ -130,7 +136,8 @@ public class Diagram {
         return map;
     }
 
-    public static Diagram createDiagram(InputGraph graph, String nodeText) {
+    public static Diagram createDiagram(InputGraph graph, String nodeText,
+                                        String shortNodeText) {
         if (graph == null) {
             return null;
         }
@@ -138,6 +145,7 @@ public class Diagram {
         Diagram d = new Diagram();
         d.graph = graph;
         d.nodeText = nodeText;
+        d.shortNodeText = shortNodeText;
 
         d.updateBlocks();
 

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
@@ -278,7 +278,7 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
             // search is done on the node label (without line breaks). See also
             // class NodeQuickSearch in the View module.
             for (InputNode n : getSource().getSourceNodes()) {
-                String label = resolveString(diagram.getNodeText(), n.getProperties());
+                String label = n.getProperties().resolveString(diagram.getNodeText());
                 n.getProperties().setProperty("label", label.replaceAll("\\R", " "));
             }
         }
@@ -290,42 +290,10 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
         String[] result = new String[strings.length];
 
         for (int i = 0; i < strings.length; i++) {
-            result[i] = resolveString(strings[i], getProperties());
+            result[i] = getProperties().resolveString(strings[i]);
         }
 
         lines = result;
-    }
-
-    public static final String resolveString(String string, Properties properties) {
-
-        StringBuilder sb = new StringBuilder();
-        boolean inBrackets = false;
-        StringBuilder curIdent = new StringBuilder();
-
-        for (int i = 0; i < string.length(); i++) {
-            char c = string.charAt(i);
-            if (inBrackets) {
-                if (c == ']') {
-                    String value = properties.get(curIdent.toString());
-                    if (value == null) {
-                        value = "";
-                    }
-                    sb.append(value);
-                    inBrackets = false;
-                } else {
-                    curIdent.append(c);
-                }
-            } else {
-                if (c == '[') {
-                    inBrackets = true;
-                    curIdent = new StringBuilder();
-                } else {
-                    sb.append(c);
-                }
-            }
-        }
-
-        return sb.toString();
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Slot.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Slot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,11 +139,16 @@ public abstract class Slot implements Port, Source.Provider, Properties.Provider
 
     public String getToolTipText() {
         StringBuilder sb = new StringBuilder();
-        sb.append(text);
+        String shortNodeText = figure.getDiagram().getShortNodeText();
+        if (!text.isEmpty()) {
+            sb.append(text);
+            if (!shortNodeText.isEmpty()) {
+                sb.append(": ");
+            }
+        }
 
         for (InputNode n : getSource().getSourceNodes()) {
-            sb.append(StringUtils.escapeHTML("Node (ID=" + n.getId() + "): " + n.getProperties().get("name")));
-            sb.append("<br>");
+            sb.append(StringUtils.escapeHTML(n.getProperties().resolveString(shortNodeText)));
         }
 
         return sb.toString();

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/Settings.java
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@ public class Settings {
 
     public final static String NODE_TEXT = "nodeText";
     public final static String NODE_TEXT_DEFAULT = "[idx] [name]";
+    public final static String NODE_SHORT_TEXT = "nodeShortText";
+    public final static String NODE_SHORT_TEXT_DEFAULT = "[idx] [name]";
     public final static String NODE_WIDTH = "nodeWidth";
     public final static String NODE_WIDTH_DEFAULT = "100";
     public final static String PORT = "port";

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.form
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.form
@@ -135,7 +135,7 @@
             <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
               <Color blue="ff" green="ff" red="ff" type="rgb"/>
             </Property>
-            <Property name="toolTipText" type="java.lang.String" value="Single-line format string for nodes in edge tooltips, slot tooltips , and node search bar. Properties are specified with brackets  (example: &quot;[idx]&quot;)."/>
+            <Property name="toolTipText" type="java.lang.String" value="Single-line format string for nodes in edge tooltips, slot tooltips, and node search bar. Properties are specified with brackets  (example: &quot;[idx]&quot;)."/>
           </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="ViewPanel_nodeShortTextField"/>

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.form
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.form
@@ -4,6 +4,7 @@
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="2"/>
@@ -27,7 +28,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="206" max="32767" attributes="0"/>
+              <EmptySpace pref="153" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -38,20 +39,26 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="1" attributes="0">
+              <Group type="102" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel3" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel4" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace min="-2" pref="39" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="portSpinner" alignment="0" min="-2" pref="63" max="-2" attributes="0"/>
-                      <Component id="nodeWidthSpinner" alignment="0" min="-2" pref="63" max="-2" attributes="0"/>
-                      <Component id="jScrollPane1" alignment="0" min="-2" pref="365" max="-2" attributes="0"/>
+                      <Group type="103" alignment="0" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="nodeShortTextField" max="32767" attributes="0"/>
+                          <Component id="jScrollPane1" pref="365" max="32767" attributes="0"/>
+                      </Group>
+                      <Group type="103" alignment="0" groupAlignment="1" max="-2" attributes="0">
+                          <Component id="nodeWidthSpinner" alignment="0" pref="100" max="32767" attributes="0"/>
+                          <Component id="portSpinner" alignment="0" max="32767" attributes="0"/>
+                      </Group>
                   </Group>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace pref="439" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -60,22 +67,24 @@
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="jScrollPane1" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="3" attributes="0">
-                              <Component id="nodeWidthSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
-                              <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="3" attributes="0">
-                              <Component id="portSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
-                              <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                      </Group>
+                      <Component id="jScrollPane1" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace min="-2" pref="73" max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="27" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
+                      <Component id="nodeShortTextField" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace pref="27" max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="nodeWidthSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace pref="27" max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="portSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
               </Group>
           </Group>
         </DimensionLayout>
@@ -104,6 +113,7 @@
               <Properties>
                 <Property name="columns" type="int" value="20"/>
                 <Property name="rows" type="int" value="5"/>
+                <Property name="toolTipText" type="java.lang.String" value="Multi-line format string for node labels. Properties are specified with brackets  (example: &quot;[idx] [name]&quot;)."/>
               </Properties>
             </Component>
           </SubComponents>
@@ -114,6 +124,22 @@
           <Properties>
             <Property name="text" type="java.lang.String" value="Network Port"/>
           </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel4">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Short Node Text"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="nodeShortTextField">
+          <Properties>
+            <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+              <Color blue="ff" green="ff" red="ff" type="rgb"/>
+            </Property>
+            <Property name="toolTipText" type="java.lang.String" value="Single-line format string for nodes in edge tooltips, slot tooltips , and node search bar. Properties are specified with brackets  (example: &quot;[idx]&quot;)."/>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="ViewPanel_nodeShortTextField"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.java
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,8 @@ final class ViewPanel extends javax.swing.JPanel {
         nodeTextArea = new javax.swing.JTextArea();
         nodeWidthSpinner = new javax.swing.JSpinner();
         jLabel3 = new javax.swing.JLabel();
+        jLabel4 = new javax.swing.JLabel();
+        nodeShortTextField = new javax.swing.JTextField();
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel1, "Node Text");
 
@@ -59,44 +61,56 @@ final class ViewPanel extends javax.swing.JPanel {
 
         nodeTextArea.setColumns(20);
         nodeTextArea.setRows(5);
+        nodeTextArea.setToolTipText("Multi-line format string for node labels. Properties are specified with brackets  (example: \"[idx] [name]\").");
         jScrollPane1.setViewportView(nodeTextArea);
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel3, "Network Port");
+
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel4, "Short Node Text");
+
+        nodeShortTextField.setBackground(new java.awt.Color(255, 255, 255));
+        nodeShortTextField.setToolTipText("Single-line format string for nodes in edge tooltips, slot tooltips , and node search bar. Properties are specified with brackets  (example: \"[idx]\").");
 
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(org.jdesktop.layout.GroupLayout.TRAILING, jPanel1Layout.createSequentialGroup()
+            .add(jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                     .add(jLabel1)
                     .add(jLabel3)
-                    .add(jLabel2))
+                    .add(jLabel2)
+                    .add(jLabel4))
                 .add(39, 39, 39)
                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(portSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 63, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(nodeWidthSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 63, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 365, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap())
+                    .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
+                        .add(nodeShortTextField)
+                        .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 365, Short.MAX_VALUE))
+                    .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING, false)
+                        .add(org.jdesktop.layout.GroupLayout.LEADING, nodeWidthSpinner, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 100, Short.MAX_VALUE)
+                        .add(org.jdesktop.layout.GroupLayout.LEADING, portSpinner)))
+                .addContainerGap(439, Short.MAX_VALUE))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(jPanel1Layout.createSequentialGroup()
-                        .add(jScrollPane1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .add(18, 18, 18)
-                        .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(nodeWidthSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(jLabel2))
-                        .add(18, 18, 18)
-                        .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(portSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(jLabel3)))
+                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                     .add(jLabel1))
-                .add(73, 73, 73))
+                .add(27, 27, 27)
+                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                    .add(jLabel4)
+                    .add(nodeShortTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, 27, Short.MAX_VALUE)
+                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(nodeWidthSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(jLabel2))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, 27, Short.MAX_VALUE)
+                .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                    .add(portSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(jLabel3)))
         );
 
         org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(this);
@@ -112,18 +126,20 @@ final class ViewPanel extends javax.swing.JPanel {
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(layout.createSequentialGroup()
                 .addContainerGap()
-                .add(jPanel1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 232, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(206, Short.MAX_VALUE))
+                .add(jPanel1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(153, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
     void load() {
         nodeTextArea.setText(Settings.get().get(Settings.NODE_TEXT, Settings.NODE_TEXT_DEFAULT));
+        nodeShortTextField.setText(Settings.get().get(Settings.NODE_SHORT_TEXT, Settings.NODE_SHORT_TEXT_DEFAULT));
         nodeWidthSpinner.setValue(Integer.parseInt(Settings.get().get(Settings.NODE_WIDTH, Settings.NODE_WIDTH_DEFAULT)));
         portSpinner.setValue(Integer.parseInt(Settings.get().get(Settings.PORT, Settings.PORT_DEFAULT)));
     }
 
     void store() {
         Settings.get().put(Settings.NODE_TEXT, nodeTextArea.getText());
+        Settings.get().put(Settings.NODE_SHORT_TEXT, nodeShortTextField.getText());
         Settings.get().put(Settings.NODE_WIDTH, nodeWidthSpinner.getValue().toString());
         Settings.get().put(Settings.PORT, portSpinner.getValue().toString());
     }
@@ -135,8 +151,10 @@ final class ViewPanel extends javax.swing.JPanel {
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel3;
+    private javax.swing.JLabel jLabel4;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JTextField nodeShortTextField;
     private javax.swing.JTextArea nodeTextArea;
     private javax.swing.JSpinner nodeWidthSpinner;
     private javax.swing.JSpinner portSpinner;

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.java
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/ViewPanel.java
@@ -69,7 +69,7 @@ final class ViewPanel extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(jLabel4, "Short Node Text");
 
         nodeShortTextField.setBackground(new java.awt.Color(255, 255, 255));
-        nodeShortTextField.setToolTipText("Single-line format string for nodes in edge tooltips, slot tooltips , and node search bar. Properties are specified with brackets  (example: \"[idx]\").");
+        nodeShortTextField.setToolTipText("Single-line format string for nodes in edge tooltips, slot tooltips, and node search bar. Properties are specified with brackets  (example: \"[idx]\").");
 
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -406,7 +406,9 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     public Diagram getDiagramToView() {
 
         if (diagram == null) {
-            diagram = Diagram.createDiagram(getGraphToView(), Settings.get().get(Settings.NODE_TEXT, Settings.NODE_TEXT_DEFAULT));
+            diagram = Diagram.createDiagram(getGraphToView(),
+                                            Settings.get().get(Settings.NODE_TEXT, Settings.NODE_TEXT_DEFAULT),
+                                            Settings.get().get(Settings.NODE_SHORT_TEXT, Settings.NODE_SHORT_TEXT_DEFAULT));
             getFilterChain().apply(diagram, getSequenceFilterChain());
             if (getFirstPosition() != getSecondPosition()) {
                 CustomFilter f = new CustomFilter(

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -58,7 +58,9 @@ public class GraphViewerImplementation implements GraphViewer {
             }
         }
 
-        Diagram diagram = Diagram.createDiagram(graph, Settings.get().get(Settings.NODE_TEXT, Settings.NODE_TEXT_DEFAULT));
+        Diagram diagram = Diagram.createDiagram(graph,
+                                                Settings.get().get(Settings.NODE_TEXT, Settings.NODE_TEXT_DEFAULT),
+                                                Settings.get().get(Settings.NODE_SHORT_TEXT, Settings.NODE_SHORT_TEXT_DEFAULT));
         EditorTopComponent tc = new EditorTopComponent(diagram);
         tc.open();
         tc.requestActive();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -28,6 +28,7 @@ import com.sun.hotspot.igv.data.InputNode;
 import com.sun.hotspot.igv.data.Properties;
 import com.sun.hotspot.igv.data.Properties.RegexpPropertyMatcher;
 import com.sun.hotspot.igv.data.services.InputGraphProvider;
+import com.sun.hotspot.igv.settings.Settings;
 import com.sun.hotspot.igv.util.LookupHistory;
 import java.util.Collections;
 import java.util.HashSet;
@@ -157,7 +158,7 @@ public class NodeQuickSearch implements SearchProvider {
                             }
                         }
                     },
-                            n.getProperties().get(name) + " (" + n.getId() + " " + n.getProperties().get("name") + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
+                            n.getProperties().get(name) + " (" + n.getProperties().resolveString(Settings.get().get(Settings.NODE_SHORT_TEXT, Settings.NODE_SHORT_TEXT_DEFAULT)) + ")" + (theGraph != null ? " in " + theGraph.getName() : "")
                     )) {
                         return;
                     }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/SlotWidget.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/widgets/SlotWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,9 @@ public abstract class SlotWidget extends Widget implements DoubleClickHandler {
         this.diagramScene = scene;
         this.slot = slot;
         figureWidget = fw;
-        this.setToolTipText("<HTML>" + slot.getToolTipText() + "</HTML>");
+        if (!slot.getSource().getSourceNodes().isEmpty()) {
+            this.setToolTipText("<HTML>" + slot.getToolTipText() + "</HTML>");
+        }
         this.setCheckClipping(true);
         parent.addChild(this);
 


### PR DESCRIPTION
This change replaces `Node::_idx` with a dedicated `Node::_igv_idx` as the internal node identifier for IGV. `_igv_idx` is unique across all phases in a compilation, which prevents IGV from wrongly treating unrelated nodes as if they were the same.`_igv_idx` is proposed instead of `Node::_debug_idx`, which is also unique across phases, for stability (the `_debug_idx` identifiers of a compilation are affected by the entire compilation history) and flexibility (future enhancements such as [JDK-8265587](https://bugs.openjdk.java.net/browse/JDK-8265587) require altering the node identifier in IGV-specific ways).

The following figure illustrates the effect of using `_igv_idx` instead of `_idx` as an internal node identifier. Using  `_idx` (left), node 54 is wrongly treated as created in two different phases (two green circles in the graph snapshot view), whereas using `_igv_idx` (right), node 54 is shown as created once, as expected:

![before-after-fix](https://user-images.githubusercontent.com/8792647/115462349-d624e380-a22a-11eb-8d29-810a5ccbd09c.png)

At the IGV user interface level, this change encapsulates the internal node identifier by showing a "short node text" (configurable from `Tools -> Options`, defaulting to `[idx] [name]`) in all places where the internal identifier was exposed before: edge tooltips, slot tooltips, and the node search results. The code in [ViewPanel.form](https://github.com/openjdk/jdk/compare/master...robcasloz:JDK-8264842?expand=1#diff-9b4fd66fc1b7a93a40abcec79b8825db44bdef62f13fede745238c3b87a2ab90) and [ViewPanel.java](https://github.com/openjdk/jdk/compare/master...robcasloz:JDK-8264842?expand=1#diff-c8cfda144359ba8b317fd0d02988dc0798418dcd211eb5eb91c3ed94567684d3) is generated by NetBeans 12.3 by editing ViewPanel.java in "Design" mode.

#### Testing

- Regression-tested HotSpot changes on hs-tier1-3, windows-x64, linux-x64, linux-aarch64, and macosx-x64 (both release and debug).
- Tested HotSpot graph generation and IGV graph loading and scheduling on tens of thousands of graphs by running `java -Xcomp -XX:-TieredCompilation -XX:PrintIdealGraphLevel=4 ...` on an instrumented IGV. Loading and scheduling are useful graph well-formedness tests, as they tend to fail for incorrect graphs, e.g. with repeated node identifiers.
- Tested manually, for a few graphs, that nodes are treated as created exactly once by IGV (by selecting single nodes and checking that a single green circle appears in the graph snapshot view, as in the right screenshot above).
- Tested manually that the new `Short Node Text` field in `Tools -> Options` is displayed and stored correctly, and that it is honored by edge tooltips, slot tooltips, and node search results (on Linux and Windows, for JDK 8, 11, and 15).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264842](https://bugs.openjdk.java.net/browse/JDK-8264842): IGV: different nodes sharing idx are treated as equal


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3593/head:pull/3593` \
`$ git checkout pull/3593`

Update a local copy of the PR: \
`$ git checkout pull/3593` \
`$ git pull https://git.openjdk.java.net/jdk pull/3593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3593`

View PR using the GUI difftool: \
`$ git pr show -t 3593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3593.diff">https://git.openjdk.java.net/jdk/pull/3593.diff</a>

</details>
