### PR TITLE
JDK-8265483: All-caps “JAVA” in the top navigation bar

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -154,13 +154,14 @@ COPYRIGHT_BOTTOM = \
     <a href="$(REDISTRIBUTION_URL)">documentation redistribution policy</a>. \
     $(DRAFT_MARKER_STR) <!-- Version $(VERSION_STRING) -->
 
-JAVADOC_BOTTOM := \
+# $1 - Optional "Other Versions" link
+JAVADOC_BOTTOM = \
     <a href="$(BUG_SUBMIT_URL)">Report a bug or suggest an enhancement</a><br> \
     For further API reference and developer documentation see the \
     <a href="$(JAVADOC_BASE_URL)" target="_blank">Java SE \
     Documentation</a>, which contains more detailed, \
     developer-targeted descriptions with conceptual overviews, definitions \
-    of terms, workarounds, and working code examples.<br> \
+    of terms, workarounds, and working code examples. $1<br> \
     Java is a trademark or registered trademark of $(FULL_COMPANY_NAME) in \
     the US and other countries.<br> \
     $(call COPYRIGHT_BOTTOM, {@docroot}/../)
@@ -300,22 +301,21 @@ define SetupApiDocsGenerationBody
   $1_OPTIONS += -Xdoclint/package:$$(call CommaList, $$(addprefix -, \
       $$(JAVADOC_DISABLED_DOCLINT_PACKAGES)))
 
-  ifneq ($$($1_OTHER_VERSIONS), )
-    $1_LINKED_SHORT_NAME = <a href="$$($1_OTHER_VERSIONS)">$$($1_SHORT_NAME)</a>
-  else
-    $1_LINKED_SHORT_NAME = $$($1_SHORT_NAME)
-  endif
-
   $1_DOC_TITLE := $$($1_LONG_NAME)<br>Version $$(VERSION_SPECIFICATION) API \
       Specification
   $1_WINDOW_TITLE := $$(subst &amp;,&,$$($1_SHORT_NAME))$$(DRAFT_MARKER_TITLE)
-  $1_HEADER_TITLE := <div $$(HEADER_STYLE)><strong>$$($1_LINKED_SHORT_NAME)</strong> \
+  $1_HEADER_TITLE := <div $$(HEADER_STYLE)><strong>$$($1_SHORT_NAME)</strong> \
       $$(DRAFT_MARKER_STR)</div>
+  ifneq ($$($1_OTHER_VERSIONS), )
+      $1_JAVADOC_BOTTOM := $$(call JAVADOC_BOTTOM, <a href="$$($1_OTHER_VERSIONS)">Other versions.</a>)
+  else
+      $1_JAVADOC_BOTTOM := $$(call JAVADOC_BOTTOM, )
+  endif
 
   $1_OPTIONS += -doctitle '$$($1_DOC_TITLE)'
   $1_OPTIONS += -windowtitle '$$($1_WINDOW_TITLE)'
   $1_OPTIONS += -header '$$($1_HEADER_TITLE)'
-  $1_OPTIONS += -bottom '$$(JAVADOC_BOTTOM)'
+  $1_OPTIONS += -bottom '$$($1_JAVADOC_BOTTOM)'
   ifeq ($$(IS_DRAFT), true)
     $1_OPTIONS += -top '$$(JAVADOC_TOP)'
   endif


### PR DESCRIPTION
Please review a moderately simple change to `make/Docs.gmk` to move the link for "Other Versions" from a "hidden" link in the top nav bar to an explicit link in the "bottom" text. The link is placed to appear after the sentence beginning "For more information..." and before all the legal text (i.e. trademark, copyright, license, etc)

A side effect of moving the link is that the top text reverts to its intended appearance of "Java ...", without all-caps.

As before, the presence of the link is optional, and depends on the specific docs target. It is set up to just appear for the main JDK/JavaSE documentation, and not the other docs bundles, such as docs-reference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265483](https://bugs.openjdk.java.net/browse/JDK-8265483): All-caps “JAVA” in the top navigation bar


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3594/head:pull/3594` \
`$ git checkout pull/3594`

Update a local copy of the PR: \
`$ git checkout pull/3594` \
`$ git pull https://git.openjdk.java.net/jdk pull/3594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3594`

View PR using the GUI difftool: \
`$ git pr show -t 3594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3594.diff">https://git.openjdk.java.net/jdk/pull/3594.diff</a>

</details>
