### PR TITLE
8265591:  Remove vestiages of intermediate JSR 175 annotation format

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -237,13 +237,8 @@ public class AnnotationParser {
         Class<? extends Annotation> annotationClass = null;
         String sig = "[unknown]";
         try {
-            try {
-                sig = constPool.getUTF8At(typeIndex);
-                annotationClass = (Class<? extends Annotation>)parseSig(sig, container);
-            } catch (IllegalArgumentException ex) {
-                // support obsolete early jsr175 format class files
-                annotationClass = (Class<? extends Annotation>)constPool.getClassAt(typeIndex);
-            }
+            sig = constPool.getUTF8At(typeIndex);
+            annotationClass = (Class<? extends Annotation>)parseSig(sig, container);
         } catch (NoClassDefFoundError e) {
             if (exceptionOnMissingAnnotationClass)
                 // note: at this point sig is "[unknown]" or VM-style
@@ -420,17 +415,11 @@ public class AnnotationParser {
                                           Class<?> container) {
         int classIndex = buf.getShort() & 0xFFFF;
         try {
-            try {
-                String sig = constPool.getUTF8At(classIndex);
-                return parseSig(sig, container);
-            } catch (IllegalArgumentException ex) {
-                // support obsolete early jsr175 format class files
-                return constPool.getClassAt(classIndex);
-            }
+            String sig = constPool.getUTF8At(classIndex);
+            return parseSig(sig, container);
         } catch (NoClassDefFoundError e) {
             return new TypeNotPresentExceptionProxy("[unknown]", e);
-        }
-        catch (TypeNotPresentException e) {
+        } catch (TypeNotPresentException e) {
             return new TypeNotPresentExceptionProxy(e.typeName(), e.getCause());
         }
     }
@@ -474,11 +463,6 @@ public class AnnotationParser {
         int constNameIndex = buf.getShort() & 0xFFFF;
         String constName = constPool.getUTF8At(constNameIndex);
         if (!enumType.isEnum()) {
-            return new AnnotationTypeMismatchExceptionProxy(
-                typeName + "." + constName);
-        } else if (!typeName.endsWith(";")) {
-            // support now-obsolete early jsr175-format class files.
-            if (!enumType.getName().equals(typeName))
             return new AnnotationTypeMismatchExceptionProxy(
                 typeName + "." + constName);
         } else if (enumType != parseSig(typeName, container)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1515,9 +1515,6 @@ public class ClassReader {
     }
 
     Type readTypeOrClassSymbol(int i) {
-        // support preliminary jsr175-format class files
-        if (poolReader.hasTag(i, CONSTANT_Class))
-            return poolReader.getClass(i).type;
         return readTypeToProxy(i);
     }
     Type readTypeToProxy(int i) {


### PR DESCRIPTION
During the recent review of JDK-8228988, I noticed again the comments in the annotation parser about support for the pre-GA annotation format used before JDK 5.0 shipped. During the development of annotations, there was a late change to correct a flaw in the annotation encoding, JDK-5020908.

I don't think it is necessary to carry forward support for this transient format any longer and this changeset removes support from both core reflection and javac.

Clean runs of relevant test; I gauge this fix as no-reg hard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265591](https://bugs.openjdk.java.net/browse/JDK-8265591): Remove vestiages of intermediate JSR 175 annotation format


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3597/head:pull/3597` \
`$ git checkout pull/3597`

Update a local copy of the PR: \
`$ git checkout pull/3597` \
`$ git pull https://git.openjdk.java.net/jdk pull/3597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3597`

View PR using the GUI difftool: \
`$ git pr show -t 3597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3597.diff">https://git.openjdk.java.net/jdk/pull/3597.diff</a>

</details>
