### PR TITLE
8265607: Avoid decrementing when no Symbol was created in ~SignatureStream

### DIFF
--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -203,6 +203,12 @@ SignatureStream::SignatureStream(const Symbol* signature,
 }
 
 SignatureStream::~SignatureStream() {
+  if (_previous_name == vmSymbols::java_lang_Object()) {
+    // no names were created
+    assert(_names == NULL, "_names unexpectedly created")
+    return;
+  }
+
   // decrement refcount for names created during signature parsing
   _previous_name->decrement_refcount();
   if (_names != NULL) {

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -205,7 +205,7 @@ SignatureStream::SignatureStream(const Symbol* signature,
 SignatureStream::~SignatureStream() {
   if (_previous_name == vmSymbols::java_lang_Object()) {
     // no names were created
-    assert(_names == NULL, "_names unexpectedly created")
+    assert(_names == NULL, "_names unexpectedly created");
     return;
   }
 


### PR DESCRIPTION
This patch trivially avoids decrementing refcount on java/lang/Object (a permanent symbol) that is used as a sentinel when the SignatureStream found no Symbols during parse. This is the common case, especially during early VM startup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265607](https://bugs.openjdk.java.net/browse/JDK-8265607): Avoid decrementing when no Symbol was created in ~SignatureStream


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3596/head:pull/3596` \
`$ git checkout pull/3596`

Update a local copy of the PR: \
`$ git checkout pull/3596` \
`$ git pull https://git.openjdk.java.net/jdk pull/3596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3596`

View PR using the GUI difftool: \
`$ git pr show -t 3596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3596.diff">https://git.openjdk.java.net/jdk/pull/3596.diff</a>

</details>
