### PR TITLE
8198422: Test java/awt/font/StyledMetrics/BoldSpace.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -246,7 +246,6 @@ java/awt/Window/GrabSequence/GrabSequence.java 6848409 macosx-all,linux-all
 java/awt/Window/LocationAtScreenCorner/LocationAtScreenCorner.java 8203371 linux-all
 java/awt/font/TextLayout/CombiningPerf.java 8192931 generic-all
 java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
-java/awt/font/StyledMetrics/BoldSpace.java 8198422 linux-all
 java/awt/FontMetrics/FontCrash.java 8198336 windows-all
 java/awt/image/BufferedImage/ICMColorDataTest/ICMColorDataTest.java 8233028 generic-all
 java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all


### PR DESCRIPTION
This test was marked as unstable in CI run due to samevm mode issue. It is now passing in default othervm mode.
Several iterations of this test running in all platforms is working fine, link in JBS.
We can remove the test from ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198422](https://bugs.openjdk.java.net/browse/JDK-8198422): Test java/awt/font/StyledMetrics/BoldSpace.java is unstable


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3601/head:pull/3601` \
`$ git checkout pull/3601`

Update a local copy of the PR: \
`$ git checkout pull/3601` \
`$ git pull https://git.openjdk.java.net/jdk pull/3601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3601`

View PR using the GUI difftool: \
`$ git pr show -t 3601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3601.diff">https://git.openjdk.java.net/jdk/pull/3601.diff</a>

</details>
