### PR TITLE
8265606: Reduce allocations in AdapterHandlerLibrary::get_adapter

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2601,6 +2601,9 @@ class AdapterHandlerTableIterator : public StackObj {
 // Implementation of AdapterHandlerLibrary
 AdapterHandlerTable* AdapterHandlerLibrary::_adapters = NULL;
 AdapterHandlerEntry* AdapterHandlerLibrary::_abstract_method_handler = NULL;
+
+BasicType AdapterHandlerLibrary::_sig_bt[255];
+VMRegPair AdapterHandlerLibrary::_regs[255];
 const int AdapterHandlerLibrary_size = 16*K;
 BufferBlob* AdapterHandlerLibrary::_buffer = NULL;
 
@@ -2662,8 +2665,10 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
     // Fill in the signature array, for the calling-convention call.
     int total_args_passed = method->size_of_parameters(); // All args on stack
 
-    BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
-    VMRegPair* regs   = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
+    assert(total_args_passed <= 255, "size of parameters too large");
+    BasicType* sig_bt = _sig_bt;
+    VMRegPair*   regs = _regs;
+
     int i = 0;
     if (!method->is_static())  // Pass in receiver first
       sig_bt[i++] = T_OBJECT;
@@ -2885,8 +2890,9 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       // Fill in the signature array, for the calling-convention call.
       const int total_args_passed = method->size_of_parameters();
 
-      BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
-      VMRegPair*   regs = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
+      assert(total_args_passed <= 255, "size of parameters too large");
+      BasicType* sig_bt = _sig_bt;
+      VMRegPair*   regs = _regs;
       int i=0;
       if (!method->is_static())  // Pass in receiver first
         sig_bt[i++] = T_OBJECT;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2601,9 +2601,6 @@ class AdapterHandlerTableIterator : public StackObj {
 // Implementation of AdapterHandlerLibrary
 AdapterHandlerTable* AdapterHandlerLibrary::_adapters = NULL;
 AdapterHandlerEntry* AdapterHandlerLibrary::_abstract_method_handler = NULL;
-
-BasicType AdapterHandlerLibrary::_sig_bt[255];
-VMRegPair AdapterHandlerLibrary::_regs[255];
 const int AdapterHandlerLibrary_size = 16*K;
 BufferBlob* AdapterHandlerLibrary::_buffer = NULL;
 
@@ -2665,10 +2662,8 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
     // Fill in the signature array, for the calling-convention call.
     int total_args_passed = method->size_of_parameters(); // All args on stack
 
-    assert(total_args_passed <= 255, "size of parameters too large");
-    BasicType* sig_bt = _sig_bt;
-    VMRegPair*   regs = _regs;
-
+    BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
+    VMRegPair* regs   = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
     int i = 0;
     if (!method->is_static())  // Pass in receiver first
       sig_bt[i++] = T_OBJECT;
@@ -2890,9 +2885,8 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       // Fill in the signature array, for the calling-convention call.
       const int total_args_passed = method->size_of_parameters();
 
-      assert(total_args_passed <= 255, "size of parameters too large");
-      BasicType* sig_bt = _sig_bt;
-      VMRegPair*   regs = _regs;
+      BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
+      VMRegPair*   regs = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
       int i=0;
       if (!method->is_static())  // Pass in receiver first
         sig_bt[i++] = T_OBJECT;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2662,8 +2662,9 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
     // Fill in the signature array, for the calling-convention call.
     int total_args_passed = method->size_of_parameters(); // All args on stack
 
-    BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
-    VMRegPair* regs   = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
+    BasicType stack_sig_bt[16];
+    BasicType* sig_bt = (total_args_passed <= 16) ? stack_sig_bt : NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
+
     int i = 0;
     if (!method->is_static())  // Pass in receiver first
       sig_bt[i++] = T_OBJECT;
@@ -2689,6 +2690,9 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
     if (entry != NULL) {
       return entry;
     }
+
+    VMRegPair stack_regs[16];
+    VMRegPair* regs = (total_args_passed <= 16) ? stack_regs : NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
 
     // Get a description of the compiled java calling convention and the largest used (VMReg) stack slot usage
     int comp_args_on_stack = SharedRuntime::java_calling_convention(sig_bt, regs, total_args_passed);
@@ -2885,9 +2889,12 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       // Fill in the signature array, for the calling-convention call.
       const int total_args_passed = method->size_of_parameters();
 
-      BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
-      VMRegPair*   regs = NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
-      int i=0;
+      BasicType stack_sig_bt[16];
+      VMRegPair stack_regs[16];
+      BasicType* sig_bt = (total_args_passed <= 16) ? stack_sig_bt : NEW_RESOURCE_ARRAY(BasicType, total_args_passed);
+      VMRegPair* regs = (total_args_passed <= 16) ? stack_regs : NEW_RESOURCE_ARRAY(VMRegPair, total_args_passed);
+
+      int i = 0;
       if (!method->is_static())  // Pass in receiver first
         sig_bt[i++] = T_OBJECT;
       SignatureStream ss(method->signature());
@@ -2954,7 +2961,7 @@ VMRegPair *SharedRuntime::find_callee_arguments(Symbol* sig, bool has_receiver, 
   // This method is returning a data structure allocating as a
   // ResourceObject, so do not put any ResourceMarks in here.
 
-  BasicType *sig_bt = NEW_RESOURCE_ARRAY(BasicType, 256);
+  BasicType sig_bt[256];
   VMRegPair *regs = NEW_RESOURCE_ARRAY(VMRegPair, 256);
   int cnt = 0;
   if (has_receiver) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2961,7 +2961,7 @@ VMRegPair *SharedRuntime::find_callee_arguments(Symbol* sig, bool has_receiver, 
   // This method is returning a data structure allocating as a
   // ResourceObject, so do not put any ResourceMarks in here.
 
-  BasicType sig_bt[256];
+  BasicType *sig_bt = NEW_RESOURCE_ARRAY(BasicType, 256);
   VMRegPair *regs = NEW_RESOURCE_ARRAY(VMRegPair, 256);
   int cnt = 0;
   if (has_receiver) {

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -682,11 +682,6 @@ class AdapterHandlerLibrary: public AllStatic {
   static BufferBlob* _buffer; // the temporary code buffer in CodeCache
   static AdapterHandlerTable* _adapters;
   static AdapterHandlerEntry* _abstract_method_handler;
-
-  // used for lookups and code generation
-  static BasicType _sig_bt[];
-  static VMRegPair _regs[];
-
   static BufferBlob* buffer_blob();
   static void initialize();
 

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -682,6 +682,11 @@ class AdapterHandlerLibrary: public AllStatic {
   static BufferBlob* _buffer; // the temporary code buffer in CodeCache
   static AdapterHandlerTable* _adapters;
   static AdapterHandlerEntry* _abstract_method_handler;
+
+  // used for lookups and code generation
+  static BasicType _sig_bt[];
+  static VMRegPair _regs[];
+
   static BufferBlob* buffer_blob();
   static void initialize();
 


### PR DESCRIPTION
Use stack allocated arrays used when looking up and creating adapters. Resource allocate if number of args grows large, which is relatively rare.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265606](https://bugs.openjdk.java.net/browse/JDK-8265606): Reduce allocations in AdapterHandlerLibrary::get_adapter


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3595/head:pull/3595` \
`$ git checkout pull/3595`

Update a local copy of the PR: \
`$ git checkout pull/3595` \
`$ git pull https://git.openjdk.java.net/jdk pull/3595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3595`

View PR using the GUI difftool: \
`$ git pr show -t 3595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3595.diff">https://git.openjdk.java.net/jdk/pull/3595.diff</a>

</details>
