### PR TITLE
8265393: VM crashes if both -XX:+RecordDynamicDumpInfo and -XX:SharedArchiveFile options are specified

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -792,6 +792,14 @@ char * os::native_path(char *path) {
 }
 
 bool os::same_files(const char* file1, const char* file2) {
+  if (file1 == nullptr && file2 == nullptr) {
+    return true;
+  }
+
+  if (file1 == nullptr || file2 == nullptr) {
+    return false;
+  }
+
   if (strcmp(file1, file2) == 0) {
     return true;
   }

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -324,7 +324,8 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java \
  -runtime/cds/appcds/javaldr/HumongousDuringDump.java \
  -runtime/cds/appcds/javaldr/LockDuringDump.java \
- -runtime/cds/appcds/jcmd/JCmdTest.java \
+ -runtime/cds/appcds/jcmd/JCmdTestStaticDump.java \
+ -runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java \
  -runtime/cds/appcds/methodHandles \
  -runtime/cds/appcds/sharedStrings \
  -runtime/cds/appcds/ArchiveRelocationTest.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.JDKToolFinder;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+
+public abstract class JCmdTestDumpBase {
+    private static boolean isStatic; // set first in subclass for dump type
+    protected static void setIsStatic(boolean value) {
+        isStatic = value;
+    }
+    /**************************************
+     * for a subclass to do static dump
+     *    public class JCmdTestStaticDump extends JCmdTestDumpBase {
+     *        isStatic = true; // must, false for dynamic
+     *        public static void test() throws Exception {
+     *            // do test
+     *        }
+     *        public static void main(String[] args) throws Exception {
+     *            runTest(JCmdTestStaticDump::test);
+     *        }
+     *    }
+     ***************************************/
+    public static interface JCmdTest {
+        public void run() throws Exception;
+    }
+
+    public static void runTest(JCmdTest t) throws Exception {
+        checkCDSEnabled();
+        t.run();
+    }
+    private static final String TEST_CLASSES[] =
+                             {"JCmdTestLingeredApp",
+                              "jdk/test/lib/apps/LingeredApp",
+                              "jdk/test/lib/apps/LingeredApp$1"};
+    private static final String BOOT_CLASSES[]    = {"Hello"};
+
+    protected static String testJar = null;
+    protected static String bootJar = null;
+    protected static String allJars = null;
+
+    protected static void buildJars() throws Exception {
+        testJar = JarBuilder.build("test", TEST_CLASSES);
+        bootJar = JarBuilder.build("boot", BOOT_CLASSES);
+        System.out.println("Jar file created: " + testJar);
+        System.out.println("Jar file created: " + bootJar);
+        allJars = testJar+ File.pathSeparator + bootJar;
+    }
+
+    private static void checkCDSEnabled() throws Exception {
+        boolean cdsEnabled = WhiteBox.getWhiteBox().getBooleanVMFlag("UseSharedSpaces");
+        if (!cdsEnabled) {
+            throw new SkippedException("CDS is not available for this JDK.");
+        }
+    }
+
+    private static boolean argsContain(String[] args, String flag) {
+         for (String s: args) {
+             if (s.contains(flag)) {
+                 return true;
+             }
+         }
+         return false;
+    }
+
+    private static boolean argsContainOpts(String[] args, String... opts) {
+        boolean allIn = true;
+        for (String f : opts) {
+            allIn &= argsContain(args, f);
+            if (!allIn) {
+                break;
+            }
+        }
+        return allIn;
+    }
+
+    protected static LingeredApp createLingeredApp(String... args) throws Exception {
+        JCmdTestLingeredApp app  = new JCmdTestLingeredApp();
+        try {
+            LingeredApp.startAppExactJvmOpts(app, args);
+        } catch (Exception e) {
+            // Check flags used.
+            if (argsContainOpts(args, new String[] {"-Xshare:off", "-XX:+RecordDynamicDumpInfo"}) ||
+                argsContainOpts(args, new String[] {"-XX:+RecordDynamicDumpInfo", "-XX:ArchiveClassesAtExit="})) {
+                // app exit premature due to incompactible args
+                return null;
+            }
+            Process proc = app.getProcess();
+            if (e instanceof IOException && proc.exitValue() == 0) {
+                // Process started and exit normally.
+                return null;
+            }
+            throw e;
+        }
+        return app;
+    }
+
+    private static int logFileCount = 0;
+    private static void runWithArchiveFile(String archiveName, boolean useBoot,  String... messages) throws Exception {
+        List<String> args = new ArrayList<String>();
+        if (useBoot) {
+            args.add("-Xbootclasspath/a:" + bootJar);
+        }
+        args.add("-cp");
+        if (useBoot) {
+            args.add(testJar);
+        } else {
+            args.add(allJars);
+        }
+        args.add("-Xshare:on");
+        args.add("-XX:SharedArchiveFile=" + archiveName);
+        args.add("-Xlog:class+load");
+
+        LingeredApp app = createLingeredApp(args.toArray(new String[0]));
+        app.setLogFileName("JCmdTestDynamicDump.log." + (logFileCount++));
+        app.stopApp();
+        String output = app.getOutput().getStdout();
+        if (messages != null) {
+            for (String msg : messages) {
+                if (!output.contains(msg)) {
+                    throw new RuntimeException(msg + " missed from output");
+                }
+            }
+        }
+    }
+
+    protected static void test(String archiveFile, long pid,
+                             boolean useBoot, boolean expectOK, String... messages) throws Exception {
+        System.out.println("Expected: " + (expectOK ? "SUCCESS" : "FAIL"));
+        String fileName = archiveFile != null ? archiveFile :
+            ("java_pid" + pid + (isStatic ? "_static.jsa" : "_dynamic.jsa"));
+        File file = new File(fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+
+        String jcmd = "VM.cds " + (isStatic ? "static_dump" : "dynamic_dump");
+        if (archiveFile  != null) {
+          jcmd +=  " " + archiveFile;
+        }
+
+        PidJcmdExecutor cmdExecutor = new PidJcmdExecutor(String.valueOf(pid));
+        OutputAnalyzer output = cmdExecutor.execute(jcmd, true/*silent*/);
+
+        if (expectOK) {
+            output.shouldHaveExitValue(0);
+            if (!file.exists()) {
+                throw new RuntimeException("Could not create shared archive: " + fileName);
+            } else {
+                runWithArchiveFile(fileName, useBoot, messages);
+                file.delete();
+            }
+        } else {
+            if (file.exists()) {
+                throw new RuntimeException("Should not create shared archive " + fileName);
+            }
+        }
+    }
+
+    protected static void print2ln(String arg) {
+        System.out.println("\n" + arg + "\n");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -28,16 +28,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jdk.test.lib.apps.LingeredApp;
-import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.JDKToolFinder;
 import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
 
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
 
 public abstract class JCmdTestDumpBase {
     private static boolean isStatic; // set first in subclass for dump type
@@ -47,8 +42,8 @@ public abstract class JCmdTestDumpBase {
     /**************************************
      * for a subclass to do static dump
      *    public class JCmdTestStaticDump extends JCmdTestDumpBase {
-     *        isStatic = true; // must, false for dynamic
      *        public static void test() throws Exception {
+     *            setIsStatic(true);
      *            // do test
      *        }
      *        public static void main(String[] args) throws Exception {
@@ -68,18 +63,23 @@ public abstract class JCmdTestDumpBase {
                              {"JCmdTestLingeredApp",
                               "jdk/test/lib/apps/LingeredApp",
                               "jdk/test/lib/apps/LingeredApp$1"};
-    private static final String BOOT_CLASSES[]    = {"Hello"};
+    private static final String BOOT_CLASSES[] = {"Hello"};
 
     protected static String testJar = null;
     protected static String bootJar = null;
     protected static String allJars = null;
+
+    public static final boolean useBoot = true;
+    public static final boolean noBoot = !useBoot;
+    public static final boolean EXPECT_PASS = true;
+    public static final boolean EXPECT_FAIL = !EXPECT_PASS;
 
     protected static void buildJars() throws Exception {
         testJar = JarBuilder.build("test", TEST_CLASSES);
         bootJar = JarBuilder.build("boot", BOOT_CLASSES);
         System.out.println("Jar file created: " + testJar);
         System.out.println("Jar file created: " + bootJar);
-        allJars = testJar+ File.pathSeparator + bootJar;
+        allJars = testJar + File.pathSeparator + bootJar;
     }
 
     private static void checkCDSEnabled() throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -25,23 +25,19 @@
 /*
  * @test
  * @bug 8259070
- * @summary Test jcmd to dump static and dynamic shared archive.
+ * @summary Test jcmd to dump dynamic shared archive.
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @modules jdk.jcmd/sun.tools.common:+open
  * @compile ../test-classes/Hello.java
  * @build sun.hotspot.WhiteBox
- * @build JCmdTestLingeredApp JCmdTest
+ * @build JCmdTestLingeredApp JCmdTestDynamicDump
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTest
+ * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestDynamicDump
  */
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.Files;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,28 +45,23 @@ import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.JDKToolFinder;
 import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
 
 import java.io.InputStreamReader;
 import java.io.BufferedReader;
 
-public class JCmdTest {
+public class JCmdTestDynamicDump {
     static final String TEST_CLASSES[]      = {"JCmdTestLingeredApp",
                                                "jdk/test/lib/apps/LingeredApp",
                                                "jdk/test/lib/apps/LingeredApp$1"};
     static final String BOOT_CLASSES[]      = {"Hello"};
-    static final String SUBCMD_STATIC_DUMP  = "static_dump";
-    static final String SUBCMD_DYNAMIC_DUMP = "dynamic_dump";
 
-    static final String STATIC_DUMP_FILE    = "mystatic";
     static final String DYNAMIC_DUMP_FILE   = "mydynamic";
 
 
-    static final String[] STATIC_MESSAGES   = {"JCmdTestLingeredApp source: shared objects file",
-                                               "LingeredApp source: shared objects file",
-                                               "Hello source: shared objects file"};
     static final String[] DYNAMIC_MESSAGES  = {"JCmdTestLingeredApp source: shared objects file (top)",
                                                "LingeredApp source: shared objects file (top)",
                                                "Hello source: shared objects file (top)"};
@@ -145,7 +136,7 @@ public class JCmdTest {
         args.add("-Xlog:class+load");
 
         LingeredApp app = createLingeredApp(args.toArray(new String[0]));
-        app.setLogFileName("JCmdTest.log." + (logFileCount++));
+        app.setLogFileName("JCmdTestDynamicDump.log." + (logFileCount++));
         app.stopApp();
         String output = app.getOutput().getStdout();
         if (messages != null) {
@@ -157,18 +148,17 @@ public class JCmdTest {
         }
     }
 
-    private static void test(String jcmdSub, String archiveFile,
-                             long pid, boolean useBoot, boolean expectOK, String... messages) throws Exception {
+    private static void test(String archiveFile, long pid,
+                             boolean useBoot, boolean expectOK, String... messages) throws Exception {
         System.out.println("Expected: " + (expectOK ? "SUCCESS" : "FAIL"));
-        boolean isStatic = jcmdSub.equals(SUBCMD_STATIC_DUMP);
         String fileName = archiveFile != null ? archiveFile :
-            ("java_pid" + pid + (isStatic ? "_static" : "_dynamic") + ".jsa");
+            ("java_pid" + pid + "_dynamic.jsa");
         File file = new File(fileName);
         if (file.exists()) {
             file.delete();
         }
 
-        String jcmd = "VM.cds " + jcmdSub;
+        String jcmd = "VM.cds dynamic_dump";
         if (archiveFile  != null) {
           jcmd +=  " " + archiveFile;
         }
@@ -195,146 +185,71 @@ public class JCmdTest {
         System.out.println("\n" + arg + "\n");
     }
 
-    // Those two flags will not create a successful LingeredApp.
-    private static String[] noDumpFlags  =
-        {"-XX:+DumpSharedSpaces",
-         "-Xshare:dump"};
-    // Those flags will be excluded in static dumping,
-    // See src/java.base/share/classes/jdk/internal/misc/CDS.java
-    private static String[] excludeFlags = {
-         "-XX:DumpLoadedClassList=AnyFileName.classlist",
-         // this flag just dump archive, won't run app normally.
-         // "-XX:+DumpSharedSpaces",
-         "-XX:+DynamicDumpSharedSpaces",
-         "-XX:+RecordDynamicDumpInfo",
-         "-Xshare:on",
-         "-Xshare:auto",
-         "-XX:SharedClassListFile=non-exist.classlist",
-         "-XX:SharedArchiveFile=non-exist.jsa",
-         "-XX:ArchiveClassesAtExit=tmp.jsa",
-         "-XX:+UseSharedSpaces",
-         "-XX:+RequireSharedSpaces"};
-
-    // Times to dump cds against same process.
-    private static final int ITERATION_TIMES = 2;
-
-    private static void test() throws Exception {
-        LingeredApp app  = null;
-        long pid;
+    private static void test_dynamic() throws Exception {
         int  test_count = 1;
         final boolean useBoot = true;
         final boolean noBoot = !useBoot;
         final boolean EXPECT_PASS = true;
         final boolean EXPECT_FAIL = !EXPECT_PASS;
 
-        // Static dump with default name multiple times.
-        print2ln(test_count++ + " Static dump with default name multiple times.");
-        app  = createLingeredApp("-cp", allJars);
-        pid = app.getPid();
-        for (int i = 0; i < ITERATION_TIMES; i++) {
-            test(SUBCMD_STATIC_DUMP, null, pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
-        }
-        app.stopApp();
-
-        // Test static dump with given file name.
-        print2ln(test_count++ + " Test static dump with given file name.");
-        app = createLingeredApp("-cp", allJars);
-        pid = app.getPid();
-        for (int i = 0; i < ITERATION_TIMES; i++) {
-            test(SUBCMD_STATIC_DUMP, STATIC_DUMP_FILE + "0" + i + ".jsa", pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
-        }
-        app.stopApp();
-
-        //  Test static dump with flags with which dumping should fail
-        //  This test will result classes.jsa in default server dir if -XX:SharedArchiveFile= not set.
-        print2ln(test_count++ + " Test static dump with flags with which dumping should fail.");
-        for (String flag : noDumpFlags) {
-            app = createLingeredApp("-cp", allJars, flag, "-XX:SharedArchiveFile=tmp.jsa");
-            // Following should not be executed.
-            if (app != null && app.getProcess().isAlive()) {
-                pid = app.getPid();
-                test(SUBCMD_STATIC_DUMP, null, pid, noBoot, EXPECT_FAIL);
-                app.stopApp();
-                // if above executed OK, mean failed.
-                throw new RuntimeException("Should not dump successful with " + flag);
-            }
-        }
-
-        // Test static with -Xbootclasspath/a:boot.jar
-        print2ln(test_count++ + " Test static with -Xbootassath/a:boot.jar");
-        app = createLingeredApp("-Xbootclasspath/a:" + bootJar, "-cp", testJar);
-        pid = app.getPid();
-        test(SUBCMD_STATIC_DUMP, null, pid, useBoot, EXPECT_PASS, STATIC_MESSAGES);
-        app.stopApp();
-
-        // Test static with limit-modules java.base.
-        print2ln(test_count++ + " Test static with --limit-modules java.base.");
-        app = createLingeredApp("--limit-modules", "java.base", "-cp", allJars);
-        pid = app.getPid();
-        test(SUBCMD_STATIC_DUMP, null, pid, noBoot, EXPECT_FAIL);
-        app.stopApp();
-
-        // Test static dump with flags which will be filtered before dumping.
-        print2ln(test_count++ + " Test static dump with flags which will be filtered before dumping.");
-        for (String flag : excludeFlags) {
-            app = createLingeredApp("-cp", allJars, flag);
-            pid = app.getPid();
-            test(SUBCMD_STATIC_DUMP, null, pid, noBoot, EXPECT_PASS, STATIC_MESSAGES);
-            app.stopApp();
-        }
-
-
-        // Test static with -Xshare:off will be OK to dump.
-        print2ln(test_count++ + " Test static with -Xshare:off will be OK to dump.");
-        app = createLingeredApp("-Xshare:off", "-cp", allJars);
-        pid = app.getPid();
-        test(SUBCMD_STATIC_DUMP, null, pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
-        app.stopApp();
+        LingeredApp app  = null;
+        long pid;
 
         // Test dynamic dump with -XX:+RecordDynamicDumpInfo.
         print2ln(test_count++ + " Test dynamic dump with -XX:+RecordDynamicDumpInfo.");
         app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, DYNAMIC_DUMP_FILE + "01.jsa", pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        test(DYNAMIC_DUMP_FILE + "01.jsa", pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
 
         // Test dynamic dump twice to same process.
         print2ln(test_count++ + " Test dynamic dump second time to the same process.");
-        test(SUBCMD_DYNAMIC_DUMP, DYNAMIC_DUMP_FILE + "02.jsa", pid, noBoot,  EXPECT_FAIL);
+        test("02.jsa", pid, noBoot,  EXPECT_FAIL);
         app.stopApp();
 
         // Test dynamic dump with -XX:-RecordDynamicDumpInfo.
         print2ln(test_count++ + " Test dynamic dump with -XX:-RecordDynamicDumpInfo.");
         app = createLingeredApp("-cp", allJars);
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, DYNAMIC_DUMP_FILE + "01.jsa", pid, noBoot, EXPECT_FAIL);
+        test("01.jsa", pid, noBoot, EXPECT_FAIL);
         app.stopApp();
 
         // Test dynamic dump with default archive name (null).
         print2ln(test_count++ + " Test dynamic dump with default archive name (null).");
         app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
         app.stopApp();
 
         // Test dynamic dump with flags -XX:+RecordDynamicDumpInfo -XX:-DynamicDumpSharedSpaces.
         print2ln(test_count++ + " Test dynamic dump with flags -XX:+RecordDynamicDumpInfo -XX:-DynamicDumpSharedSpaces.");
         app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo", "-XX:-DynamicDumpSharedSpaces");
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
         app.stopApp();
 
         // Test dynamic dump with flags -XX:-DynamicDumpSharedSpaces -XX:+RecordDynamicDumpInfo.
         print2ln(test_count++ + " Test dynamic dump with flags -XX:-DynamicDumpSharedSpaces -XX:+RecordDynamicDumpInfo.");
         app = createLingeredApp("-cp", allJars, "-XX:-DynamicDumpSharedSpaces", "-XX:+RecordDynamicDumpInfo");
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, null, pid, noBoot,  EXPECT_PASS, DYNAMIC_MESSAGES);
+        test(null, pid, noBoot,  EXPECT_PASS, DYNAMIC_MESSAGES);
         app.stopApp();
 
         // Test dynamic with -Xbootclasspath/a:boot.jar
         print2ln(test_count++ + " Test dynamic with -Xbootclasspath/a:boot.jar");
         app = createLingeredApp("-cp", testJar, "-Xbootclasspath/a:" + bootJar, "-XX:+RecordDynamicDumpInfo");
         pid = app.getPid();
-        test(SUBCMD_DYNAMIC_DUMP, null, pid, useBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        test(null, pid, useBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test -XX:+RecordDynamicDump -XX:SharedArchiveFile=test_static.jsa
+        print2ln(test_count++ + " Test -XX:+RecordDynamicDumpInfo -XX:SharedArchiveFile=test_static.jsa");
+        // Dump a static archive as base (here do not use the default classes.jsa)
+        String archiveFile = "test_static.jsa";
+        dumpStaticArchive(archiveFile);
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo",
+                                "-XX:SharedArchiveFile=" + archiveFile);
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
         app.stopApp();
 
         // Test dynamic dump with -XX:ArchiveClassAtExit will fail.
@@ -343,11 +258,24 @@ public class JCmdTest {
                                 "-Xshare:auto",
                                 "-XX:+RecordDynamicDumpInfo",
                                 "-XX:ArchiveClassesAtExit=AnyName.jsa");
-
         if (app != null) {
             if (app.getProcess().isAlive()) {
                 throw new RuntimeException("The JCmdTestLingeredApp should not start up!");
             }
+        }
+    }
+
+    // Dump a static archive, not using TestCommon.dump(...), we do not take jtreg args.
+    private static void dumpStaticArchive(String archiveFile) throws Exception {
+        String javapath = JDKToolFinder.getJDKTool("java");
+        String cmd[] = {javapath, "-Xshare:dump",  "-XX:SharedArchiveFile=" + archiveFile};
+        // Do not use ProcessTools.createTestJvm(cmd) here, it copies jtreg env.
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        CDSTestUtils.executeAndLog(pb, "dump")
+            .shouldHaveExitValue(0);
+        File file = new File(archiveFile);
+        if (!file.exists()) {
+            throw new RuntimeException("Shared archive file " + archiveFile + " is not created");
         }
     }
 
@@ -357,6 +285,6 @@ public class JCmdTest {
             throw new SkippedException("CDS is not available for this JDK.");
         }
         buildJar();
-        test();
+        test_dynamic();
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -37,19 +37,10 @@
  */
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.cds.CDSTestUtils;
-import jdk.test.lib.dcmd.PidJcmdExecutor;
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.JDKToolFinder;
-
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
 
 public class JCmdTestDynamicDump extends JCmdTestDumpBase {
     static final String DYNAMIC_DUMP_FILE   = "mydynamic";
@@ -58,17 +49,12 @@ public class JCmdTestDynamicDump extends JCmdTestDumpBase {
                                                "Hello source: shared objects file (top)"};
     static void test() throws Exception {
         setIsStatic(false);
-        int  test_count = 1;
-        final boolean useBoot = true;
-        final boolean noBoot = !useBoot;
-        final boolean EXPECT_PASS = true;
-        final boolean EXPECT_FAIL = !EXPECT_PASS;
+        buildJars();
 
         LingeredApp app  = null;
         long pid;
 
-        // build test.jar and boot.jar
-        buildJars();
+        int  test_count = 1;
         // Test dynamic dump with -XX:+RecordDynamicDumpInfo.
         print2ln(test_count++ + " Test dynamic dump with -XX:+RecordDynamicDumpInfo.");
         app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
@@ -36,18 +36,7 @@
  * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestStaticDump
  */
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
 import jdk.test.lib.apps.LingeredApp;
-import jdk.test.lib.dcmd.PidJcmdExecutor;
-import jdk.test.lib.process.OutputAnalyzer;
-
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
 
 public class JCmdTestStaticDump extends JCmdTestDumpBase {
 
@@ -82,15 +71,11 @@ public class JCmdTestStaticDump extends JCmdTestDumpBase {
     static void test() throws Exception {
         setIsStatic(true);
         buildJars();
-        int  test_count = 1;
-        final boolean useBoot = true;
-        final boolean noBoot = !useBoot;
-        final boolean EXPECT_PASS = true;
-        final boolean EXPECT_FAIL = !EXPECT_PASS;
 
         LingeredApp app = null;
         long pid;
 
+        int  test_count = 1;
         // Static dump with default name multiple times.
         print2ln(test_count++ + " Static dump with default name multiple times.");
         app  = createLingeredApp("-cp", allJars);

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8259070
+ * @summary Test jcmd to dump static shared archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../test-classes/Hello.java
+ * @build sun.hotspot.WhiteBox
+ * @build JCmdTestLingeredApp JCmdTestStaticDump
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestStaticDump
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+
+public class JCmdTestStaticDump {
+    static final String TEST_CLASSES[]      = {"JCmdTestLingeredApp",
+                                               "jdk/test/lib/apps/LingeredApp",
+                                               "jdk/test/lib/apps/LingeredApp$1"};
+    static final String BOOT_CLASSES[]      = {"Hello"};
+
+    static final String STATIC_DUMP_FILE    = "mystatic";
+
+
+    static final String[] STATIC_MESSAGES   = {"JCmdTestLingeredApp source: shared objects file",
+                                               "LingeredApp source: shared objects file",
+                                               "Hello source: shared objects file"};
+
+    static String testJar = null;
+    static String bootJar = null;
+    static String allJars = null;
+
+    private static void buildJar() throws Exception {
+        testJar = JarBuilder.build("test", TEST_CLASSES);
+        bootJar = JarBuilder.build("boot", BOOT_CLASSES);
+        System.out.println("Jar file created: " + testJar);
+        System.out.println("Jar file created: " + bootJar);
+        allJars = testJar+ File.pathSeparator + bootJar;
+    }
+
+    private static LingeredApp createLingeredApp(String... args) throws Exception {
+        JCmdTestLingeredApp app  = new JCmdTestLingeredApp();
+        try {
+            LingeredApp.startAppExactJvmOpts(app, args);
+        } catch (Exception e) {
+            Process proc = app.getProcess();
+            if (e instanceof IOException && proc.exitValue() == 0) {
+                // Process started and exit normally.
+                return null;
+            }
+            throw e;
+        }
+        return app;
+    }
+
+    static int logFileCount = 0;
+    private static void runWithArchiveFile(String archiveName, boolean useBoot,  String... messages) throws Exception {
+        List<String> args = new ArrayList<String>();
+        if (useBoot) {
+            args.add("-Xbootclasspath/a:" + bootJar);
+        }
+        args.add("-cp");
+        if (useBoot) {
+            args.add(testJar);
+        } else {
+            args.add(allJars);
+        }
+        args.add("-Xshare:on");
+        args.add("-XX:SharedArchiveFile=" + archiveName);
+        args.add("-Xlog:class+load");
+
+        LingeredApp app = createLingeredApp(args.toArray(new String[0]));
+        app.setLogFileName("JCmdTestStaticDump.log" + (logFileCount++));
+        app.stopApp();
+        String output = app.getOutput().getStdout();
+        if (messages != null) {
+            for (String msg : messages) {
+                if (!output.contains(msg)) {
+                    throw new RuntimeException(msg + " missed from output");
+                }
+            }
+        }
+    }
+
+    private static void test(String archiveFile,
+                             long pid, boolean useBoot, boolean expectOK, String... messages) throws Exception {
+        System.out.println("Expected: " + (expectOK ? "SUCCESS" : "FAIL"));
+        String fileName = archiveFile != null ? archiveFile : ("java_pid" + pid + "_static.jsa");
+        File file = new File(fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+
+        String jcmd = "VM.cds static_dump";
+        if (archiveFile  != null) {
+          jcmd +=  " " + archiveFile;
+        }
+
+        PidJcmdExecutor cmdExecutor = new PidJcmdExecutor(String.valueOf(pid));
+        OutputAnalyzer output = cmdExecutor.execute(jcmd, true/*silent*/);
+
+        if (expectOK) {
+            output.shouldHaveExitValue(0);
+            if (!file.exists()) {
+                throw new RuntimeException("Could not create shared archive: " + fileName);
+            } else {
+                runWithArchiveFile(fileName, useBoot, messages);
+                file.delete();
+            }
+        } else {
+            if (file.exists()) {
+                throw new RuntimeException("Should not create shared archive " + fileName);
+            }
+        }
+    }
+
+    private static void print2ln(String arg) {
+        System.out.println("\n" + arg + "\n");
+    }
+
+    // Those two flags will not create a successful LingeredApp.
+    private static String[] noDumpFlags  =
+        {"-XX:+DumpSharedSpaces",
+         "-Xshare:dump"};
+    // Those flags will be excluded in static dumping,
+    // See src/java.base/share/classes/jdk/internal/misc/CDS.java
+    private static String[] excludeFlags = {
+         "-XX:DumpLoadedClassList=AnyFileName.classlist",
+         // this flag just dump archive, won't run app normally.
+         // "-XX:+DumpSharedSpaces",
+         "-XX:+DynamicDumpSharedSpaces",
+         "-XX:+RecordDynamicDumpInfo",
+         "-Xshare:on",
+         "-Xshare:auto",
+         "-XX:SharedClassListFile=non-exist.classlist",
+         "-XX:SharedArchiveFile=non-exist.jsa",
+         "-XX:ArchiveClassesAtExit=tmp.jsa",
+         "-XX:+UseSharedSpaces",
+         "-XX:+RequireSharedSpaces"};
+
+    // Times to dump cds against same process.
+    private static final int ITERATION_TIMES = 2;
+
+    private static void test_static() throws Exception {
+        int  test_count = 1;
+        final boolean useBoot = true;
+        final boolean noBoot = !useBoot;
+        final boolean EXPECT_PASS = true;
+        final boolean EXPECT_FAIL = !EXPECT_PASS;
+
+        LingeredApp app = null;
+        long pid;
+
+        // Static dump with default name multiple times.
+        print2ln(test_count++ + " Static dump with default name multiple times.");
+        app  = createLingeredApp("-cp", allJars);
+        pid = app.getPid();
+        for (int i = 0; i < ITERATION_TIMES; i++) {
+            test(null, pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
+        }
+        app.stopApp();
+
+        // Test static dump with given file name.
+        print2ln(test_count++ + " Test static dump with given file name.");
+        app = createLingeredApp("-cp", allJars);
+        pid = app.getPid();
+        for (int i = 0; i < ITERATION_TIMES; i++) {
+            test("0" + i + ".jsa", pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
+        }
+        app.stopApp();
+
+        //  Test static dump with flags with which dumping should fail
+        //  This test will result classes.jsa in default server dir if -XX:SharedArchiveFile= not set.
+        print2ln(test_count++ + " Test static dump with flags with which dumping should fail.");
+        for (String flag : noDumpFlags) {
+            app = createLingeredApp("-cp", allJars, flag, "-XX:SharedArchiveFile=tmp.jsa");
+            // Following should not be executed.
+            if (app != null && app.getProcess().isAlive()) {
+                pid = app.getPid();
+                test(null, pid, noBoot, EXPECT_FAIL);
+                app.stopApp();
+                // if above executed OK, mean failed.
+                throw new RuntimeException("Should not dump successful with " + flag);
+            }
+        }
+
+        // Test static with -Xbootclasspath/a:boot.jar
+        print2ln(test_count++ + " Test static with -Xbootassath/a:boot.jar");
+        app = createLingeredApp("-Xbootclasspath/a:" + bootJar, "-cp", testJar);
+        pid = app.getPid();
+        test(null, pid, useBoot, EXPECT_PASS, STATIC_MESSAGES);
+        app.stopApp();
+
+        // Test static with limit-modules java.base.
+        print2ln(test_count++ + " Test static with --limit-modules java.base.");
+        app = createLingeredApp("--limit-modules", "java.base", "-cp", allJars);
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_FAIL);
+        app.stopApp();
+
+        // Test static dump with flags which will be filtered before dumping.
+        print2ln(test_count++ + " Test static dump with flags which will be filtered before dumping.");
+        for (String flag : excludeFlags) {
+            app = createLingeredApp("-cp", allJars, flag);
+            pid = app.getPid();
+            test(null, pid, noBoot, EXPECT_PASS, STATIC_MESSAGES);
+            app.stopApp();
+        }
+
+        // Test static with -Xshare:off will be OK to dump.
+        print2ln(test_count++ + " Test static with -Xshare:off will be OK to dump.");
+        app = createLingeredApp("-Xshare:off", "-cp", allJars);
+        pid = app.getPid();
+        test(null, pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
+        app.stopApp();
+
+        // Test static with -XX:+RecordDynamicDumpInfo will be OK to dump.
+        print2ln(test_count++ + " Test static with -XX:+RecordDynamicDumpInfo will be OK to dump.");
+        app = createLingeredApp("-XX:+RecordDynamicDumpInfo", "-cp", allJars);
+        pid = app.getPid();
+        test(null, pid, noBoot,  EXPECT_PASS, STATIC_MESSAGES);
+        app.stopApp();
+    }
+
+    public static void main(String... args) throws Exception {
+        boolean cdsEnabled = WhiteBox.getWhiteBox().getBooleanVMFlag("UseSharedSpaces");
+        if (!cdsEnabled) {
+            throw new SkippedException("CDS is not available for this JDK.");
+        }
+        buildJar();
+        test_static();
+    }
+}


### PR DESCRIPTION
Hi, Please review
  1) When the two flags -XX:+RecordDynamicDumpInfo and -XX:SharedArchiveFile used,  in
     Arguments::init_shared_archive_paths() :
          if (DynamicDumpSharedSpaces) {
            if (os::same_files(SharedArchiveFile, ArchiveClassesAtExit)) {
               ...
  ArchiveClassesAtExit is NULL.
  C++ does not have a defined behavior of strcmp with strings of NULL. Posix version of os::same_files(const char* file1, const char* file2) calls strcmp without checking input args. This should be same as it is treated on Windows.
  2) JCmdTest.java is fat and possible to cause test timeout. Split JCmdTest.java into two separate Tests: JCmdTestStaticDump.java and JCmdTestDynamicDump.java.
  3) Add a test to check run with -XX:+RecordDynamicDumpInfo and -XX:SharedArchiveFile in JCmdTestDynamicDump.java
       The test does not use utility to create jvm process  since it will take testing envs into process, but the way in the test using LingeredApp does not take envs.

  Tests: tier1,tier2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265393](https://bugs.openjdk.java.net/browse/JDK-8265393): VM crashes if both -XX:+RecordDynamicDumpInfo and -XX:SharedArchiveFile options are specified


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3599/head:pull/3599` \
`$ git checkout pull/3599`

Update a local copy of the PR: \
`$ git checkout pull/3599` \
`$ git pull https://git.openjdk.java.net/jdk pull/3599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3599`

View PR using the GUI difftool: \
`$ git pr show -t 3599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3599.diff">https://git.openjdk.java.net/jdk/pull/3599.diff</a>

</details>
